### PR TITLE
v0.3.0 — pre-session hooks, work + meta-review, action-items GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,16 @@ Launch sessions manually with skills:
 /scout-research       # Knowledge expansion
 ```
 
+Or run interactive sessions in the current conversation:
+
+```
+/scout-work           # Walk through today's action items one at a time, approve each action
+/scout-meta-review    # System-level audit — are sessions running, is the mistake audit trending well, are proposals flowing?
+```
+
 ## How It Works
 
-Four session types form a daily rhythm:
+Six session types, split into **scheduled background sessions** (Briefing, Consolidation, Dreaming, Research) and **interactive conversation sessions** (Work, Meta Review):
 
 ### Morning Briefing (once per day, weekdays)
 
@@ -69,7 +76,29 @@ Knowledge expansion:
 3. **Knowledge integration** — Updates entity files, extends the knowledge graph with new relationships, creates new entity files for discovered entities. Validates against the ontology schema.
 4. **Commit & notify** — Commits findings, updates the session log, sends a concise summary to the user.
 
+### Work (interactive, user-triggered)
+
+Runs in the current conversation instead of as a background process. Walks through today's action items one at a time — presenting each item with fresh context (latest PR state, last Slack reply, meeting conflicts), a recommended action, and a draft of any outbound message or command. Executes each item only with explicit approval (`do it`, `skip`, or a modification).
+
+Commits land in the git log as `work [HH:MM]: <summary>`, distinguishing manual work from scheduled runs.
+
+### Meta Review (interactive, diagnostic)
+
+A system-level audit that sits above the individual session types. Does not read SKILL.md or DREAMING.md — instead it reviews the Scout system itself: are sessions actually running? Is the mistake audit trending better or worse? Are dreaming proposals flowing or clogged? Is the data-source coverage matrix consistent across session types? Writes a report to `knowledge-base/meta-review-YYYY-MM-DD.md`, applies low-risk quick fixes directly, and writes proposals for anything that needs judgment. Run weekly, or when something feels off.
+
 Everything is a git repo. Every change Scout makes is committed with a descriptive message. The commit history is as much a part of the system as the files.
+
+## Pre-Session Hooks
+
+Scout's runner scripts call three shell hooks before launching Claude. Each hook writes a cache file into `.scout-cache/`, which the skill files read instead of running the same queries from inside the session. This trades a few seconds of shell work for a meaningful reduction in tool calls and tokens per session.
+
+| Hook | Output | What it replaces |
+|------|--------|-----------------|
+| `hooks/kb-pre-filter.sh` | `.scout-cache/kb-filter.md` — KB files bucketed into stale / fresh / undated, with ages | Walking every KB file from inside the session to check "Last updated" dates |
+| `scripts/pre-session-data.sh` | `.scout-cache/session-context.json` — recent git log, open PRs, PR review requests, KB file dates, open personal tasks | `git log`, `gh pr list`, `gh search prs`, ontology parser queries |
+| `scripts/cc-session-cache.sh` | `.scout-cache/cc-sessions.md` — non-Scout Claude Code sessions from the last 24h: project paths, first prompts, files touched | Discovering + parsing `~/.claude/projects/*/*.jsonl` manually |
+
+The `.scout-cache/` directory is gitignored — everything in it is recomputed on every run. If a hook fails, the runner script continues anyway and the skill falls back to live queries. Hooks never block a run.
 
 ## Supported Connectors
 
@@ -163,17 +192,30 @@ scout-plugin/
   commands/
     scout-setup.md          -- Interactive setup wizard
     scout-status.md         -- Dashboard command
+    scout-work.md           -- Interactive work session (in-conversation)
+    scout-meta-review.md    -- System-level diagnostic audit (in-conversation)
   skills/
-    scout-briefing.md       -- Launch a briefing session
-    scout-consolidation.md  -- Launch a consolidation session
-    scout-dream.md          -- Launch a dreaming session
-    scout-research.md       -- Launch a research session
+    scout-briefing.md       -- Launch a briefing session (background)
+    scout-consolidation.md  -- Launch a consolidation session (background)
+    scout-dream.md          -- Launch a dreaming session (background)
+    scout-research.md       -- Launch a research session (background)
   phases/
     core/                   -- Always included (git, KB management, action items)
     connectors/             -- One per tool (Slack, Calendar, Linear, etc.)
     modes/                  -- Dreaming-specific (feedback, KB deep work, wishlist)
     research/               -- Research session phases
-  templates/                -- Runner scripts, schedulers, KB scaffold, ontology, scripts
+  templates/
+    hooks/                  -- Pre-session hooks (kb-pre-filter)
+    scripts/                -- Budget tracking + pre-session data gathering
+    action-items/           -- MD-to-HTML dashboard renderer + file watcher
+    docs/                   -- Wishlist templates (active / in-progress / done)
+    knowledge-base/         -- KB scaffold and ontology
+    run-scout.sh.tmpl
+    run-dreaming.sh.tmpl
+    run-research.sh.tmpl
+    scout-config.yaml.tmpl
+    launchd-plist.tmpl
+    cron-entry.tmpl
 ```
 
 ### What gets created in your Scout directory
@@ -183,16 +225,20 @@ scout-plugin/
   SKILL.md                  -- Assembled skill file (briefing + consolidation)
   DREAMING.md               -- Assembled skill file (dreaming)
   RESEARCH.md               -- Assembled skill file (research)
-  run-scout.sh              -- Briefing/consolidation runner
-  run-dreaming.sh           -- Dreaming runner
+  run-scout.sh              -- Briefing/consolidation runner (calls pre-session hooks)
+  run-dreaming.sh           -- Dreaming runner (calls pre-session hooks)
   run-research.sh           -- Research runner
   scout-config.yaml         -- Your configuration
   dreaming-proposals.md     -- Proposal gate for skill improvements
+  hooks/
+    kb-pre-filter.sh        -- Pre-session: bucket KB files by staleness
   scripts/
     budget-check.sh         -- Pre-run budget verification
     write-session-cost.sh   -- Session cost logging
     rate-limit-detect.sh    -- Rate limit signal detection
     heartbeat.sh            -- Opportunistic session triggering
+    pre-session-data.sh     -- Pre-session: gather git log, PRs, KB dates, tasks
+    cc-session-cache.sh     -- Pre-session: summarize non-Scout CC sessions
   knowledge-base/           -- Your persistent knowledge base (Obsidian vault)
     ontology/
       schema.yaml           -- Knowledge graph schema
@@ -202,8 +248,19 @@ scout-plugin/
     personal/               -- Personal task and family entity files
     projects/               -- Project files
     research-queue.md       -- Queued research topics
+    scout-mistake-audit.md  -- Error-pattern log written by dreaming
+    review-queue.md         -- Claims waiting on user verification
   action-items/             -- Daily action items
-  docs/Wishlist.md          -- Feature requests for your instance
+    archive/                -- Older-than-7-days action items
+    meeting-prep/           -- Auto-generated meeting prep docs
+    render.py               -- Optional MD → HTML dashboard
+    watch.sh                -- Auto-re-render HTML on MD change (fswatch)
+  docs/
+    Wishlist.md             -- New feature requests
+    Wishlist-in-progress.md -- Active work, with sub-task checkboxes
+    Wishlist-done.md        -- Completed items archive
+  .scout-cache/             -- Hook outputs (gitignored, regenerated every run)
+  .scout-logs/              -- Run logs and usage-tracker.jsonl (gitignored)
 ```
 
 The assembled skill files are self-contained — they don't reference the plugin at runtime. You can customize them freely. Run `/scout-setup` again to regenerate from the latest phase modules.

--- a/commands/scout-meta-review.md
+++ b/commands/scout-meta-review.md
@@ -1,0 +1,251 @@
+---
+name: scout-meta-review
+description: Run an interactive Scout meta-review — a system-level audit that sits above the individual session types. Checks whether sessions are running, mistake audit is trending well, proposals are flowing, KB files are healthy, and data-source coverage is consistent across session types. Runs in the current conversation.
+---
+
+# Scout Meta Review
+
+Run an interactive Scout **Meta Review** — a system-level audit that sits ABOVE the individual session types (briefing, consolidation, dreaming, research, work).
+
+This is NOT a Scout session. It does not read SKILL.md or DREAMING.md. It reviews the Scout system itself: are all the parts working together? Are improvements actually improving things? Is anything rotting, stalling, or drifting?
+
+Run this in the **current conversation** so the user has full visibility. Run it weekly, or whenever something feels off.
+
+---
+
+## Phase 1: System Health Check
+
+Read `scout-config.yaml` first to locate the Scout directory (`scout_dir`) and the user's Slack ID (if Slack is enabled).
+
+### 1a: Session Execution Audit
+
+Check whether Scout sessions are actually running and completing:
+
+```bash
+# Count sessions by type in the last 7 days
+for type in scout dreaming research; do
+  echo "=== $type ==="
+  ls -1 <SCOUT_DIR>/.scout-logs/${type}-*.log 2>/dev/null | while read f; do
+    mod=$(stat -f '%Sm' -t '%Y-%m-%d' "$f" 2>/dev/null || stat -c '%y' "$f" 2>/dev/null | cut -d' ' -f1)
+    echo "$mod $(basename "$f")"
+  done | sort -r | head -20
+done
+```
+
+```bash
+# Check for failures
+cat <SCOUT_DIR>/.scout-logs/failures.log 2>/dev/null | tail -20
+```
+
+```bash
+# macOS: check launchd. Linux: check cron.
+launchctl list | grep -i scout 2>/dev/null || crontab -l 2>/dev/null | grep -i scout || echo "No scheduled jobs found"
+```
+
+**Report:**
+- Sessions per day by type (last 7 days)
+- Failure rate (failures / total runs)
+- Any session types not running at all
+- Gaps in schedule (e.g., no afternoon consolidation for 3 days)
+
+### 1b: Git Health
+
+```bash
+cd <SCOUT_DIR> && git log --oneline --since="7 days ago" | head -30
+cd <SCOUT_DIR> && git status
+```
+
+- Are sessions committing? Average commits per day?
+- Any uncommitted changes lingering?
+- Commit message patterns — are they following conventions (`briefing [HH:MM]:`, `dreaming [HH:MM]:`, `work [HH:MM]:`)?
+
+### 1c: Budget & Cost
+
+```bash
+cat <SCOUT_DIR>/.scout-logs/usage-tracker.jsonl 2>/dev/null | tail -20
+```
+
+- What's the recent spending trend?
+- Any rate limit events?
+- Are budget caps being hit?
+
+---
+
+## Phase 2: Quality Trend Analysis
+
+### 2a: Mistake Audit Trends
+
+Read `knowledge-base/scout-mistake-audit.md` and analyze:
+
+1. **Total patterns logged** — how many?
+2. **Open vs resolved** — are patterns getting fixed or just accumulating?
+3. **Repeat offenders** — which patterns have multiple instances? (These are the systemic failures.)
+4. **Age distribution** — are old patterns still open? How old is the oldest unresolved pattern?
+5. **Category breakdown** — what types of errors dominate? (data source gaps? KB staleness? false positives? process failures?)
+
+**Verdict:** Is the system getting better, plateauing, or getting worse? Back it up with data.
+
+### 2b: Dreaming Proposals Pipeline
+
+Read `dreaming-proposals.md` (and `dreaming-proposals-archive.md` if it exists):
+
+1. **Total pending** — how many proposals are waiting for review?
+2. **Age of oldest pending** — how long has it been waiting?
+3. **Throughput** — how many proposals were applied in the last 7 days?
+4. **Bottleneck diagnosis** — is the bottleneck proposal generation, review, or application?
+
+**Verdict:** Is the improvement pipeline flowing or clogged?
+
+### 2c: Feedback Signal Analysis
+
+If Slack is connected, read Scout's recent DMs to the user. For the last 7 days of DMs:
+
+1. Count **+1 reactions** (positive signal)
+2. Count **-1 reactions** (negative signal)
+3. Count **thread replies** that are corrections vs. confirmations
+4. Calculate a **signal ratio** (+1 / total reactions)
+
+**Verdict:** Is user satisfaction trending up or down? Any session types consistently getting negative feedback?
+
+---
+
+## Phase 3: Architecture Coherence
+
+### 3a: KB File Health
+
+For every file in `knowledge-base/`:
+
+1. Check **"Last updated" timestamps** — which files haven't been touched in 7+ days?
+2. Check **file sizes** — which files are over 200 lines? (Candidates for splitting)
+3. Check **wikilink integrity** — sample 10 wikilinks across KB files. Do the targets exist?
+4. Check **knowledge-base.md root** — does it link to all projects? Is the session history current?
+
+**Report:** Stale files, oversized files, broken links.
+
+### 3b: Action Items Continuity
+
+Read the last 3 days of action items files. Check:
+
+1. **Carryover integrity** — did all unchecked items from Day N appear on Day N+1? (Or were they dropped?)
+2. **Completion tracking** — are completed items being moved to the "Recently Completed" section consistently?
+3. **Category hygiene** — are items in the right sections (urgent vs to-do vs watching vs personal)?
+4. **Meeting prep** — are prep docs being generated for all calendar meetings?
+
+**Report:** Items that were dropped, miscategorized items, missing prep docs.
+
+### 3c: Ontology & Knowledge Graph
+
+```bash
+ls <SCOUT_DIR>/knowledge-base/ontology/entities/*.md 2>/dev/null | wc -l
+ls <SCOUT_DIR>/knowledge-base/people/*.md 2>/dev/null | wc -l
+ls <SCOUT_DIR>/knowledge-base/personal/*.md 2>/dev/null | wc -l
+```
+
+```bash
+cd <SCOUT_DIR> && python knowledge-base/ontology/parser.py stats
+cd <SCOUT_DIR> && python knowledge-base/ontology/parser.py validate
+```
+
+- Is the graph growing?
+- Are personal entities being created?
+- Does validation pass?
+- Quick-check `ontology/schema.yaml` against actual entity frontmatter.
+
+---
+
+## Phase 4: Skill & Session Effectiveness
+
+### 4a: Cross-Skill Consistency
+
+Read all skill files and check for contradictions or gaps:
+- `SKILL.md` (briefing/consolidation)
+- `DREAMING.md` (dreaming)
+- `RESEARCH.md` (research)
+- `.claude/commands/scout-work.md` (if installed locally)
+
+Look for:
+- Contradictory instructions between skills
+- Data sources mentioned in one skill but not others (when they should be shared)
+- Formatting conventions that differ between skills
+- Commit message formats — consistent?
+
+### 4b: Data Source Coverage Matrix
+
+Build a matrix of which data sources are checked by which session types:
+
+| Source | Briefing | Consolidation | Dreaming | Research | Work |
+|--------|----------|---------------|----------|----------|------|
+| Slack | ? | ? | ? | ? | ? |
+| Gmail | ? | ? | ? | ? | ? |
+| Calendar | ? | ? | ? | ? | ? |
+| Linear | ? | ? | ? | ? | ? |
+| GitHub | ? | ? | ? | ? | ? |
+| Claude Code sessions | ? | ? | ? | ? | ? |
+| Granola | ? | ? | ? | ? | ? |
+| Google Drive | ? | ? | ? | ? | ? |
+
+Flag any session type that SHOULD check a source but doesn't (based on mistake audit patterns).
+
+---
+
+## Phase 5: Report & Fix
+
+### 5a: Generate the Meta Review Report
+
+Write a report to `knowledge-base/meta-review-YYYY-MM-DD.md` with:
+
+1. **System Health Score** (0-10) — based on session execution, failure rate, budget
+2. **Quality Trend** (improving / stable / degrading) — based on mistake patterns, feedback signals
+3. **Architecture Coherence Score** (0-10) — based on KB health, action items continuity, ontology growth
+4. **Top 3 Systemic Issues** — the biggest problems found, with evidence
+5. **Top 3 Strengths** — what's working well (so future reviews don't break it)
+6. **Recommended Actions** — specific, actionable fixes ranked by impact
+
+### 5b: Apply Quick Fixes
+
+For any issues found that are:
+- **Low risk** (formatting, broken links, stale timestamps)
+- **Clearly correct** (no judgment call needed)
+- **Immediately fixable** (edit a file, not a process change)
+
+Fix them directly. Commit as: `meta-review [HH:MM]: <summary of fix>`
+
+### 5c: Propose Structural Changes
+
+For issues that require:
+- Skill file changes → write a dreaming proposal in `dreaming-proposals.md`
+- Hook changes → note in the report with a recommended implementation
+- New tooling → note in the report for the user's review
+
+### 5d: Present to the User
+
+End by presenting a concise summary in the conversation:
+
+```
+## Scout Meta Review — [date]
+
+**Health:** [score]/10 | **Quality trend:** [direction] | **Coherence:** [score]/10
+
+### What's working
+- [strength 1]
+- [strength 2]
+
+### What needs attention
+- [issue 1] — [quick fix applied / proposal written / needs user's decision]
+- [issue 2] — ...
+
+### Quick fixes applied
+- [fix 1]
+- [fix 2]
+
+Full report: knowledge-base/meta-review-YYYY-MM-DD.md
+```
+
+---
+
+## Important Notes
+
+- This is a **diagnostic** routine, not an operational one. It doesn't produce action items or scan for today's activity.
+- Run this weekly, or when something feels off. It's the "are we actually getting better?" check.
+- Be honest in scoring. A 10/10 system doesn't need a meta-review. If things are working perfectly, say so briefly and spend less time here.
+- When in doubt about whether to fix something directly vs. propose it, ask the user — this runs interactively for a reason.

--- a/commands/scout-setup.md
+++ b/commands/scout-setup.md
@@ -181,8 +181,10 @@ Tell the user: "Creating the directory structure at `{{SCOUT_DIR}}`..."
 ### 3a. Create directories
 
 ```bash
-mkdir -p "{{SCOUT_DIR}}"/{knowledge-base/projects,knowledge-base/ontology/entities,knowledge-base/people,knowledge-base/personal,action-items/archive,docs,scripts,.scout-logs}
+mkdir -p "{{SCOUT_DIR}}"/{knowledge-base/projects,knowledge-base/ontology/entities,knowledge-base/people,knowledge-base/personal,action-items/archive,action-items/meeting-prep,docs,scripts,hooks,.scout-logs,.scout-cache}
 ```
+
+The `hooks/` directory holds pre-session hook scripts that runner scripts call before launching Claude. The `.scout-cache/` directory is where those hooks write their output for the skill files to consume at runtime. Both are gitignored — they're recomputed on every run.
 
 ### 3b. Process template files
 
@@ -224,6 +226,8 @@ The plugin's template files are in `${CLAUDE_PLUGIN_ROOT}/templates/`. Read each
 3. Read `${CLAUDE_PLUGIN_ROOT}/templates/knowledge-base/channels.md.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/knowledge-base/channels.md`
 4. Read `${CLAUDE_PLUGIN_ROOT}/templates/knowledge-base/projects/projects.md.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/knowledge-base/projects/projects.md`
 5. Read `${CLAUDE_PLUGIN_ROOT}/templates/docs/Wishlist.md.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/docs/Wishlist.md`
+5a. Read `${CLAUDE_PLUGIN_ROOT}/templates/docs/Wishlist-in-progress.md.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/docs/Wishlist-in-progress.md`
+5b. Read `${CLAUDE_PLUGIN_ROOT}/templates/docs/Wishlist-done.md.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/docs/Wishlist-done.md`
 6. Read `${CLAUDE_PLUGIN_ROOT}/templates/scout-config.yaml.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/scout-config.yaml`
 7. Read `${CLAUDE_PLUGIN_ROOT}/templates/knowledge-base/research-queue.md.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/knowledge-base/research-queue.md`
 8. Read `${CLAUDE_PLUGIN_ROOT}/templates/knowledge-base/ontology/schema.yaml.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/knowledge-base/ontology/schema.yaml`
@@ -237,6 +241,17 @@ The plugin's template files are in `${CLAUDE_PLUGIN_ROOT}/templates/`. Read each
 13. Read `${CLAUDE_PLUGIN_ROOT}/templates/scripts/rate-limit-detect.sh.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/scripts/rate-limit-detect.sh` -> `chmod +x`
 14. Read `${CLAUDE_PLUGIN_ROOT}/templates/scripts/heartbeat.sh.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/scripts/heartbeat.sh` -> `chmod +x`
 
+**Pre-session hook templates (new in v0.3.0):**
+
+15. Read `${CLAUDE_PLUGIN_ROOT}/templates/hooks/kb-pre-filter.sh.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/hooks/kb-pre-filter.sh` -> `chmod +x`
+16. Read `${CLAUDE_PLUGIN_ROOT}/templates/scripts/pre-session-data.sh.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/scripts/pre-session-data.sh` -> `chmod +x`
+17. Read `${CLAUDE_PLUGIN_ROOT}/templates/scripts/cc-session-cache.sh.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/scripts/cc-session-cache.sh` -> `chmod +x`
+
+**Action-items dashboard templates (optional GUI, new in v0.3.0):**
+
+18. Copy `${CLAUDE_PLUGIN_ROOT}/templates/action-items/render.py` -> write to `{{SCOUT_DIR}}/action-items/render.py` (no variable replacement — standalone Python script). After copying, `chmod +x` is not required; the script is invoked via `python3`.
+19. Read `${CLAUDE_PLUGIN_ROOT}/templates/action-items/watch.sh.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/action-items/watch.sh` -> `chmod +x`
+
 For each template: read the file content, perform a global find-and-replace for every `{{VARIABLE}}` in the table above, and write the result. If a variable has no value (e.g., `USER_SLACK_ID` when Slack is not connected), replace it with an empty string.
 
 ### 3c. Create additional files
@@ -245,8 +260,11 @@ For each template: read the file content, perform a global find-and-replace for 
 
 ```
 .scout-logs/
+.scout-cache/
 .obsidian/
 .DS_Store
+__pycache__/
+*.pyc
 ```
 
 **`dreaming-proposals.md`** at `{{SCOUT_DIR}}/dreaming-proposals.md`:

--- a/commands/scout-status.md
+++ b/commands/scout-status.md
@@ -63,7 +63,7 @@ Run all of the following data-gathering steps before composing the dashboard out
 git -C "SCOUT_DIR" log --oneline -10
 ```
 
-Collect the 10 most recent commit messages. Identify the most recent commit that mentions "briefing", "consolidation", "dreaming", and "research" respectively (case-insensitive match on the commit message).
+Collect the 10 most recent commit messages. Identify the most recent commit that mentions "briefing", "consolidation", "dreaming", "research", "work", and "meta-review" respectively (case-insensitive match on the commit message).
 
 ### 3b. KB Health
 
@@ -102,9 +102,11 @@ Count how many Pending and Approved proposals exist.
 
 ### 3d. Wishlist
 
-Read `SCOUT_DIR/docs/Wishlist.md` (if it exists).
+Read `SCOUT_DIR/docs/Wishlist.md` and `SCOUT_DIR/docs/Wishlist-in-progress.md` (if either exists). The three-file split (Wishlist / Wishlist-in-progress / Wishlist-done) means active items can live in either of the first two files.
 
-Collect all items that are NOT marked `[done]`. An item is done if the line starts with `- [done]`. Items marked `[in progress]` or with no status marker are considered active.
+Collect all items that are NOT marked `[done]`. An item is done if the line starts with `- [done]` or is marked with `~~strikethrough~~`. Items marked `[in progress]` or with no status marker are considered active.
+
+Count items in each file separately so the dashboard can report: "3 new, 2 in progress."
 
 ### 3e. Scheduler Health (macOS only)
 
@@ -180,6 +182,8 @@ Then below the list, highlight:
   Last consolidation:  <commit message and date/time if identifiable>
   Last dreaming:       <commit message and date/time if identifiable>
   Last research:       <commit message and date/time if identifiable>
+  Last work session:   <commit message and date/time if identifiable>
+  Last meta-review:    <commit message and date/time if identifiable>
 ```
 
 If a run type hasn't happened yet, show: `(none found)`

--- a/commands/scout-work.md
+++ b/commands/scout-work.md
@@ -1,0 +1,157 @@
+---
+name: scout-work
+description: Interactive work session — walks through today's actionable items one at a time, presents a recommended action with draft content, and executes each one only with explicit approval. Runs in the current conversation (not as a background session).
+---
+
+# Scout Work Session
+
+Run an interactive Scout work session to knock items off today's action items list.
+
+Unlike `/scout-briefing`, `/scout-consolidation`, `/scout-dream`, and `/scout-research` (which run as background processes), this runs **in the current conversation**. You present actionable items one at a time with a recommended action ready to go, and wait for approval before executing.
+
+The goal: the user decides, Scout drafts and executes. Never send a message, merge a PR, create a meeting, or take any externally-visible action without explicit approval.
+
+---
+
+## Phase 1: Load & Filter
+
+1. Get today's date in the user's timezone. Read `scout-config.yaml` for the `timezone` field (default `America/New_York` if missing):
+   ```bash
+   TZ=<timezone> date '+%Y-%m-%d'
+   ```
+
+2. Read today's action items file: `<SCOUT_DIR>/action-items/action-items-YYYY-MM-DD.md`
+   - If it doesn't exist, tell the user: "No action items file for today. Run `/scout-briefing` or `/scout-consolidation` first to generate one."
+   - Stop here if no file.
+
+3. Parse the file and collect all unchecked items (`- [ ]`) from these sections:
+   - **🔴 Urgent / Time-Sensitive**
+   - **🟡 To Do**
+   - **Personal**
+
+4. **Skip** items from the **🟢 Watching** section — those are monitoring, not actionable.
+
+5. **Skip** items explicitly described as blocked by another item (e.g., "Blocked by AI-2630", "Waiting on Legal review").
+
+6. Present a numbered summary:
+   ```
+   Found N actionable items:
+   - X urgent
+   - Y to do
+   - Z personal
+
+   Ready to start?
+   ```
+
+Wait for the user to confirm before proceeding.
+
+---
+
+## Phase 2: Work Loop
+
+Process items in priority order: Urgent first, then To Do, then Personal.
+
+For **each item**, do the following:
+
+### Step 1: Triage — classify the action type
+
+Use the user's connected tools to determine what kind of action this is. The matrix below is a starting point — use judgment when an item spans multiple categories.
+
+| Type | Tools to use | Signals in the item |
+|------|-------------|-------------------|
+| **GitHub** | `gh` CLI (pr view, pr merge, pr review) | PR #, merge, reviewer, CI, GitHub URL |
+| **Slack** | Slack MCP (slack_send_message, slack_read_channel, etc.) | Slack DM, reply, post, thread, channel name |
+| **Calendar** | Google Calendar MCP (create_event, list_events) | Schedule, meeting, invite, calendar |
+| **Linear** | Linear MCP (save_issue, get_issue) | Linear issue ID, status update, create issue |
+| **Email** | Gmail MCP (create_draft, send_message) | Email, reply, draft, follow-up with an email address |
+| **Research** | WebSearch, WebFetch | Research, look up, find out, investigate, compare |
+| **Compound** | Multiple of the above | Item needs several steps in sequence |
+
+### Step 2: Gather fresh context
+
+Before presenting the item, get current state from the relevant tool. Items written in the morning briefing may already be resolved by the time the user sits down to work them.
+
+- **GitHub:** `gh pr view <number> --json state,reviews,mergeable,statusCheckRollup` or `gh issue view` as appropriate
+- **Slack:** Read the relevant channel or thread to get latest messages
+- **Linear:** Get the issue's current status, assignee, and recent activity
+- **Email:** Search the relevant thread for recent replies
+- **Calendar:** List upcoming events to check for conflicts or existing meetings
+- **Research:** Run a WebSearch query relevant to the item, fetch key results with WebFetch, summarize findings
+
+### Step 3: Present the item
+
+Use this format:
+
+```
+### [N/total] Item title
+**Type:** GitHub | Slack | Calendar | Linear | Email | Research | Compound
+**Current status:** <what you just found — has anything changed since the action items were written?>
+
+**Recommended action:**
+<specific action you'll take, with draft content shown>
+
+> [For messages: show the exact draft text]
+> [For GitHub: show the exact command]
+> [For Calendar: show the meeting details]
+> [For Research: show the summary and recommended next step]
+
+**do it** / **skip** / **modify?**
+```
+
+### Step 4: Wait for approval
+
+Do **nothing** until the user responds. Accept:
+- **"do it"** / **"yes"** / **"go"** / **"y"** → execute the action
+- **"skip"** / **"next"** / **"s"** / **"n"** → move to next item
+- **"done"** / **"stop"** / **"quit"** → end the session, go to summary
+- **Any other text** → treat as a modification (e.g., "change the message to say X", "merge but use squash", "also CC <name>")
+
+### Step 5: Execute on approval
+
+1. Take the action using the appropriate tool.
+2. Update the action items file:
+   - Change `- [ ]` to `- [x]` on the item's line
+   - Append ` — ✅ Done via work session` to the line
+3. Commit immediately with a `work [HH:MM]:` message so the git log shows work-session activity distinct from briefing/consolidation/dreaming:
+   ```bash
+   git -C <SCOUT_DIR> add -A && git -C <SCOUT_DIR> commit -m "work [HH:MM]: <brief item summary>"
+   ```
+4. Move to the next item.
+
+### Step 6: Handle edge cases during the loop
+
+- **Item already done:** If fresh context shows the item is already completed (PR merged by someone else, message already sent, meeting scheduled), mark it complete automatically, tell the user, and move on. Commit with a note that it was auto-resolved.
+- **Item now blocked:** If fresh context reveals a new blocker, note it and skip.
+- **Tool unavailable:** If a tool call fails, explain what happened and offer to skip or retry.
+
+---
+
+## Phase 3: Summary
+
+After all items are done or the user says stop:
+
+```
+## Work Session Summary
+
+**Completed (N):**
+- ✅ Item 1 — [link/evidence]
+- ✅ Item 2 — [link/evidence]
+
+**Skipped (N):**
+- ⏭️ Item 3 — reason
+- ⏭️ Item 4 — reason
+
+**Auto-resolved (N):**
+- 🔄 Item 5 — was already done
+
+**Remaining actionable items:** N
+```
+
+---
+
+## Important Notes
+
+- **Commit format:** `work [HH:MM]: <summary>` — consistent with `briefing [HH:MM]:`, `consolidation [HH:MM]:`, `dreaming [HH:MM]:`, `research [HH:MM]:`. The format makes the git log readable as an audit trail of who did what and when.
+- **Never take an externally-visible action without explicit approval.** The whole point of this mode is that the user decides.
+- **One item at a time.** Don't batch. Don't skip ahead. Present, wait, execute, commit, next.
+- **If the user says "do all" or "auto"** — still present each item, but execute without waiting for individual approval. The user has given blanket consent for the session. Stop and ask again if anything non-obvious comes up (e.g., a draft that needs judgment on tone or recipient).

--- a/phases/modes/kb-deep-work.md
+++ b/phases/modes/kb-deep-work.md
@@ -12,6 +12,20 @@ This is the substantive knowledge-base improvement phase. Score every KB file, p
 
 ---
 
+### Step 2-cache: Read the Pre-Session Caches
+
+Before doing anything else, read the caches that the runner script generated before Claude started. These are already on disk — don't re-query what they already contain.
+
+| Cache file | What's in it | Replaces |
+|---|---|---|
+| `.scout-cache/kb-filter.md` | Per-file staleness: which KB files are stale, fresh, or undated, with ages | Walking every KB file to check "Last updated" headers |
+| `.scout-cache/session-context.json` | Recent git log, open PRs, PR review requests, KB file dates, open personal tasks | Running `git log`, `gh pr list`, `gh search prs`, parser queries |
+| `.scout-cache/cc-sessions.md` | Non-{{INSTANCE_NAME}} Claude Code sessions from the last 24h: project paths, first prompts, files touched | Manually discovering + parsing `~/.claude/projects/*/**.jsonl` |
+
+Prefer these caches over live tool calls during scoring. Fall back to live queries only when a cache is missing, obviously stale, or you need deeper detail (e.g., full PR diff, full session transcript).
+
+---
+
 ### Step 2-pre: Scan for Inline Comments
 
 Before scoring files, search all `.md` files under `{{SCOUT_DIR}}` for {{USER_NAME}}'s inline comment markers:

--- a/phases/modes/wishlist.md
+++ b/phases/modes/wishlist.md
@@ -14,13 +14,21 @@ Process items from {{USER_NAME}}'s wishlist — feature requests, improvements, 
 
 ### Step 3a: Read the Wishlist
 
-Read `docs/Wishlist.md`. Understand the current state of every item using these conventions:
+Read the three wishlist files, in this order:
 
-| Format | State |
-|---|---|
-| Bare text (no marker) | Not started |
-| `[in progress]` suffix or prefix | Work has begun but is not complete |
-| `[done]` suffix or ~~strikethrough~~ | Completed |
+1. `docs/Wishlist.md` — new items, not yet picked up
+2. `docs/Wishlist-in-progress.md` — items actively being worked on across dreaming runs
+3. `docs/Wishlist-done.md` — archive of completed items (read only to avoid re-doing work)
+
+Item-state conventions:
+
+| Format | State | Typical location |
+|---|---|---|
+| Bare text (no marker) | Not started | `Wishlist.md` |
+| `[in progress]` suffix or prefix | Work has begun | `Wishlist-in-progress.md` (move here when you start) |
+| `[done]` suffix or ~~strikethrough~~ | Completed | `Wishlist-done.md` (move here after completion) |
+
+The three-file split keeps the active wishlist token-efficient. When you start a new item, move it from `Wishlist.md` into `Wishlist-in-progress.md`. When you finish an item, move it from `Wishlist-in-progress.md` into `Wishlist-done.md`.
 
 Identify all items and their current state before proceeding.
 
@@ -59,28 +67,32 @@ Select actionable items and push as far as possible. Don't artificially limit yo
 
 ---
 
-### Step 3d: Update the Wishlist
+### Step 3d: Update the Wishlist Files
 
-After executing (or deciding to skip), update `docs/Wishlist.md`:
+After executing (or deciding to skip), move items between the three files as appropriate.
 
-**For completed items:**
+**For completed items → `docs/Wishlist-done.md`:**
 ```markdown
 - ~~Original item text~~ [done] — Delivered in dreaming run [date]. [One-sentence description of what was created/changed.]
 ```
+Delete the item from `Wishlist.md` or `Wishlist-in-progress.md` (wherever it lived) in the same commit.
 
-**For partially completed items (multi-run):**
+**For newly-started items → `docs/Wishlist-in-progress.md`:**
+Move the item out of `Wishlist.md` and into `Wishlist-in-progress.md` with sub-tasks spelled out:
 ```markdown
 - Original item text [in progress]
   - [x] Sub-task 1 — completed [date]
