### PR TITLE
docs: spec, plan 1, and followups tracker

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -1,0 +1,215 @@
+# Followup Items
+
+Tracking items surfaced during code reviews that aren't blocking individual
+PRs but should be addressed in subsequent work. Use this as the single
+catalog — don't let items decay in PR comments.
+
+## How to use this file
+
+- Items are tagged by priority:
+  - **blocker** — must address before the enclosing PR merges
+  - **important** — should address soon; file as its own PR or bundle with related work
+  - **minor** — polish; pick up when touching the relevant code
+- When opening a PR that addresses an item, reference it by link / anchor
+  and move the item to the `Resolved` section at the bottom with the PR number.
+- New items discovered in review should be added here, not lost in PR comments.
+
+---
+
+## Open
+
+### Cross-cutting (affects multiple modules)
+
+#### Wheel-packaging readiness **(important)**
+
+- `scout.config.PACKAGE_DEFAULTS_PATH` and `scout.manifest.ENGINE_DIR` both
+  use `Path(__file__).parent.parent` navigation. This works for
+  `pip install -e .` (editable) but breaks when the package is built as a
+  wheel: `pyproject.toml` `[tool.hatch.build.targets.wheel]` only includes
+  `packages = ["scout"]`, so `defaults/scout-config.yaml` and the
+  `manifest.json` write target are outside the packaged tree.
+- **Fix direction:** before building any wheel, migrate to
+  `importlib.resources.files("scout") / "defaults" / "scout-config.yaml"`,
+  and either move `defaults/` under `scout/` or add an explicit
+  `[tool.hatch.build.targets.wheel.force-include]` entry. Add a CI smoke
+  test that does `pip wheel .` then `pip install` the built wheel and runs
+  `scoutctl version`.
+
+#### Unexpected-exception policy in `scout.cli.main` **(important)**
+
+- `main()` catches only `ScoutError`. Any other exception bubbles up as a
+  raw Python traceback with exit code 1 — indistinguishable from
+  `ScoutError.exit_code = 1`. Scout-app will parse exit codes to decode
+  errors; a bare traceback breaks that contract.
+- **Fix direction:** either wrap `app()` in a broader `except Exception`
+  that maps to a reserved code (e.g. 70, "internal error") and formats
+  stderr consistently, or explicitly document that non-ScoutError bubbling
+  is intentional with a comment explaining why. Current ambiguity is the
+  worst outcome.
+
+#### Subcommand drift between `scout.manifest` and `scout.cli` **(important)**
+
+- `scout.manifest.build_manifest()` hardcodes
+  `subcommands=["version", "manifest"]`. `scout.cli` registers these via
+  Typer. Adding a new subcommand in Plan 2+ requires a manual update to
+  `manifest.py`; easy to forget, and scout-app's capability check won't
+  notice the divergence until something is invoked that isn't declared.
+- **Fix direction:** derive `subcommands` from the live Typer app at build
+  time:
+  `[cmd.name for cmd in app.registered_commands] + [g.name for g in app.registered_groups]`.
+  Or add a static-assertion test that fails if the two diverge.
+
+### scout.errors
+
+- **(minor)** `SchemaVersionMismatch` message references
+  `scoutctl migrate data-dir --from X --to Y`, but the `migrate` command
+  doesn't exist until Plan 4. Acceptable as a forward-looking message;
+  flag when Plan 4 reviews happen.
+- **(minor)** `test_errors.py` doesn't assert `err.have == 1` /
+  `err.want == 2` on `SchemaVersionMismatch` — the attribute contract is
+  untested even though call sites will read it.
+- **(minor)** No explicit test that `ScoutError` is raisable and caught
+  as a base `Exception` — a future refactor of the base class could
+  silently break this.
+
+### scout.paths
+
+- **(minor)** Empty-string `SCOUT_DATA_DIR` (from a misconfigured shell)
+  silently falls back to `~/Scout` via `if env:` truthy check. Behavior
+  is reasonable but unpinned. Add a test asserting this, so a future
+  "fix" of the truthy check can't silently change semantics.
+- **(minor)** `data or data_dir()` in every derived helper treats
+  `Path("")` as None (`bool(Path("")) is False`). Type hint
+  `Path | None` slightly lies. Fix: change to
+  `data if data is not None else data_dir()`.
+- **(minor)** No test that `data_dir()`'s explicit-argument branch
+  expands tildes. `test_data_dir_expands_tilde` covers only the env-var
+  branch. Cheap insurance against a future refactor.
+- **(minor)** `require_data_dir` doesn't distinguish broken symlinks,
+  permission errors, or "exists but inaccessible". Acceptable for v1;
+  revisit if real users hit these.
+
+### scout.config
+
+- **(minor)** No test covers `load_config(data_dir=None)` — the
+  `paths.config_path()` → `paths.data_dir()` resolution chain. All
+  current tests pass `fake_data_dir` explicitly.
+- **(minor)** `_env_overrides` whitelist is two `if v := …` branches.
+  Refactor to a declarative
+  `_ENV_MAP = [("SCOUT_USER_EMAIL", ("user", "email")), …]` when N≥4
+  env vars.
+- **(minor)** `_deep_merge` replaces lists rather than concatenating.
+  This is correct config-library behavior (Hydra, Dynaconf default).
+  Document in the docstring when lists first appear in the schema, so
+  callers aren't surprised.
+
+### scout.manifest
+
+- **(important)** Circular-import risk: `from scout import __version__`
+  works today because `scout/__init__.py` is minimal, but adding
+  transitive imports to `__init__.py` (e.g., a
+  `from scout.manifest import EngineManifest` convenience re-export)
+  would cause a loop. Options: (a) keep `__init__.py` bare,
+  (b) read the version via `importlib.metadata.version("scout-engine")`,
+  (c) move `__version__` to a leaf `scout/_version.py`.
+- **(minor)** `write_manifest(path)` always calls `build_manifest()`
+  internally — can't write a custom/test manifest to disk. Add an
+  optional `manifest: EngineManifest | None = None` kwarg if a second
+  caller emerges.
+- **(minor)** `test_manifest.py` doesn't assert `sort_keys=True`
+  stability — test name says "stable and decodable" but only checks
+  decodability.
+- **(minor)** No test asserts the trailing newline on file write.
+- **(minor)** No test asserts all features are False at v0.4.0 (the
+  scaffolding invariant). Should fail loudly when Plan 2 flips
+  `action_items_cli_v1` without updating the test.
+
+### scout.cli
+
+- **(important)** No `test_cli.py`. Task 8's perf/import-discipline
+  checks don't exercise the actual CLI plumbing. Add `CliRunner`-based
+  tests for:
+  - exit-code forwarding on `ScoutError`
+  - `manifest build` writes the file
+  - `manifest show` emits valid JSON
+  - `version` equals `__version__` exactly
+  - end-to-end subprocess invocation of each subcommand
+- **(minor)** `print()` used four times. Swap to `typer.echo()` for
+  broken-pipe handling (`scoutctl version | head` without a `BrokenPipeError`)
+  and future `err=True` / color options.
+- **(minor)** `manifest build` success message is human-only. Future
+  `--json` mode should emit `{"path": "…"}`.
+
+### engine/bin/scoutctl (launcher shim)
+
+- **(minor)** `ENGINE_DIR="${DIR%/bin}"` is a conditional suffix strip.
+  If the shim is symlinked to a location whose parent isn't named `bin`
+  (e.g., `~/.local/bin/`), `ENGINE_DIR` doesn't strip correctly and the
+  venv lookup fails — degrades to `python3 -m scout.cli` fallback.
+  Consider `readlink -f` canonicalization before `dirname`, or document
+  that symlink installs hit the fallback Python.
+- **(minor)** Fallback `python3 -m scout.cli` failure emits a raw
+  `ModuleNotFoundError`. A pre-check with a friendlier error message
+  ("scout package not installed — run `pip install -e engine/[dev]`")
+  would help LaunchAgent debugging.
+
+### tests/perf (import discipline + latency)
+
+- **(important)** AST check in `test_no_heavy_imports.py` only scans
+  `scout/cli.py` directly. Transitive imports — `cli.py` imports a
+  lightweight module X, which imports `textual` — pass silently. Use
+  `python -X importtime -c 'import scout.cli'` and parse the trace to
+  assert no banned module appears, or walk the import closure.
+- **(important)** `BANNED_TOP_LEVEL` is missing HTTP libraries
+  (`requests`, `httpx`, `aiohttp`) and heavy data libraries (`pandas`,
+  `numpy`). Scout will grow HTTP (connector health, usage API). Add
+  preemptively so the first "lift HTTP to the top" regression fires
+  the test.
+- **(minor)** `test_startup.py` has no warm-up run. First subprocess
+  pays filesystem cache-miss cost. Add a throwaway invocation before
+  `time.perf_counter()` to stabilize the measurement, especially on
+  cold CI runners.
+
+### CI (.github/workflows/)
+
+- **(minor)** `astral-sh/setup-uv@v3`'s caching is disabled. Add
+  `enable-cache: true` + `cache-dependency-glob: engine/pyproject.toml`.
+  Saves ~3–5s per job across the 4-row matrix.
+- **(minor)** No concurrency groups. Rapid-fire pushes queue redundant
+  runs. Add:
+  ```yaml
+  concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+  ```
+- **(minor)** Perf tests run alongside unit tests. If CI runners get
+  flaky, split perf into its own job (or use `-m "not perf"` on main
+  plus a soft-fail perf job).
+- **(minor)** `pytest-cov` is in `[dev]` but CI doesn't collect
+  coverage. Add `pytest --cov=scout --cov-report=xml` once there's a
+  reason to track it (e.g., PR coverage comments).
+- **(minor)** `mypy scout` but not `mypy tests`. Relaxed-config mypy
+  for tests catches fixture-signature drift. Re-evaluate once the
+  engine stabilizes.
+- **(minor)** Node.js 20 deprecation warning from `actions/checkout@v4`
+  and `astral-sh/setup-uv@v3`. Auto-enforced to Node 24 in June 2026.
+  No action needed now; upgrade when newer major versions of those
+  actions ship.
+- **(minor)** `apt-get install -y shellcheck` runs every lint job.
+  Low ROI to cache; leave as-is.
+
+### pyproject.toml
+
+- **(minor)** `[tool.mypy]` has `strict = false`. Revisit when the CLI
+  surface grows. Flip to strict on a per-module basis —
+  `scout.manifest`, `scout.config`, `scout.paths` are pure enough today.
+- **(minor)** `concurrency` pytest marker is declared but has no
+  consumers. Will be used by Plan 2+ concurrency tests per the spec
+  (§ 6 Concurrency and file-locking rules).
+
+---
+
+## Resolved
+
+_(Move entries here as PRs close them. Format:
+`- **[item title]** — PR #N, date.`)_

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,41 @@
+# Scout Plugin Docs
+
+This directory holds design specs, implementation plans, and ongoing
+tracking for the Scout unification effort. For code and CI, see
+`../engine/` and `../.github/workflows/`.
+
+## Layout
+
+- **`specs/`** — approved design specs. Each file is dated and scoped to a single
+  coherent design. Specs are the source of truth for what's being built and why.
+- **`plans/`** — implementation plans derived from specs. Each plan produces
+  working, testable software on its own; plans are numbered (`plan-1`, `plan-2`)
+  when a spec is big enough to span multiple PRs.
+- **`FOLLOWUPS.md`** — consolidated list of non-blocking followup items
+  surfaced during reviews. New items land here; PRs that address items move
+  them to the `Resolved` section at the bottom.
+
+## Current scope
+
+The Scout system consists of three pieces that must stay coordinated:
+
+1. **`scout-plugin` (this repo)** — the Claude Code plugin and Python engine
+   (`scoutctl` CLI, hooks, runners, ontology parser, TUI). This is the
+   canonical home for shippable engine code after unification.
+2. **`scout-app`** (`github.com/jordanrburger/Scout`) — SwiftUI Mac menu-bar
+   app that drives the engine and renders telemetry.
+3. **User data directory** (default `~/Scout`) — per-user knowledge base,
+   action items, drafts, logs. Never in git; created by `scoutctl setup`.
+
+The unification spec (`specs/2026-04-24-scout-unification-design.md`) captures
+the target architecture. Plan 1 (engine scaffolding, merged) landed the
+Python package foundation. Plans 2–7 follow.
+
+## Contributing
+
+If you're picking up a followup item or starting a new plan:
+
+1. Read the spec section the work targets.
+2. Check `FOLLOWUPS.md` for any related pending items.
+3. Open a PR that either (a) lands a plan task with tests + CI, or (b) resolves
+   one or more followup items (move to `Resolved` in the same PR).