-  - [x] Sub-task 2 — completed [date]
+  - [ ] Sub-task 2 — remaining
   - [ ] Sub-task 3 — remaining
-  - [ ] Sub-task 4 — remaining
 ```
 
-**For items skipped as ambiguous:**
-Do not modify the item. Leave it as-is for {{USER_NAME}} to clarify. Optionally add a comment in the session log noting which item was skipped and why.
+**For items continuing from a prior run:**
+Update the checkbox list in `Wishlist-in-progress.md` in place. Add newly-identified sub-tasks as needed.
 
-**Archive done items:** Move any `[done]` items (including their description and implementation notes) from `docs/Wishlist.md` to `docs/Wishlist-done.md` and delete them from the active file. This keeps the active wishlist small and token-efficient.
+**For items skipped as ambiguous:**
+Do not move or modify the item. Leave it in `Wishlist.md` for {{USER_NAME}} to clarify. Optionally log which item was skipped and why in the session summary.
+
+The three-file split is how the active wishlist stays token-efficient. Never leave `[done]` items sitting in `Wishlist.md` — they belong in `Wishlist-done.md`.
 
 ---
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,10 +1,12 @@
 {
   "name": "scout",
-  "version": "0.2.0",
-  "description": "Autonomous knowledge management and daily briefing system. Monitors your work tools (Slack, Calendar, Linear, GitHub, etc.), synthesizes findings into a persistent knowledge base with a formal ontology, and delivers daily action items — all running unattended via scheduled Claude Code sessions. Four session types: Morning Briefing, Consolidation, Dreaming, and Research.",
+  "version": "0.3.0",
+  "description": "Autonomous knowledge management and daily briefing system. Monitors your work tools (Slack, Calendar, Linear, GitHub, etc.), synthesizes findings into a persistent knowledge base with a formal ontology, and delivers daily action items — all running unattended via scheduled Claude Code sessions. Six session types: Morning Briefing, Consolidation, Dreaming, Research, interactive Work sessions, and Meta Review. Pre-session hooks pre-compute KB staleness, recent git activity, PR state, and Claude Code session summaries before each run, trading a few seconds of shell work for large token savings inside the session.",
   "commands": [
     "commands/scout-setup.md",
-    "commands/scout-status.md"
+    "commands/scout-status.md",
+    "commands/scout-work.md",
+    "commands/scout-meta-review.md"
   ],
   "skills": [
     "skills/scout-briefing.md",

--- a/templates/action-items/render.py
+++ b/templates/action-items/render.py
@@ -1,0 +1,780 @@
+#!/usr/bin/env python3
+"""
+Render a Scout action-items markdown file into the HTML dashboard.
+
+Usage:
+    python render.py action-items-2026-04-17.md
+    # → writes action-items-2026-04-17.html next to it
+
+The markdown file is the source of truth. This script is a pure view renderer —
+if something is wrong in the dashboard, fix the markdown and re-run.
+"""
+
+from __future__ import annotations
+
+import html
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Task:
+    done: bool
+    subject: str
+    body: str
+    raw: str
+
+
+@dataclass
+class BulletLine:
+    """A non-task bullet (used in Today's Focus, Scout Digest, etc.)."""
+
+    text: str
+
+
+@dataclass
+class Table:
+    headers: list[str]
+    rows: list[list[str]]
+
+
+@dataclass
+class Section:
+    emoji: str
+    title: str
+    subtitle: Optional[str] = None
+    tasks: list[Task] = field(default_factory=list)
+    bullets: list[BulletLine] = field(default_factory=list)
+    tables: list[Table] = field(default_factory=list)
+    subheads: list[str] = field(default_factory=list)  # ### subheads
+
+
+SECTION_RE = re.compile(r"^## (?P<emoji>\S+?)\s+(?P<title>.+?)(?:\s*\(.*?\))?\s*$")
+SIMPLE_SECTION_RE = re.compile(r"^## (?P<title>.+?)\s*$")
+TASK_RE = re.compile(r"^\s*- \[(?P<mark>[ xX])\]\s+(?P<rest>.+?)\s*$")
+BULLET_RE = re.compile(r"^\s*-\s+(?P<rest>.+?)\s*$")
+TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
+
+
+def parse(md_path: Path) -> tuple[str, list[str], list[Section]]:
+    """Return (title, preamble_paragraphs, sections)."""
+
+    text = md_path.read_text()
+    lines = text.splitlines()
+
+    title = ""
+    preamble: list[str] = []
+    sections: list[Section] = []
+    current: Optional[Section] = None
+    in_table = False
+    table: Optional[Table] = None
+
+    # Find title
+    for i, line in enumerate(lines):
+        if line.startswith("# ") and not title:
+            title = line[2:].strip()
+            start = i + 1
+            break
+    else:
+        start = 0
+
+    i = start
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        # Horizontal rules are separators
+        if stripped in ("---", "***"):
+            in_table = False
+            table = None
+            i += 1
+            continue
+
+        # Section header. Try "## <emoji> <title>" first; fall back to plain "## <title>".
+        if line.startswith("## "):
+            m = SECTION_RE.match(line)
+            if m:
+                emoji = m.group("emoji")
+                rest = m.group("title")
+                if not re.match(
+                    r"^[\u2600-\u27BF\U0001F300-\U0001FAFF✅🔴🟡🟢💡📋📅]", emoji
+                ):
+                    # First token wasn't an emoji — treat whole thing as plain title.
+                    emoji = ""
+                    rest = line[3:].strip()
+            else:
+                emoji = ""
+                rest = line[3:].strip()
+            current = Section(emoji=emoji, title=rest)
+            sections.append(current)
+            in_table = False
+            i += 1
+            continue
+
+        # Sub-heading
+        if line.startswith("### ") and current is not None:
+            current.subheads.append(line[4:].strip())
+            in_table = False
+            i += 1
+            continue
+
+        # Preamble (before first section)
+        if current is None:
+            if stripped:
+                preamble.append(stripped)
+            i += 1
+            continue
+
+        # Table detection
+        if TABLE_ROW_RE.match(line):
+            cells = [c.strip() for c in line.strip().strip("|").split("|")]
+            # Separator row: ignore
+            if all(re.match(r"^:?-+:?$", c) for c in cells):
+                i += 1
+                continue
+            if not in_table:
+                in_table = True
+                table = Table(headers=cells, rows=[])
+                current.tables.append(table)
+            else:
+                assert table is not None
+                table.rows.append(cells)
+            i += 1
+            continue
+        else:
+            in_table = False
+            table = None
+
+        # Task line
+        t = TASK_RE.match(line)
+        if t and current is not None:
+            done = t.group("mark").lower() == "x"
+            rest = t.group("rest")
+            # Split subject/body: first " — " or " – " after optional bold/strike
+            subject, body = _split_subject(rest)
+            current.tasks.append(Task(done=done, subject=subject, body=body, raw=rest))
+            i += 1
+            continue
+
+        # Regular bullet line (section-level)
+        b = BULLET_RE.match(line)
+        if b and current is not None:
+            current.bullets.append(BulletLine(text=b.group("rest")))
+            i += 1
+            continue
+
+        # Paragraph line inside a section
+        if stripped and current is not None:
+            current.bullets.append(BulletLine(text=stripped))
+
+        i += 1
+
+    return title, preamble, sections
+
+
+def _split_subject(rest: str) -> tuple[str, str]:
+    """Split a task line into (subject, body-remainder).
+
+    The dash separator must be *outside* of bold (`**...**`), strike (`~~...~~`),
+    inline code (`` ` ``), wikilinks (`[[...]]`), and markdown links (`[...](...)`).
+    Otherwise splits land in the middle of a markdown token and break rendering.
+    """
+    dashes = (" — ", " – ", " - ")
+
+    def find_outside_tokens(text: str) -> int:
+        in_bold = False
+        in_strike = False
+        in_code = False
+        bracket_depth = 0  # inside [[ or [
+        paren_depth = 0    # inside (...) of a link
+        i = 0
+        n = len(text)
+        while i < n:
+            two = text[i : i + 2]
+            ch = text[i]
+            if ch == "`" and not in_bold and not in_strike:
+                in_code = not in_code
+                i += 1
+                continue
+            if in_code:
+                i += 1
+                continue
+            if two == "**":
+                in_bold = not in_bold
+                i += 2
+                continue
+            if two == "~~":
+                in_strike = not in_strike
+                i += 2
+                continue
+            if two == "[[":
+                bracket_depth += 1
+                i += 2
+                continue
+            if two == "]]" and bracket_depth > 0:
+                bracket_depth -= 1
+                i += 2
+                continue
+            if ch == "[" and bracket_depth == 0:
+                bracket_depth = 1
+                i += 1
+                continue
+            if ch == "]" and bracket_depth > 0 and text[i : i + 2] != "]]":
+                bracket_depth = 0
+                if i + 1 < n and text[i + 1] == "(":
+                    paren_depth = 1
+                    i += 2
+                    continue
+                i += 1
+                continue
+            if ch == ")" and paren_depth > 0:
+                paren_depth -= 1
+                i += 1
+                continue
+            # Clean spot — is this a separator?
+            if (
+                not in_bold
+                and not in_strike
+                and bracket_depth == 0
+                and paren_depth == 0
+            ):
+                for d in dashes:
+                    if text[i : i + len(d)] == d:
+                        return i
+            i += 1
+        return -1
+
+    idx = find_outside_tokens(rest)
+    if idx != -1:
+        # Determine which dash matched
+        for d in dashes:
+            if rest[idx : idx + len(d)] == d:
+                return rest[:idx].rstrip(), rest[idx + len(d) :].lstrip()
+
+    # Fallback: a colon split outside tokens
+    idx = -1
+    in_bold = False
+    in_strike = False
+    in_code = False
+    i = 0
+    while i < len(rest):
+        two = rest[i : i + 2]
+        if rest[i] == "`" and not in_bold and not in_strike:
+            in_code = not in_code
+        elif not in_code and two == "**":
+            in_bold = not in_bold
+            i += 2
+            continue
+        elif not in_code and two == "~~":
+            in_strike = not in_strike
+            i += 2
+            continue
+        elif (
+            not in_code
+            and not in_bold
+            and not in_strike
+            and rest[i : i + 2] == ": "
+        ):
+            idx = i
+            break
+        i += 1
+    if idx != -1:
+        return rest[:idx].rstrip(), rest[idx + 2 :].lstrip()
+    return rest, ""
+
+
+# ---------------------------------------------------------------------------
+# Inline markdown → HTML
+# ---------------------------------------------------------------------------
+
+
+WIKILINK_RE = re.compile(r"\[\[([^\]|]+?)(?:\|([^\]]+))?\]\]")
+LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+STRIKE_RE = re.compile(r"~~(.+?)~~")
+BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
+ITALIC_RE = re.compile(r"(?<![\*_])\*(?!\*)([^*]+?)\*(?!\*)")
+CODE_RE = re.compile(r"`([^`]+)`")
+
+
+def inline(text: str) -> str:
+    """Render inline markdown to HTML."""
+    # Escape first, then re-substitute for markdown tokens. Tokens are chosen
+    # so we can safely find them after escaping.
+    s = html.escape(text, quote=False)
+    # Wikilinks become pills
+    s = WIKILINK_RE.sub(lambda m: _wiki_pill(m.group(1), m.group(2)), s)
+    # Regular links
+    s = LINK_RE.sub(
+        lambda m: f'<a href="{m.group(2)}" target="_blank" rel="noopener">{m.group(1)}</a>',
+        s,
+    )
+    s = CODE_RE.sub(r"<code>\1</code>", s)
+    s = STRIKE_RE.sub(r"<s>\1</s>", s)
+    s = BOLD_RE.sub(r"<strong>\1</strong>", s)
+    s = ITALIC_RE.sub(r"<em>\1</em>", s)
+    return s
+
+
+def _wiki_pill(target: str, label: Optional[str]) -> str:
+    display = label or target.split("/")[-1]
+    return f'<span class="wiki">{html.escape(display)}</span>'
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+SECTION_STYLES = {
+    "🔴": ("urgent", "Urgent / Time-sensitive"),
+    "🟡": ("todo", "To do"),
+    "🟢": ("watching", "Watching"),
+    "💡": ("focus", "Today's focus"),
+    "📅": ("meetings", "Today's meetings"),
+    "✅": ("done", "Recently completed"),
+    "📋": ("digest", "Scout digest"),
+}
+
+
+def section_kind(section: Section) -> str:
+    if section.emoji in SECTION_STYLES:
+        return SECTION_STYLES[section.emoji][0]
+    t = section.title.lower()
+    if "personal" in t:
+        return "personal"
+    return "neutral"
+
+
+def render(title: str, preamble: list[str], sections: list[Section]) -> str:
+    # Compute summary stats from task counts
+    def count(kind: str) -> int:
+        return sum(
+            sum(1 for t in s.tasks if not t.done)
+            for s in sections
+            if section_kind(s) == kind
+        )
+
+    n_urgent = count("urgent")
+    n_todo = count("todo")
+    n_watching = count("watching")
+    n_personal = count("personal")
+    n_done = sum(
+        sum(1 for t in s.tasks if t.done) for s in sections if section_kind(s) == "done"
+    )
+
+    stats = [
+        ("urgent", n_urgent, "🔥 Urgent"),
+        ("warn", n_todo, "📋 To do"),
+        ("info", n_watching, "👀 Watching"),
+        ("muted", n_personal, "🏡 Personal"),
+        ("ok", n_done, "✅ Done"),
+    ]
+
+    body_sections: list[str] = []
+
+    for s in sections:
+        kind = section_kind(s)
+        if kind == "focus":
+            body_sections.append(_render_focus(s))
+        elif kind in ("urgent", "todo", "watching", "personal"):
+            body_sections.append(_render_cards(s, kind))
+        elif kind == "meetings":
+            body_sections.append(_render_meetings(s))
+        elif kind == "done":
+            body_sections.append(_render_completed(s))
+        elif kind == "digest":
+            body_sections.append(_render_digest(s))
+        else:
+            body_sections.append(_render_cards(s, "neutral"))
+
+    preamble_html = "".join(f"<p>{inline(p)}</p>" for p in preamble)
+
+    stat_cards = "".join(
+        f'<div class="stat {cls}"><div class="num">{n}</div><div class="label">{label}</div></div>'
+        for cls, n, label in stats
+    )
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>{html.escape(title)}</title>
+<style>{CSS}</style>
+</head>
+<body>
+<header class="site-header">
+  <div>
+    <h1>{html.escape(title)}</h1>
+    <div class="preamble">{preamble_html}</div>
+  </div>
+</header>
+
+<section class="summary">{stat_cards}</section>
+
+{''.join(body_sections)}
+
+<footer>
+  <div>Rendered from <code>action-items-2026-04-17.md</code>. Markdown is the source of truth — edit it and re-run <code>render.py</code>.</div>
+</footer>
+</body>
+</html>"""
+
+
+def _render_focus(s: Section) -> str:
+    items = "".join(f"<li>{inline(b.text)}</li>" for b in s.bullets)
+    return f"""
+<section class="focus-box">
+  <h2>{html.escape(s.emoji)} {html.escape(s.title)}</h2>
+  <ul>{items}</ul>
+</section>
+"""
+
+
+def _render_cards(s: Section, kind: str) -> str:
+    cards: list[str] = []
+    for t in s.tasks:
+        subj = inline(t.subject)
+        body = inline(t.body) if t.body else ""
+        done_cls = " done" if t.done else ""
+        stamp = '<span class="stamp">✅ Done</span>' if t.done else ""
+        cards.append(
+            f"""
+<article class="card kind-{kind}{done_cls}">
+  {stamp}
+  <h3>{subj}</h3>
+  {f'<div class="body">{body}</div>' if body else ''}
+</article>
+"""
+        )
+    # Also render non-task bullets if any
+    if s.bullets:
+        bullets_html = "".join(f"<li>{inline(b.text)}</li>" for b in s.bullets)
+        cards.append(f'<div class="extra-notes"><ul>{bullets_html}</ul></div>')
+    grid = "".join(cards) if cards else '<p class="muted">Nothing here.</p>'
+    return f"""
+<section class="section section-{kind}">
+  <h2>{html.escape(s.emoji)} {html.escape(s.title)}</h2>
+  <div class="grid">{grid}</div>
+</section>
+"""
+
+
+def _render_meetings(s: Section) -> str:
+    parts: list[str] = [f'<h2>{html.escape(s.emoji)} {html.escape(s.title)}</h2>']
+    for idx, table in enumerate(s.tables):
+        subhead = s.subheads[idx - 1] if idx > 0 and idx - 1 < len(s.subheads) else ""
+        if subhead:
+            parts.append(f"<h3>{html.escape(subhead)}</h3>")
+        head = "".join(f"<th>{inline(h)}</th>" for h in table.headers)
+        rows_html = []
+        for row in table.rows:
+            cells = "".join(f"<td>{inline(c)}</td>" for c in row)
+            rows_html.append(f"<tr>{cells}</tr>")
+        parts.append(
+            f'<table class="mtg"><thead><tr>{head}</tr></thead><tbody>{"".join(rows_html)}</tbody></table>'
+        )
+    return f'<section class="section section-meetings">{"".join(parts)}</section>'
+
+
+def _render_completed(s: Section) -> str:
+    items = []
+    for t in s.tasks:
+        if not t.done:
+            continue
+        items.append(
+            f'<li><strong>{inline(t.subject)}</strong>{" — " + inline(t.body) if t.body else ""}</li>'
+        )
+    return f"""
+<details class="completed" open>
+  <summary><h2>{html.escape(s.emoji)} {html.escape(s.title)} <span class="count">({len(items)})</span></h2></summary>
+  <ul>{''.join(items)}</ul>
+</details>
+"""
+
+
+def _render_digest(s: Section) -> str:
+    blocks: list[str] = []
+    buffer: list[str] = []
+
+    def flush():
+        if buffer:
+            blocks.append('<div class="digest-block">' + "".join(buffer) + "</div>")
+            buffer.clear()
+
+    for b in s.bullets:
+        t = b.text
+        # Bold-only lines act as subheads within the digest
+        if re.match(r"^\*\*[^*]+\*\*:?\s*$", t):
+            flush()
+            blocks.append(f"<h3>{inline(t)}</h3>")
+        else:
+            buffer.append(f"<p>{inline(t)}</p>")
+    flush()
+    return f"""
+<details class="digest">
+  <summary><h2>{html.escape(s.emoji)} {html.escape(s.title)}</h2></summary>
+  {''.join(blocks)}
+</details>
+"""
+
+
+# ---------------------------------------------------------------------------
+# CSS
+# ---------------------------------------------------------------------------
+
+
+CSS = """
+:root {
+  --bg: #0f1115;
+  --panel: #171a21;
+  --panel-2: #1f2430;
+  --border: #2a2f3c;
+  --text: #e7ecf3;
+  --muted: #9aa3b2;
+  --accent: #6ea8ff;
+  --urgent: #ff5370;
+  --warn: #f7b955;
+  --ok: #50c878;
+  --info: #59c7ff;
+  --purple: #b085f5;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background:
+    radial-gradient(1200px 600px at 10% -10%, #1a2033 0%, transparent 60%),
+    radial-gradient(900px 500px at 110% 0%, #24183a 0%, transparent 55%),
+    var(--bg);
+  color: var(--text);
+  padding: 32px;
+  line-height: 1.5;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+code {
+  font-family: ui-monospace, Menlo, monospace;
+  background: var(--panel-2);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 0.9em;
+  color: #c7cedb;
+}
+s { color: var(--muted); }
+.site-header {
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 24px;
+}
+h1 { font-size: 28px; margin: 0 0 6px 0; letter-spacing: -0.4px; }
+.preamble { color: var(--muted); font-size: 13px; }
+.preamble p { margin: 4px 0; }
+
+.summary {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 12px;
+  margin-bottom: 28px;
+}
+.stat {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px;
+  text-align: center;
+}
+.stat .num { font-size: 28px; font-weight: 700; line-height: 1; }
+.stat .label { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; margin-top: 6px; }
+.stat.urgent .num { color: var(--urgent); }
+.stat.warn   .num { color: var(--warn); }
+.stat.info   .num { color: var(--info); }
+.stat.ok     .num { color: var(--ok); }
+.stat.muted  .num { color: var(--muted); }
+
+.focus-box {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 8px;
+  padding: 16px 20px;
+  margin-bottom: 28px;
+}
+.focus-box h2 { margin: 0 0 10px 0; font-size: 16px; }
+.focus-box ul { margin: 0; padding-left: 18px; }
+.focus-box li { margin: 6px 0; font-size: 13px; color: #c7cedb; }
+
+.section { margin-bottom: 28px; }
+.section > h2 { font-size: 18px; margin: 0 0 14px 0; }
+.section-urgent   > h2 { color: var(--urgent); }
+.section-todo     > h2 { color: var(--warn); }
+.section-watching > h2 { color: var(--info); }
+.section-personal > h2 { color: var(--muted); }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 12px;
+}
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 16px;
+  position: relative;
+  transition: border-color 0.15s, transform 0.15s;
+}
+.card:hover { border-color: var(--accent); transform: translateY(-1px); }
+.card.kind-urgent   { border-left: 3px solid var(--urgent); }
+.card.kind-todo     { border-left: 3px solid var(--warn); }
+.card.kind-watching { border-left: 3px solid var(--info); }
+.card.kind-personal { border-left: 3px solid var(--muted); }
+.card.kind-neutral  { border-left: 3px solid var(--border); }
+.card h3 { margin: 0 0 6px 0; font-size: 14px; font-weight: 600; }
+.card .body { font-size: 13px; color: #c7cedb; }
+.card .body p { margin: 4px 0; }
+
+.card.done {
+  background: linear-gradient(90deg, rgba(80,200,120,0.08), var(--panel) 60%);
+  opacity: 0.85;
+}
+.card.done h3 {
+  text-decoration: line-through;
+  text-decoration-color: rgba(80,200,120,0.5);
+  color: var(--muted);
+}
+.card .stamp {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  background: rgba(80,200,120,0.12);
+  color: var(--ok);
+  border: 1px solid rgba(80,200,120,0.3);
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 6px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.wiki {
+  display: inline-block;
+  background: var(--panel-2);
+  color: var(--muted);
+  border: 1px solid var(--border);
+  padding: 0 6px;
+  margin: 0 2px;
+  border-radius: 4px;
+  font-size: 0.82em;
+  font-family: ui-monospace, Menlo, monospace;
+}
+
+.mtg {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  margin-bottom: 12px;
+}
+.mtg th, .mtg td {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+.mtg th { background: var(--panel-2); color: var(--muted); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+.mtg tr:last-child td { border-bottom: none; }
+
+details.completed, details.digest {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0 18px;
+  margin-bottom: 20px;
+}
+details.completed summary, details.digest summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 14px 0;
+  display: flex;
+  align-items: center;
+}
+details.completed summary::-webkit-details-marker,
+details.digest summary::-webkit-details-marker { display: none; }
+details.completed summary h2, details.digest summary h2 {
+  display: inline;
+  margin: 0;
+  font-size: 16px;
+}
+details.completed .count { color: var(--muted); font-weight: 400; font-size: 13px; margin-left: 6px; }
+details.completed ul { margin: 0 0 16px 0; padding-left: 20px; color: var(--muted); font-size: 13px; }
+details.completed ul li { margin: 4px 0; }
+details.digest h3 { color: var(--muted); font-size: 13px; margin: 14px 0 6px 0; }
+details.digest p { font-size: 12px; color: var(--muted); margin: 4px 0; }
+details.digest .digest-block { margin-bottom: 10px; }
+
+footer {
+  margin-top: 40px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 12px;
+  text-align: center;
+}
+.extra-notes {
+  grid-column: 1 / -1;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 16px;
+}
+.extra-notes ul { margin: 4px 0; padding-left: 20px; }
+.extra-notes li { font-size: 12px; color: var(--muted); margin: 3px 0; }
+
+@media (max-width: 760px) {
+  .summary { grid-template-columns: repeat(2, 1fr); }
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: python render.py <action-items.md> [output.html]", file=sys.stderr)
+        return 2
+
+    md_path = Path(sys.argv[1]).expanduser().resolve()
+    if not md_path.exists():
+        print(f"Not found: {md_path}", file=sys.stderr)
+        return 1
+
+    out_path = Path(sys.argv[2]).expanduser().resolve() if len(sys.argv) > 2 else md_path.with_suffix(".html")
+
+    title, preamble, sections = parse(md_path)
+    html_text = render(title, preamble, sections)
+    out_path.write_text(html_text)
+
+    print(f"Wrote {out_path} ({len(html_text):,} bytes, {sum(len(s.tasks) for s in sections)} tasks across {len(sections)} sections)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/action-items/watch.sh.tmpl
+++ b/templates/action-items/watch.sh.tmpl
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# action-items/watch.sh — auto-regenerate the action-items HTML dashboard
+# whenever the source markdown changes. Useful while you're working an action
+# items file and want a live-updating browser view.
+#
+# Usage:
+#   ./action-items/watch.sh                 # today's file (in configured timezone)
+#   ./action-items/watch.sh 2026-04-17      # specific date
+#   ./action-items/watch.sh path/to/file.md # explicit path
+#
+# Uses fswatch if available (efficient), polling every 2s as a fallback.
+
+set -euo pipefail
+
+SCOUT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$SCOUT_DIR"
+
+ARG="${1:-}"
+if [[ -z "$ARG" ]]; then
+  DATE="$(TZ={{TIMEZONE}} date '+%Y-%m-%d')"
+  MD="action-items/action-items-${DATE}.md"
+elif [[ -f "$ARG" ]]; then
+  MD="$ARG"
+elif [[ "$ARG" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+  MD="action-items/action-items-${ARG}.md"
+else
+  echo "Unrecognized argument: $ARG (expected date YYYY-MM-DD or a path)" >&2
+  exit 2
+fi
+
+if [[ ! -f "$MD" ]]; then
+  echo "Not found: $MD" >&2
+  exit 1
+fi
+
+# render.py writes the HTML next to the MD by default, but the convention is
+# to keep the rendered dashboard at repo root as action-items-YYYY-MM-DD.html
+# so it's easy to open. Pass the target path explicitly.
+BASENAME="$(basename "$MD" .md)"
+HTML="${SCOUT_DIR}/${BASENAME}.html"
+
+render() {
+  if python3 action-items/render.py "$MD" "$HTML" >/dev/null; then
+    echo "[$(TZ={{TIMEZONE}} date '+%H:%M:%S')] rendered $(basename "$HTML")"
+  else
+    echo "[$(TZ={{TIMEZONE}} date '+%H:%M:%S')] render failed for $MD" >&2
+  fi
+}
+
+render
+
+if command -v fswatch >/dev/null 2>&1; then
+  echo "Watching $MD with fswatch… (Ctrl-C to stop)"
+  fswatch -o "$MD" | while read -r _; do render; done
+else
+  echo "fswatch not installed; polling $MD every 2s. For efficiency: brew install fswatch"
+  LAST="$(stat -f %m "$MD" 2>/dev/null || stat -c %Y "$MD")"
+  while :; do
+    sleep 2
+    NOW="$(stat -f %m "$MD" 2>/dev/null || stat -c %Y "$MD")"
+    if [[ "$NOW" != "$LAST" ]]; then
+      LAST="$NOW"
+      render
+    fi
+  done
+fi

--- a/templates/docs/Wishlist-done.md.tmpl
+++ b/templates/docs/Wishlist-done.md.tmpl
@@ -1,0 +1,9 @@
+# Wishlist — Done
+
+See also: [[Wishlist]] (new items) | [[Wishlist-in-progress]] (active work) | [[DREAMING]] (implements wishlist items in Phase 3)
+
+Completed wishlist items are archived here with the implementation date and a short description of what was delivered. This keeps the active wishlist small while preserving the history of what {{INSTANCE_NAME}} has shipped.
+
+---
+
+*No completed items yet. Items will appear here as dreaming runs ship them.*

--- a/templates/docs/Wishlist-in-progress.md.tmpl
+++ b/templates/docs/Wishlist-in-progress.md.tmpl
@@ -1,0 +1,9 @@
+# Wishlist — In Progress
+
+See also: [[Wishlist]] (new items) | [[Wishlist-done]] (completed) | [[DREAMING]] (implements wishlist items in Phase 3)
+
+Items below are actively being worked on across dreaming sessions. Each sub-task gets checked off as it completes.
+
+---
+
+*No items currently in progress.*

--- a/templates/docs/Wishlist.md.tmpl
+++ b/templates/docs/Wishlist.md.tmpl
@@ -1,11 +1,15 @@
 # {{INSTANCE_NAME}} Wishlist
 
-Add feature requests and improvements for {{INSTANCE_NAME}} here. The dreaming session checks this file each evening run, picks one actionable item, and implements it.
+See also: [[Wishlist-in-progress]] (active work) | [[Wishlist-done]] (completed) | [[DREAMING]] (implements wishlist items in Phase 3)
+
+Add feature requests and improvements for {{INSTANCE_NAME}} here. The dreaming session checks this file each evening run, picks one or more actionable items, and implements them.
 
 **Item states:**
 - Bare text = not yet started
-- `[in progress]` = work has begun
-- `[done]` = completed
+- `[in progress]` = work has begun (usually moved into [[Wishlist-in-progress]] while active)
+- `[done]` = completed (usually moved into [[Wishlist-done]] after a grace period)
+
+The three-file split keeps the active wishlist token-efficient. Dreaming runs scan this file first for new items, then [[Wishlist-in-progress]] for continuing work.
 
 ---
 

--- a/templates/hooks/kb-pre-filter.sh.tmpl
+++ b/templates/hooks/kb-pre-filter.sh.tmpl
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# kb-pre-filter.sh — Pre-filter KB files by staleness before a {{INSTANCE_NAME}} session.
+# Outputs a compact summary of which files need reading vs. which are fresh.
+# Runner scripts call this before invoking Claude; {{INSTANCE_NAME}} reads the cache
+# file instead of re-scanning every KB file from inside the session.
+#
+# Usage: ./hooks/kb-pre-filter.sh [session-type]
+#   session-type: briefing | consolidation | dreaming
+#
+# Output: Writes to .scout-cache/kb-filter.md — a compact markdown list
+# that skills can read instead of opening every KB file.
+
+set -eu
+
+SESSION_TYPE="${1:-dreaming}"
+SCOUT_DIR="${SCOUT_DIR:-{{SCOUT_DIR}}}"
+CACHE_DIR="$SCOUT_DIR/.scout-cache"
+OUTPUT="$CACHE_DIR/kb-filter.md"
+mkdir -p "$CACHE_DIR"
+
+NOW_EPOCH=$(date +%s)
+NOW_LOCAL=$(TZ={{TIMEZONE}} date '+%Y-%m-%d %H:%M %Z')
+
+# Freshness standards (in hours) by file pattern and priority
+# 🔴 projects = 72h (3 days), 🟡 = 168h (7 days), 🟢 = 336h (14 days)
+# Special files: linear-issues = 6h, knowledge-base.md = 6h, people = 168h, channels = 336h
+get_freshness_hours() {
+  local filepath="$1"
+  local basename
+  basename=$(basename "$filepath")
+
+  case "$basename" in
+    linear-issues.md|issues.md|knowledge-base.md) echo 6 ;;
+    people.md) echo 168 ;;
+    channels.md) echo 336 ;;
+    ai-costs.md|ai-landscape.md) echo 168 ;;
+    *)
+      # For project files, check priority from YAML frontmatter or inline marker
+      local priority
+      priority=$(head -25 "$filepath" 2>/dev/null | grep -i 'priority:' | head -1 | sed 's/.*priority: *//' | tr -d '"' || true)
+      case "$priority" in
+        *🔴*) echo 72 ;;
+        *🟡*) echo 168 ;;
+        *🟢*) echo 336 ;;
+        *) echo 168 ;; # default
+      esac
+      ;;
+  esac
+}
+
+# Parse a date string into epoch seconds (best-effort across macOS/Linux).
+parse_date_to_epoch() {
+  local datestr="$1"
+  # Strip markdown bold markers, "at", timezone suffixes, parenthetical notes
+  datestr=$(echo "$datestr" | sed 's/\*\*//g' | sed 's/ at / /g' | sed 's/ ET.*//I' | sed 's/ EDT.*//I' | sed 's/ EST.*//I' | sed 's/ UTC.*//I' | sed 's/(.*//g' | sed 's/^ *//;s/ *$//')
+
+  # Try BSD date parsing (macOS)
+  if date -j -f "%B %d, %Y %I:%M %p" "$datestr" +%s 2>/dev/null; then return; fi
+  if date -j -f "%B %d, %Y %H:%M" "$datestr" +%s 2>/dev/null; then return; fi
+  if date -j -f "%B %d, %Y" "$datestr" +%s 2>/dev/null; then return; fi
+
+  # Fallback: python3 (portable)
+  python3 -c "
+import sys
+from datetime import datetime
+s = '''$datestr'''.strip()
+for fmt in ['%B %d, %Y %I:%M %p', '%B %d, %Y %H:%M', '%B %d, %Y', '%Y-%m-%d %H:%M', '%Y-%m-%d']:
+    try:
+        dt = datetime.strptime(s, fmt)
+        print(int(dt.timestamp()))
+        sys.exit(0)
+    except ValueError:
+        continue
+print(0)
+" 2>/dev/null || echo 0
+}
+
+STALE_FILES=()
+FRESH_FILES=()
+NO_DATE_FILES=()
+
+while IFS= read -r filepath; do
+  rel="${filepath#$SCOUT_DIR/}"
+  basename_f=$(basename "$filepath")
+
+  # Skip archives, drafts, and queue files — they have their own freshness semantics
+  case "$basename_f" in
+    review-queue.md|archived.md|*-archive*|*-draft*|*-prompt*) continue ;;
+  esac
+
+  # Entity files under people/ and ontology/ have YAML frontmatter, not "Last updated" lines
+  case "$rel" in
+    */people/*.md|*/ontology/*) continue ;;
+  esac
+
+  datestr=$(head -25 "$filepath" 2>/dev/null | grep -i 'last updated\|last verified' | head -1 \
+    | sed 's/\*\*//g' \
+    | sed 's/^[^:]*: *//' \
+    | sed 's/\. Source.*//I' \
+    | sed 's/\. Verified.*//I' \
+    | sed 's/ (.*//g' \
+    | sed 's/^ *//;s/ *$//' \
+    || true)
+
+  if [ -z "$datestr" ]; then
+    NO_DATE_FILES+=("$rel")
+    continue
+  fi
+
+  file_epoch=$(parse_date_to_epoch "$datestr")
+  if [ "$file_epoch" -eq 0 ] 2>/dev/null; then
+    NO_DATE_FILES+=("$rel")
+    continue
+  fi
+
+  freshness_hours=$(get_freshness_hours "$filepath")
+  age_hours=$(( (NOW_EPOCH - file_epoch) / 3600 ))
+
+  if [ "$age_hours" -gt "$freshness_hours" ]; then
+    STALE_FILES+=("$rel|${age_hours}h|${freshness_hours}h|$datestr")
+  else
+    FRESH_FILES+=("$rel|${age_hours}h|$datestr")
+  fi
+done < <(find "$SCOUT_DIR/knowledge-base" -name '*.md' \
+  -not -path '*/ontology/*' \
+  -not -path '*archive*' \
+  -not -path '*/personal/*' \
+  2>/dev/null | sort)
+
+cat > "$OUTPUT" <<HEADER
+# KB Pre-Filter — $NOW_LOCAL ($SESSION_TYPE)
+
+HEADER
+
+if [ ${#STALE_FILES[@]} -gt 0 ]; then
+  echo "## STALE — Need reading/audit" >> "$OUTPUT"
+  for entry in "${STALE_FILES[@]}"; do
+    IFS='|' read -r path age standard lastdate <<< "$entry"
+    echo "- **$path** — ${age} old (standard: ${standard}) — last: $lastdate" >> "$OUTPUT"
+  done
+  echo "" >> "$OUTPUT"
+fi
+
+if [ ${#NO_DATE_FILES[@]} -gt 0 ]; then
+  echo "## NO DATE — Need checking" >> "$OUTPUT"
+  for path in "${NO_DATE_FILES[@]}"; do
+    echo "- $path" >> "$OUTPUT"
+  done
+  echo "" >> "$OUTPUT"
+fi
+
+echo "## FRESH — Skip unless feedback signals" >> "$OUTPUT"
+for entry in "${FRESH_FILES[@]}"; do
+  IFS='|' read -r path age lastdate <<< "$entry"
+  echo "- $path (${age} old)" >> "$OUTPUT"
+done
+
+echo "" >> "$OUTPUT"
+echo "---" >> "$OUTPUT"
+echo "Stale: ${#STALE_FILES[@]} | No date: ${#NO_DATE_FILES[@]} | Fresh: ${#FRESH_FILES[@]}" >> "$OUTPUT"
+
+echo "KB pre-filter written to $OUTPUT (${#STALE_FILES[@]} stale, ${#FRESH_FILES[@]} fresh, ${#NO_DATE_FILES[@]} undated)"

--- a/templates/run-dreaming.sh.tmpl
+++ b/templates/run-dreaming.sh.tmpl
@@ -46,6 +46,21 @@ Important:
 
 echo "=== {{INSTANCE_NAME}} Dreaming run starting at $(date) ===" >> "$LOG_FILE"
 
+# Pre-session hooks — gather data before Claude starts (saves tool calls inside the session).
+# These write to .scout-cache/ for DREAMING.md to consume.
+PRE_FILTER="$SCOUT_DIR/hooks/kb-pre-filter.sh"
+if [ -x "$PRE_FILTER" ]; then
+    "$PRE_FILTER" dreaming >> "$LOG_FILE" 2>&1 || true
+fi
+PRE_SESSION="$SCOUT_DIR/scripts/pre-session-data.sh"
+if [ -x "$PRE_SESSION" ]; then
+    "$PRE_SESSION" dreaming >> "$LOG_FILE" 2>&1 || true
+fi
+CC_CACHE="$SCOUT_DIR/scripts/cc-session-cache.sh"
+if [ -x "$CC_CACHE" ]; then
+    "$CC_CACHE" 24 >> "$LOG_FILE" 2>&1 || true
+fi
+
 # Budget check — skip if we're over the spending threshold
 BUDGET_CHECK="$SCOUT_DIR/scripts/budget-check.sh"
 if [ -x "$BUDGET_CHECK" ]; then
@@ -89,8 +104,9 @@ if [ $EXIT_CODE -ne 0 ]; then
     fi
 fi
 
-# Track session cost
+# Track session cost (skill self-reports actual cost from inside the session via the
+# same script; this runner call is a fallback so failed/crashed runs still leave a row).
 COST_TRACKER="$SCOUT_DIR/scripts/write-session-cost.sh"
 if [ -x "$COST_TRACKER" ]; then
-    "$COST_TRACKER" "dreaming" {{MAX_BUDGET}} 0 "$EXIT_CODE" 2>/dev/null || true
+    "$COST_TRACKER" "dreaming" {{MAX_BUDGET}} 0 "$EXIT_CODE" "runner" 2>/dev/null || true
 fi

--- a/templates/run-research.sh.tmpl
+++ b/templates/run-research.sh.tmpl
@@ -85,8 +85,9 @@ if [ $EXIT_CODE -ne 0 ]; then
     fi
 fi
 
-# Track session cost
+# Track session cost (skill self-reports actual cost from inside the session via the
+# same script; this runner call is a fallback so failed/crashed runs still leave a row).
 COST_TRACKER="$SCOUT_DIR/scripts/write-session-cost.sh"
 if [ -x "$COST_TRACKER" ]; then
-    "$COST_TRACKER" "research" {{MAX_BUDGET}} 0 "$EXIT_CODE" 2>/dev/null || true
+    "$COST_TRACKER" "research" {{MAX_BUDGET}} 0 "$EXIT_CODE" "runner" 2>/dev/null || true
 fi

--- a/templates/run-scout.sh.tmpl
+++ b/templates/run-scout.sh.tmpl
@@ -51,16 +51,7 @@ Important:
 
 echo "=== {{INSTANCE_NAME}} run starting at $(date) ===" >> "$LOG_FILE"
 
-# Budget check — skip if we're over the spending threshold
-BUDGET_CHECK="$SCOUT_DIR/scripts/budget-check.sh"
-if [ -x "$BUDGET_CHECK" ]; then
-    if ! "$BUDGET_CHECK" --verbose >> "$LOG_FILE" 2>&1; then
-        echo "=== Budget check: skipping this run ===" >> "$LOG_FILE"
-        exit 0
-    fi
-fi
-
-# Determine mode label for session name
+# Determine mode label for session name (must happen before pre-session hooks that use $MODE)
 HOUR=$(date +%H)
 DAY_OF_WEEK=$(date +%u)  # 1=Mon ... 6=Sat, 7=Sun
 
@@ -77,6 +68,30 @@ else
         {{CONSOLIDATION_HOURS_CASE}}
         *)  MODE="manual" ;;
     esac
+fi
+
+# Pre-session hooks — gather data before Claude starts (saves tool calls inside the session).
+# These write to .scout-cache/ for the skill files to consume.
+PRE_FILTER="$SCOUT_DIR/hooks/kb-pre-filter.sh"
+if [ -x "$PRE_FILTER" ]; then
+    "$PRE_FILTER" "$MODE" >> "$LOG_FILE" 2>&1 || true
+fi
+PRE_SESSION="$SCOUT_DIR/scripts/pre-session-data.sh"
+if [ -x "$PRE_SESSION" ]; then
+    "$PRE_SESSION" "$MODE" >> "$LOG_FILE" 2>&1 || true
+fi
+CC_CACHE="$SCOUT_DIR/scripts/cc-session-cache.sh"
+if [ -x "$CC_CACHE" ]; then
+    "$CC_CACHE" 24 >> "$LOG_FILE" 2>&1 || true
+fi
+
+# Budget check — skip if we're over the spending threshold
+BUDGET_CHECK="$SCOUT_DIR/scripts/budget-check.sh"
+if [ -x "$BUDGET_CHECK" ]; then
+    if ! "$BUDGET_CHECK" --verbose >> "$LOG_FILE" 2>&1; then
+        echo "=== Budget check: skipping this run ===" >> "$LOG_FILE"
+        exit 0
+    fi
 fi
 
 START_TIME=$(date +%s)
@@ -106,8 +121,9 @@ if [ $EXIT_CODE -ne 0 ]; then
     fi
 fi
 
-# Track session cost
+# Track session cost (skill self-reports actual cost from inside the session via the
+# same script; this runner call is a fallback so failed/crashed runs still leave a row).
 COST_TRACKER="$SCOUT_DIR/scripts/write-session-cost.sh"
 if [ -x "$COST_TRACKER" ]; then
-    "$COST_TRACKER" "$MODE" {{MAX_BUDGET}} 0 "$EXIT_CODE" 2>/dev/null || true
+    "$COST_TRACKER" "$MODE" {{MAX_BUDGET}} 0 "$EXIT_CODE" "runner" 2>/dev/null || true
 fi

--- a/templates/scout-config.yaml.tmpl
+++ b/templates/scout-config.yaml.tmpl
@@ -1,9 +1,18 @@
+# {{INSTANCE_NAME}} configuration
+# Budget defaults here are a STARTING point — calibrate after ~2 weeks of real session
+# data by analyzing .scout-logs/usage-tracker.jsonl. Typical per-session costs observed:
+#   Dreaming:      ~$5/session (most expensive — does full KB scoring + Phase 1-3)
+#   Briefing:      ~$4/session (full connector sweep + cross-check)
+#   Consolidation: ~$4/session
+#   Research:      ~$2.50/session (scoped external research)
+
 instance_name: {{INSTANCE_NAME}}
 user:
   name: {{USER_NAME}}
   email: {{USER_EMAIL}}
   slack_id: {{USER_SLACK_ID}}
   github_username: {{GITHUB_USERNAME}}
+
 connectors:
   slack: {{SLACK_ENABLED}}
   calendar: {{CALENDAR_ENABLED}}
@@ -13,11 +22,38 @@ connectors:
   granola: {{GRANOLA_ENABLED}}
   drive: {{DRIVE_ENABLED}}
   claude_sessions: {{CLAUDE_SESSIONS_ENABLED}}
+
 schedule:
   briefing: "{{BRIEFING_TIME}}"
   consolidation: [{{CONSOLIDATION_TIMES}}]
   dreaming: [{{DREAMING_TIMES}}]
   weekdays_only: {{WEEKDAYS_ONLY}}
+
 platform: {{PLATFORM}}
 scout_dir: {{SCOUT_DIR}}
+timezone: {{TIMEZONE}}
 github_repos: [{{GITHUB_REPOS}}]
+
+# Budget + session-limit awareness — consumed by scripts/budget-check.sh,
+# scripts/heartbeat.sh, and scripts/rate-limit-detect.sh.
+plan:
+  type: claude-max
+  daily_budget_estimate_usd: 150
+  rate_limit_window_hours: 3
+
+sessions:
+  max_per_session_usd: {{MAX_BUDGET}}
+  min_session_gap_minutes: 30
+
+thresholds:
+  # Skip session if cumulative cost in the rolling window exceeds this % of window budget.
+  skip_threshold_pct: 90
+  # Heartbeat triggers an extra session if remaining window budget is at least this %.
+  extra_session_threshold_pct: 30
+  # Back off this many minutes after a failed/rate-limited run (rate limits get 2× this).
+  failure_backoff_minutes: 30
+
+off_peak:
+  # Off-peak hours (local time) — heartbeat prefers these for opportunistic sessions.
+  start: 23
+  end: 6

--- a/templates/scripts/cc-session-cache.sh.tmpl
+++ b/templates/scripts/cc-session-cache.sh.tmpl
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# cc-session-cache.sh — Pre-fetch Claude Code session summaries for {{INSTANCE_NAME}}.
+# Scans {{USER_NAME}}'s CC session files, extracts recent session metadata,
+# and writes a summary to .scout-cache/cc-sessions.md.
+#
+# {{INSTANCE_NAME}} reads the cache file instead of discovering and parsing JSONL files
+# from inside the session — saves tool calls and tokens.
+#
+# Usage: Called by {{INSTANCE_NAME}} runner scripts before invoking Claude.
+#   ./scripts/cc-session-cache.sh [hours-lookback]
+#   hours-lookback: How many hours back to scan (default: 24)
+
+set -eu
+
+HOURS="${1:-24}"
+SCOUT_DIR="${SCOUT_DIR:-{{SCOUT_DIR}}}"
+CC_PROJECTS="$HOME/.claude/projects"
+CACHE_DIR="$SCOUT_DIR/.scout-cache"
+OUTPUT="$CACHE_DIR/cc-sessions.md"
+mkdir -p "$CACHE_DIR"
+
+NOW_LOCAL=$(TZ={{TIMEZONE}} date '+%Y-%m-%d %H:%M %Z')
+
+# Find JSONL session files modified within the lookback window, excluding {{INSTANCE_NAME}}'s own sessions
+CUTOFF=$(date -v-${HOURS}H '+%s' 2>/dev/null || date -d "${HOURS} hours ago" '+%s' 2>/dev/null || echo "0")
+
+cat > "$OUTPUT" <<HEADER
+# Claude Code Sessions — Last ${HOURS}h
+**Generated:** ${NOW_LOCAL}
+**Source:** ~/.claude/projects/ (non-{{INSTANCE_NAME}} sessions only)
+
+HEADER
+
+SESSION_COUNT=0
+
+for projdir in "$CC_PROJECTS"/*/; do
+  [ -d "$projdir" ] || continue
+  dirname=$(basename "$projdir")
+
+  # Skip {{INSTANCE_NAME}}'s own sessions
+  case "$dirname" in
+    *"-{{INSTANCE_NAME}}"|*"-{{INSTANCE_NAME_LOWER}}"|*"-Scout"|*"-scout") continue ;;
+  esac
+
+  while IFS= read -r jsonl; do
+    [ -z "$jsonl" ] && continue
+
+    if [[ "$(uname)" == "Darwin" ]]; then
+      file_mtime=$(stat -f '%m' "$jsonl" 2>/dev/null || echo "0")
+    else
+      file_mtime=$(stat -c '%Y' "$jsonl" 2>/dev/null || echo "0")
+    fi
+
+    if [ "$file_mtime" -lt "$CUTOFF" ]; then
+      continue
+    fi
+
+    session_id=$(basename "$jsonl" .jsonl)
+
+    # Derive the project path from the directory name
+    # Format: -Users-username-keboola-repo-name → /Users/username/keboola/repo-name
+    project_path=$(echo "$dirname" | sed 's/^-/\//' | sed 's/-/\//g')
+
+    file_size=$(wc -c < "$jsonl" | tr -d ' ')
+    file_size_kb=$((file_size / 1024))
+
+    # Extract first user message (the initial prompt/context)
+    first_msg=$(head -50 "$jsonl" 2>/dev/null | python3 -c "
+import sys, json
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        obj = json.loads(line)
+        if obj.get('type') in ('user', 'human') or obj.get('role') in ('user', 'human'):
+            msg = obj.get('message', {})
+            content = msg.get('content', '') if isinstance(msg, dict) else obj.get('content', '')
+            if isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict) and part.get('type') == 'text':
+                        text = part['text'][:500]
+                        print(text)
+                        sys.exit(0)
+            elif isinstance(content, str) and content.strip():
+                print(content[:500])
+                sys.exit(0)
+    except (json.JSONDecodeError, KeyError, TypeError):
+        continue
+print('(could not extract first message)')
+" 2>/dev/null || echo "(parse error)")
+
+    # Extract files touched. Filter out agent-internal noise (tool-results, memory,
+    # plugin caches, node_modules, /private/tmp) so only signal reaches the LLM.
+    files_touched=$(grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' "$jsonl" 2>/dev/null \
+      | sed 's/"file_path"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//' \
+      | grep -Ev '/\.claude/projects/.*/tool-results/|/\.claude/projects/.*/tasks/|/\.claude/plugins/cache/|/node_modules/|^/private/tmp/claude-|/\.claude/projects/.*/memory/' \
+      | sort -u | head -10 \
+      | sed "s|^$HOME/|~/|" \
+      || echo "(none detected)")
+
+    if [[ "$(uname)" == "Darwin" ]]; then
+      session_time=$(TZ={{TIMEZONE}} date -r "$file_mtime" '+%Y-%m-%d %H:%M %Z' 2>/dev/null || echo "unknown")
+    else
+      session_time=$(TZ={{TIMEZONE}} date -d "@$file_mtime" '+%Y-%m-%d %H:%M %Z' 2>/dev/null || echo "unknown")
+    fi
+
+    SESSION_COUNT=$((SESSION_COUNT + 1))
+
+    cat >> "$OUTPUT" <<SESSION
+---
+
+## Session ${SESSION_COUNT}: ${project_path}
+**Last active:** ${session_time} | **Size:** ${file_size_kb} KB | **ID:** \`${session_id}\`
+
+**First message/context:**
+> ${first_msg}
+
+**Files touched:**
+$(echo "$files_touched" | sed 's/^/- /')
+
+SESSION
+
+  done < <(find "$projdir" -name '*.jsonl' -type f 2>/dev/null)
+done
+
+if [ "$SESSION_COUNT" -eq 0 ]; then
+  echo "*No non-{{INSTANCE_NAME}} CC sessions found in the last ${HOURS} hours.*" >> "$OUTPUT"
+fi
+
+echo "" >> "$OUTPUT"
+echo "**Total:** ${SESSION_COUNT} session(s) found." >> "$OUTPUT"
+
+echo "CC session cache written to $OUTPUT ($SESSION_COUNT sessions, ${HOURS}h lookback, at $NOW_LOCAL)"

--- a/templates/scripts/pre-session-data.sh.tmpl
+++ b/templates/scripts/pre-session-data.sh.tmpl
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# pre-session-data.sh — Gather routine data before a {{INSTANCE_NAME}} session starts.
+# Writes to .scout-cache/session-context.json for skills to read instead of
+# making live API calls for repetitive checks (git log, PR lists, KB dates, personal tasks).
+#
+# Usage: Called by {{INSTANCE_NAME}} runner scripts before invoking Claude.
+#   ./scripts/pre-session-data.sh [session-type]
+#   session-type: briefing | consolidation | dreaming | research
+
+set -eu
+
+SESSION_TYPE="${1:-unknown}"
+SCOUT_DIR="${SCOUT_DIR:-{{SCOUT_DIR}}}"
+CACHE_DIR="$SCOUT_DIR/.scout-cache"
+OUTPUT="$CACHE_DIR/session-context.json"
+mkdir -p "$CACHE_DIR"
+
+NOW_LOCAL=$(TZ={{TIMEZONE}} date '+%Y-%m-%dT%H:%M:%S')
+
+# --- Git recent activity (last 12 hours) ---
+GIT_LOG=$(cd "$SCOUT_DIR" && git log --oneline --since="12 hours ago" 2>/dev/null || echo "")
+
+# --- KB file staleness (Last updated dates from first 5 lines) ---
+KB_STALENESS=""
+while IFS= read -r f; do
+  rel="${f#$SCOUT_DIR/}"
+  updated=$(head -5 "$f" 2>/dev/null | grep -i 'last updated\|last verified' | head -1 | sed 's/.*: *//' | sed 's/ *$//' || true)
+  if [ -n "$updated" ]; then
+    KB_STALENESS="${KB_STALENESS}    \"${rel}\": \"${updated}\",\n"
+  fi
+done < <(find "$SCOUT_DIR/knowledge-base" -name '*.md' -not -path '*/ontology/*' -not -path '*archive*' 2>/dev/null)
+
+# --- PR statuses (only if gh CLI is available and authenticated) ---
+PR_AUTHORED="[]"
+PR_REVIEW="[]"
+if command -v gh &>/dev/null; then
+  PR_AUTHORED=$(gh pr list --author @me --state open --json number,title,repository,reviewDecision,updatedAt --limit 10 2>/dev/null || echo "[]")
+  PR_REVIEW=$(gh search prs --review-requested @me --state open --json number,title,repository --limit 10 2>/dev/null || echo "[]")
+fi
+
+# --- Active personal tasks (only if ontology parser is set up) ---
+TASKS=""
+if [ -f "$SCOUT_DIR/knowledge-base/ontology/parser.py" ]; then
+  TASKS=$(cd "$SCOUT_DIR" && python3 knowledge-base/ontology/parser.py query --type task 2>/dev/null || echo "")
+fi
+
+# --- Write JSON ---
+GIT_JSON=$(echo "$GIT_LOG" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read().strip()))" 2>/dev/null || echo '""')
+TASKS_JSON=$(echo "$TASKS" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read().strip()))" 2>/dev/null || echo '""')
+
+cat > "$OUTPUT" <<ENDJSON
+{
+  "generated_at": "$NOW_LOCAL",
+  "session_type": "$SESSION_TYPE",
+  "git_recent": $GIT_JSON,
+  "kb_file_dates": {
+$(echo -e "$KB_STALENESS" | sed '$ s/,$//')
+  },
+  "pr_authored": $PR_AUTHORED,
+  "pr_review_requested": $PR_REVIEW,
+  "personal_tasks": $TASKS_JSON
+}
+ENDJSON
+
+echo "Pre-session data written to $OUTPUT ($SESSION_TYPE at $NOW_LOCAL)"

--- a/templates/scripts/write-session-cost.sh.tmpl
+++ b/templates/scripts/write-session-cost.sh.tmpl
@@ -1,9 +1,13 @@
 #!/bin/bash
 # Write session cost entry to the usage tracker
-# Called by sessions as their final action before exit
+# Called by {{INSTANCE_NAME}} sessions as their final action before exit
 #
-# Usage: write-session-cost.sh <type> <budget_cap> <budget_spent> [exit_code]
-# Example: write-session-cost.sh dreaming 10 7.42 0
+# Usage: write-session-cost.sh <type> <budget_cap> <budget_spent> [exit_code] [source]
+# Example: write-session-cost.sh dreaming 10 7.42 0 session
+#
+# source: "session" (actual Claude-reported cost) or "runner" (fallback from shell script).
+# budget-check.sh uses source=session entries for cost calculations — runner entries
+# exist only so crashed sessions still leave a row, and get $0 as the spent amount.
 
 set -euo pipefail
 
@@ -11,11 +15,36 @@ TRACKER_FILE="{{SCOUT_DIR}}/.scout-logs/usage-tracker.jsonl"
 mkdir -p "$(dirname "$TRACKER_FILE")"
 
 TYPE="${1:-unknown}"
-BUDGET_CAP="${2:-0}"
-BUDGET_SPENT="${3:-0}"
+BUDGET_CAP_RAW="${2:-0}"
+BUDGET_SPENT_RAW="${3:-0}"
 EXIT_CODE="${4:-0}"
+SOURCE="${5:-session}"
 TIMESTAMP=$(TZ=UTC date '+%Y-%m-%dT%H:%M:%SZ')
-TIMESTAMP_ET=$(TZ={{TIMEZONE}} date '+%Y-%m-%d %H:%M %Z')
+TIMESTAMP_LOCAL=$(TZ={{TIMEZONE}} date '+%Y-%m-%d %H:%M %Z')
 
-# Write JSON line
-echo "{\"ts\":\"$TIMESTAMP\",\"ts_et\":\"$TIMESTAMP_ET\",\"type\":\"$TYPE\",\"budget_cap\":$BUDGET_CAP,\"budget_spent\":$BUDGET_SPENT,\"exit_code\":$EXIT_CODE}" >> "$TRACKER_FILE"
+# Numeric validation — falls back to 0 if the arg isn't a plain number.
+# Prevents malformed JSON when the caller accidentally passes a summary string,
+# a timestamp, or the literal word "session" (arg-order confusion observed in practice).
+is_numeric() {
+    [[ "$1" =~ ^-?[0-9]+(\.[0-9]+)?$ ]]
+}
+
+if is_numeric "$BUDGET_CAP_RAW"; then
+    BUDGET_CAP="$BUDGET_CAP_RAW"
+else
+    echo "write-session-cost.sh: non-numeric budget_cap '$BUDGET_CAP_RAW' — falling back to 0" >&2
+    BUDGET_CAP=0
+fi
+
+if is_numeric "$BUDGET_SPENT_RAW"; then
+    BUDGET_SPENT="$BUDGET_SPENT_RAW"
+else
+    echo "write-session-cost.sh: non-numeric budget_spent '$BUDGET_SPENT_RAW' — falling back to 0" >&2
+    BUDGET_SPENT=0
+fi
+
+if ! is_numeric "$EXIT_CODE"; then
+    EXIT_CODE=0
+fi
+
+echo "{\"ts\":\"$TIMESTAMP\",\"ts_local\":\"$TIMESTAMP_LOCAL\",\"type\":\"$TYPE\",\"budget_cap\":$BUDGET_CAP,\"budget_spent\":$BUDGET_SPENT,\"exit_code\":$EXIT_CODE,\"source\":\"$SOURCE\"}" >> "$TRACKER_FILE"


### PR DESCRIPTION
## Summary

Brings the public plugin in line with improvements made to Jordan's live Scout system over the past weeks. Version bumped to **0.3.0**.

## New features

- **Pre-session hooks** (`hooks/kb-pre-filter.sh`, `scripts/pre-session-data.sh`, `scripts/cc-session-cache.sh`). Runner scripts pre-compute KB staleness, recent git activity, open PRs, and non-Scout CC session summaries into `.scout-cache/*` *before* launching Claude. The dreaming phase now tells the session to read those caches instead of running the same queries live — meaningful token savings per run.
- **`/scout-work`** — interactive in-conversation command that walks through today's action items one at a time, presents each with fresh context and a draft action, and executes only on explicit approval. Commits as `work [HH:MM]:`.
- **`/scout-meta-review`** — system-level diagnostic that audits whether sessions are actually running, whether mistake-audit patterns are trending better or worse, whether dreaming proposals are flowing, and whether data-source coverage is consistent across session types. Writes a report to `knowledge-base/meta-review-YYYY-MM-DD.md`.
- **Action-items HTML dashboard** (`templates/action-items/render.py` + `watch.sh.tmpl`) — optional MD → HTML renderer with fswatch auto-rebuild for a live browser view.
- **Wishlist three-file split** (`Wishlist.md` / `Wishlist-in-progress.md` / `Wishlist-done.md`) — keeps the active wishlist token-efficient. The `wishlist.md` phase describes the move-between-files workflow.

## Changed

- Runner templates (`run-scout.sh.tmpl`, `run-dreaming.sh.tmpl`) call the three pre-session hooks before the budget check.
- Runner fallback cost tracker passes `source=runner` so `budget-check.sh` can distinguish real session costs from runner-wrapper rows.
- `write-session-cost.sh.tmpl` adds numeric validation (prevents malformed JSON from arg-order mistakes) and accepts a `source` field.
- `scout-config.yaml.tmpl` now includes the `plan`, `sessions`, `thresholds`, and `off_peak` blocks that `budget-check.sh` reads from config.
- `.gitignore` template adds `.scout-cache/` and Python cache patterns.
- `scout-setup.md` creates `hooks/`, `.scout-cache/`, `action-items/meeting-prep/` and installs the new hook + action-items templates.
- `scout-status.md` surfaces Last work / meta-review commits and reads `Wishlist-in-progress.md` alongside `Wishlist.md`.

## Plugin manifest

Four commands (setup, status, work, meta-review) + four skills (briefing, consolidation, dream, research) = six session types total.

## Test plan

- [ ] Fresh install: `/scout-setup` scaffolds the new directories, writes the hook + action-items templates, seeds the three wishlist files
- [ ] Existing install → Reassemble: skill files pick up the new `Step 2-cache` section that reads from `.scout-cache/`
- [ ] Runner scripts regenerate and include the three pre-session hook calls
- [ ] `/scout-work` and `/scout-meta-review` appear in Claude Code after plugin reload
- [ ] `python3 templates/action-items/render.py <action-items.md>` produces valid HTML on a real action-items file
- [ ] `bash -n` passes on all shell templates after placeholder substitution

🤖 Generated with [Claude Code](https://claude.com/claude-code)