--- a/docs/plans/2026-04-24-plan-1-engine-scaffolding.md
+++ b/docs/plans/2026-04-24-plan-1-engine-scaffolding.md
@@ -1,0 +1,1610 @@
+# Scout Engine Package Scaffolding (Plan 1 of 7) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Scaffold the `scout-engine` Python package inside `~/scout-plugin/engine/` with a Typer-based `scoutctl` CLI, core modules (`errors`, `paths`, `config`, `manifest`), a launcher shim for LaunchAgent contexts, full unit + performance test coverage, and GitHub Actions CI. When Plan 1 merges, `scoutctl --help`, `scoutctl version`, and `scoutctl manifest show` work; CI is green on macOS + Linux × Python 3.11/3.12; the foundation is in place for Plans 2–7 to port existing scripts and features.
+
+**Architecture:** The engine is a proper Python package (`hatchling` build backend, `pip install -e .` for editable dev installs), with strict separation between a minimal-import CLI surface (Typer, stdlib only at module top) and heavy subsystems (textual, rich, jinja2, kb, tui) that load lazily. All paths resolve via `scout.paths` with `expanduser().resolve()` applied at the boundary. Config layers engine defaults → user overrides → env vars. The manifest (`manifest.json`) is the future contract with scout-app — this plan wires the baseline version/features scaffold.
+
+**Tech Stack:** Python 3.11+, Typer 0.12+, PyYAML, Jinja2, pytest, mypy, ruff, hatchling, uv (for dev install), GitHub Actions.
+
+---
+
+## Context for the implementer
+
+**Working directory:** All file paths in this plan are relative to `/Users/jordanburger/scout-plugin/`, which is a **separate repository** from the one where this plan lives. Before starting, `cd` into `~/scout-plugin` and confirm you're on the right repo:
+
+```bash
+cd ~/scout-plugin
+git status
+git remote -v
+# Should show origin: https://github.com/jordanrburger/scout-plugin.git
+```
+
+**This plan does NOT modify** `~/scout-plugin/plugin.json`, `~/scout-plugin/commands/`, `~/scout-plugin/skills/`, `~/scout-plugin/phases/`, or `~/scout-plugin/templates/`. Those stay as they are; they're touched in Plans 4 and 5.
+
+**Reference spec:** `/Users/jordanburger/scout-app/docs/superpowers/specs/2026-04-24-scout-unification-design.md` — see especially §4 (Engine package design) and §9 (Testing strategy).
+
+## File structure (what Plan 1 creates)
+
+```
+~/scout-plugin/
+├── engine/
+│   ├── pyproject.toml
+│   ├── README.md
+│   ├── bin/scoutctl                  (bash launcher shim)
+│   ├── defaults/scout-config.yaml
+│   ├── scout/
+│   │   ├── __init__.py
+│   │   ├── __main__.py
+│   │   ├── cli.py                    (Typer app — minimal imports)
+│   │   ├── errors.py                 (exception hierarchy → exit codes)
+│   │   ├── paths.py                  (path resolution)
+│   │   ├── config.py                 (three-layer merge)
+│   │   └── manifest.py               (capability manifest)
+│   └── tests/
+│       ├── __init__.py
+│       ├── conftest.py               (shared fixtures)
+│       ├── unit/
+│       │   ├── __init__.py
+│       │   ├── test_errors.py
+│       │   ├── test_paths.py
+│       │   ├── test_config.py
+│       │   └── test_manifest.py
+│       └── perf/
+│           ├── __init__.py
+│           ├── test_startup.py
+│           └── test_no_heavy_imports.py
+└── .github/
+    └── workflows/
+        ├── test.yml
+        └── lint.yml
+```
+
+Every file in this tree has one clear responsibility. `cli.py` wires subcommands but defers to the other modules. `errors.py` has no dependencies on other scout modules. `paths.py` depends only on `errors`. `config.py` depends on `paths` + `errors`. `manifest.py` depends only on `scout.__version__`. This keeps the import graph acyclic and easy to test in isolation.
+
+---
+
+## Task 0: Branch + pyproject.toml + package skeleton
+
+**Files:**
+- Create: `~/scout-plugin/engine/pyproject.toml`
+- Create: `~/scout-plugin/engine/README.md`
+- Create: `~/scout-plugin/engine/scout/__init__.py`
+- Create: `~/scout-plugin/engine/scout/__main__.py`
+- Create: `~/scout-plugin/engine/tests/__init__.py`
+- Create: `~/scout-plugin/engine/tests/unit/__init__.py`
+- Create: `~/scout-plugin/engine/tests/perf/__init__.py`
+- Create: `~/scout-plugin/engine/tests/conftest.py`
+
+- [ ] **Step 1: Create the migration branch**
+
+Run:
+```bash
+cd ~/scout-plugin
+git checkout main
+git pull
+git checkout -b migrate/v0.4.0-engine-scaffolding
+```
+
+Expected: branch created, clean working tree.
+
+- [ ] **Step 2: Create `engine/pyproject.toml`**
+
+```toml
+[project]
+name = "scout-engine"
+version = "0.4.0"
+description = "Scout engine: CLI, hooks, runners, and Python library for the Scout productivity system."
+readme = "README.md"
+requires-python = ">=3.11"
+authors = [{name = "Jordan Burger"}]
+license = {text = "MIT"}
+
+dependencies = [
+    "typer>=0.12",
+    "pyyaml>=6.0",
+    "jinja2>=3.1",
+]
+
+[project.optional-dependencies]
+full = [
+    "textual>=0.63",
+    "rich>=13.7",
+    "watchdog>=4.0",
+]
+dev = [
+    "pytest>=8.0",
+    "pytest-cov>=5.0",
+    "mypy>=1.10",
+    "ruff>=0.5",
+    "types-PyYAML",
+]
+
+[project.scripts]
+scoutctl = "scout.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["scout"]
+
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "B", "UP"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = false
+warn_unused_ignores = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+addopts = "-ra --strict-markers"
+markers = [
+    "perf: performance tests (may be skipped in fast CI runs)",
+    "concurrency: tests involving multiple processes/threads",
+    "slow: tests taking > 1 second",
+]
+```
+
+- [ ] **Step 3: Create `engine/README.md`**
+
+````markdown
+# Scout Engine
+
+Python package providing the `scoutctl` CLI, hooks, runners, and
+library code for the Scout productivity system.
+
+## Install (dev)
+
+From this directory:
+
+```bash
+uv venv
+uv pip install -e ".[dev,full]"
+```
+
+Verify:
+
+```bash
+scoutctl --help
+scoutctl version
+scoutctl manifest show
+```
+
+## Tests
+
+```bash
+pytest tests/
+```
+
+## See also
+
+- `../plugin.json` — Claude Code plugin manifest
+- Scout unification design spec lives in the scout-app repo under
+  `docs/superpowers/specs/`.
+````
+
+- [ ] **Step 4: Create the empty package skeleton files**
+
+Create `engine/scout/__init__.py`:
+```python
+"""Scout engine package."""
+
+__version__ = "0.4.0"
+```
+
+Create `engine/scout/__main__.py`:
+```python
+"""Enable `python -m scout` invocation."""
+
+from scout.cli import main
+
+if __name__ == "__main__":
+    main()
+```
+
+Create `engine/tests/__init__.py` (empty file):
+```python
+```
+
+Create `engine/tests/unit/__init__.py` (empty):
+```python
+```
+
+Create `engine/tests/perf/__init__.py` (empty):
+```python
+```
+
+- [ ] **Step 5: Create `engine/tests/conftest.py`**
+
+```python
+"""Shared pytest fixtures."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def fake_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """A writable tmp data dir wired up via SCOUT_DATA_DIR."""
+    d = tmp_path / "Scout"
+    d.mkdir()
+    (d / ".scout-logs").mkdir()
+    (d / ".scout-cache").mkdir()
+    (d / ".scout-state").mkdir()
+    (d / "knowledge-base").mkdir()
+    (d / "action-items").mkdir()
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(d))
+    yield d
+
+
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unset any SCOUT_* env vars that might leak between tests."""
+    for key in list(os.environ):
+        if key.startswith("SCOUT_"):
+            monkeypatch.delenv(key, raising=False)
+```
+
+- [ ] **Step 6: Create the venv and verify editable install**
+
+Run:
+```bash
+cd ~/scout-plugin/engine
+uv venv
+uv pip install -e ".[dev]"
+```
+
+Expected: "Built scout-engine @ ..." and no errors.
+
+Verify the venv exists:
+```bash
+ls .venv/bin/scoutctl
+```
+
+Expected: the file exists (but currently fails because `scout/cli.py` does not exist yet — that's fine, it'll be created in Task 5).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd ~/scout-plugin
+git add engine/pyproject.toml engine/README.md engine/scout/__init__.py engine/scout/__main__.py engine/tests/
+git commit -m "feat(engine): scaffold scout-engine package with pyproject + empty package"
+```
+
+---
+
+## Task 1: `scout.errors` with exit-code contract
+
+**Files:**
+- Create: `~/scout-plugin/engine/tests/unit/test_errors.py`
+- Create: `~/scout-plugin/engine/scout/errors.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `engine/tests/unit/test_errors.py`:
+```python
+"""Unit tests for scout.errors."""
+
+from __future__ import annotations
+
+from scout.errors import (
+    ActionItemError,
+    ConfigError,
+    ContractViolation,
+    DataDirError,
+    ExternalProcessError,
+    KBError,
+    SchemaVersionMismatch,
+    ScoutError,
+)
+
+
+def test_exit_codes_are_stable() -> None:
+    assert ScoutError.exit_code == 1
+    assert ConfigError.exit_code == 10
+    assert DataDirError.exit_code == 11
+    assert SchemaVersionMismatch.exit_code == 12
+    assert KBError.exit_code == 20
+    assert ActionItemError.exit_code == 21
+    assert ExternalProcessError.exit_code == 30
+    assert ContractViolation.exit_code == 40
+
+
+def test_schema_version_mismatch_message_names_versions() -> None:
+    err = SchemaVersionMismatch(have=1, want=2)
+    assert "v1" in str(err)
+    assert "v2" in str(err)
+    assert "scoutctl migrate" in str(err)
+
+
+def test_all_subclasses_inherit_from_scout_error() -> None:
+    for cls in (
+        ConfigError,
+        DataDirError,
+        SchemaVersionMismatch,
+        KBError,
+        ActionItemError,
+        ExternalProcessError,
+        ContractViolation,
+    ):
+        assert issubclass(cls, ScoutError)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+cd ~/scout-plugin/engine
+.venv/bin/pytest tests/unit/test_errors.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'scout.errors'` — tests fail to import.
+
+- [ ] **Step 3: Implement `scout/errors.py`**
+
+Create `engine/scout/errors.py`:
+```python
+"""Scout engine exception hierarchy and exit code contract.
+
+Each ScoutError subclass maps to a specific exit code. The CLI
+layer converts exceptions to exit codes + stderr messages.
+Scout-app decodes exit codes back into specific Swift error cases.
+"""
+
+from __future__ import annotations
+
+
+class ScoutError(Exception):
+    """Base for all scout-specific errors."""
+
+    exit_code = 1
+
+
+class ConfigError(ScoutError):
+    """Invalid or missing configuration."""
+
+    exit_code = 10
+
+
+class DataDirError(ScoutError):
+    """SCOUT_DATA_DIR unset, invalid, or inaccessible."""
+
+    exit_code = 11
+
+
+class SchemaVersionMismatch(ScoutError):
+    """Data dir schema version does not match engine expectation."""
+
+    exit_code = 12
+
+    def __init__(self, have: int, want: int) -> None:
+        super().__init__(
+            f"Data dir at schema v{have}; engine expects v{want}. "
+            f"Run: scoutctl migrate data-dir --from {have} --to {want}"
+        )
+        self.have = have
+        self.want = want
+
+
+class KBError(ScoutError):
+    """Knowledge-base query failure."""
+
+    exit_code = 20
+
+
+class ActionItemError(ScoutError):
+    """Action-item operation failure (no-match, ambiguous, write error)."""
+
+    exit_code = 21
+
+
+class ExternalProcessError(ScoutError):
+    """Subprocess (git, claude, launchctl) failed."""
+
+    exit_code = 30
+
+
+class ContractViolation(ScoutError):
+    """Manifest missing a required feature flag."""
+
+    exit_code = 40
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+cd ~/scout-plugin/engine
+.venv/bin/pytest tests/unit/test_errors.py -v
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/scout-plugin
+git add engine/scout/errors.py engine/tests/unit/test_errors.py
+git commit -m "feat(engine): add errors module with stable exit-code contract"
+```
+
+---
+
+## Task 2: `scout.paths` with tilde/symlink expansion
+
+**Files:**
+- Create: `~/scout-plugin/engine/tests/unit/test_paths.py`
+- Create: `~/scout-plugin/engine/scout/paths.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `engine/tests/unit/test_paths.py`:
+```python
+"""Unit tests for scout.paths."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scout import paths
+from scout.errors import DataDirError
+
+
+def test_data_dir_explicit_argument(clean_env: None, tmp_path: Path) -> None:
+    target = tmp_path / "custom-scout"
+    result = paths.data_dir(target)
+    assert result == target.resolve()
+
+
+def test_data_dir_reads_env_var(
+    clean_env: None, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    assert paths.data_dir() == tmp_path.resolve()
+
+
+def test_data_dir_falls_back_to_home(clean_env: None) -> None:
+    result = paths.data_dir()
+    assert result == (Path.home() / "Scout").resolve()
+
+
+def test_data_dir_expands_tilde(
+    clean_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SCOUT_DATA_DIR", "~/Scout")
+    result = paths.data_dir()
+    assert "~" not in str(result)
+    assert result.is_absolute()
+
+
+def test_resolve_path_resolves_symlinks(tmp_path: Path) -> None:
+    real = tmp_path / "real"
+    real.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(real)
+    assert paths.resolve_path(link) == real.resolve()
+
+
+def test_require_data_dir_missing_raises(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist"
+    with pytest.raises(DataDirError, match="does not exist"):
+        paths.require_data_dir(missing)
+
+
+def test_require_data_dir_file_not_dir(tmp_path: Path) -> None:
+    not_dir = tmp_path / "file"
+    not_dir.write_text("")
+    with pytest.raises(DataDirError, match="not a directory"):
+        paths.require_data_dir(not_dir)
+
+
+def test_derived_paths_under_data_dir(tmp_path: Path) -> None:
+    assert paths.logs_dir(tmp_path) == tmp_path / ".scout-logs"
+    assert paths.cache_dir(tmp_path) == tmp_path / ".scout-cache"
+    assert paths.state_dir(tmp_path) == tmp_path / ".scout-state"
+    assert paths.config_path(tmp_path) == tmp_path / ".scout-config.yaml"
+    assert paths.kb_dir(tmp_path) == tmp_path / "knowledge-base"
+    assert paths.action_items_dir(tmp_path) == tmp_path / "action-items"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+cd ~/scout-plugin/engine
+.venv/bin/pytest tests/unit/test_paths.py -v
+```
+
+Expected: ImportError — `scout.paths` does not exist.
+
+- [ ] **Step 3: Implement `scout/paths.py`**
+
+Create `engine/scout/paths.py`:
+```python
+"""Path resolution for Scout engine and data dirs.
+
+All paths are expanded (~) and resolved (symlinks, relative segments).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from scout.errors import DataDirError
+
+DEFAULT_DATA_DIR_NAME = "Scout"
+
+
+def resolve_path(p: str | Path) -> Path:
+    """Expand ~ and resolve symlinks/relative segments to an absolute Path."""
+    return Path(p).expanduser().resolve()
+
+
+def data_dir(explicit: str | Path | None = None) -> Path:
+    """Resolve the Scout data directory.
+
+    Precedence:
+      1. Explicit argument
+      2. $SCOUT_DATA_DIR env var
+      3. ~/Scout
+
+    Does NOT validate that the dir exists — callers use require_data_dir().
+    """
+    if explicit is not None:
+        return resolve_path(explicit)
+
+    env = os.environ.get("SCOUT_DATA_DIR")
+    if env:
+        return resolve_path(env)
+
+    return resolve_path(Path.home() / DEFAULT_DATA_DIR_NAME)
+
+
+def logs_dir(data: Path | None = None) -> Path:
+    return (data or data_dir()) / ".scout-logs"
+
+
+def cache_dir(data: Path | None = None) -> Path:
+    return (data or data_dir()) / ".scout-cache"
+
+
+def state_dir(data: Path | None = None) -> Path:
+    return (data or data_dir()) / ".scout-state"
+
+
+def config_path(data: Path | None = None) -> Path:
+    return (data or data_dir()) / ".scout-config.yaml"
+
+
+def kb_dir(data: Path | None = None) -> Path:
+    return (data or data_dir()) / "knowledge-base"
+
+
+def action_items_dir(data: Path | None = None) -> Path:
+    return (data or data_dir()) / "action-items"
+
+
+def require_data_dir(data: Path | None = None) -> Path:
+    """Return the data dir, raising DataDirError if it does not exist."""
+    d = data or data_dir()
+    if not d.exists():
+        raise DataDirError(
+            f"Scout data dir does not exist: {d}\n"
+            f"Run: scoutctl setup data-dir"
+        )
+    if not d.is_dir():
+        raise DataDirError(f"Scout data dir is not a directory: {d}")
+    return d
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+cd ~/scout-plugin/engine
+.venv/bin/pytest tests/unit/test_paths.py -v
+```
+
+Expected: 8 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/scout-plugin
+git add engine/scout/paths.py engine/tests/unit/test_paths.py
+git commit -m "feat(engine): add paths module with tilde/symlink resolution"
+```
+
+---
+
+## Task 3: `defaults/scout-config.yaml` (prerequisite for config module)
+
+**Files:**
+- Create: `~/scout-plugin/engine/defaults/scout-config.yaml`
+
+- [ ] **Step 1: Create the defaults file**
+
+Create `engine/defaults/scout-config.yaml`:
+```yaml
+schema_version: 1
+
+user:
+  email: ""
+  github_username: ""
+  slack_user_id: ""
+  timezone: America/New_York
+  company: ""
+  display_name: ""
+
+budgets:
+  daily_budget_estimate_usd: 150
+  max_per_session_usd: 20
+
+thresholds:
+  rate_limit_warn_pct: 80
+  rate_limit_block_pct: 95
+  connector_staleness_hours: 24
+
+features:
+  tui: true
+  connector_health: true
+  dreaming: true
+```
+
+- [ ] **Step 2: Verify the YAML parses**
+
+Run:
+```bash
+cd ~/scout-plugin/engine
+.venv/bin/python -c "import yaml; print(yaml.safe_load(open('defaults/scout-config.yaml')))"
+```
+
+Expected: a dict with keys `schema_version`, `user`, `budgets`, `thresholds`, `features` printed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd ~/scout-plugin
+git add engine/defaults/scout-config.yaml
+git commit -m "feat(engine): add engine defaults scout-config.yaml"
+```
+
+---
+
+## Task 4: `scout.config` with three-layer merge
+
+**Files:**
+- Create: `~/scout-plugin/engine/tests/unit/test_config.py`
+- Create: `~/scout-plugin/engine/scout/config.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `engine/tests/unit/test_config.py`:
+```python
+"""Unit tests for scout.config."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scout import config
+from scout.errors import ConfigError
+
+
+def _write(path: Path, data: dict) -> None:
+    path.write_text(yaml.safe_dump(data))
+
+
+def test_load_config_returns_defaults_when_no_user_override(
+    clean_env: None, fake_data_dir: Path
+) -> None:
+    cfg = config.load_config(fake_data_dir)
+    assert "budgets" in cfg
+    assert "thresholds" in cfg
+    assert cfg["schema_version"] == 1
+
+
+def test_user_config_overrides_defaults(clean_env: None, fake_data_dir: Path) -> None:
+    _write(
+        fake_data_dir / ".scout-config.yaml",
+        {"budgets": {"daily_budget_estimate_usd": 999}},
+    )
+    cfg = config.load_config(fake_data_dir)
+    assert cfg["budgets"]["daily_budget_estimate_usd"] == 999
+    # Other default keys preserved
+    assert "max_per_session_usd" in cfg["budgets"]
+
+
+def test_deep_merge_preserves_sibling_keys(clean_env: None, fake_data_dir: Path) -> None:
+    _write(
+        fake_data_dir / ".scout-config.yaml",
+        {"user": {"email": "test@example.com"}},
+    )
+    cfg = config.load_config(fake_data_dir)
+    assert cfg["user"]["email"] == "test@example.com"
+    # Defaults for other user keys preserved
+    assert "timezone" in cfg["user"]
+
+
+def test_env_var_overrides_user_config(
+    clean_env: None, fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write(
+        fake_data_dir / ".scout-config.yaml",
+        {"user": {"email": "user@example.com"}},
+    )
+    monkeypatch.setenv("SCOUT_USER_EMAIL", "env@example.com")
+    cfg = config.load_config(fake_data_dir)
+    assert cfg["user"]["email"] == "env@example.com"
+
+
+def test_invalid_yaml_raises_config_error(
+    clean_env: None, fake_data_dir: Path
+) -> None:
+    (fake_data_dir / ".scout-config.yaml").write_text("key: [unclosed")
+    with pytest.raises(ConfigError, match="Invalid YAML"):
+        config.load_config(fake_data_dir)
+
+
+def test_non_mapping_yaml_raises_config_error(
+    clean_env: None, fake_data_dir: Path
+) -> None:
+    (fake_data_dir / ".scout-config.yaml").write_text("- a\n- b\n")
+    with pytest.raises(ConfigError, match="YAML mapping"):
+        config.load_config(fake_data_dir)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+cd ~/scout-plugin/engine
+.venv/bin/pytest tests/unit/test_config.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'scout.config'`.
+
+- [ ] **Step 3: Implement `scout/config.py`**
+
+Create `engine/scout/config.py`:
+```python
+"""Layered configuration loader for Scout.
+
+Precedence (low → high, later overrides earlier):
+  1. Engine defaults (engine/defaults/scout-config.yaml, shipped with package)
+  2. User overrides ($SCOUT_DATA_DIR/.scout-config.yaml)
+  3. SCOUT_* environment variables (whitelisted keys)
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scout import paths
+from scout.errors import ConfigError
+
+PACKAGE_DEFAULTS_PATH = (
+    Path(__file__).parent.parent / "defaults" / "scout-config.yaml"
+)
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except yaml.YAMLError as e:
+        raise ConfigError(f"Invalid YAML in {path}: {e}") from e
+    if not isinstance(data, dict):
+        raise ConfigError(f"{path} must contain a YAML mapping at the top level")
+    return data
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Recursive dict merge. `override` wins on conflicts."""
+    result = dict(base)
+    for key, value in override.items():
+        if (
+            key in result
+            and isinstance(result[key], dict)
+            and isinstance(value, dict)
+        ):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _env_overrides() -> dict[str, Any]:
+    """Whitelisted SCOUT_* env vars → config overrides."""
+    out: dict[str, Any] = {}
+    if v := os.environ.get("SCOUT_USER_EMAIL"):
+        out.setdefault("user", {})["email"] = v
+    if v := os.environ.get("SCOUT_USER_TIMEZONE"):
+        out.setdefault("user", {})["timezone"] = v
+    return out
+
+
+def load_config(data_dir: Path | None = None) -> dict[str, Any]:
+    """Load the three-layer merged config."""
+    defaults = _read_yaml(PACKAGE_DEFAULTS_PATH)
+    user_path = paths.config_path(data_dir)
+    user_overrides = _read_yaml(user_path)
+    env_overrides = _env_overrides()
+
+    merged = _deep_merge(defaults, user_overrides)
+    merged = _deep_merge(merged, env_overrides)
+    return merged
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+cd ~/scout-plugin/engine
+.venv/bin/pytest tests/unit/test_config.py -v
+```
+
+Expected: 6 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/scout-plugin
+git add engine/scout/config.py engine/tests/unit/test_config.py
+git commit -m "feat(engine): add config module with three-layer merge"
+```
+
+---
+
+## Task 5: `scout.manifest` with capability declaration
+
+**Files:**
+- Create: `~/scout-plugin/engine/tests/unit/test_manifest.py`
+- Create: `~/scout-plugin/engine/scout/manifest.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `engine/tests/unit/test_manifest.py`:
+```python
+"""Unit tests for scout.manifest."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scout import __version__
+from scout.manifest import build_manifest, write_manifest
+
+
+def test_build_manifest_has_version() -> None:
+    m = build_manifest()
+    assert m.version == __version__
+
+
+def test_build_manifest_has_schema_version() -> None:
+    assert build_manifest().schema_version == 1
+
+
+def test_build_manifest_exposes_known_features() -> None:
+    m = build_manifest()
+    expected = {
+        "session_tokens_v1",
+        "connector_health_v1",
+        "action_items_cli_v1",
+        "kb_ontology_v1",
+        "tui_v1",
+    }
+    assert expected.issubset(m.features.keys())
+
+
+def test_build_manifest_exposes_baseline_subcommands() -> None:
+    m = build_manifest()
+    assert "version" in m.subcommands
+    assert "manifest" in m.subcommands
+
+
+def test_manifest_json_is_stable_and_decodable() -> None:
+    js = build_manifest().to_json()
+    decoded = json.loads(js)
+    assert decoded["version"] == __version__
+    assert "features" in decoded
+    assert "subcommands" in decoded
+
+
+def test_write_manifest_round_trip(tmp_path: Path) -> None:
+    target = tmp_path / "manifest.json"
+    written = write_manifest(target)
+    assert written == target
+    decoded = json.loads(target.read_text())
+    assert decoded["version"] == __version__
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+cd ~/scout-plugin/engine
+.venv/bin/pytest tests/unit/test_manifest.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'scout.manifest'`.
+
+- [ ] **Step 3: Implement `scout/manifest.py`**
+
+Create `engine/scout/manifest.py`:
+```python
+"""Engine capability manifest.
+
+The manifest is the contract between scout-plugin (engine) and scout-app.
+It declares which features and CLI subcommands this engine version
+supports. Scout-app reads it at launch and refuses (with a helpful
+banner) to use features the engine cannot provide.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+from scout import __version__
+
+ENGINE_DIR = Path(__file__).parent.parent
+
+
+@dataclass
+class EngineManifest:
+    """Serializable capability manifest."""
+
+    version: str
+    schema_version: int
+    features: dict[str, bool] = field(default_factory=dict)
+    subcommands: list[str] = field(default_factory=list)
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2, sort_keys=True)
+
+
+def build_manifest() -> EngineManifest:
+    """Construct the manifest from package state.
+
+    Feature flags reflect what this version of the engine promises.
+    Plans 2 and 3 flip individual flags to True as subsystems land.
+    """
+    return EngineManifest(
+        version=__version__,
+        schema_version=1,
+        features={
+            "session_tokens_v1": False,
+            "connector_health_v1": False,
+            "action_items_cli_v1": False,
+            "kb_ontology_v1": False,
+            "tui_v1": False,
+        },
+        subcommands=[
+            "version",
+            "manifest",
+        ],
+    )
+
+
+def write_manifest(path: Path | None = None) -> Path:
+    """Write the manifest to disk. Returns the path written."""
+    target = path or (ENGINE_DIR / "manifest.json")
+    target.write_text(build_manifest().to_json() + "\n")
+    return target
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+cd ~/scout-plugin/engine
+.venv/bin/pytest tests/unit/test_manifest.py -v
+```
+
+Expected: 6 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/scout-plugin
+git add engine/scout/manifest.py engine/tests/unit/test_manifest.py
+git commit -m "feat(engine): add manifest module with capability declaration"
+```
+
+---
+
+## Task 6: `scout.cli` — Typer app with minimal imports
+
+**Files:**
+- Create: `~/scout-plugin/engine/scout/cli.py`
+
+This task does not have a dedicated test file — `cli.py`'s correctness is covered by the perf test in Task 8 (no heavy imports) and by running the CLI manually. The Typer framework is well-tested upstream.
+
+- [ ] **Step 1: Create `scout/cli.py`**
+
+Create `engine/scout/cli.py`:
+```python
+"""scoutctl CLI entry point.
+
+Top-level imports are intentionally minimal — Typer + stdlib only —
+to keep `scoutctl --help` under 100ms. Heavy libraries (textual, rich,
+jinja2, watchdog, scout.kb.*, scout.tui.*) must be imported inside
+the subcommand functions, not at module level.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import typer
+
+from scout import __version__
+from scout.errors import ScoutError
+
+app = typer.Typer(
+    name="scoutctl",
+    help="Scout engine control CLI.",
+    no_args_is_help=True,
+    add_completion=False,
+    rich_markup_mode=None,  # avoid importing rich at startup
+)
+
+
+@app.command()
+def version() -> None:
+    """Print the engine version."""
+    print(__version__)
+
+
+manifest_app = typer.Typer(help="Engine capability manifest operations.")
+app.add_typer(manifest_app, name="manifest")
+
+
+@manifest_app.command("build")
+def manifest_build() -> None:
+    """Write manifest.json to the engine dir."""
+    from scout.manifest import write_manifest
+
+    path = write_manifest()
+    print(f"Wrote: {path}")
+
+
+@manifest_app.command("show")
+def manifest_show() -> None:
+    """Print the current manifest to stdout."""
+    from scout.manifest import build_manifest
+
+    print(build_manifest().to_json())
+
+
+def main() -> None:
+    try:
+        app()
+    except ScoutError as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(e.exit_code)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Reinstall the package (so the scoutctl script binding updates)**
+
+Run:
+```bash
+cd ~/scout-plugin/engine
+uv pip install -e ".[dev]"
+```
+
+Expected: "Successfully installed scout-engine..."
+
+- [ ] **Step 3: Verify the CLI works end-to-end**
+
+Run each command and confirm expected output:
+
+```bash
+.venv/bin/scoutctl --help
+```
+Expected: Typer help listing `version` and `manifest` commands, no errors.
+
+```bash
+.venv/bin/scoutctl version
+```
+Expected: `0.4.0`
+
+```bash
+.venv/bin/scoutctl manifest show
+```
+Expected: JSON matching the manifest structure (version, schema_version, features, subcommands).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd ~/scout-plugin
+git add engine/scout/cli.py
+git commit -m "feat(engine): add scoutctl Typer CLI with version + manifest subcommands"
+```
+
+---
+
+## Task 7: `bin/scoutctl` launcher shim
+
+**Files:**
+- Create: `~/scout-plugin/engine/bin/scoutctl`
+
+The shim exists so LaunchAgents (which don't inherit user PATH) can still find the right Python interpreter.
+
+- [ ] **Step 1: Create `engine/bin/scoutctl`**
+
+Create `engine/bin/scoutctl`:
+```bash
+#!/usr/bin/env bash
+# scoutctl launcher — resolves the venv Python deterministically so
+# hooks invoked from LaunchAgents (which don't inherit user PATH)
+# still find the right interpreter.
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ENGINE_DIR="${DIR%/bin}"
+VENV_PY="${ENGINE_DIR}/.venv/bin/python"
+
+if [ -x "$VENV_PY" ]; then
+    exec "$VENV_PY" -m scout.cli "$@"
+else
+    exec python3 -m scout.cli "$@"
+fi
+```
+
+- [ ] **Step 2: Make it executable**
+
+Run:
+```bash
+chmod +x ~/scout-plugin/engine/bin/scoutctl
+```
+
+- [ ] **Step 3: Verify the shim runs without the venv on PATH**
+
+Run (explicitly clearing PATH to simulate a LaunchAgent):
+```bash
+cd ~/scout-plugin
+env -i PATH=/usr/bin:/bin HOME="$HOME" engine/bin/scoutctl version
+```
+
+Expected: `0.4.0` on stdout.
+
+- [ ] **Step 4: Verify shellcheck is clean**
+
+Run:
+```bash
+shellcheck ~/scout-plugin/engine/bin/scoutctl
+```
+
+Expected: no output (clean). If `shellcheck` is not installed, run `brew install shellcheck` first.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/scout-plugin
+git add engine/bin/scoutctl
+git commit -m "feat(engine): add scoutctl bash launcher shim for LaunchAgent contexts"
+```
+
+---
+
+## Task 8: Performance tests — startup + no-heavy-imports
+
+**Files:**
+- Create: `~/scout-plugin/engine/tests/perf/test_startup.py`
+- Create: `~/scout-plugin/engine/tests/perf/test_no_heavy_imports.py`
+
+- [ ] **Step 1: Create `tests/perf/test_startup.py`**
+
+```python
+"""Startup-latency tests for scoutctl.
+
+These assert that import + help + version paths stay fast so the
+scout-app UI doesn't feel laggy when invoking scoutctl on user actions.
+
+Budgets have CI headroom; local Macs hit them in half the listed time.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+import pytest
+
+HELP_BUDGET_MS = 250
+VERSION_BUDGET_MS = 150
+
+
+@pytest.mark.perf
+def test_scoutctl_help_latency() -> None:
+    start = time.perf_counter()
+    result = subprocess.run(
+        [sys.executable, "-m", "scout.cli", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    assert result.returncode == 0
+    assert elapsed_ms < HELP_BUDGET_MS, (
+        f"scoutctl --help took {elapsed_ms:.0f}ms "
+        f"(budget: {HELP_BUDGET_MS}ms). Check for heavy top-level imports."
+    )
+
+
+@pytest.mark.perf
+def test_scoutctl_version_latency() -> None:
+    start = time.perf_counter()
+    result = subprocess.run(
+        [sys.executable, "-m", "scout.cli", "version"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    assert result.returncode == 0
+    assert result.stdout.strip(), "version should emit to stdout"
+    assert elapsed_ms < VERSION_BUDGET_MS, (
+        f"scoutctl version took {elapsed_ms:.0f}ms "
+        f"(budget: {VERSION_BUDGET_MS}ms)."
+    )
+```
+
+- [ ] **Step 2: Create `tests/perf/test_no_heavy_imports.py`**
+
+```python
+"""Static import-graph test: forbids heavy imports at scoutctl startup.
+
+Scout-app invokes scoutctl on every user action. If scout.cli imports
+textual / rich / jinja2 / watchdog / scout.kb.*, startup balloons past
+the latency budget. This test parses scout/cli.py's AST and fails on
+top-level imports of the banned modules.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+BANNED_TOP_LEVEL = {
+    "textual",
+    "rich",
+    "jinja2",
+    "watchdog",
+    "scout.kb",
+    "scout.tui",
+    "scout.action_items",
+    "scout.runners",
+    "scout.hooks",
+    "scout.scripts",
+}
+
+
+def _top_level_imports(source: str) -> set[str]:
+    tree = ast.parse(source)
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name.split(".")[0])
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                names.add(node.module)
+                names.add(node.module.split(".")[0])
+    return names
+
+
+CLI_PATH = Path(__file__).parent.parent.parent / "scout" / "cli.py"
+
+
+@pytest.mark.perf
+def test_cli_has_no_banned_top_level_imports() -> None:
+    source = CLI_PATH.read_text()
+    imports = _top_level_imports(source)
+    offenders = imports & BANNED_TOP_LEVEL
+    assert not offenders, (
+        f"scout/cli.py has banned top-level imports: {offenders}. "
+        f"Move them inside subcommand functions to preserve startup latency."
+    )
+```
+
+- [ ] **Step 3: Run perf tests to verify they pass**
+
+Run:
+```bash
+cd ~/scout-plugin/engine
+.venv/bin/pytest tests/perf/ -v -m perf
+```
+
+Expected: 3 passed. If latency tests fail on a slow machine, examine the actual ms and confirm it's a machine issue, not a regression.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd ~/scout-plugin
+git add engine/tests/perf/test_startup.py engine/tests/perf/test_no_heavy_imports.py
+git commit -m "test(engine): add perf tests for startup latency + import discipline"
+```
+
+---
+
+## Task 9: GitHub Actions — `test.yml`
+
+**Files:**
+- Create: `~/scout-plugin/.github/workflows/test.yml`
+
+- [ ] **Step 1: Create the workflow file**
+
+Create `.github/workflows/test.yml`:
+```yaml
+name: test
+
+on:
+  push:
+    branches: [main, "migrate/**"]
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python: ["3.11", "3.12"]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: engine
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - name: Setup Python
+        run: uv python install ${{ matrix.python }}
+      - name: Install
+        run: uv pip install --system -e ".[dev]"
+      - name: Pytest
+        run: pytest tests/ -v
+```
+
+- [ ] **Step 2: Validate the YAML locally**
+
+Run:
+```bash
+cd ~/scout-plugin
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"
+```
+
+Expected: no output (valid YAML).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd ~/scout-plugin
+git add .github/workflows/test.yml
+git commit -m "ci(engine): add GitHub Actions test workflow for macOS + Linux x py3.11/3.12"
+```
+
+---
+
+## Task 10: GitHub Actions — `lint.yml`
+
+**Files:**
+- Create: `~/scout-plugin/.github/workflows/lint.yml`
+
+- [ ] **Step 1: Create the lint workflow**
+
+Create `.github/workflows/lint.yml`:
+```yaml
+name: lint
+
+on:
+  pull_request:
+  push:
+    branches: [main, "migrate/**"]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: engine
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - name: Setup Python
+        run: uv python install 3.12
+      - name: Install
+        run: uv pip install --system -e ".[dev]"
+      - name: Ruff check
+        run: ruff check scout tests
+      - name: Ruff format check
+        run: ruff format --check scout tests
+      - name: Mypy
+        run: mypy scout
+      - name: Shellcheck scoutctl
+        run: |
+          sudo apt-get update && sudo apt-get install -y shellcheck
+          shellcheck bin/scoutctl
+```
+
+- [ ] **Step 2: Run ruff and mypy locally to confirm they're green**
+
+Run:
+```bash
+cd ~/scout-plugin/engine
+.venv/bin/ruff check scout tests
+.venv/bin/ruff format --check scout tests
+.venv/bin/mypy scout
+```
+
+Expected: each command exits 0 with no errors. If `ruff format --check` reports formatting issues, run `.venv/bin/ruff format scout tests` and commit the result before continuing.
+
+- [ ] **Step 3: Validate the YAML**
+
+```bash
+cd ~/scout-plugin
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/lint.yml'))"
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd ~/scout-plugin
+git add .github/workflows/lint.yml
+git commit -m "ci(engine): add GitHub Actions lint workflow (ruff + mypy + shellcheck)"
+```
+
+---
+
+## Task 11: Full verification + push
+
+**Files:** none created in this task.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run:
+```bash
+cd ~/scout-plugin/engine
+.venv/bin/pytest tests/ -v
+```
+
+Expected: all unit + perf tests pass. Note the count — should be approximately 23 tests (3 errors + 8 paths + 6 config + 6 manifest + 3 perf).
+
+- [ ] **Step 2: Run ruff and mypy one more time**
+
+Run:
+```bash
+cd ~/scout-plugin/engine
+.venv/bin/ruff check scout tests
+.venv/bin/ruff format --check scout tests
+.venv/bin/mypy scout
+```
+
+Expected: all green.
+
+- [ ] **Step 3: Confirm `scoutctl` end-to-end from shim**
+
+Run:
+```bash
+cd ~/scout-plugin
+engine/bin/scoutctl version
+engine/bin/scoutctl manifest show
+```
+
+Expected: version prints `0.4.0`; manifest show prints JSON with the expected keys.
+
+- [ ] **Step 4: Review the commits and push**
+
+Run:
+```bash
+cd ~/scout-plugin
+git log --oneline main..HEAD
+```
+
+Expected: ~11 commits corresponding to the tasks above.
+
+Push the branch:
+```bash
+git push -u origin migrate/v0.4.0-engine-scaffolding
+```
+
+- [ ] **Step 5: Open a draft PR on GitHub (optional but recommended)**
+
+Use `gh` CLI:
+```bash
+cd ~/scout-plugin
+gh pr create --draft --title "v0.4.0 Plan 1: engine package scaffolding" --body "$(cat <<'EOF'
+## Summary
+
+Plan 1 of 7 for Scout unification. Scaffolds the scout-engine Python package with:
+
+- pyproject.toml + hatchling build backend
+- `scout.errors` exit-code contract
+- `scout.paths` tilde/symlink resolution
+- `scout.config` three-layer merge (defaults → user → env)
+- `scout.manifest` capability declaration
+- `scout.cli` Typer app (minimal imports; `scoutctl --help` < 250ms)
+- `bin/scoutctl` bash launcher shim for LaunchAgent contexts
+- Unit tests + perf tests (startup latency + no-heavy-imports static check)
+- CI: test (macOS + Linux × py3.11/3.12) and lint (ruff + mypy + shellcheck)
+
+Plans 2–7 follow.
+
+## Test plan
+
+- [ ] CI test workflow green on both matrix rows
+- [ ] CI lint workflow green
+- [ ] Manual: `scoutctl --help`, `scoutctl version`, `scoutctl manifest show` all work locally
+- [ ] Manual: `env -i PATH=/usr/bin:/bin HOME=$HOME engine/bin/scoutctl version` succeeds (LaunchAgent simulation)
+
+Ref: `docs/superpowers/specs/2026-04-24-scout-unification-design.md` (in the scout-app repo).
+EOF
+)"
+```
+
+- [ ] **Step 6: Update the task tracker**
+
+Plan 1 is complete when this PR merges. Plans 2–7 in the spec section 8 Migration Journey 1 are ready to begin.
+
+---
+
+## What Plans 2–7 will build on
+
+Each subsequent plan operates on the same `migrate/v0.4.0-*` branch pattern in `~/scout-plugin` (or a successor branch), with the scaffolding from Plan 1 in place. Rough outlines:
+
+- **Plan 2 — Port existing Python into the package.** Create `scout/action_items/`, `scout/kb/`, `scout/tui/` from `~/Scout/action-items/*.py`, `~/Scout/knowledge-base/ontology/*`, and `~/Scout/tui/*`. Flip `action_items_cli_v1`, `kb_ontology_v1`, `tui_v1` to True in the manifest.
+- **Plan 3 — Port 11 shell scripts to Python.** `scout/runners/`, `scout/hooks/`, `scout/scripts/`. Each port paired with a parity test (bats diff of old shell vs new Python). Flip `session_tokens_v1`, `connector_health_v1` to True.
+- **Plan 4 — `scoutctl setup` + plugin-level hooks.** Add `setup` subcommands; update `plugin.json` hooks array; render `~/Scout/.mcp.json` from template; render `~/Library/LaunchAgents/*.plist` from `engine/launchd_templates/`. Add `--with-examples` seed KB.
+- **Plan 5 — Personal-data scrub + skill rewrites + kb_summary cache.** Build `kb_summary.json` cache; scrub SKILL.md / DREAMING.md / RESEARCH.md to generic templates; populate user KB entries for all cited people/projects/channels.
+- **Plan 6 — scout-app refactor.** `ScoutEnvironment`, `EngineClient`, capability check, first-run wizard, path normalization, contract tests. Lives in the scout-app repo.
+- **Plan 7 — Jordan's migration + v0.4.0 publish.** Unload old LaunchAgents, reload from new templates; remove dead files from `~/Scout`; tag v0.4.0; colleague updates.
+
+---
+
+## Self-review (inline; already applied)
+
+**Spec coverage for Plan 1's scope:** §4 (Engine package design, layout, pyproject) → Tasks 0–6. §4 "Startup latency budget" → Tasks 6 + 8. §7 "Path normalization" (engine side; Python defense-in-depth) → Task 2. §9 (Testing strategy — unit + perf) → Tasks 1–8. §9 "CI" → Tasks 9–10. §10 (Error handling / exit codes) → Task 1. All §4 items for this plan are covered; wider items (hooks, runners, scripts, action_items, kb, tui, launchd) are explicitly deferred to Plans 2–4.
+
+**Placeholder scan:** No "TBD" / "TODO" / "implement later" in tasks. Every code block is complete. Every test asserts concrete behavior.
+
+**Type consistency:** `EngineManifest` fields `version: str`, `schema_version: int`, `features: dict[str, bool]`, `subcommands: list[str]` used consistently across `manifest.py`, `test_manifest.py`. `ScoutError.exit_code` is a class attribute (int) inherited by every subclass — consistent across `errors.py` and `test_errors.py`. `paths.data_dir()`, `paths.logs_dir()`, etc. all return `Path` and take `Path | None`. `config.load_config()` returns `dict[str, Any]` — consistent with test expectations.

--- a/docs/specs/2026-04-24-scout-unification-design.md
+++ b/docs/specs/2026-04-24-scout-unification-design.md
@@ -1,0 +1,922 @@
+# Scout Unification Design
+
+**Date:** 2026-04-24
+**Status:** Design approved, ready for implementation planning
+**Author:** Jordan Burger (brainstormed with Claude)
+**Repos affected:** `scout-plugin`, `scout-app`, `~/Scout` (personal data dir)
+
+## 1. Problem statement
+
+Scout today consists of three tightly-coupled pieces with inconsistent distribution:
+
+- **`~/Scout`** — Jordan's private, actively-evolving engine instance. Contains a mix of (a) shippable engine code (shell scripts, Python files, hooks, runners, skills) and (b) personal data (knowledge-base, action-items, drafts, session logs). Local-only, no git remote.
+- **`~/scout-plugin`** — a Claude Code plugin published at `github.com/jordanrburger/scout-plugin`. Intended to be the shareable engine, but lags `~/Scout` substantially. Many engine pieces exist only as templates; several are missing entirely.
+- **`~/scout-app`** — a SwiftUI Mac menu-bar app published at `github.com/jordanrburger/Scout`. Hardcodes `~/Scout` as the engine root; invokes scripts and reads JSONL artifacts from there.
+
+### Observable symptoms
+
+1. **Colleague installs break silently.** Features in scout-app (connector health, session tokens, action-item CLI) depend on engine artifacts produced only by scripts that live in `~/Scout` but have no template or package equivalent in `~/scout-plugin`. A colleague who installs scout-plugin + scout-app hits empty cards and unresponsive buttons with no diagnostic surface.
+2. **Improvements flow the wrong way.** Jordan edits engine code in `~/Scout` (edit-and-go). Porting changes to `~/scout-plugin` is manual and rarely done, so the published plugin perpetually trails.
+3. **Personal data is tangled with skill definitions.** `SKILL.md`, `DREAMING.md`, `RESEARCH.md` contain family names, phone numbers, colleague rosters, and internal project codes inlined as context. They cannot be shipped as-is.
+4. **`scout-app` hardcodes paths.** `AppState.swift:34-36` resolves `scoutDir` from `~/Scout` with no override. Even if a colleague had a complete plugin install at a different path, the app wouldn't find it.
+5. **No contract between app and engine.** If the engine is missing a feature the app needs, the app silently renders an empty view instead of telling the user the engine is out of date.
+
+### Root cause
+
+`~/Scout` is simultaneously the canonical location of engine code and of Jordan's personal data. No boundary. Every improvement becomes a choice between "ship it" (port to plugin) and "keep hacking" (edit in place) — and "keep hacking" wins because it preserves edit-and-go.
+
+## 2. Goals and non-goals
+
+### Goals
+
+1. Make `scout-plugin` the single canonical home for all engine code.
+2. Demote `~/Scout` to a pure data directory — user state only, never shipped, never git-tracked.
+3. Preserve Jordan's edit-and-go workflow — no rebuild/publish step between editing a file and having it take effect.
+4. Give `scout-app` a configurable engine path and a capability contract with the engine, so mismatches are diagnosable rather than silent.
+5. Make the engine UI-independent — usable via CLI, TUI, Mac app, or a future web UI — and cross-platform-capable (Python, not Swift).
+6. Give a colleague a five-command install that yields a working Scout.
+
+### Non-goals
+
+- Windows port (Python leaves the door open; not in scope).
+- TUI rewrite (moves in as-is).
+- Plugin auto-update (`git pull` is sufficient).
+- Web UI.
+- Migration tooling beyond schema-version scaffolding (v1 is the starting state; no older versions to migrate from).
+- Re-signing `scoutctl` (it's Python; no binary signing required).
+- Rewriting the engine in Go/Rust/Swift (explicitly considered and rejected — kills edit-and-go, doesn't fix the real jankiness which is structural, not linguistic).
+
+## 3. Architecture
+
+Three locations with clear, non-overlapping roles.
+
+```
+┌─────────────────────────────────────┐   ┌─────────────────────────────────┐
+│  ENGINE  (shippable, git-tracked)   │   │  DATA DIR  (personal, never     │
+│  ~/scout-plugin (dev clone)         │   │  in git, never bundled)         │
+│  = Claude Code plugin               │   │  ~/Scout  (default)             │
+│                                     │   │                                 │
+│  engine/                            │   │  knowledge-base/                │
+│    scout/ (Python package)          │   │  action-items/ (markdown only)  │
+│    bin/scoutctl (entry shim)        │   │  drafts/                        │
+│    tests/                           │   │  .scout-logs/                   │
+│    manifest.json                    │   │  .scout-cache/                  │
+│    launchd_templates/               │   │  .scout-state/                  │
+│  commands/  skills/  phases/        │   │  .obsidian/                     │
+│  plugin.json                        │   │  .scout-config.yaml             │
+│                                     │   │  .mcp.json                      │
+└─────────────────┬───────────────────┘   └────────────────┬────────────────┘
+                  │                                         │
+                  │  SCOUT_ENGINE_DIR                       │  SCOUT_DATA_DIR
+                  │  (env var or NSUserDefaults)            │  (env var or NSUserDefaults)
+                  ▼                                         ▼
+         ┌────────────────────────────────────────────────────────┐
+         │              scout-app  (SwiftUI, Mac)                 │
+         │  - Resolves both dirs at launch                        │
+         │  - Reads engine/manifest.json for capability check     │
+         │  - Invokes engine via EngineClient → scoutctl          │
+         │  - Reads data_dir/.scout-logs/*, action-items/*, etc.  │
+         │  - First-run wizard if either dir unresolved           │
+         └────────────────────────────────────────────────────────┘
+```
+
+### Three anchors
+
+1. **Engine = clone of `scout-plugin`.** Contains every shell script (now Python), Python file, hook, command, skill, TUI, ontology parser, launchd template. Git-tracked. Pushed to GitHub. Jordan edits here. Colleagues pull here.
+2. **Data dir = `~/Scout`** (default; overrideable). Pure user state. Never in git. Never bundled. Created by `scoutctl setup` if absent.
+3. **App = `scout-app`.** Resolves engine + data paths via env vars → NSUserDefaults → first-run wizard. Reads the engine's `manifest.json` at launch; degrades individual features gracefully if missing.
+
+### Key design moves
+
+- **Templates shrink dramatically.** Today's `scout-plugin/templates/` exists because the install model is "render and scatter." Under this design, most files live directly in the package and are invoked from there. Only launchd plists (which embed absolute paths) and the default `.scout-config.yaml` remain as templates.
+- **Hooks declared by the plugin, not by the user.** `plugin.json` includes a `hooks` array; installing the plugin wires them up. No per-user `.claude/settings.json` surgery.
+- **Single CLI surface.** Engine exposes one entry point (`scoutctl`) with subcommands. Scout-app invokes `scoutctl <subcommand>` for every engine interaction — one path to test, one version to check.
+
+## 4. Engine package design
+
+### Directory layout
+
+```
+scout-plugin/
+├── plugin.json                 (Claude Code plugin manifest)
+├── commands/                   (slash commands)
+├── skills/                     (skill markdown — scrubbed, generic)
+├── phases/                     (phase docs)
+├── engine/
+│   ├── pyproject.toml
+│   ├── README.md
+│   ├── manifest.json           (built by scoutctl manifest build)
+│   ├── bin/scoutctl            (shell launcher shim)
+│   ├── defaults/
+│   │   ├── scout-config.yaml   (baseline config; user overrides in data dir)
+│   │   └── mcp.json.tmpl       (MCP schema; secrets in data dir)
+│   ├── launchd_templates/
+│   │   └── *.plist.tmpl
+│   ├── scout/                  (THE Python package)
+│   │   ├── __init__.py
+│   │   ├── __main__.py         (enables `python -m scout`)
+│   │   ├── cli.py              (Typer app — scoutctl entry point)
+│   │   ├── config.py           (resolves SCOUT_DATA_DIR, layers config)
+│   │   ├── paths.py            (single source of truth for path resolution)
+│   │   ├── manifest.py         (builds capability manifest)
+│   │   ├── errors.py           (exception classes mapped to exit codes)
+│   │   ├── hooks/
+│   │   │   ├── connector_log.py
+│   │   │   ├── kb_pre_filter.py
+│   │   │   └── session_tokens.py
+│   │   ├── scripts/
+│   │   │   ├── budget_check.py
+│   │   │   ├── heartbeat.py
+│   │   │   ├── rate_limit_detect.py
+│   │   │   ├── collect_events.py
+│   │   │   ├── connector_health_report.py
+│   │   │   ├── pre_session_data.py
+│   │   │   ├── write_session_cost.py
+│   │   │   └── cc_session_cache.py
+│   │   ├── runners/
+│   │   │   ├── scout.py
+│   │   │   ├── dreaming.py
+│   │   │   └── research.py
+│   │   ├── action_items/
+│   │   │   ├── cli.py
+│   │   │   ├── parser.py       (shared with TUI)
+│   │   │   ├── writer.py       (shared with TUI)
+│   │   │   ├── mark_done.py
+│   │   │   ├── snooze.py
+│   │   │   ├── add_comment.py
+│   │   │   ├── render.py
+│   │   │   └── watch.py
+│   │   ├── kb/
+│   │   │   ├── ontology.py
+│   │   │   ├── schema.yaml     (package data; user may override in data dir)
+│   │   │   └── query.py
+│   │   ├── tui/                (Textual app; shares parser/writer with action_items)
+│   │   │   ├── app.py
+│   │   │   ├── config.py
+│   │   │   └── screens/
+│   │   └── setup/
+│   │       ├── init_data_dir.py
+│   │       ├── register_hooks.py
+│   │       ├── install_launchd.py
+│   │       └── migrations/     (schema-version migrations)
+│   └── tests/
+│       ├── unit/
+│       ├── integration/
+│       ├── contract/           (snapshots the Swift side decodes)
+│       └── fixtures/
+└── .github/workflows/
+    ├── test.yml
+    ├── lint.yml
+    └── release.yml
+```
+
+### `scoutctl` CLI surface
+
+| Command | Purpose |
+|---|---|
+| `scoutctl run {scout\|dreaming\|research}` | Launch a Claude session (replaces `run-*.sh`) |
+| `scoutctl hook {connector-log\|session-tokens\|kb-pre-filter}` | Claude Code hook entry (stdin = event JSON) |
+| `scoutctl action-items {mark-done\|snooze\|add-comment\|render\|watch\|list}` | Action-item operations |
+| `scoutctl kb query [--type X --status Y --name-match "..."]` | KB graph query |
+| `scoutctl report {connector-health\|heartbeat\|budget-check\|rate-limit\|session-cost}` | Reporting/monitoring |
+| `scoutctl manifest {build\|show}` | Capability manifest emit |
+| `scoutctl setup {data-dir\|hooks\|launchd\|mcp\|verify}` | First-run and maintenance |
+| `scoutctl migrate data-dir --from N --to M` | Data dir schema migrations |
+| `scoutctl tui` | Launch Textual TUI |
+| `scoutctl version` | Engine version (app uses this for manifest check) |
+| `scoutctl diagnose` | Full diagnostic dump (redacted) for bug reports |
+
+### `engine/bin/scoutctl` shim
+
+A small bash wrapper that resolves the venv Python deterministically, so hooks invoked from LaunchAgents (which don't inherit user PATH) still find the right interpreter:
+
+```bash
+#!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ENGINE_DIR="${DIR%/bin}"
+VENV_PY="${ENGINE_DIR}/.venv/bin/python"
+
+if [ -x "$VENV_PY" ]; then
+    exec "$VENV_PY" -m scout.cli "$@"
+else
+    exec python3 -m scout.cli "$@"
+fi
+```
+
+### `pyproject.toml`
+
+```toml
+[project]
+name = "scout-engine"
+version = "0.4.0"
+requires-python = ">=3.11"
+dependencies = ["typer", "pyyaml", "textual", "rich", "watchdog", "jinja2"]
+
+[project.scripts]
+scoutctl = "scout.cli:main"
+
+[project.optional-dependencies]
+dev = ["pytest", "pytest-cov", "mypy", "ruff"]
+```
+
+### Startup latency budget
+
+The app invokes `scoutctl` on interactive user actions (checkbox clicks, alert acks). Python import of `textual`, `rich`, and the KB ontology can add 200–400ms if imported at module top. This is not acceptable for UI responsiveness.
+
+**Rules enforced via test:**
+
+- `scoutctl` top-level imports are restricted to `typer`, `pathlib`, `sys`, `os`, and the small internal modules (`config`, `paths`, `errors`). No heavy imports at module top of `cli.py` or any subcommand module's top-level body.
+- Heavy imports (`textual`, `rich`, `jinja2`, `yaml` where possible, `watchdog`, `scout.kb.*`) live **inside** the subcommand function body — imported on first call, not at CLI startup.
+- A dedicated latency test in `engine/tests/perf/test_startup.py` asserts:
+  - `scoutctl --help` completes in < 100ms (cold).
+  - `scoutctl version` completes in < 50ms.
+  - `scoutctl action-items mark-done ...` completes in < 200ms including the file rewrite (warm).
+- A ruff rule or a simple import-analysis test flags top-level imports of the blacklisted modules and fails CI.
+
+This keeps the CLI responsive enough that scout-app's UI doesn't feel laggy when driving it.
+
+### File migration map (source → destination)
+
+Moves to plugin:
+
+| Current location | New location |
+|---|---|
+| `~/Scout/run-scout.sh` | `engine/scout/runners/scout.py` |
+| `~/Scout/run-dreaming.sh` | `engine/scout/runners/dreaming.py` |
+| `~/Scout/run-research.sh` | `engine/scout/runners/research.py` |
+| `~/Scout/hooks/connector-log.sh` | `engine/scout/hooks/connector_log.py` |
+| `~/Scout/hooks/kb-pre-filter.sh` | `engine/scout/hooks/kb_pre_filter.py` |
+| `~/Scout/scripts/sum-session-tokens.sh` | `engine/scout/hooks/session_tokens.py` |
+| `~/Scout/scripts/{budget-check,heartbeat,rate-limit-detect,collect-events,connector-health-report,pre-session-data,write-session-cost,cc-session-cache}.sh` | `engine/scout/scripts/*.py` |
+| `~/Scout/action-items/{mark_done,snooze,add_comment,render}.py` | `engine/scout/action_items/*.py` |
+| `~/Scout/action-items/watch.sh` | `engine/scout/action_items/watch.py` (using `watchdog`) |
+| `~/Scout/knowledge-base/ontology/parser.py` | `engine/scout/kb/ontology.py` |
+| `~/Scout/knowledge-base/ontology/schema.yaml` | copied to `engine/scout/kb/schema.yaml` (shipped default); a copy stays in data dir as optional user override (see below) |
+| `~/Scout/tui/*` | `engine/scout/tui/*` |
+| `~/Scout/launchd/*.plist` | `engine/launchd_templates/*.plist.tmpl` |
+| `~/Scout/.claude/commands/scout-meta-review.md` | `scout-plugin/commands/scout-meta-review.md` |
+| `~/Scout/.claude/commands/scout-work.md` (live) | overwrites `scout-plugin/commands/scout-work.md` |
+| `~/Scout/SKILL.md`, `DREAMING.md`, `RESEARCH.md` (scrubbed) | `scout-plugin/skills/*.md` |
+| `~/Scout/.scout-config.yaml` (de-personalized defaults) | `engine/defaults/scout-config.yaml` |
+| `~/Scout/.mcp.json` (schema only, no secrets) | `engine/defaults/mcp.json.tmpl` |
+
+Stays in `~/Scout` (data dir):
+
+| Path | Reason |
+|---|---|
+| `knowledge-base/` (minus `ontology/parser.py`; `ontology/schema.yaml` optional) | User's personal KB content. `ontology/schema.yaml` is optional here — engine falls back to the packaged default when absent. |
+| `action-items/*.md` | Daily markdown files user authors |
+| `drafts/` | Personal message drafts |
+| `.scout-logs/`, `.scout-cache/` | Runtime logs and cache |
+| `.obsidian/` | Editor workspace |
+| `.scout-config.yaml` (user values) | Per-user overrides layered on defaults |
+| `.mcp.json` (secrets) | User-specific secrets |
+
+Deleted after migration:
+
+- `~/Scout/app/` (dead Xcode stub, last touched 2026-04-22).
+
+## 5. Claude Code plugin integration
+
+### `plugin.json`
+
+```json
+{
+  "name": "scout",
+  "version": "0.4.0",
+  "description": "Autonomous knowledge management and daily briefing system.",
+  "commands": [
+    "commands/scout-setup.md",
+    "commands/scout-status.md",
+    "commands/scout-work.md",
+    "commands/scout-meta-review.md"
+  ],
+  "skills": [
+    "skills/scout-briefing.md",
+    "skills/scout-consolidation.md",
+    "skills/scout-dream.md",
+    "skills/scout-research.md",
+    "skills/SKILL.md",
+    "skills/DREAMING.md",
+    "skills/RESEARCH.md"
+  ],
+  "hooks": [
+    {
+      "event": "PostToolUse",
+      "matcher": ".*",
+      "command": "${CLAUDE_PLUGIN_ROOT}/engine/bin/scoutctl hook connector-log",
+      "timeout": 5
+    },
+    {
+      "event": "Stop",
+      "command": "${CLAUDE_PLUGIN_ROOT}/engine/bin/scoutctl hook session-tokens",
+      "timeout": 10
+    },
+    {
+      "event": "UserPromptSubmit",
+      "matcher": ".*",
+      "command": "${CLAUDE_PLUGIN_ROOT}/engine/bin/scoutctl hook kb-pre-filter",
+      "timeout": 5
+    }
+  ]
+}
+```
+
+### Command and skill engine invocation
+
+Skills and commands that need engine data invoke `scoutctl` directly:
+
+```markdown
+---
+name: scout-status
+description: Show current Scout health
+---
+
+Run the health report:
+
+!`${CLAUDE_PLUGIN_ROOT}/engine/bin/scoutctl report connector-health --json`
+
+Then summarize any alerts above threshold.
+```
+
+### MCP server handling
+
+- **Plugin ships:** `engine/defaults/mcp.json.tmpl` — schema with `${LANGSMITH_API_KEY}` style placeholders.
+- **Data dir holds:** `~/Scout/.mcp.json` — user secrets, rendered by `scoutctl setup mcp`.
+- **Setup flow:** `scoutctl setup mcp` prompts for each required env var (or reads from shell env / keychain), writes resolved config to data dir, registers with Claude Code.
+
+### Env var contract
+
+| Variable | Default | Set by |
+|---|---|---|
+| `SCOUT_DATA_DIR` | `~/Scout` | User shell profile, or app first-run wizard |
+| `SCOUT_ENGINE_DIR` | Resolved from `${CLAUDE_PLUGIN_ROOT}` | Plugin install; app may override |
+
+## 6. Data directory contract
+
+### Layout
+
+```
+$SCOUT_DATA_DIR/
+├── .scout-config.yaml          (user-owned; scalars + thresholds)
+├── .mcp.json                   (user-owned; secrets)
+├── .scout-logs/                (runtime JSONL/log; engine-writable)
+│   ├── connector-calls-*.jsonl
+│   ├── session-tokens.jsonl
+│   ├── usage-tracker.jsonl
+│   ├── connector-alerts.log
+│   ├── heartbeat.jsonl
+│   └── sessions/
+├── .scout-cache/               (regenerable; engine-writable)
+│   ├── connector-alerts-acked.json
+│   └── session-context/
+├── .scout-state/               (persistent state; engine-writable)
+│   └── schema-version
+├── knowledge-base/             (user-owned; relational context source)
+│   ├── ontology/schema.yaml    (optional user override)
+│   ├── people/
+│   ├── projects/
+│   ├── channels/
+│   └── ...
+├── action-items/               (user-owned; engine reads/writes)
+│   └── action-items-YYYY-MM-DD.md
+├── drafts/                     (user-owned)
+├── .obsidian/                  (user-owned editor state)
+└── exports/                    (engine-written snapshots)
+```
+
+### `.scout-config.yaml` — three-layer merge
+
+Precedence (low → high): engine defaults → user overrides → env vars.
+
+```yaml
+schema_version: 1
+
+user:
+  email: jordan.burger@keboola.com
+  github_username: jordanrburger
+  slack_user_id: U02T4ADKB38
+  timezone: America/New_York
+  company: Keboola
+  display_name: Jordan
+
+budgets:
+  daily_budget_estimate_usd: 150
+  max_per_session_usd: 20
+
+thresholds:
+  rate_limit_warn_pct: 80
+  rate_limit_block_pct: 95
+  connector_staleness_hours: 24
+
+features:
+  tui: true
+  connector_health: true
+  dreaming: true
+```
+
+The `user:` block consolidates the "Jordan's Details" footer found duplicated across all three skill files. Skills reference `{{ user.email }}`, `{{ user.timezone }}`, etc., via Jinja at session start.
+
+### KB as canonical relational context
+
+The `~/Scout/knowledge-base/` directory is the source of truth for people, projects, channels, and any other entities with relationships. Skills query via `scoutctl kb query --type person --name-match "${name}"` instead of inlining names.
+
+Per-entity entries use frontmatter:
+
+```yaml
+---
+type: person
+name: Example Person
+team: Example Team
+works_on: [ProjectA, ProjectB]
+slack: "@example"
+---
+```
+
+### `scoutctl setup data-dir` contract
+
+**Does:**
+- Creates missing top-level directories.
+- Writes starter `.scout-config.yaml` from defaults if missing.
+- Writes `$SCOUT_DATA_DIR/.scout-state/schema-version`.
+- Writes starter `knowledge-base/ontology/schema.yaml` if missing.
+- Creates a data-dir `README.md` explaining user-owned vs engine-written paths.
+- Reports per-item success/failure.
+
+**Does not:**
+- Touch existing files.
+- Populate KB content (unless `--with-examples` passed).
+- Write secrets (`scoutctl setup mcp` does that).
+- Run silent migrations — schema mismatches fail fast with a `scoutctl migrate` instruction.
+
+### `--with-examples` flag (colleague first-run bootstrap)
+
+`scoutctl setup data-dir --with-examples` additionally copies a small seed dataset from `engine/defaults/example_kb/` into the data dir if the target KB subdirs are empty. Contents:
+
+- `knowledge-base/people/example-colleague.md` (2 entries) — schema-valid placeholder persons.
+- `knowledge-base/projects/example-project.md` (1 entry) — placeholder project.
+- `knowledge-base/channels/example-channel.md` (1 entry) — placeholder Slack channel.
+- `action-items/action-items-<today>.md` — a 3-task sample file with at least one task referencing an example person and one with a `[ ]` checkbox so mark-done can be tested.
+
+The seed is labeled in-file with a leading comment (`<!-- example seed; safe to delete -->`) so the user can identify and remove it once they've populated their own content. Running `scoutctl setup data-dir` without `--with-examples` skips this; running with the flag on an already-populated directory is a no-op (existing files untouched).
+
+**Why v0.4.0, not a follow-up:** without seed data, a colleague's first scout-app launch shows empty cards — they can't tell the install succeeded or failed. With seed data, they see populated cards immediately and can verify end-to-end by marking an example task done. This is the difference between "did it work?" and obvious success.
+
+**Smoke test:** `scoutctl setup verify --smoke-test` exercises the example data (list action items, mark one done, query an example person, emit a connector-health report against empty JSONL) and reports a green checklist. Runs automatically at the end of `scoutctl setup` when `--with-examples` was used.
+
+### Data dir schema versioning
+
+Plain-text `$SCOUT_DATA_DIR/.scout-state/schema-version` holds the integer version. Migrations are numbered Python scripts in `engine/scout/setup/migrations/00N_description.py`. Only forward migrations; no downgrade path (backup before migrating).
+
+| Version | Change |
+|---|---|
+| 1 | Initial — matches current `~/Scout` layout |
+
+### Concurrency and file-locking rules
+
+Multiple processes touch the data dir simultaneously: scout-app reads (logs, KB, action items), Claude Code hooks write (JSONL logs, session tokens), Claude sessions mutate markdown (action items), scheduled LaunchAgents run reports, and the TUI may be running in a terminal.
+
+**Writer rules:**
+
+| File class | Pattern | Rationale |
+|---|---|---|
+| JSONL logs (`.scout-logs/*.jsonl`) | Append-only with `O_APPEND`; single `write()` per line; keep lines under 4KB when possible | POSIX guarantees atomic append for writes ≤ `PIPE_BUF` (typically 4KB). Multiple concurrent appenders interleave cleanly line-by-line. |
+| JSONL lines > 4KB | Same `O_APPEND` path + advisory `flock(LOCK_EX)` around the `write()` call | Defensive; large lines are rare but shouldn't risk interleaving. |
+| Action-item markdown (`action-items/*.md`) | Write to `<file>.tmp`, `fsync()`, then `os.replace(tmp, final)` | Atomic rename is POSIX-guaranteed; readers see either the old or new complete file, never a half-written state. |
+| Stateful JSON (`connector-alerts-acked.json`) | Read-modify-write under `flock(LOCK_EX)` on the file itself; write via temp + rename | Protects against lost updates when app and engine both ack. |
+| `schema-version` file | Written only by `scoutctl migrate`; held under exclusive lock for the duration | Single-writer invariant. |
+
+**Reader rules:**
+
+- JSONL readers must tolerate malformed / truncated trailing lines (common at tail during an active append) — log + skip, never crash.
+- Markdown readers can read without locking thanks to atomic rename.
+- Stateful JSON readers take `flock(LOCK_SH)` briefly; retry once on failure.
+
+**Concurrency tests** (`engine/tests/concurrency/`):
+
+- `test_jsonl_parallel_appenders` — N processes each append K lines; final file has N*K parseable lines, no partial/interleaved rows.
+- `test_action_item_atomic_rewrite` — Writer loops rewriting a file; reader loops reading; reader never sees an incomplete file over 1000 iterations.
+- `test_ack_store_concurrent` — Two processes ack different alerts concurrently; both end up persisted.
+
+## 7. Scout-app integration
+
+### Resolution order (per path, independent)
+
+```
+Env var (SCOUT_DATA_DIR / SCOUT_ENGINE_DIR)
+    ↓ (if unset)
+NSUserDefaults (scout.dataDir / scout.engineDir)
+    ↓ (if unset)
+Legacy default (~/Scout for data; ${CLAUDE_PLUGIN_ROOT}/engine if discoverable)
+    ↓ (if unresolved)
+First-run wizard
+```
+
+### Path normalization rule (critical)
+
+Swift, Python, and bash handle `~` and symlinks inconsistently. A value like `~/Scout` read from the process environment is never expanded by Swift; `URL(fileURLWithPath: "~/Scout")` yields a literal path with a tilde character. Passing that to a subprocess fails or behaves surprisingly.
+
+**Rule:** **The app normalizes all paths at the resolution boundary.** Immediately on resolution — from env, NSUserDefaults, or wizard — the app applies:
+
+1. Tilde expansion (`NSString.expandingTildeInPath` or `stringByExpandingTildeInPath`).
+2. Symlink resolution (`URL.resolvingSymlinksInPath`).
+3. Absolute-path canonicalization (`URL.standardizedFileURL`).
+
+Only fully-expanded absolute paths are ever persisted to NSUserDefaults or passed to `EngineClient`. `EngineClient` asserts incoming paths are absolute and non-tilde-prefixed before invoking `scoutctl`.
+
+**Defense in depth (Python side):** `scout.paths` also applies `Path(...).expanduser().resolve()` on any env-var-sourced path, so a hand-edited shell profile with `SCOUT_DATA_DIR=~/Scout` still works — just slightly less cleanly than via the app.
+
+Test: `ScoutEnvironmentResolverTests.testExpandsAndResolvesPaths` covers tilde input, symlink chain, relative path, and already-absolute input.
+
+### `ScoutEnvironment` value
+
+Injected at `AppState.init`, passed to every service:
+
+```swift
+struct ScoutEnvironment {
+    let engineDir: URL
+    let dataDir: URL
+    let source: ResolutionSource  // env | defaults | legacy | wizard
+}
+```
+
+Services receive `ScoutEnvironment` via constructor injection. No service calls `FileManager.homeDirectoryForCurrentUser` directly — that becomes a lint/review red flag.
+
+### `EngineClient`
+
+Consolidates every engine invocation behind a single type:
+
+```swift
+struct EngineClient {
+    let engineDir: URL
+
+    func run(_ args: [String], input: Data?) async throws -> ProcessResult
+    func runJSON<T: Decodable>(_ args: [String], as: T.Type) async throws -> T
+    func loadManifest() throws -> EngineManifest
+}
+
+extension EngineClient {
+    func markActionItemDone(_ taskID: String) async throws
+    func snoozeActionItem(_ taskID: String, until: Date) async throws
+    func connectorHealthReport() async throws -> ConnectorHealthReport
+    func runSession(mode: SessionMode) async throws -> SessionResult
+    // ... one method per engine operation the app uses
+}
+```
+
+All subprocess invocation goes through `EngineClient`. Failure modes (nonzero exit, missing subcommand, stale manifest) handled in one place.
+
+### Capability manifest check
+
+At `AppState.init`, after resolving env:
+
+```swift
+let manifest = try EngineClient(engineDir: env.engineDir).loadManifest()
+try CapabilityChecker.require(manifest, features: [
+    .sessionTokensV1,
+    .connectorHealthV1,
+    .actionItemsCLIv1,
+    .kbOntologyV1,
+])
+```
+
+On failure: app launches normally, a non-dismissable banner appears:
+
+> "This app needs scout-plugin ≥ 0.5 for connector health. You have 0.3.
+> Run `scoutctl upgrade` or `cd ~/scout-plugin && git pull`."
+
+Feature-specific cards degrade to "Requires plugin update" stubs. Rest of app works.
+
+### First-run wizard
+
+Three-step sheet, triggered when either dir is unresolved:
+
+1. **Engine location.** Auto-detects `~/.claude/plugins/scout-plugin` and `${CLAUDE_PLUGIN_ROOT}`; allows browse.
+2. **Data dir location.** Default `~/Scout`; offers "Create for me" (invokes `scoutctl setup data-dir`).
+3. **Verify.** Runs `scoutctl manifest show`; shows green checklist; persists paths to NSUserDefaults.
+
+Re-accessible from Preferences → Paths.
+
+### Degradation matrix
+
+| Condition | Behavior |
+|---|---|
+| Neither env nor persisted, defaults missing | First-run wizard |
+| Data dir exists but no `.scout-config.yaml` | Prompt to run `scoutctl setup data-dir`; affected views show "Data dir not initialized" |
+| Engine dir resolved but `manifest.json` missing | Banner: "Scout engine not installed. Run `scoutctl setup verify`"; engine features disabled |
+| Engine present but required feature missing | Feature-specific "Requires plugin update" stub |
+| `scoutctl` invocation fails | Toast: subcommand + exit code; "Copy diagnostic" button |
+| JSONL file malformed | Log, skip bad lines, show "partial data" indicator on affected card |
+
+### Removed or slimmed
+
+- Hardcoded `scoutDir` constant in `AppState.swift`.
+- Direct `~/Scout/run-scout.sh` invocation in `RunnerService.swift` → `engineClient.runSession(mode: .scout)`.
+- Direct Python invocation in `ActionItemsWriter.swift` → `engineClient.markActionItemDone(...)`.
+- `ActionItemsEnvironmentCheck.swift` (manifest subsumes "is python3 available, are scripts present").
+- `GitService` remains but points at `$SCOUT_DATA_DIR` instead of `~/Scout`.
+
+## 8. Distribution and update flows
+
+### Jordan's one-time migration
+
+Ordered, gated, reversible. Run from dedicated branches (`migrate/v0.4.0` in scout-plugin, `migrate/scout-env-resolution` in scout-app). Full `~/Scout` backup before starting.
+
+1. Scaffold `engine/` package with `pyproject.toml`, empty `scout/`, CI workflows. Verify `uv pip install -e .` succeeds.
+2. Port Python files as-is (action_items, ontology, TUI). Adjust imports. Per-subsystem commits.
+3. Port shell scripts to Python one at a time. Each port paired with a pytest asserting observable I/O parity. Shell originals retained until parity confirmed, then deleted.
+4. Wire `scoutctl` CLI (Typer). `scoutctl --help` enumerates everything.
+5. **Personal-data scrub and split** (see §11).
+6. Plugin-level hook registration via `plugin.json`. Remove per-user hook registrations from `~/Scout/.claude/settings.json`. Restart Claude Code. Verify hooks fire.
+7. Scout-app refactor in a single PR: `ScoutEnvironment`, `EngineClient`, first-run wizard, capability check, service migrations.
+8. Launchd re-registration via `scoutctl setup launchd`: unload old plists, render and load new.
+9. Delete dead files from `~/Scout` (runners, hooks, scripts, action-items Python, TUI, old Xcode stub, launchd, `.claude/settings.json` hooks block, SKILL/DREAMING/RESEARCH originals). Keep all user data.
+10. Publish: tag scout-plugin v0.4.0 and push; merge scout-app PR.
+
+Rollback: revert migration branch; restore `~/Scout` from backup; reload old launchd plists.
+
+### Jordan's day-to-day (after migration)
+
+One-time:
+```bash
+cd ~/scout-plugin/engine
+uv venv
+uv pip install -e ".[dev]"
+claude plugin add --dev ~/scout-plugin  # or symlink to ~/.claude/plugins/
+```
+
+Daily:
+```bash
+$EDITOR ~/scout-plugin/engine/scout/hooks/connector_log.py  # edit-and-go
+# ... iterate locally ...
+cd ~/scout-plugin && git commit -am "fix: ..." && git push
+```
+
+Cross-repo contract changes bump manifest version AND scout-app required floor in the same linked-PR pair.
+
+### Colleague first-time install
+
+```bash
+# 1. Plugin
+claude plugin install github:jordanrburger/scout-plugin
+
+# 2. Dev clone (optional, for modification)
+git clone https://github.com/jordanrburger/scout-plugin.git ~/scout-plugin
+cd ~/scout-plugin/engine && uv pip install -e ".[dev]"
+
+# 3. Setup
+scoutctl setup
+# - creates ~/Scout data dir
+# - prompts for user scalars
+# - prompts for MCP secrets
+# - renders + loads launchd plists
+# - runs verify
+
+# 4. App
+curl -L https://github.com/jordanrburger/Scout/releases/latest/download/Scout.app.dmg -o Scout.dmg
+open Scout.dmg
+# First-run wizard discovers plugin + data dir, verifies manifest.
+```
+
+Five commands + one app install. Every step idempotent.
+
+### Update flow
+
+Fix ships:
+```bash
+cd ~/scout-plugin && git push                   # Jordan
+cd ~/scout-plugin && git pull \
+    && cd engine && uv pip install -e ".[dev]" --upgrade \
+    && scoutctl setup verify                     # colleague
+```
+
+App update: download new DMG, drag-replace. (Sparkle auto-updater is a future consideration, not v0.4.)
+
+### Versioning contract
+
+| Artifact | Where | Bump rules |
+|---|---|---|
+| Plugin version | `plugin.json` + `pyproject.toml` (sync by pre-commit) | Semver; minor for additive, patch for fix, major for breaking contract |
+| Manifest version | `engine/manifest.json` | Derived from plugin version + `features: {}` dict of capability flags |
+| App required floor | `CapabilityChecker.swift` | Bumped deliberately when adding cross-repo features |
+| Data dir schema | `~/Scout/.scout-state/schema-version` | Bumped only on directory contract changes |
+
+## 9. Testing strategy
+
+### Unit tests (pytest)
+
+Targets `engine/scout/*.py`. Fast, no real I/O (uses `tmp_path` fixtures). Coverage target: **90%+ for `scout/` package.**
+
+| Module | Focus |
+|---|---|
+| `hooks/*` | JSONL line shape, event parsing, categorization, dedup, token math |
+| `scripts/*` | Happy path + empty-input path per report |
+| `action_items/*` | Substring match, date parse, atomic write, exit-code contract |
+| `kb/ontology`, `kb/query` | Graph build, filters, relationship validation |
+| `config` | Three-layer merge, missing-file fallback, invalid YAML error |
+| `paths` | Env → config → default resolution; schema-version gate |
+| `manifest` | Feature flag detection, version compare, missing-feature signaling |
+
+### Integration tests (pytest, fake data dir)
+
+| Scenario | Covers |
+|---|---|
+| `test_setup_fresh_data_dir` | `scoutctl setup data-dir` on empty dir creates all expected subdirs + seed files |
+| `test_setup_idempotent` | Second `scoutctl setup` run changes nothing |
+| `test_setup_with_examples` | `--with-examples` copies seed data; re-running is a no-op when KB non-empty |
+| `test_setup_refuses_on_schema_mismatch` | v1 data dir, v2 engine → refuses with migrate instruction |
+| `test_hook_end_to_end` | Pipe Claude Code event JSON to `scoutctl hook connector-log`; assert JSONL row appended |
+| `test_manifest_round_trip` | `manifest build` → `manifest show` equality |
+| `test_action_items_cli_contract` | Every action-items subcommand's stdout/stderr/exit-code shape scout-app depends on |
+| `test_verify_smoke_test` | `scoutctl setup verify --smoke-test` on an example-seeded data dir returns green |
+
+### Performance tests (pytest, `engine/tests/perf/`)
+
+| Scenario | Assertion |
+|---|---|
+| `test_startup_help` | `scoutctl --help` completes in < 100ms (cold process) |
+| `test_startup_version` | `scoutctl version` completes in < 50ms |
+| `test_action_items_mark_done_latency` | End-to-end `scoutctl action-items mark-done` including atomic file rewrite completes in < 200ms |
+| `test_no_heavy_imports_at_startup` | Static import analysis fails if `textual`, `rich`, `jinja2`, `watchdog`, or `scout.kb.*` are imported at module top of `cli.py` or any subcommand module |
+
+### Concurrency tests (pytest, `engine/tests/concurrency/`)
+
+| Scenario | Assertion |
+|---|---|
+| `test_jsonl_parallel_appenders` | N=8 processes each append K=100 JSONL lines; final file has 800 parseable lines, no partial rows |
+| `test_action_item_atomic_rewrite` | Writer + reader loop 1000 iterations; reader never sees a half-written markdown file |
+| `test_ack_store_concurrent` | Two processes ack different alerts concurrently; both persist |
+
+### Contract tests (both sides)
+
+Snapshot files committed to `engine/tests/contract/snapshots/`. Python side asserts the engine produces matching output; Swift side decodes the same snapshots via the app's types. CI fails if either drifts.
+
+Contract changes = update snapshots + bump manifest capability + bump app floor, all in a linked PR pair.
+
+### Shell parity tests (migration-only)
+
+For each of the 11 shell scripts being ported: bats test runs `bash old_script.sh < fixture` and `scoutctl <subcommand> < fixture`; diffs stdout + produced files. Must be green before old script deleted. Removed from CI after migration step 9.
+
+### Swift tests (XCTest)
+
+| Target | Focus |
+|---|---|
+| `ScoutEnvironmentResolverTests` | 4 resolution paths |
+| `EngineClientTests` | Mock Process injection; argv, stdin, timeout, nonzero-exit |
+| `CapabilityCheckerTests` | Manifest version + feature-flag matrix |
+| `FirstRunWizardTests` | Screen validation, happy path persistence |
+| `ContractTests` | Decode committed engine snapshots |
+
+### CI
+
+`scout-plugin/.github/workflows/test.yml`:
+
+```yaml
+on: [push, pull_request]
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python: ["3.11", "3.12"]
+    steps:
+      - uv pip install -e "./engine[dev]"
+      - ruff check engine/scout engine/tests
+      - mypy engine/scout
+      - pytest engine/tests --cov=scout --cov-fail-under=90
+      - shellcheck engine/bin/scoutctl
+```
+
+`scout-app/.github/workflows/test.yml`:
+
+```yaml
+  - xcodebuild test
+  - contract-tests against pinned scout-plugin version (submodule or fetched tarball)
+```
+
+`scout-plugin/.github/workflows/release.yml` on tags `v*`:
+
+```yaml
+  - build manifest.json
+  - publish GitHub release
+  - repository_dispatch → scout-app to refresh contract tests
+```
+
+## 10. Error handling
+
+### Exit codes (`engine/scout/errors.py`)
+
+Every `scoutctl` subcommand maps Python exceptions to an exit code + single-line stderr message + (optional) structured JSON stdout when `--json` is passed.
+
+| Code | Class | Example |
+|---|---|---|
+| 0 | Success | — |
+| 1 | Generic / unexpected | Uncaught exception |
+| 10 | Config error | `.scout-config.yaml` missing or invalid |
+| 11 | Data dir error | `$SCOUT_DATA_DIR` unset or not a directory |
+| 12 | Schema version mismatch | Data dir v1, engine expects v2 |
+| 20 | KB error | Entity not found, schema violation |
+| 21 | Action-item error | `no-match` / `ambiguous` substring lookup |
+| 30 | External process error | `git`, `claude`, `launchctl` failed |
+| 40 | Contract violation | Manifest missing required feature |
+
+### Swift side
+
+`EngineClientError` enum maps engine exit codes to specific cases. `EngineClient.markActionItemDone` throws `ActionItemError.noMatch(taskID)` — not a generic process failure.
+
+### User-visible error format
+
+Every failure a user sees has three parts:
+
+1. **What** — one sentence.
+2. **Why** — the cause.
+3. **Next step** — a specific command to try.
+
+Example:
+
+> Scout data directory is at schema v1 but engine expects v2.
+> Run: `scoutctl migrate data-dir --from 1 --to 2`
+
+### Observability
+
+- `scoutctl --log-level debug <cmd>` — structured JSON-line logs to stderr.
+- `scoutctl diagnose` — redacted dump of resolved paths, manifest, config (without `user.*` scalars or `.mcp.json` values), recent log tails, schema version.
+- App's Help → Copy Diagnostic invokes `scoutctl diagnose` and puts output on the clipboard.
+
+## 11. Personal-data scrub pass
+
+The audit surfaced ~56 findings across SKILL.md (1074 lines, 35 findings), DREAMING.md (549 lines, 14 findings), and RESEARCH.md (196 lines, 7 findings) including family names, phone numbers, home city, pet name, colleague names, internal project codes (Geneea, NAH, P3, E2B, KAI), Slack channels, emails, and specific dates.
+
+The design handles this via **split**, not **scrub-and-delete**:
+
+- **Scalars** (email, GitHub username, Slack ID, timezone, phone) → `~/Scout/.scout-config.yaml` under `user:`. Jinja-rendered into skill templates at session start.
+- **Relations** (people, projects, channels, companies) → `~/Scout/knowledge-base/` entries. Skills query via `scoutctl kb query --type person --name-match "${name}"` at runtime.
+
+### Ordered task list (Step 5 of Jordan's migration)
+
+**Phase A — Set up canonical user-context homes:**
+1. Define `user:` block schema in `engine/defaults/scout-config.yaml` with placeholder values.
+2. Write real `user:` values into `~/Scout/.scout-config.yaml`.
+3. Audit `~/Scout/knowledge-base/people/` — ensure entries exist for every colleague and family member named in SKILL/DREAMING/RESEARCH (audit cited specific names).
+4. Audit `~/Scout/knowledge-base/projects/` — ensure entries exist for every project code cited in audit.
+5. Create `~/Scout/knowledge-base/channels/` with entries for every Slack channel cited.
+
+**Phase B — Rewrite skills in ascending difficulty order (RESEARCH → DREAMING → SKILL):**
+6. RESEARCH.md (7 findings) — scalar substitutions only. Pattern reference.
+7. DREAMING.md (14 findings) — scalar substitutions; relational references rewritten as `scoutctl kb query` invocations.
+8. SKILL.md (35 findings) — same pattern, more instances. Family phone numbers deleted from skill entirely; move to KB person entries with `phone:` frontmatter if retention is desired.
+
+**Phase C — Verify:**
+9. Re-run the audit prompt against the scrubbed copies in `scout-plugin/skills/` → must return zero findings.
+10. Grep `scout-plugin/` for every specific name/email/phone the audit flagged → must be absent.
+11. Commit scout-plugin with tag `scrub-complete`.
+
+**Phase D — Wire runtime context injection:**
+
+12. Engine adds a template rendering step before session start: Jinja over the skill markdown with `{user: {...}, kb_summary: {...}}` context.
+
+    **`kb_summary` is pre-computed, not live-queried per session.** The session-start path must stay fast (< 200ms KB summary resolution). Approach:
+
+    - `scoutctl kb refresh-summary` builds a `kb_summary.json` in `$SCOUT_DATA_DIR/.scout-cache/kb-summary.json`. Contents: compact denormalized projection of people, projects, channels, and open-task counts — just the fields skills actually reference, not the full graph.
+    - Refresh triggers, any of:
+      - A new launchd job (`kb-summary-refresh.plist`) running every 15 minutes.
+      - The existing `kb-pre-filter` hook fires `refresh-summary` when it detects KB mutations since the last refresh.
+      - Manual via `scoutctl kb refresh-summary` from the TUI or app's Preferences.
+    - Session start reads the cached JSON. If the cache is missing or older than 1 hour, it triggers a synchronous refresh once and logs a slow-path warning (`scoutctl --log-level debug` visible).
+    - Cache validity is checksummed against KB directory mtimes; stale-but-fresh detection is O(number of KB files), not O(KB content size).
+
+13. Test with live data: run a session with the template-rendered skills; verify Claude's output quality is not degraded relative to pre-scrub inlined-context behavior. Degradation fix: enrich the `kb_summary` projection (more fields, more entities), not re-inline into skills.
+
+**Phase E — Delete originals:**
+14. `rm ~/Scout/SKILL.md ~/Scout/DREAMING.md ~/Scout/RESEARCH.md`.
+
+## 12. YAGNI list (explicit non-scope)
+
+Out of scope for this design:
+
+- Windows port.
+- TUI rewrite (moves as-is).
+- Plugin auto-update (git pull is fine).
+- Web UI.
+- Sparkle auto-updater in scout-app (future).
+- Migration tooling beyond schema-version scaffolding.
+- Touching `~/Scout/.obsidian/` or existing KB content beyond Phase A scrub gap-fill.
+- Signing `scoutctl` (Python; no binary).
+- Rewriting engine in Go/Rust/Swift.
+- Any engine capability not currently present in `~/Scout` (this spec is consolidation, not feature work).
+
+## 13. Open questions
+
+None blocking implementation. Possible followups after v0.4.0 ships:
+
+- Sparkle auto-updater for scout-app.
+- A `scoutctl plugin sync` command that wraps `git pull && uv pip install -e .[dev] --upgrade && scoutctl setup verify` into one colleague-friendly update step.
+- Auto-prompt in app when plugin has updates available (polls `git fetch` periodically).
+- Richer seed KB dataset (the v0.4 seed is minimal — just enough to verify the install).
+
+## 14. References
+
+- Existing cross-repo feature example: `docs/superpowers/specs/2026-04-22-usage-and-connector-health-design.md`.
+- scout-plugin repository: `github.com/jordanrburger/scout-plugin`.
+- scout-app repository: `github.com/jordanrburger/Scout`.
+- Audit of personal-info in SKILL.md, DREAMING.md, RESEARCH.md: performed 2026-04-24; ~56 findings across three files.


### PR DESCRIPTION
## Summary

Sibling docs to the Plan 1 merge (#4). Lands the spec, plan, and
consolidated followup catalog in this repo so the three artifacts
live next to the code they describe.

- `docs/specs/2026-04-24-scout-unification-design.md` — approved design
  spec covering the full three-repo unification (engine + app + data dir).
- `docs/plans/2026-04-24-plan-1-engine-scaffolding.md` — implementation
  plan for Plan 1 (what just shipped in #4). Plans 2–7 outlined at the bottom.
- `docs/FOLLOWUPS.md` — 20+ items surfaced during Plan 1 reviews
  (wheel-packaging, cli/manifest drift, circular-import risk, test
  coverage gaps, CI polish). Tagged important / minor. Items move
  to a `Resolved` section as PRs close them.
- `docs/README.md` — orientation for contributors.

The spec and plan also exist in the scout-app repo where they
originated; this copy is the canonical "living" version that tracks
progress. We can decide later whether to dedupe.

## Test plan

- [ ] Docs render cleanly on the GitHub PR view
- [ ] FOLLOWUPS.md items resolve existing review threads from #4
- [ ] Colleagues can discover `docs/README.md` as the entry point