### PR TITLE
v0.4.0 Plan 2: port action_items, kb, tui Python

### DIFF
--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -47,6 +47,9 @@ select = ["E", "F", "W", "I", "B", "UP"]
 [tool.ruff.lint.per-file-ignores]
 # render.py contains embedded CSS/HTML template strings with unavoidable long lines
 "scout/action_items/render.py" = ["E501"]
+# CLI files use typer.Argument/typer.Option in function defaults — standard Typer idiom, B008 is a false positive here
+"scout/action_items/cli.py" = ["B008"]
+"scout/cli.py" = ["B008"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -44,6 +44,10 @@ target-version = "py311"
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "B", "UP"]
 
+[tool.ruff.lint.per-file-ignores]
+# render.py contains embedded CSS/HTML template strings with unavoidable long lines
+"scout/action_items/render.py" = ["E501"]
+
 [tool.mypy]
 python_version = "3.11"
 strict = false

--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -56,6 +56,14 @@ python_version = "3.11"
 strict = false
 warn_unused_ignores = true
 
+# Textual is in the [full] extras, not [dev]. CI lint runs in a [dev]-only
+# environment to keep that job lean, so its mypy invocation cannot resolve
+# textual.* — silence those imports rather than installing the heavier
+# extra just for type-checking.
+[[tool.mypy.overrides]]
+module = ["textual", "textual.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/engine/scout/action_items/__init__.py
+++ b/engine/scout/action_items/__init__.py
@@ -1,0 +1,1 @@
+"""Action-items operations and shared markdown parser/writer."""

--- a/engine/scout/action_items/add_comment.py
+++ b/engine/scout/action_items/add_comment.py
@@ -1,0 +1,202 @@
+"""Insert a comment under a matched task in daily action-items markdown.
+
+Comments are written as indented blockquote lines directly under the matched
+task bullet:
+
+    - [ ] Task subject — body
+      > jordan (2026-04-18 10:20 AM ET): text here
+      > scout  (2026-04-18 11:00 AM ET): reply
+
+This mirrors the schema parsed by the action-items parser.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import re
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from scout import paths
+from scout.action_items.writer import atomic_write_lines
+from scout.errors import ActionItemError
+
+EASTERN = ZoneInfo("America/New_York")
+TASK_RE = re.compile(r"^(?P<indent>\s*)- \[(?P<mark>[ xX])\]\s+(?P<rest>.+?)\s*$")
+
+
+def _timestamp() -> str:
+    """Return current timestamp in Eastern time (YYYY-MM-DD HH:MM AM/PM ET format)."""
+    return dt.datetime.now(EASTERN).strftime("%Y-%m-%d %-I:%M %p ET")
+
+
+def _strip_markdown_tokens(text: str) -> str:
+    """Collapse a task subject to plain text for matching."""
+    text = re.sub(r"~~(.+?)~~", r"\1", text)
+    text = re.sub(r"\*\*(.+?)\*\*", r"\1", text)
+    text = re.sub(r"`([^`]+)`", r"\1", text)
+    text = re.sub(r"\[\[([^\]|]+?)(?:\|[^\]]+)?\]\]", r"\1", text)
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    return text
+
+
+def _first_separator_outside_tokens(text: str, separators: tuple[str, ...]) -> int:
+    """Return the earliest offset where any of ``separators`` starts outside
+    markdown tokens (bold, strike, code, wiki links, links). -1 if none found.
+    """
+    in_bold = in_strike = in_code = False
+    bracket_depth = 0
+    i = 0
+    n = len(text)
+    while i < n:
+        two = text[i : i + 2]
+        ch = text[i]
+        if ch == "`" and not in_bold and not in_strike:
+            in_code = not in_code
+            i += 1
+            continue
+        if in_code:
+            i += 1
+            continue
+        if two == "**":
+            in_bold = not in_bold
+            i += 2
+            continue
+        if two == "~~":
+            in_strike = not in_strike
+            i += 2
+            continue
+        if two == "[[":
+            bracket_depth += 1
+            i += 2
+            continue
+        if two == "]]" and bracket_depth > 0:
+            bracket_depth -= 1
+            i += 2
+            continue
+        if ch == "[" and bracket_depth == 0:
+            bracket_depth = 1
+            i += 1
+            continue
+        if ch == "]" and bracket_depth > 0 and two != "]]":
+            bracket_depth = 0
+            i += 1
+            continue
+        if not in_bold and not in_strike and bracket_depth == 0:
+            for sep in separators:
+                if text[i : i + len(sep)] == sep:
+                    return i
+        i += 1
+    return -1
+
+
+def _task_subject(rest: str) -> str:
+    """Extract the subject (title) part of a task line."""
+    idx = _first_separator_outside_tokens(rest, (" — ", " – ", " - "))
+    if idx != -1:
+        return rest[:idx]
+    idx = _first_separator_outside_tokens(rest, (": ",))
+    if idx != -1:
+        return rest[:idx]
+    return rest
+
+
+def _matching_lines(lines: list[str], subject: str) -> list[tuple[int, str]]:
+    """Find all task lines whose subject contains the substring (case-insensitive).
+
+    Returns list of (1-indexed line number, line text) tuples.
+    """
+    needle = subject.casefold()
+    out: list[tuple[int, str]] = []
+    for i, line in enumerate(lines, start=1):
+        m = TASK_RE.match(line)
+        if not m:
+            continue
+        subject_plain = _strip_markdown_tokens(_task_subject(m.group("rest"))).lower()
+        if needle in subject_plain:
+            out.append((i, line))
+    return out
+
+
+def _insert_comment_line(
+    lines: list[str],
+    task_idx: int,
+    author: str,
+    text: str,
+    timestamp: str,
+) -> list[str]:
+    """Insert a comment line after the task and its existing comment block.
+
+    Args:
+        lines: List of markdown lines.
+        task_idx: 0-indexed line number of the task.
+        author: Author name for the comment.
+        text: Comment body.
+        timestamp: Timestamp string.
+
+    Returns: modified lines list.
+    """
+    task_indent = TASK_RE.match(lines[task_idx]).group("indent")  # type: ignore[union-attr]
+    comment_indent = task_indent + "  "
+    insert_at = task_idx + 1
+
+    # Skip continuation lines that belong to this task: comment lines
+    # (blockquotes starting with >) or indented non-bullet prose.
+    # Stop at blank line, new bullet at same/shallower indent, or header.
+    while insert_at < len(lines):
+        cur = lines[insert_at]
+        if not cur.strip():
+            break
+        if cur.lstrip().startswith("#"):
+            break
+        m = TASK_RE.match(cur)
+        if m and len(m.group("indent")) <= len(task_indent):
+            break
+        if re.match(r"^\s*-\s+", cur) and len(cur) - len(cur.lstrip()) <= len(task_indent):
+            break
+        insert_at += 1
+
+    new_line = f"{comment_indent}> {author} ({timestamp}): {text}"
+    return lines[:insert_at] + [new_line] + lines[insert_at:]
+
+
+def add_comment(
+    path: Path | None,
+    *,
+    subject: str,
+    text: str,
+    author: str = "jordan",
+    timestamp: bool = True,
+) -> Path:
+    """Insert a comment beneath the unique matching task.
+
+    Args:
+        path: Daily markdown file. None resolves to today's file in SCOUT_DATA_DIR.
+        subject: Case-insensitive substring of the task title.
+        text: Comment body.
+        author: Author name for the comment (default: "jordan").
+        timestamp: If True, prepend a timestamp decoration (default: True).
+
+    Returns: the file modified.
+
+    Raises ActionItemError on no-match or ambiguous match.
+    """
+    target = path or paths.action_items_daily_path()
+    if not target.exists():
+        raise ActionItemError(f"add_comment: no daily file at {target}")
+
+    lines = target.read_text(encoding="utf-8").splitlines()
+    matches = _matching_lines(lines, subject)
+
+    if not matches:
+        raise ActionItemError(f"add_comment: no match for subject '{subject}' in {target.name}")
+    if len(matches) > 1:
+        listing = "\n".join(f"  {ln}: {ln_text}" for ln, ln_text in matches)
+        raise ActionItemError(f"add_comment: ambiguous match for '{subject}' ({len(matches)} candidates):\n{listing}")
+
+    line_number, _ = matches[0]
+    task_idx = line_number - 1
+    ts = _timestamp() if timestamp else ""
+    new_lines = _insert_comment_line(lines, task_idx, author, text, ts)
+    atomic_write_lines(target, new_lines)
+    return target

--- a/engine/scout/action_items/add_comment.py
+++ b/engine/scout/action_items/add_comment.py
@@ -4,8 +4,8 @@ Comments are written as indented blockquote lines directly under the matched
 task bullet:
 
     - [ ] Task subject — body
-      > jordan (2026-04-18 10:20 AM ET): text here
-      > scout  (2026-04-18 11:00 AM ET): reply
+      > scout (2026-04-18 10:20 AM ET): text here
+      > scout (2026-04-18 11:00 AM ET): reply
 
 This mirrors the schema parsed by the action-items parser.
 """
@@ -165,7 +165,7 @@ def add_comment(
     *,
     subject: str,
     text: str,
-    author: str = "jordan",
+    author: str = "scout",
     timestamp: bool = True,
 ) -> Path:
     """Insert a comment beneath the unique matching task.
@@ -174,7 +174,10 @@ def add_comment(
         path: Daily markdown file. None resolves to today's file in SCOUT_DATA_DIR.
         subject: Case-insensitive substring of the task title.
         text: Comment body.
-        author: Author name for the comment (default: "jordan").
+        author: Author name for the comment (default: "scout"). The CLI
+            wrapper or caller should pass the resolved user display name
+            from `.scout-config.yaml` (`user.display_name`); the generic
+            default here keeps the engine free of personal identity.
         timestamp: If True, prepend a timestamp decoration (default: True).
 
     Returns: the file modified.

--- a/engine/scout/action_items/cli.py
+++ b/engine/scout/action_items/cli.py
@@ -1,0 +1,102 @@
+"""scoutctl action-items sub-app.
+
+Top-level imports are intentionally minimal — Typer + stdlib + scout.errors.
+Each subcommand imports its scout.action_items.* module inside the function
+body so scoutctl startup latency is unaffected (Plan 1 perf rule, enforced
+by tests/perf/test_no_heavy_imports.py).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json as _json
+import sys
+from pathlib import Path
+
+import typer
+
+from scout.errors import ActionItemError, ScoutError
+
+app = typer.Typer(help="Action-items operations.", no_args_is_help=True)
+
+
+@app.command("mark-done")
+def cli_mark_done(
+    subject: str = typer.Option(..., "--subject", help="Substring of task title."),
+    path: Path | None = typer.Argument(None, help="Daily markdown file (default: today)."),
+    undo: bool = typer.Option(False, "--undo", help="Flip [x] back to [ ]."),
+) -> None:
+    from scout.action_items.mark_done import mark_done
+
+    mark_done(path, subject=subject, undo=undo)
+
+
+@app.command("snooze")
+def cli_snooze(
+    subject: str = typer.Option(..., "--subject"),
+    until: str = typer.Option(..., "--until", help="YYYY-MM-DD"),
+    path: Path | None = typer.Argument(None),
+) -> None:
+    from scout.action_items.snooze import snooze
+
+    try:
+        target_date = _dt.date.fromisoformat(until)
+    except ValueError as e:
+        raise ActionItemError(f"--until: invalid date {until!r}") from e
+    snooze(path, subject=subject, until=target_date)
+
+
+@app.command("add-comment")
+def cli_add_comment(
+    subject: str = typer.Option(..., "--subject"),
+    text: str = typer.Option(..., "--text"),
+    path: Path | None = typer.Argument(None),
+) -> None:
+    from scout.action_items.add_comment import add_comment
+
+    add_comment(path, subject=subject, text=text)
+
+
+@app.command("render")
+def cli_render(
+    path: Path | None = typer.Argument(None),
+) -> None:
+    from scout import paths
+    from scout.action_items.render import render
+
+    target = path or paths.action_items_daily_path()
+    sys.stdout.write(render(target))
+
+
+@app.command("list")
+def cli_list(
+    path: Path | None = typer.Argument(None),
+    include_done: bool = typer.Option(False, "--include-done"),
+    priority: str | None = typer.Option(None, "--priority"),
+    section: str | None = typer.Option(None, "--section"),
+    json_out: bool = typer.Option(False, "--json"),
+) -> None:
+    from scout import paths
+    from scout.action_items.list import list_items
+
+    target = path or paths.action_items_daily_path()
+    items = list_items(target, include_done=include_done, priority=priority, section=section)
+    if json_out:
+        payload = [
+            {
+                "title": i.title,
+                "priority": i.priority,
+                "status": i.status,
+                "section": i.section,
+            }
+            for i in items
+        ]
+        sys.stdout.write(_json.dumps(payload) + "\n")
+    else:
+        for i in items:
+            sys.stdout.write(f"{i.priority} [{i.status}] {i.title}\n")
+
+
+@app.command("watch")
+def cli_watch() -> None:
+    raise ScoutError("scoutctl action-items watch is implemented in Plan 3")

--- a/engine/scout/action_items/list.py
+++ b/engine/scout/action_items/list.py
@@ -1,0 +1,40 @@
+"""Enumerate action items from a daily markdown file with filters."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scout.action_items.parser import ActionItem, parse_file
+
+PRIORITY_ALIASES = {
+    "high": "🔴",
+    "medium": "🟡",
+    "low": "🟢",
+    "🔴": "🔴",
+    "🟡": "🟡",
+    "🟢": "🟢",
+}
+
+
+def list_items(
+    path: Path,
+    *,
+    include_done: bool = False,
+    priority: str | None = None,
+    section: str | None = None,
+) -> list[ActionItem]:
+    """Return ActionItems matching the given filters.
+
+    By default returns only open items (status == 'open').
+    """
+    items = parse_file(path)
+    if not include_done:
+        items = [i for i in items if i.status == "open"]
+    if priority is not None:
+        glyph = PRIORITY_ALIASES.get(priority)
+        if glyph is None:
+            raise ValueError(f"unknown priority {priority!r}; expected one of {sorted(PRIORITY_ALIASES)}")
+        items = [i for i in items if i.priority == glyph]
+    if section is not None:
+        items = [i for i in items if i.section == section]
+    return items

--- a/engine/scout/action_items/mark_done.py
+++ b/engine/scout/action_items/mark_done.py
@@ -1,0 +1,61 @@
+"""Toggle a task's checkbox to done in a daily action-items markdown.
+
+Match is case-insensitive substring on the task title; must be unambiguous.
+Undo flips `[x]` back to `[ ]`. Atomic rewrite via scout.action_items.writer.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from scout import paths
+from scout.action_items.writer import flip_checkbox
+from scout.errors import ActionItemError
+
+TASK_RE = re.compile(r"^(?P<indent>\s*)- \[(?P<mark>[ xX])\] (?P<rest>.+?)\s*$")
+
+
+def _matching_lines(lines: list[str], subject: str, *, want_mark: str) -> list[tuple[int, str]]:
+    needle = subject.casefold()
+    out: list[tuple[int, str]] = []
+    for i, line in enumerate(lines, start=1):
+        m = TASK_RE.match(line)
+        if not m:
+            continue
+        if m.group("mark") not in want_mark:
+            continue
+        if needle in m.group("rest").casefold():
+            out.append((i, line))
+    return out
+
+
+def mark_done(path: Path | None, *, subject: str, undo: bool = False) -> Path:
+    """Mark the unique matching task done (or open if undo=True).
+
+    Args:
+        path: Daily markdown file. None resolves to today's file in SCOUT_DATA_DIR.
+        subject: Case-insensitive substring of the task title.
+        undo: If True, flip `[x]` back to `[ ]`.
+
+    Returns: the file actually modified (useful when `path is None`).
+
+    Raises ActionItemError on no-match or ambiguous match.
+    """
+    target = path or paths.action_items_daily_path()
+    if not target.exists():
+        raise ActionItemError(f"no daily file at {target}")
+
+    lines = target.read_text(encoding="utf-8").splitlines()
+    want_mark = "x X" if undo else " "
+    matches = _matching_lines(lines, subject, want_mark=want_mark)
+
+    if not matches:
+        raise ActionItemError(f"mark_done: no match for subject '{subject}' in {target.name}")
+    if len(matches) > 1:
+        listing = "\n".join(f"  {ln}: {ln_text}" for ln, ln_text in matches)
+        raise ActionItemError(f"mark_done: ambiguous match for '{subject}' ({len(matches)} candidates):\n{listing}")
+
+    line_number, _ = matches[0]
+    flip_checkbox(target, line_number=line_number, to_done=not undo)
+    return target

--- a/engine/scout/action_items/parser.py
+++ b/engine/scout/action_items/parser.py
@@ -1,0 +1,276 @@
+"""Parse Scout action items markdown files into structured data.
+
+Handles the actual action items format:
+- Section headers (## Completed Today, ## In Progress, ## To Do, ## Watching)
+- Checkbox items: [x] done, [ ] open
+- Priority emojis: 🔴 urgent, 🟡 medium, 🟢 low
+- Strikethrough ~~text~~ as done
+- Sub-bullets with context links and details
+- Section-prefixed items (### 🔴 URGENT: ..., ### ✅ ... — Done)
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class ActionItem:
+    """A single action item parsed from the markdown file."""
+
+    priority: str  # "🔴", "🟡", "🟢", or ""
+    title: str
+    status: str  # "open", "done", "in_progress", "watching"
+    section: str  # which markdown section this came from
+    context_links: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    details: list[str] = field(default_factory=list)
+    raw_line: str = ""
+    line_number: int = 0
+
+
+PRIORITY_MAP = {
+    "🔴": "urgent",
+    "🟡": "medium",
+    "🟢": "low",
+}
+
+# Patterns
+CHECKBOX_DONE = re.compile(r"^\s*-\s*\[x\]\s*", re.IGNORECASE)
+CHECKBOX_OPEN = re.compile(r"^\s*-\s*\[\s*\]\s*")
+PRIORITY_EMOJI = re.compile(r"(🔴|🟡|🟢)")
+URL_PATTERN = re.compile(r"https?://[^\s\)>]+")
+WIKILINK_PATTERN = re.compile(r"\[\[([^\]]+)\]\]")
+STRIKETHROUGH = re.compile(r"~~(.+?)~~")
+NOTE_PATTERN = re.compile(r"^\s*-\s*\*\*\[TUI note")
+SECTION_H2 = re.compile(r"^##\s+(.+)")
+SECTION_H3 = re.compile(r"^###\s+(.+)")
+STATUS_EMOJI = re.compile(r"^(✅|🔄|❓|⬜)")
+BULLET_LINE = re.compile(r"^(\s*)-\s+(.+)")
+
+# Section name → default status mapping
+SECTION_STATUS_MAP = {
+    "completed today": "done",
+    "completed": "done",
+    "done": "done",
+    "in progress": "in_progress",
+    "to do": "open",
+    "todo": "open",
+    "watching": "watching",
+    "upcoming": "open",
+}
+
+
+def parse_file(path: Path) -> list[ActionItem]:
+    """Parse `path` into a list of ActionItem records.
+
+    Entry point for parsing action items markdown files.
+    """
+    return parse_action_items(path)
+
+
+def parse_action_items(filepath: Path) -> list[ActionItem]:
+    """Parse an action items markdown file into a list of ActionItem objects.
+
+    Returns items sorted by: in_progress first, then open, then watching, then done.
+    Within each status group, sorted by priority (🔴 > 🟡 > 🟢 > none).
+    """
+    if not filepath.exists():
+        return []
+
+    items: list[ActionItem] = []
+    lines = filepath.read_text().splitlines()
+
+    current_section = ""
+    current_subsection = ""
+    current_item: ActionItem | None = None
+
+    for i, line in enumerate(lines, start=1):
+        # Track section headers
+        h2_match = SECTION_H2.match(line)
+        if h2_match:
+            current_section = h2_match.group(1).strip()
+            current_subsection = ""
+            current_item = None
+            continue
+
+        h3_match = SECTION_H3.match(line)
+        if h3_match:
+            current_subsection = h3_match.group(1).strip()
+            # H3 sections like "### ✅ Security Plugin — Done" are status markers
+            if "✅" in current_subsection or "done" in current_subsection.lower():
+                # Items under this are done
+                pass
+            current_item = None
+            continue
+
+        # Skip non-content lines
+        stripped = line.strip()
+        if not stripped or stripped.startswith("|") or stripped.startswith(">"):
+            continue
+
+        # Check for TUI note (belongs to current item)
+        if current_item and NOTE_PATTERN.match(line):
+            current_item.notes.append(stripped)
+            continue
+
+        # Parse bullet items
+        bullet_match = BULLET_LINE.match(line)
+        if not bullet_match:
+            continue
+
+        indent = len(bullet_match.group(1))
+        content = bullet_match.group(2)
+
+        # Sub-bullets (indented) belong to current item
+        if indent >= 2 and current_item:
+            # Extract links from sub-bullets
+            urls = URL_PATTERN.findall(content)
+            current_item.context_links.extend(urls)
+            wikilinks = WIKILINK_PATTERN.findall(content)
+            current_item.context_links.extend([f"kb://{wl}" for wl in wikilinks])
+            current_item.details.append(stripped)
+            continue
+
+        # Top-level bullet — this is an action item
+        item = _parse_item_line(line, i, current_section, current_subsection)
+        items.append(item)
+        current_item = item
+
+    return _sort_items(items)
+
+
+def _parse_item_line(
+    line: str,
+    line_number: int,
+    section: str,
+    subsection: str,
+) -> ActionItem:
+    """Parse a single action item line."""
+    stripped = line.strip()
+
+    # Determine status
+    status = _infer_status(stripped, section, subsection)
+
+    # Extract priority emoji
+    priority_match = PRIORITY_EMOJI.search(stripped)
+    priority = priority_match.group(1) if priority_match else ""
+
+    # Infer priority from subsection or section header if not in the line itself
+    if not priority and subsection:
+        sub_priority = PRIORITY_EMOJI.search(subsection)
+        if sub_priority:
+            priority = sub_priority.group(1)
+    if not priority and section:
+        sec_priority = PRIORITY_EMOJI.search(section)
+        if sec_priority:
+            priority = sec_priority.group(1)
+
+    # Clean up title
+    title = stripped
+    # Remove checkbox markers (must come before lstrip to match regex properly)
+    title = CHECKBOX_DONE.sub("", title)
+    title = CHECKBOX_OPEN.sub("", title)
+    # Remove leading dash
+    title = title.lstrip("- ")
+    # Remove status emojis at start
+    title = STATUS_EMOJI.sub("", title).strip()
+    # Remove strikethrough markers but keep text for context
+    title = STRIKETHROUGH.sub(r"\1", title)
+    # Remove bold markers
+    title = title.replace("**", "")
+    # Remove priority emojis
+    title = PRIORITY_EMOJI.sub("", title).strip()
+    # Trim leading/trailing dashes and whitespace
+    title = title.strip("- ").strip()
+
+    # Extract URLs
+    context_links = URL_PATTERN.findall(line)
+    wikilinks = WIKILINK_PATTERN.findall(line)
+    context_links.extend([f"kb://{wl}" for wl in wikilinks])
+
+    section_label = subsection if subsection else section
+
+    return ActionItem(
+        priority=priority,
+        title=title,
+        status=status,
+        section=section_label,
+        context_links=context_links,
+        raw_line=line,
+        line_number=line_number,
+    )
+
+
+def _infer_status(line: str, section: str, subsection: str) -> str:
+    """Infer item status from line content, section, and subsection."""
+    # Explicit checkbox
+    if CHECKBOX_DONE.match(line):
+        return "done"
+    if CHECKBOX_OPEN.match(line):
+        return "open"
+
+    # Status emoji prefix
+    if line.lstrip("- ").startswith("✅"):
+        return "done"
+    if line.lstrip("- ").startswith("🔄"):
+        return "in_progress"
+
+    # Strikethrough = done
+    if "~~" in line:
+        return "done"
+
+    # Check for "Done" or "Completed" in the line
+    lower = line.lower()
+    if "— done" in lower or "— completed" in lower or "✅ done" in lower:
+        return "done"
+
+    # Infer from subsection
+    if subsection:
+        sub_lower = subsection.lower()
+        if "✅" in subsection or "done" in sub_lower:
+            return "done"
+
+    # Infer from parent section
+    section_lower = section.lower()
+    for key, default_status in SECTION_STATUS_MAP.items():
+        if key in section_lower:
+            return default_status
+
+    return "open"
+
+
+def _sort_items(items: list[ActionItem]) -> list[ActionItem]:
+    """Sort items: in_progress > open > watching > done, then by priority."""
+    status_order = {"in_progress": 0, "open": 1, "watching": 2, "done": 3}
+    priority_order = {"🔴": 0, "🟡": 1, "🟢": 2, "": 3}
+
+    return sorted(
+        items,
+        key=lambda item: (
+            status_order.get(item.status, 9),
+            priority_order.get(item.priority, 9),
+        ),
+    )
+
+
+def filter_actionable(items: list[ActionItem]) -> list[ActionItem]:
+    """Return only actionable items (not done, not calendar entries)."""
+    return [item for item in items if item.status != "done" and "calendar" not in item.section.lower()]
+
+
+def items_by_priority(
+    items: list[ActionItem],
+) -> dict[str, list[ActionItem]]:
+    """Group items by priority level."""
+    groups: dict[str, list[ActionItem]] = {
+        "🔴": [],
+        "🟡": [],
+        "🟢": [],
+        "": [],
+    }
+    for item in items:
+        groups.setdefault(item.priority, []).append(item)
+    return groups

--- a/engine/scout/action_items/render.py
+++ b/engine/scout/action_items/render.py
@@ -8,6 +8,13 @@ Public API
 render(path: Path) -> str
     Parse *path* and return a complete HTML string.  Raises
     ``scout.errors.ActionItemError`` if the file is not found.
+
+parse(md_path: Path) -> tuple[str, list[str], list[Section]]
+    Lower-level entry point: returns (title, preamble paragraphs,
+    sections) for callers that want the structured form (e.g., a TUI
+    dashboard or the Plan 6 EngineClient). The dataclasses
+    ``Comment``, ``Task``, ``BulletLine``, ``Table``, ``Section``
+    describe the parsed shape.
 """
 
 from __future__ import annotations
@@ -330,7 +337,7 @@ ITALIC_RE = re.compile(r"(?<![\*_])\*(?!\*)([^*]+?)\*(?!\*)")
 CODE_RE = re.compile(r"`([^`]+)`")
 
 
-def inline(text: str) -> str:
+def _inline(text: str) -> str:
     """Render inline markdown to HTML."""
     # Escape first, then re-substitute for markdown tokens. Tokens are chosen
     # so we can safely find them after escaping.
@@ -370,7 +377,7 @@ SECTION_STYLES = {
 }
 
 
-def section_kind(section: Section) -> str:
+def _section_kind(section: Section) -> str:
     if section.emoji in SECTION_STYLES:
         return SECTION_STYLES[section.emoji][0]
     t = section.title.lower()
@@ -382,13 +389,13 @@ def section_kind(section: Section) -> str:
 def _render_html(title: str, preamble: list[str], sections: list[Section], source_stem: str = "") -> str:
     # Compute summary stats from task counts
     def count(kind: str) -> int:
-        return sum(sum(1 for t in s.tasks if not t.done) for s in sections if section_kind(s) == kind)
+        return sum(sum(1 for t in s.tasks if not t.done) for s in sections if _section_kind(s) == kind)
 
     n_urgent = count("urgent")
     n_todo = count("todo")
     n_watching = count("watching")
     n_personal = count("personal")
-    n_done = sum(sum(1 for t in s.tasks if t.done) for s in sections if section_kind(s) == "done")
+    n_done = sum(sum(1 for t in s.tasks if t.done) for s in sections if _section_kind(s) == "done")
 
     stats = [
         ("urgent", n_urgent, "🔥 Urgent"),
@@ -401,7 +408,7 @@ def _render_html(title: str, preamble: list[str], sections: list[Section], sourc
     body_sections: list[str] = []
 
     for s in sections:
-        kind = section_kind(s)
+        kind = _section_kind(s)
         if kind == "focus":
             body_sections.append(_render_focus(s))
         elif kind in ("urgent", "todo", "watching", "personal"):
@@ -415,7 +422,7 @@ def _render_html(title: str, preamble: list[str], sections: list[Section], sourc
         else:
             body_sections.append(_render_cards(s, "neutral", source_stem))
 
-    preamble_html = "".join(f"<p>{inline(p)}</p>" for p in preamble)
+    preamble_html = "".join(f"<p>{_inline(p)}</p>" for p in preamble)
 
     stat_cards = "".join(
         f'<div class="stat {cls}"><div class="num">{n}</div><div class="label">{label}</div></div>'
@@ -466,7 +473,7 @@ def render(path: Path) -> str:
 
 
 def _render_focus(s: Section) -> str:
-    items = "".join(f"<li>{inline(b.text)}</li>" for b in s.bullets)
+    items = "".join(f"<li>{_inline(b.text)}</li>" for b in s.bullets)
     return f"""
 <section class="focus-box">
   <h2>{html.escape(s.emoji)} {html.escape(s.title)}</h2>
@@ -479,8 +486,8 @@ def _render_cards(s: Section, kind: str, source_stem: str = "") -> str:
     date_slug = source_stem.replace("action-items-", "") if source_stem else ""
     cards: list[str] = []
     for t in s.tasks:
-        subj = inline(t.subject)
-        body = inline(t.body) if t.body else ""
+        subj = _inline(t.subject)
+        body = _inline(t.body) if t.body else ""
         done_cls = " done" if t.done else ""
         stamp = '<span class="stamp">✅ Done</span>' if t.done else ""
         comments_html = _render_comments(t)
@@ -511,7 +518,7 @@ def _render_cards(s: Section, kind: str, source_stem: str = "") -> str:
         )
     # Also render non-task bullets if any
     if s.bullets:
-        bullets_html = "".join(f"<li>{inline(b.text)}</li>" for b in s.bullets)
+        bullets_html = "".join(f"<li>{_inline(b.text)}</li>" for b in s.bullets)
         cards.append(f'<div class="extra-notes"><ul>{bullets_html}</ul></div>')
     grid = "".join(cards) if cards else '<p class="muted">Nothing here.</p>'
     return f"""
@@ -532,7 +539,7 @@ def _render_comments(t: Task) -> str:
         items.append(
             f'<li class="comment comment-{author_cls}">'
             f'<span class="author">{html.escape(c.author)}</span>{ts}'
-            f'<div class="text">{inline(c.text)}</div>'
+            f'<div class="text">{_inline(c.text)}</div>'
             f"</li>"
         )
     return f'<ul class="comments">{"".join(items)}</ul>'
@@ -644,10 +651,10 @@ def _render_meetings(s: Section) -> str:
         subhead = s.subheads[idx - 1] if idx > 0 and idx - 1 < len(s.subheads) else ""
         if subhead:
             parts.append(f"<h3>{html.escape(subhead)}</h3>")
-        head = "".join(f"<th>{inline(h)}</th>" for h in table.headers)
+        head = "".join(f"<th>{_inline(h)}</th>" for h in table.headers)
         rows_html = []
         for row in table.rows:
-            cells = "".join(f"<td>{inline(c)}</td>" for c in row)
+            cells = "".join(f"<td>{_inline(c)}</td>" for c in row)
             rows_html.append(f"<tr>{cells}</tr>")
         parts.append(f'<table class="mtg"><thead><tr>{head}</tr></thead><tbody>{"".join(rows_html)}</tbody></table>')
     return f'<section class="section section-meetings">{"".join(parts)}</section>'
@@ -658,7 +665,7 @@ def _render_completed(s: Section) -> str:
     for t in s.tasks:
         if not t.done:
             continue
-        items.append(f"<li><strong>{inline(t.subject)}</strong>{' — ' + inline(t.body) if t.body else ''}</li>")
+        items.append(f"<li><strong>{_inline(t.subject)}</strong>{' — ' + _inline(t.body) if t.body else ''}</li>")
     return f"""
 <details class="completed" open>
   <summary><h2>{html.escape(s.emoji)} {html.escape(s.title)} <span class="count">({len(items)})</span></h2></summary>
@@ -681,9 +688,9 @@ def _render_digest(s: Section) -> str:
         # Bold-only lines act as subheads within the digest
         if re.match(r"^\*\*[^*]+\*\*:?\s*$", t):
             flush()
-            blocks.append(f"<h3>{inline(t)}</h3>")
+            blocks.append(f"<h3>{_inline(t)}</h3>")
         else:
-            buffer.append(f"<p>{inline(t)}</p>")
+            buffer.append(f"<p>{_inline(t)}</p>")
     flush()
     return f"""
 <details class="digest">

--- a/engine/scout/action_items/render.py
+++ b/engine/scout/action_items/render.py
@@ -1,0 +1,1087 @@
+"""Render a Scout action-items markdown file into the HTML dashboard.
+
+Port of ~/Scout/action-items/render.py into the scout-plugin engine.
+Pure stdlib — no heavy imports (no rich, jinja2, or watchdog).
+
+Public API
+----------
+render(path: Path) -> str
+    Parse *path* and return a complete HTML string.  Raises
+    ``scout.errors.ActionItemError`` if the file is not found.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from scout.errors import ActionItemError
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Comment:
+    """A conversation turn attached to a task.
+
+    Serialized in the markdown as an indented quote line:
+        - [ ] Task — body
+          > jordan (2026-04-18 10:20 AM ET): text here
+          > scout (2026-04-18 11:00 AM ET): reply here
+
+    The indentation under the task bullet is what binds the comment to that task.
+    See ``action-items/README.md`` for the full schema.
+    """
+
+    author: str
+    timestamp: str
+    text: str
+
+
+@dataclass
+class Task:
+    done: bool
+    subject: str
+    body: str
+    raw: str
+    comments: list[Comment] = field(default_factory=list)
+
+
+@dataclass
+class BulletLine:
+    """A non-task bullet (used in Today's Focus, Scout Digest, etc.)."""
+
+    text: str
+
+
+@dataclass
+class Table:
+    headers: list[str]
+    rows: list[list[str]]
+
+
+@dataclass
+class Section:
+    emoji: str
+    title: str
+    subtitle: str | None = None
+    tasks: list[Task] = field(default_factory=list)
+    bullets: list[BulletLine] = field(default_factory=list)
+    tables: list[Table] = field(default_factory=list)
+    subheads: list[str] = field(default_factory=list)  # ### subheads
+
+
+SECTION_RE = re.compile(r"^## (?P<emoji>\S+?)\s+(?P<title>.+?)(?:\s*\(.*?\))?\s*$")
+SIMPLE_SECTION_RE = re.compile(r"^## (?P<title>.+?)\s*$")
+TASK_RE = re.compile(r"^\s*- \[(?P<mark>[ xX])\]\s+(?P<rest>.+?)\s*$")
+BULLET_RE = re.compile(r"^\s*-\s+(?P<rest>.+?)\s*$")
+TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
+# Indented quote-line comment bound to the preceding task:
+#   "  > jordan (2026-04-18 10:20 AM ET): text"
+# Author/timestamp are captured; loose format tolerated (timestamp optional).
+COMMENT_RE = re.compile(
+    r"^(?P<indent>\s+)>\s+(?P<author>[A-Za-z][A-Za-z0-9._-]*)"
+    r"(?:\s+\((?P<timestamp>[^)]+)\))?\s*:\s*(?P<text>.+?)\s*$"
+)
+
+
+def parse(md_path: Path) -> tuple[str, list[str], list[Section]]:
+    """Return (title, preamble_paragraphs, sections)."""
+
+    text = md_path.read_text()
+    lines = text.splitlines()
+
+    title = ""
+    preamble: list[str] = []
+    sections: list[Section] = []
+    current: Section | None = None
+    in_table = False
+    table: Table | None = None
+
+    # Find title
+    for i, line in enumerate(lines):
+        if line.startswith("# ") and not title:
+            title = line[2:].strip()
+            start = i + 1
+            break
+    else:
+        start = 0
+
+    i = start
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        # Horizontal rules are separators
+        if stripped in ("---", "***"):
+            in_table = False
+            table = None
+            i += 1
+            continue
+
+        # Section header. Try "## <emoji> <title>" first; fall back to plain "## <title>".
+        if line.startswith("## "):
+            m = SECTION_RE.match(line)
+            if m:
+                emoji = m.group("emoji")
+                rest = m.group("title")
+                if not re.match(r"^[\u2600-\u27BF\U0001F300-\U0001FAFF✅🔴🟡🟢💡📋📅]", emoji):
+                    # First token wasn't an emoji — treat whole thing as plain title.
+                    emoji = ""
+                    rest = line[3:].strip()
+            else:
+                emoji = ""
+                rest = line[3:].strip()
+            current = Section(emoji=emoji, title=rest)
+            sections.append(current)
+            in_table = False
+            i += 1
+            continue
+
+        # Sub-heading
+        if line.startswith("### ") and current is not None:
+            current.subheads.append(line[4:].strip())
+            in_table = False
+            i += 1
+            continue
+
+        # Preamble (before first section)
+        if current is None:
+            if stripped:
+                preamble.append(stripped)
+            i += 1
+            continue
+
+        # Table detection
+        if TABLE_ROW_RE.match(line):
+            cells = [c.strip() for c in line.strip().strip("|").split("|")]
+            # Separator row: ignore
+            if all(re.match(r"^:?-+:?$", c) for c in cells):
+                i += 1
+                continue
+            if not in_table:
+                in_table = True
+                table = Table(headers=cells, rows=[])
+                current.tables.append(table)
+            else:
+                assert table is not None
+                table.rows.append(cells)
+            i += 1
+            continue
+        else:
+            in_table = False
+            table = None
+
+        # Task line
+        t = TASK_RE.match(line)
+        if t and current is not None:
+            done = t.group("mark").lower() == "x"
+            rest = t.group("rest")
+            # Split subject/body: first " — " or " – " after optional bold/strike
+            subject, body = _split_subject(rest)
+            current.tasks.append(Task(done=done, subject=subject, body=body, raw=rest))
+            i += 1
+            continue
+
+        # Comment line bound to the preceding task (indented quote).
+        c = COMMENT_RE.match(line)
+        if c and current is not None and current.tasks:
+            current.tasks[-1].comments.append(
+                Comment(
+                    author=c.group("author"),
+                    timestamp=(c.group("timestamp") or "").strip(),
+                    text=c.group("text"),
+                )
+            )
+            i += 1
+            continue
+
+        # Regular bullet line (section-level)
+        b = BULLET_RE.match(line)
+        if b and current is not None:
+            current.bullets.append(BulletLine(text=b.group("rest")))
+            i += 1
+            continue
+
+        # Paragraph line inside a section
+        if stripped and current is not None:
+            current.bullets.append(BulletLine(text=stripped))
+
+        i += 1
+
+    return title, preamble, sections
+
+
+def _split_subject(rest: str) -> tuple[str, str]:
+    """Split a task line into (subject, body-remainder).
+
+    The dash separator must be *outside* of bold (`**...**`), strike (`~~...~~`),
+    inline code (`` ` ``), wikilinks (`[[...]]`), and markdown links (`[...](...)`).
+    Otherwise splits land in the middle of a markdown token and break rendering.
+    """
+    dashes = (" — ", " – ", " - ")
+
+    def find_outside_tokens(text: str) -> int:
+        in_bold = False
+        in_strike = False
+        in_code = False
+        bracket_depth = 0  # inside [[ or [
+        paren_depth = 0  # inside (...) of a link
+        i = 0
+        n = len(text)
+        while i < n:
+            two = text[i : i + 2]
+            ch = text[i]
+            if ch == "`" and not in_bold and not in_strike:
+                in_code = not in_code
+                i += 1
+                continue
+            if in_code:
+                i += 1
+                continue
+            if two == "**":
+                in_bold = not in_bold
+                i += 2
+                continue
+            if two == "~~":
+                in_strike = not in_strike
+                i += 2
+                continue
+            if two == "[[":
+                bracket_depth += 1
+                i += 2
+                continue
+            if two == "]]" and bracket_depth > 0:
+                bracket_depth -= 1
+                i += 2
+                continue
+            if ch == "[" and bracket_depth == 0:
+                bracket_depth = 1
+                i += 1
+                continue
+            if ch == "]" and bracket_depth > 0 and text[i : i + 2] != "]]":
+                bracket_depth = 0
+                if i + 1 < n and text[i + 1] == "(":
+                    paren_depth = 1
+                    i += 2
+                    continue
+                i += 1
+                continue
+            if ch == ")" and paren_depth > 0:
+                paren_depth -= 1
+                i += 1
+                continue
+            # Clean spot — is this a separator?
+            if not in_bold and not in_strike and bracket_depth == 0 and paren_depth == 0:
+                for d in dashes:
+                    if text[i : i + len(d)] == d:
+                        return i
+            i += 1
+        return -1
+
+    idx = find_outside_tokens(rest)
+    if idx != -1:
+        # Determine which dash matched
+        for d in dashes:
+            if rest[idx : idx + len(d)] == d:
+                return rest[:idx].rstrip(), rest[idx + len(d) :].lstrip()
+
+    # Fallback: a colon split outside tokens
+    idx = -1
+    in_bold = False
+    in_strike = False
+    in_code = False
+    i = 0
+    while i < len(rest):
+        two = rest[i : i + 2]
+        if rest[i] == "`" and not in_bold and not in_strike:
+            in_code = not in_code
+        elif not in_code and two == "**":
+            in_bold = not in_bold
+            i += 2
+            continue
+        elif not in_code and two == "~~":
+            in_strike = not in_strike
+            i += 2
+            continue
+        elif not in_code and not in_bold and not in_strike and rest[i : i + 2] == ": ":
+            idx = i
+            break
+        i += 1
+    if idx != -1:
+        return rest[:idx].rstrip(), rest[idx + 2 :].lstrip()
+    return rest, ""
+
+
+# ---------------------------------------------------------------------------
+# Inline markdown → HTML
+# ---------------------------------------------------------------------------
+
+
+WIKILINK_RE = re.compile(r"\[\[([^\]|]+?)(?:\|([^\]]+))?\]\]")
+LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+STRIKE_RE = re.compile(r"~~(.+?)~~")
+BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
+ITALIC_RE = re.compile(r"(?<![\*_])\*(?!\*)([^*]+?)\*(?!\*)")
+CODE_RE = re.compile(r"`([^`]+)`")
+
+
+def inline(text: str) -> str:
+    """Render inline markdown to HTML."""
+    # Escape first, then re-substitute for markdown tokens. Tokens are chosen
+    # so we can safely find them after escaping.
+    s = html.escape(text, quote=False)
+    # Wikilinks become pills
+    s = WIKILINK_RE.sub(lambda m: _wiki_pill(m.group(1), m.group(2)), s)
+    # Regular links
+    s = LINK_RE.sub(
+        lambda m: f'<a href="{m.group(2)}" target="_blank" rel="noopener">{m.group(1)}</a>',
+        s,
+    )
+    s = CODE_RE.sub(r"<code>\1</code>", s)
+    s = STRIKE_RE.sub(r"<s>\1</s>", s)
+    s = BOLD_RE.sub(r"<strong>\1</strong>", s)
+    s = ITALIC_RE.sub(r"<em>\1</em>", s)
+    return s
+
+
+def _wiki_pill(target: str, label: str | None) -> str:
+    display = label or target.split("/")[-1]
+    return f'<span class="wiki">{html.escape(display)}</span>'
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+SECTION_STYLES = {
+    "🔴": ("urgent", "Urgent / Time-sensitive"),
+    "🟡": ("todo", "To do"),
+    "🟢": ("watching", "Watching"),
+    "💡": ("focus", "Today's focus"),
+    "📅": ("meetings", "Today's meetings"),
+    "✅": ("done", "Recently completed"),
+    "📋": ("digest", "Scout digest"),
+}
+
+
+def section_kind(section: Section) -> str:
+    if section.emoji in SECTION_STYLES:
+        return SECTION_STYLES[section.emoji][0]
+    t = section.title.lower()
+    if "personal" in t:
+        return "personal"
+    return "neutral"
+
+
+def _render_html(title: str, preamble: list[str], sections: list[Section], source_stem: str = "") -> str:
+    # Compute summary stats from task counts
+    def count(kind: str) -> int:
+        return sum(sum(1 for t in s.tasks if not t.done) for s in sections if section_kind(s) == kind)
+
+    n_urgent = count("urgent")
+    n_todo = count("todo")
+    n_watching = count("watching")
+    n_personal = count("personal")
+    n_done = sum(sum(1 for t in s.tasks if t.done) for s in sections if section_kind(s) == "done")
+
+    stats = [
+        ("urgent", n_urgent, "🔥 Urgent"),
+        ("warn", n_todo, "📋 To do"),
+        ("info", n_watching, "👀 Watching"),
+        ("muted", n_personal, "🏡 Personal"),
+        ("ok", n_done, "✅ Done"),
+    ]
+
+    body_sections: list[str] = []
+
+    for s in sections:
+        kind = section_kind(s)
+        if kind == "focus":
+            body_sections.append(_render_focus(s))
+        elif kind in ("urgent", "todo", "watching", "personal"):
+            body_sections.append(_render_cards(s, kind, source_stem))
+        elif kind == "meetings":
+            body_sections.append(_render_meetings(s))
+        elif kind == "done":
+            body_sections.append(_render_completed(s))
+        elif kind == "digest":
+            body_sections.append(_render_digest(s))
+        else:
+            body_sections.append(_render_cards(s, "neutral", source_stem))
+
+    preamble_html = "".join(f"<p>{inline(p)}</p>" for p in preamble)
+
+    stat_cards = "".join(
+        f'<div class="stat {cls}"><div class="num">{n}</div><div class="label">{label}</div></div>'
+        for cls, n, label in stats
+    )
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>{html.escape(title)}</title>
+<style>{CSS}</style>
+</head>
+<body>
+<header class="site-header">
+  <div>
+    <h1>{html.escape(title)}</h1>
+    <div class="preamble">{preamble_html}</div>
+  </div>
+</header>
+
+<section class="summary">{stat_cards}</section>
+
+{"".join(body_sections)}
+
+<footer>
+  <div>Rendered from <code>{html.escape(source_stem + ".md") if source_stem else "action-items.md"}</code>. Markdown is the source of truth — edit it and re-run <code>render.py</code>.</div>
+</footer>
+<script>{CLIPBOARD_JS}</script>
+</body>
+</html>"""
+
+
+def render(path: Path) -> str:
+    """Parse *path* and return a complete HTML string.
+
+    This is the primary public entry point for the renderer.
+
+    Raises
+    ------
+    ActionItemError
+        If *path* does not exist.
+    """
+    if not path.exists():
+        raise ActionItemError(f"render: file not found: {path}")
+    title, preamble, sections = parse(path)
+    return _render_html(title, preamble, sections, source_stem=path.stem)
+
+
+def _render_focus(s: Section) -> str:
+    items = "".join(f"<li>{inline(b.text)}</li>" for b in s.bullets)
+    return f"""
+<section class="focus-box">
+  <h2>{html.escape(s.emoji)} {html.escape(s.title)}</h2>
+  <ul>{items}</ul>
+</section>
+"""
+
+
+def _render_cards(s: Section, kind: str, source_stem: str = "") -> str:
+    date_slug = source_stem.replace("action-items-", "") if source_stem else ""
+    cards: list[str] = []
+    for t in s.tasks:
+        subj = inline(t.subject)
+        body = inline(t.body) if t.body else ""
+        done_cls = " done" if t.done else ""
+        stamp = '<span class="stamp">✅ Done</span>' if t.done else ""
+        comments_html = _render_comments(t)
+        # Subject slug doubles as the identifier for write-back: add_comment.py
+        # locates the task by matching --subject against this same text.
+        slug = html.escape(t.subject, quote=True)
+        textarea_html = (
+            f'<div class="add-comment">'
+            f'<textarea data-subject="{slug}" rows="2" '
+            f'placeholder="Add comment — run: ./action-items/add_comment.py '
+            f'&lt;date&gt; --subject &quot;…&quot; --text &quot;…&quot;"></textarea>'
+            f"</div>"
+        )
+        actions_html = _render_task_actions(t, date_slug)
+        links_html = _render_task_links(t)
+        cards.append(
+            f"""
+<article class="card kind-{kind}{done_cls}">
+  {stamp}
+  <h3>{subj}</h3>
+  {f'<div class="body">{body}</div>' if body else ""}
+  {comments_html}
+  {links_html}
+  {actions_html}
+  {textarea_html}
+</article>
+"""
+        )
+    # Also render non-task bullets if any
+    if s.bullets:
+        bullets_html = "".join(f"<li>{inline(b.text)}</li>" for b in s.bullets)
+        cards.append(f'<div class="extra-notes"><ul>{bullets_html}</ul></div>')
+    grid = "".join(cards) if cards else '<p class="muted">Nothing here.</p>'
+    return f"""
+<section class="section section-{kind}">
+  <h2>{html.escape(s.emoji)} {html.escape(s.title)}</h2>
+  <div class="grid">{grid}</div>
+</section>
+"""
+
+
+def _render_comments(t: Task) -> str:
+    if not t.comments:
+        return ""
+    items: list[str] = []
+    for c in t.comments:
+        ts = f" <time>{html.escape(c.timestamp)}</time>" if c.timestamp else ""
+        author_cls = "scout" if c.author.lower() == "scout" else "human"
+        items.append(
+            f'<li class="comment comment-{author_cls}">'
+            f'<span class="author">{html.escape(c.author)}</span>{ts}'
+            f'<div class="text">{inline(c.text)}</div>'
+            f"</li>"
+        )
+    return f'<ul class="comments">{"".join(items)}</ul>'
+
+
+_MD_TOKEN_STRIPPER = [
+    (re.compile(r"~~(.+?)~~"), r"\1"),
+    (re.compile(r"\*\*(.+?)\*\*"), r"\1"),
+    (re.compile(r"`([^`]+)`"), r"\1"),
+    (re.compile(r"\[\[([^\]|]+?)(?:\|[^\]]+)?\]\]"), r"\1"),
+    (re.compile(r"\[([^\]]+)\]\([^)]+\)"), r"\1"),
+]
+
+
+def _plain_subject(subject: str) -> str:
+    """Mirror mark_done.py / snooze.py _strip_markdown_tokens so the --subject
+    substring we render actually matches the stripped comparison those CLIs do.
+    """
+    s = subject
+    for pat, repl in _MD_TOKEN_STRIPPER:
+        s = pat.sub(repl, s)
+    return s
+
+
+# Deep-link detection ------------------------------------------------------
+# Linear: `AI-2619`, `ST-3853`, `SUPPORT-15915`, `LDRS-321`, `KAI-12`. The
+# allowed prefixes below are the ones seen in real action items / KB; adding
+# more is cheap. Note that a Linear ID also appears inside `[[AI-XXXX]]`
+# wikilinks — those render as plain text, so the same regex finds both.
+_LINEAR_ID_RE = re.compile(r"\b(AI|ST|SUPPORT|LDRS|KAI|DATA)-\d+\b")
+_GITHUB_PR_RE = re.compile(r"https://github\.com/([\w.\-]+)/([\w.\-]+)/pull/(\d+)")
+_SLACK_LINK_RE = re.compile(r"https://[\w.\-]+\.slack\.com/archives/[A-Z0-9]+/p\d+(?:\?[^\s)\"']+)?")
+
+
+def _render_task_links(t: Task) -> str:
+    """Emit deep-link buttons (Linear / GitHub PR / Slack) for the task.
+
+    Links come from scanning the subject + body for well-known URL shapes and
+    Linear issue IDs. De-duplicated per-card so `[[AI-2619]]` mentioned three
+    times still yields one button.
+    """
+    text = f"{t.subject} {t.body}"
+    links: list[tuple[str, str]] = []
+    seen: set[tuple[str, ...]] = set()
+    for m in _LINEAR_ID_RE.finditer(text):
+        iid = m.group(0)
+        key: tuple[str, ...] = ("linear", iid)
+        if key in seen:
+            continue
+        seen.add(key)
+        links.append((f"Linear {iid}", f"https://linear.app/keboola/issue/{iid}"))
+    for m in _GITHUB_PR_RE.finditer(text):
+        repo = f"{m.group(1)}/{m.group(2)}"
+        pr = m.group(3)
+        key = ("gh", repo, pr)
+        if key in seen:
+            continue
+        seen.add(key)
+        links.append((f"PR {repo}#{pr}", m.group(0)))
+    for m in _SLACK_LINK_RE.finditer(text):
+        url = m.group(0)
+        key = ("slack", url)
+        if key in seen:
+            continue
+        seen.add(key)
+        links.append(("Slack thread", url))
+    if not links:
+        return ""
+    anchors = "".join(
+        f'<a class="task-link" href="{html.escape(url, quote=True)}" '
+        f'target="_blank" rel="noopener noreferrer" '
+        f'title="{html.escape(url, quote=True)}">{html.escape(label)}</a>'
+        for label, url in links
+    )
+    return f'<div class="task-links">{anchors}</div>'
+
+
+def _render_task_actions(t: Task, date_slug: str) -> str:
+    """Emit click-to-copy CLI commands for mark-done/snooze on each task.
+
+    The commands mirror the subject-substring contract in ``mark_done.py`` and
+    ``snooze.py`` — use a distinctive slice of the subject so the match is
+    unambiguous without the user re-reading the file.
+    """
+    # Quote-safe substring: first ~40 chars of the plain-text subject.
+    needle = _plain_subject(t.subject).strip().replace('"', r"\"")
+    if len(needle) > 40:
+        needle = needle[:40].rstrip()
+    date_arg = f"{date_slug} " if date_slug else ""
+    if t.done:
+        cmd = f'./action-items/mark_done.py {date_arg}--subject "{needle}" --undo'
+        chips = [("Reopen", cmd)]
+    else:
+        mark_cmd = f'./action-items/mark_done.py {date_arg}--subject "{needle}"'
+        snooze_tmpl = f'./action-items/snooze.py {date_arg}--subject "{needle}" --until +1d'
+        launch_cmd = f'cd ~/Scout && claude "Help me make progress on this action item: {needle}"'
+        chips = [("Mark done", mark_cmd), ("Snooze", snooze_tmpl), ("Launch Claude", launch_cmd)]
+    buttons = "".join(
+        f'<button type="button" class="task-action" data-cmd="{html.escape(cmd, quote=True)}" '
+        f'title="Click to copy: {html.escape(cmd, quote=True)}">{html.escape(label)}</button>'
+        for label, cmd in chips
+    )
+    return f'<div class="task-actions">{buttons}</div>'
+
+
+def _render_meetings(s: Section) -> str:
+    parts: list[str] = [f"<h2>{html.escape(s.emoji)} {html.escape(s.title)}</h2>"]
+    for idx, table in enumerate(s.tables):
+        subhead = s.subheads[idx - 1] if idx > 0 and idx - 1 < len(s.subheads) else ""
+        if subhead:
+            parts.append(f"<h3>{html.escape(subhead)}</h3>")
+        head = "".join(f"<th>{inline(h)}</th>" for h in table.headers)
+        rows_html = []
+        for row in table.rows:
+            cells = "".join(f"<td>{inline(c)}</td>" for c in row)
+            rows_html.append(f"<tr>{cells}</tr>")
+        parts.append(f'<table class="mtg"><thead><tr>{head}</tr></thead><tbody>{"".join(rows_html)}</tbody></table>')
+    return f'<section class="section section-meetings">{"".join(parts)}</section>'
+
+
+def _render_completed(s: Section) -> str:
+    items = []
+    for t in s.tasks:
+        if not t.done:
+            continue
+        items.append(f"<li><strong>{inline(t.subject)}</strong>{' — ' + inline(t.body) if t.body else ''}</li>")
+    return f"""
+<details class="completed" open>
+  <summary><h2>{html.escape(s.emoji)} {html.escape(s.title)} <span class="count">({len(items)})</span></h2></summary>
+  <ul>{"".join(items)}</ul>
+</details>
+"""
+
+
+def _render_digest(s: Section) -> str:
+    blocks: list[str] = []
+    buffer: list[str] = []
+
+    def flush():
+        if buffer:
+            blocks.append('<div class="digest-block">' + "".join(buffer) + "</div>")
+            buffer.clear()
+
+    for b in s.bullets:
+        t = b.text
+        # Bold-only lines act as subheads within the digest
+        if re.match(r"^\*\*[^*]+\*\*:?\s*$", t):
+            flush()
+            blocks.append(f"<h3>{inline(t)}</h3>")
+        else:
+            buffer.append(f"<p>{inline(t)}</p>")
+    flush()
+    return f"""
+<details class="digest">
+  <summary><h2>{html.escape(s.emoji)} {html.escape(s.title)}</h2></summary>
+  {"".join(blocks)}
+</details>
+"""
+
+
+# ---------------------------------------------------------------------------
+# CSS
+# ---------------------------------------------------------------------------
+
+
+CSS = """
+:root {
+  --bg: #0f1115;
+  --panel: #171a21;
+  --panel-2: #1f2430;
+  --border: #2a2f3c;
+  --text: #e7ecf3;
+  --muted: #9aa3b2;
+  --accent: #6ea8ff;
+  --urgent: #ff5370;
+  --warn: #f7b955;
+  --ok: #50c878;
+  --info: #59c7ff;
+  --purple: #b085f5;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background:
+    radial-gradient(1200px 600px at 10% -10%, #1a2033 0%, transparent 60%),
+    radial-gradient(900px 500px at 110% 0%, #24183a 0%, transparent 55%),
+    var(--bg);
+  color: var(--text);
+  padding: 32px;
+  line-height: 1.5;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+code {
+  font-family: ui-monospace, Menlo, monospace;
+  background: var(--panel-2);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 0.9em;
+  color: #c7cedb;
+}
+s { color: var(--muted); }
+.site-header {
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 24px;
+}
+h1 { font-size: 28px; margin: 0 0 6px 0; letter-spacing: -0.4px; }
+.preamble { color: var(--muted); font-size: 13px; }
+.preamble p { margin: 4px 0; }
+
+.summary {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 12px;
+  margin-bottom: 28px;
+}
+.stat {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px;
+  text-align: center;
+}
+.stat .num { font-size: 28px; font-weight: 700; line-height: 1; }
+.stat .label { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; margin-top: 6px; }
+.stat.urgent .num { color: var(--urgent); }
+.stat.warn   .num { color: var(--warn); }
+.stat.info   .num { color: var(--info); }
+.stat.ok     .num { color: var(--ok); }
+.stat.muted  .num { color: var(--muted); }
+
+.focus-box {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 8px;
+  padding: 16px 20px;
+  margin-bottom: 28px;
+}
+.focus-box h2 { margin: 0 0 10px 0; font-size: 16px; }
+.focus-box ul { margin: 0; padding-left: 18px; }
+.focus-box li { margin: 6px 0; font-size: 13px; color: #c7cedb; }
+
+.section { margin-bottom: 28px; }
+.section > h2 { font-size: 18px; margin: 0 0 14px 0; }
+.section-urgent   > h2 { color: var(--urgent); }
+.section-todo     > h2 { color: var(--warn); }
+.section-watching > h2 { color: var(--info); }
+.section-personal > h2 { color: var(--muted); }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 12px;
+}
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 16px;
+  position: relative;
+  transition: border-color 0.15s, transform 0.15s;
+}
+.card:hover { border-color: var(--accent); transform: translateY(-1px); }
+.card.kind-urgent   { border-left: 3px solid var(--urgent); }
+.card.kind-todo     { border-left: 3px solid var(--warn); }
+.card.kind-watching { border-left: 3px solid var(--info); }
+.card.kind-personal { border-left: 3px solid var(--muted); }
+.card.kind-neutral  { border-left: 3px solid var(--border); }
+.card h3 { margin: 0 0 6px 0; font-size: 14px; font-weight: 600; }
+.card .body { font-size: 13px; color: #c7cedb; }
+.card .body p { margin: 4px 0; }
+
+.card.done {
+  background: linear-gradient(90deg, rgba(80,200,120,0.08), var(--panel) 60%);
+  opacity: 0.85;
+}
+.card.done h3 {
+  text-decoration: line-through;
+  text-decoration-color: rgba(80,200,120,0.5);
+  color: var(--muted);
+}
+.card .stamp {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  background: rgba(80,200,120,0.12);
+  color: var(--ok);
+  border: 1px solid rgba(80,200,120,0.3);
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 6px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.wiki {
+  display: inline-block;
+  background: var(--panel-2);
+  color: var(--muted);
+  border: 1px solid var(--border);
+  padding: 0 6px;
+  margin: 0 2px;
+  border-radius: 4px;
+  font-size: 0.82em;
+  font-family: ui-monospace, Menlo, monospace;
+}
+
+.mtg {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  margin-bottom: 12px;
+}
+.mtg th, .mtg td {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+.mtg th { background: var(--panel-2); color: var(--muted); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+.mtg tr:last-child td { border-bottom: none; }
+
+details.completed, details.digest {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0 18px;
+  margin-bottom: 20px;
+}
+details.completed summary, details.digest summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 14px 0;
+  display: flex;
+  align-items: center;
+}
+details.completed summary::-webkit-details-marker,
+details.digest summary::-webkit-details-marker { display: none; }
+details.completed summary h2, details.digest summary h2 {
+  display: inline;
+  margin: 0;
+  font-size: 16px;
+}
+details.completed .count { color: var(--muted); font-weight: 400; font-size: 13px; margin-left: 6px; }
+details.completed ul { margin: 0 0 16px 0; padding-left: 20px; color: var(--muted); font-size: 13px; }
+details.completed ul li { margin: 4px 0; }
+details.digest h3 { color: var(--muted); font-size: 13px; margin: 14px 0 6px 0; }
+details.digest p { font-size: 12px; color: var(--muted); margin: 4px 0; }
+details.digest .digest-block { margin-bottom: 10px; }
+
+footer {
+  margin-top: 40px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 12px;
+  text-align: center;
+}
+.extra-notes {
+  grid-column: 1 / -1;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 16px;
+}
+.extra-notes ul { margin: 4px 0; padding-left: 20px; }
+.extra-notes li { font-size: 12px; color: var(--muted); margin: 3px 0; }
+
+.comments {
+  list-style: none;
+  margin: 10px 0 0 0;
+  padding: 0;
+  border-top: 1px dashed var(--border);
+  padding-top: 8px;
+}
+.comments .comment {
+  font-size: 12px;
+  margin: 6px 0;
+  padding: 6px 10px;
+  border-left: 2px solid var(--border);
+  background: var(--panel-2);
+  border-radius: 0 6px 6px 0;
+}
+.comments .comment .author {
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 11px;
+  text-transform: lowercase;
+}
+.comments .comment time {
+  color: var(--muted);
+  font-size: 10px;
+  margin-left: 6px;
+}
+.comments .comment-scout .author { color: var(--purple); }
+.comments .comment .text { margin-top: 2px; color: #c7cedb; }
+.add-comment { margin-top: 8px; }
+.add-comment textarea {
+  width: 100%;
+  background: var(--panel-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 8px;
+  font-family: inherit;
+  font-size: 12px;
+  resize: vertical;
+  min-height: 28px;
+}
+.add-comment textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.add-comment textarea::placeholder { color: var(--muted); font-size: 11px; }
+
+.task-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+.task-action {
+  background: var(--panel-2);
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 3px 9px;
+  font-size: 11px;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.task-action:hover {
+  background: var(--panel);
+  color: var(--text);
+  border-color: var(--accent);
+}
+.task-action.copied {
+  background: rgba(80,200,120,0.15);
+  color: var(--ok);
+  border-color: rgba(80,200,120,0.4);
+}
+.card.done .task-action {
+  opacity: 0.7;
+}
+
+.task-links {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+.task-link {
+  background: var(--panel-2);
+  color: var(--accent);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 3px 9px;
+  font-size: 11px;
+  font-family: inherit;
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.task-link::after {
+  content: " ↗";
+  opacity: 0.6;
+  font-size: 10px;
+}
+.task-link:hover {
+  background: var(--panel);
+  border-color: var(--accent);
+  text-decoration: none;
+}
+.card.done .task-link {
+  opacity: 0.7;
+}
+
+@media (max-width: 760px) {
+  .summary { grid-template-columns: repeat(2, 1fr); }
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Clipboard JS — click a .task-action button to copy its data-cmd to clipboard
+# ---------------------------------------------------------------------------
+
+
+CLIPBOARD_JS = """
+document.addEventListener('click', function(e) {
+  const btn = e.target.closest('.task-action');
+  if (!btn) return;
+  const cmd = btn.getAttribute('data-cmd');
+  if (!cmd) return;
+  const done = () => {
+    const prev = btn.textContent;
+    btn.classList.add('copied');
+    btn.textContent = 'Copied!';
+    setTimeout(() => { btn.classList.remove('copied'); btn.textContent = prev; }, 1200);
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(cmd).then(done, () => {});
+  } else {
+    const ta = document.createElement('textarea');
+    ta.value = cmd; document.body.appendChild(ta); ta.select();
+    try { document.execCommand('copy'); done(); } catch(_) {}
+    document.body.removeChild(ta);
+  }
+});
+"""
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: python render.py <action-items.md> [output.html]", file=sys.stderr)
+        return 2
+
+    md_path = Path(sys.argv[1]).expanduser().resolve()
+    out_path = Path(sys.argv[2]).expanduser().resolve() if len(sys.argv) > 2 else md_path.with_suffix(".html")
+
+    try:
+        html_text = render(md_path)
+    except ActionItemError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    out_path.write_text(html_text)
+    _, _, sections = parse(md_path)
+    print(
+        f"Wrote {out_path} ({len(html_text):,} bytes, {sum(len(s.tasks) for s in sections)} tasks across {len(sections)} sections)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/engine/scout/action_items/render.py
+++ b/engine/scout/action_items/render.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import html
 import re
-import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -31,7 +30,7 @@ class Comment:
 
     Serialized in the markdown as an indented quote line:
         - [ ] Task — body
-          > jordan (2026-04-18 10:20 AM ET): text here
+          > scout (2026-04-18 10:20 AM ET): text here
           > scout (2026-04-18 11:00 AM ET): reply here
 
     The indentation under the task bullet is what binds the comment to that task.
@@ -82,7 +81,7 @@ TASK_RE = re.compile(r"^\s*- \[(?P<mark>[ xX])\]\s+(?P<rest>.+?)\s*$")
 BULLET_RE = re.compile(r"^\s*-\s+(?P<rest>.+?)\s*$")
 TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
 # Indented quote-line comment bound to the preceding task:
-#   "  > jordan (2026-04-18 10:20 AM ET): text"
+#   "  > scout (2026-04-18 10:20 AM ET): text"
 # Author/timestamp are captured; loose format tolerated (timestamp optional).
 COMMENT_RE = re.compile(
     r"^(?P<indent>\s+)>\s+(?P<author>[A-Za-z][A-Za-z0-9._-]*)"
@@ -1054,34 +1053,3 @@ document.addEventListener('click', function(e) {
   }
 });
 """
-
-
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
-
-
-def main() -> int:
-    if len(sys.argv) < 2:
-        print("Usage: python render.py <action-items.md> [output.html]", file=sys.stderr)
-        return 2
-
-    md_path = Path(sys.argv[1]).expanduser().resolve()
-    out_path = Path(sys.argv[2]).expanduser().resolve() if len(sys.argv) > 2 else md_path.with_suffix(".html")
-
-    try:
-        html_text = render(md_path)
-    except ActionItemError as exc:
-        print(str(exc), file=sys.stderr)
-        return 1
-
-    out_path.write_text(html_text)
-    _, _, sections = parse(md_path)
-    print(
-        f"Wrote {out_path} ({len(html_text):,} bytes, {sum(len(s.tasks) for s in sections)} tasks across {len(sections)} sections)"
-    )
-    return 0
-
-
-if __name__ == "__main__":
-    sys.exit(main())

--- a/engine/scout/action_items/snooze.py
+++ b/engine/scout/action_items/snooze.py
@@ -1,0 +1,282 @@
+"""Snooze a task to a future-dated daily action-items file.
+
+Two complementary writes happen:
+
+1.  The task in the source file is **removed entirely** (along with any
+    immediately-following indented continuation lines).  No marker is left
+    on the source side — git history and the destination carry-in annotation
+    provide full traceability.
+2.  The task is appended (as an open ``[ ]`` item) to a ``## 🛌 Snoozed``
+    section in the target day's file.  The file and section are created on
+    demand.  A ``_(carried in from YYYY-MM-DD)_`` annotation is appended so
+    the origin date is visible.
+
+Ported from ~/Scout/action-items/snooze.py (362 lines).
+argparse / __main__ block removed; public surface is the ``snooze()`` function.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import re
+from pathlib import Path
+
+from scout import paths
+from scout.action_items.writer import atomic_write_lines
+from scout.errors import ActionItemError
+
+# ---------------------------------------------------------------------------
+# Regex helpers
+# ---------------------------------------------------------------------------
+
+TASK_RE = re.compile(r"^(?P<indent>\s*)- \[(?P<mark>[ xX])\] (?P<rest>.+?)\s*$")
+SNOOZE_SUFFIX_RE = re.compile(r"\s*(?:—|–|-)\s*🛌 Snoozed until \d{4}-\d{2}-\d{2}$")
+
+
+# ---------------------------------------------------------------------------
+# Matching
+#
+# NOTE: the source snooze.py matches on ALL tasks regardless of checkbox mark
+# (open [ ], done [x], or [X]).  This intentionally differs from
+# mark_done._matching_lines, which filters by want_mark.  A local helper is
+# kept here rather than importing from mark_done to avoid coupling to the
+# want_mark contract.  The subject comparison uses plain .lower() (not
+# .casefold()) to match the source's original behaviour.
+# ---------------------------------------------------------------------------
+
+
+def _strip_markdown_tokens(text: str) -> str:
+    text = re.sub(r"~~(.+?)~~", r"\1", text)
+    text = re.sub(r"\*\*(.+?)\*\*", r"\1", text)
+    text = re.sub(r"`([^`]+)`", r"\1", text)
+    text = re.sub(r"\[\[([^\]|]+?)(?:\|[^\]]+)?\]\]", r"\1", text)
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    return text
+
+
+def _first_separator_outside_tokens(text: str, separators: tuple[str, ...]) -> int:
+    """Return the earliest offset where any separator starts outside Markdown
+    inline tokens (bold, strike, code, wiki-links, hyperlinks).  -1 if none."""
+    in_bold = in_strike = in_code = False
+    bracket_depth = 0
+    i = 0
+    n = len(text)
+    while i < n:
+        two = text[i : i + 2]
+        ch = text[i]
+        if ch == "`" and not in_bold and not in_strike:
+            in_code = not in_code
+            i += 1
+            continue
+        if in_code:
+            i += 1
+            continue
+        if two == "**":
+            in_bold = not in_bold
+            i += 2
+            continue
+        if two == "~~":
+            in_strike = not in_strike
+            i += 2
+            continue
+        if two == "[[":
+            bracket_depth += 1
+            i += 2
+            continue
+        if two == "]]" and bracket_depth > 0:
+            bracket_depth -= 1
+            i += 2
+            continue
+        if ch == "[" and bracket_depth == 0:
+            bracket_depth = 1
+            i += 1
+            continue
+        if ch == "]" and bracket_depth > 0 and two != "]]":
+            bracket_depth = 0
+            i += 1
+            continue
+        if not in_bold and not in_strike and bracket_depth == 0:
+            for sep in separators:
+                if text[i : i + len(sep)] == sep:
+                    return i
+        i += 1
+    return -1
+
+
+def _task_subject(rest: str) -> str:
+    idx = _first_separator_outside_tokens(rest, (" — ", " – ", " - "))
+    if idx != -1:
+        return rest[:idx]
+    idx = _first_separator_outside_tokens(rest, (": ",))
+    if idx != -1:
+        return rest[:idx]
+    return rest
+
+
+def _find_task_lines(lines: list[str], needle: str) -> list[int]:
+    """Return 0-based indices of lines whose task subject contains *needle*.
+
+    Matches all tasks regardless of checkbox state (open, done, or X-done).
+    Case-insensitive substring match on the plain-text subject (markdown tokens
+    stripped).
+    """
+    needle_norm = needle.lower().strip()
+    hits: list[int] = []
+    for i, line in enumerate(lines):
+        m = TASK_RE.match(line)
+        if not m:
+            continue
+        subject_plain = _strip_markdown_tokens(_task_subject(m.group("rest"))).lower()
+        if needle_norm in subject_plain:
+            hits.append(i)
+    return hits
+
+
+# ---------------------------------------------------------------------------
+# Source-file mutation
+# ---------------------------------------------------------------------------
+
+
+def _remove_task_block(lines: list[str], task_idx: int) -> list[str]:
+    """Return lines with the task at task_idx and its indented continuation
+    lines removed.
+
+    The source removes the task entirely rather than leaving a snooze-marker
+    stub.  See remove_task_block() in ~/Scout/action-items/snooze.py for the
+    original rationale (git history + destination carry-in provide traceability).
+    """
+    m = TASK_RE.match(lines[task_idx])
+    task_indent_len = len(m.group("indent")) if m else 0
+    end = task_idx + 1
+    while end < len(lines):
+        line = lines[end]
+        if not line.strip():
+            break
+        line_indent_len = len(line) - len(line.lstrip())
+        if line_indent_len > task_indent_len:
+            end += 1
+        else:
+            break
+    return lines[:task_idx] + lines[end:]
+
+
+# ---------------------------------------------------------------------------
+# Destination-file mutation
+# ---------------------------------------------------------------------------
+
+
+def _append_to_target(target_path: Path, task_line: str, source_date: str) -> None:
+    """Append the task to a ## 🛌 Snoozed section in target_path.
+
+    Creates the file (with a minimal header + section) if it does not exist.
+    Flips the checkbox back to open [ ] and drops any snooze suffix; the
+    carry-in annotation _(carried in from <source_date>)_ replaces it.
+    Deduplicates: if the same subject is already present in the section, skips.
+    """
+    m = TASK_RE.match(task_line)
+    rest = m.group("rest") if m else task_line.strip()
+    rest = SNOOZE_SUFFIX_RE.sub("", rest)
+    indent = m.group("indent") if m else ""
+    subject_key = _strip_markdown_tokens(_task_subject(rest)).strip().lower()
+    carry_line = f"{indent}- [ ] {rest} _(carried in from {source_date})_"
+
+    if target_path.exists():
+        text = target_path.read_text(encoding="utf-8")
+        lines = text.splitlines()
+        section_idx = next(
+            (i for i, ln in enumerate(lines) if ln.strip().lower().startswith("## 🛌 snoozed")),
+            None,
+        )
+        if section_idx is None:
+            if lines and lines[-1].strip():
+                lines.append("")
+            lines.append("## 🛌 Snoozed")
+            lines.append("")
+            lines.append(carry_line)
+        else:
+            section_end = len(lines)
+            for j in range(section_idx + 1, len(lines)):
+                if lines[j].startswith("## "):
+                    section_end = j
+                    break
+            # Dedupe: skip if same subject already present.
+            for j in range(section_idx + 1, section_end):
+                mt = TASK_RE.match(lines[j])
+                if not mt:
+                    continue
+                existing_subject = _strip_markdown_tokens(_task_subject(mt.group("rest"))).strip().lower()
+                if existing_subject == subject_key:
+                    return
+            insert_at = section_end
+            while insert_at > section_idx + 1 and not lines[insert_at - 1].strip():
+                insert_at -= 1
+            lines.insert(insert_at, carry_line)
+        atomic_write_lines(target_path, lines)
+        return
+
+    # Fresh target file: minimal header + snoozed section.
+    date_label = target_path.stem.replace("action-items-", "")
+    header_lines = [
+        f"# Action Items — {date_label}",
+        "",
+        "## 🛌 Snoozed",
+        "",
+        carry_line,
+    ]
+    atomic_write_lines(target_path, header_lines)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def snooze(src: Path | None, *, subject: str, until: dt.date) -> Path:
+    """Snooze the uniquely matching task to a future daily file.
+
+    Args:
+        src:     Source daily markdown file.  None resolves to today's file.
+        subject: Case-insensitive substring of the task subject to snooze.
+        until:   Target date (must be strictly after today).
+
+    Returns:
+        Path to the destination daily file the task was moved into.
+
+    Raises:
+        ActionItemError: no match, ambiguous match, or until is in the past.
+    """
+    today = dt.date.today()
+    if until <= today:
+        raise ActionItemError(
+            f"until date {until.isoformat()} is in the past or today "
+            f"(today is {today.isoformat()}); must be a future date"
+        )
+
+    source_path = src if src is not None else paths.action_items_daily_path()
+    if not source_path.exists():
+        raise ActionItemError(f"snooze: source file not found: {source_path}")
+
+    # Extract the date label from the filename (e.g. "action-items-2026-04-15.md" → "2026-04-15").
+    source_date = source_path.stem.replace("action-items-", "")
+
+    lines = source_path.read_text(encoding="utf-8").splitlines()
+    hits = _find_task_lines(lines, subject)
+
+    if not hits:
+        raise ActionItemError(f"snooze: no match for subject {subject!r} in {source_path.name}")
+    if len(hits) > 1:
+        listing = "\n".join(f"  line {i + 1}: {lines[i].strip()}" for i in hits)
+        raise ActionItemError(f"snooze: ambiguous match for {subject!r} ({len(hits)} candidates):\n{listing}")
+
+    task_idx = hits[0]
+    original_line = lines[task_idx]
+
+    # Remove the task (and any continuation lines) from the source file.
+    new_lines = _remove_task_block(lines, task_idx)
+    atomic_write_lines(source_path, new_lines)
+
+    # Write the carry-in entry to the target daily file.
+    target_path = source_path.parent / f"action-items-{until.isoformat()}.md"
+    _append_to_target(target_path, original_line, source_date)
+
+    return target_path

--- a/engine/scout/action_items/writer.py
+++ b/engine/scout/action_items/writer.py
@@ -1,0 +1,63 @@
+"""Atomic write-back for action-items markdown files.
+
+POSIX `os.replace` is atomic: readers see either the old complete
+file or the new complete file, never a torn state. We write to a
+sibling temp file in the same directory, fsync it, then rename.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+from scout.errors import ActionItemError
+
+
+def atomic_write_lines(target: Path, lines: list[str]) -> None:
+    """Replace `target`'s contents with `lines` (one per line, trailing newline)."""
+    parent = target.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(prefix=f".{target.name}.", suffix=".tmp", dir=str(parent))
+    tmp = Path(tmp_path)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+            if lines:
+                f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, target)
+    except BaseException:
+        # Cleanup on any failure (including the simulated OSError in tests).
+        if tmp.exists():
+            tmp.unlink()
+        raise
+
+
+def _read_lines(target: Path) -> list[str]:
+    return target.read_text(encoding="utf-8").splitlines()
+
+
+def flip_checkbox(target: Path, *, line_number: int, to_done: bool) -> None:
+    """Toggle `[ ]` ⇄ `[x]` on the 1-indexed line. Preserves all other bytes."""
+    lines = _read_lines(target)
+    idx = line_number - 1
+    if not 0 <= idx < len(lines):
+        raise ActionItemError(f"flip_checkbox: line {line_number} out of range (1..{len(lines)})")
+    old = "[ ]" if to_done else "[x]"
+    new = "[x]" if to_done else "[ ]"
+    if old not in lines[idx]:
+        raise ActionItemError(f"flip_checkbox: line {line_number} does not contain `{old}`")
+    lines[idx] = lines[idx].replace(old, new, 1)
+    atomic_write_lines(target, lines)
+
+
+def insert_below(target: Path, *, line_number: int, text: str) -> None:
+    """Insert `text` as a new line directly below the 1-indexed line."""
+    lines = _read_lines(target)
+    idx = line_number - 1
+    if not 0 <= idx < len(lines):
+        raise ActionItemError(f"insert_below: line {line_number} out of range (1..{len(lines)})")
+    lines.insert(idx + 1, text)
+    atomic_write_lines(target, lines)

--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -56,6 +56,15 @@ def manifest_show() -> None:
     print(build_manifest().to_json())
 
 
+def _register_action_items() -> None:
+    from scout.action_items.cli import app as action_items_app
+
+    app.add_typer(action_items_app, name="action-items")
+
+
+_register_action_items()
+
+
 def main() -> None:
     try:
         app()

--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -65,6 +65,19 @@ def _register_action_items() -> None:
 _register_action_items()
 
 
+@app.command()
+def tui() -> None:
+    """Launch the Textual action-items TUI."""
+    try:
+        # Lazy: textual is heavy; import only when the user invokes tui.
+        from scout.tui.app import ScoutApp  # noqa: PLC0415
+    except ImportError as e:
+        from scout.errors import ActionItemError
+
+        raise ActionItemError('Textual is not installed. Install with: uv pip install -e ".[full]"') from e
+    ScoutApp().run()
+
+
 def main() -> None:
     try:
         app()

--- a/engine/scout/kb/__init__.py
+++ b/engine/scout/kb/__init__.py
@@ -1,0 +1,1 @@
+"""Knowledge-base ontology and entity-graph queries."""

--- a/engine/scout/kb/ontology.py
+++ b/engine/scout/kb/ontology.py
@@ -1,0 +1,185 @@
+"""SCOUT Knowledge Graph — ontology parser and query interface.
+
+Loads the ontology schema and entity files from the knowledge base,
+builds an in-memory graph, and exposes a query interface.
+
+Usage::
+
+    from scout.kb.ontology import KnowledgeGraph
+
+    graph = KnowledgeGraph(schema_path="path/to/schema.yaml", kb_root="path/to/knowledge-base")
+    graph.load()
+    results = graph.query(type="task", domain="personal", status="open")
+
+The future CLI surface is ``scoutctl kb query`` (Plan 4).
+"""
+
+from __future__ import annotations
+
+import json as _json
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class KnowledgeGraph:
+    """Markdown-native knowledge graph with YAML frontmatter entities."""
+
+    def __init__(self, schema_path: str, kb_root: str) -> None:
+        self.schema_path = schema_path
+        self.kb_root = kb_root
+        self.schema = self._load_schema()
+        self.entities: dict[str, dict[str, Any]] = {}
+        self.relationships: list[dict[str, str]] = []
+
+    def _load_schema(self) -> dict[str, Any]:
+        with open(self.schema_path) as f:
+            return yaml.safe_load(f)
+
+    def load(self) -> KnowledgeGraph:
+        """Walk all .md files in kb_root, extract frontmatter, build graph."""
+        self.entities = {}
+        self.relationships = []
+
+        for md_file in Path(self.kb_root).rglob("*.md"):
+            frontmatter = self._extract_frontmatter(md_file)
+            if not frontmatter or "name" not in frontmatter or "type" not in frontmatter:
+                continue
+
+            name = frontmatter["name"]
+            frontmatter["_source_path"] = str(md_file)
+            raw_relationships = frontmatter.pop("relationships", [])
+            self.entities[name] = frontmatter
+
+            for rel in raw_relationships or []:
+                target = self._resolve_wikilink(rel.get("target", ""))
+                rel_type = rel.get("type", "")
+                if target and rel_type:
+                    self.relationships.append({"source": name, "type": rel_type, "target": target})
+                    inverse = self._get_inverse(rel_type)
+                    if inverse:
+                        self.relationships.append({"source": target, "type": inverse, "target": name})
+
+        return self
+
+    def _extract_frontmatter(self, path: Path) -> dict[str, Any] | None:
+        """Extract YAML frontmatter from a markdown file."""
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return None
+
+        if not text.startswith("---"):
+            return None
+
+        end = text.find("---", 3)
+        if end == -1:
+            return None
+
+        try:
+            return yaml.safe_load(text[3:end])
+        except yaml.YAMLError:
+            return None
+
+    def _resolve_wikilink(self, text: str) -> str:
+        """Extract entity name from '[[Name]]' syntax."""
+        match = re.search(r"\[\[(.+?)]]", text)
+        return match.group(1) if match else text
+
+    def entity(self, name: str) -> dict[str, Any] | None:
+        """Get an entity by name. Returns None if not found."""
+        return self.entities.get(name)
+
+    def query(self, **filters: Any) -> list[dict[str, Any]]:
+        """Query entities by property filters.
+
+        Special filters:
+            deadline_before: str (ISO date) — matches entities with deadline <= value
+            birthday_month: int — matches entities with birthday in that month
+
+        All other filters match exact property values.
+        """
+        results = []
+        for entity in self.entities.values():
+            if self._matches_filters(entity, filters):
+                results.append(entity)
+        return results
+
+    def related(self, name: str) -> list[dict[str, str]]:
+        """Get all relationships where ``name`` is the source."""
+        return [r for r in self.relationships if r["source"] == name]
+
+    def export_json(self, indent: int = 2) -> str:
+        """Export the full knowledge graph as JSON."""
+        clean_entities = {}
+        for name, entity in self.entities.items():
+            clean_entities[name] = {k: v for k, v in entity.items() if not k.startswith("_")}
+
+        return _json.dumps(
+            {"entities": clean_entities, "relationships": self.relationships},
+            indent=indent,
+            default=str,
+        )
+
+    def validate(self) -> list[dict[str, str]]:
+        """Validate all entities against the schema. Returns list of errors."""
+        errors: list[dict[str, str]] = []
+        entity_types = self.schema.get("entity_types", {})
+        rel_types = self.schema.get("relationship_types", {})
+
+        for name, entity in self.entities.items():
+            etype = entity.get("type", "")
+            type_def = entity_types.get(etype)
+
+            if not type_def:
+                errors.append({"entity": name, "message": f"Unknown entity type: {etype}"})
+                continue
+
+            # Check required properties
+            for prop in type_def["properties"].get("required", []):
+                if prop not in entity:
+                    errors.append({"entity": name, "message": f"Missing required property: {prop}"})
+
+            # Check relationships from this entity
+            for rel in self.relationships:
+                if rel["source"] == name:
+                    if rel["type"] not in rel_types:
+                        errors.append({"entity": name, "message": f"Invalid relationship type: {rel['type']}"})
+
+            # Check for orphaned entities (no relationships at all)
+            has_rels = any(r["source"] == name or r["target"] == name for r in self.relationships)
+            if not has_rels:
+                errors.append({"entity": name, "message": "Orphaned entity — no relationships"})
+
+        return errors
+
+    def _matches_filters(self, entity: dict[str, Any], filters: dict[str, Any]) -> bool:
+        """Check if an entity matches all provided filters."""
+        for key, value in filters.items():
+            if key == "deadline_before":
+                deadline = entity.get("deadline", "")
+                if not deadline or str(deadline) > str(value):
+                    return False
+            elif key == "birthday_month":
+                birthday = entity.get("birthday", "")
+                if not birthday:
+                    return False
+                try:
+                    month = int(str(birthday).split("-")[1])
+                    if month != value:
+                        return False
+                except (IndexError, ValueError):
+                    return False
+            else:
+                if entity.get(key) != value:
+                    return False
+        return True
+
+    def _get_inverse(self, rel_type: str) -> str | None:
+        """Look up the inverse relationship type from the schema."""
+        rel_def = self.schema.get("relationship_types", {}).get(rel_type)
+        if rel_def:
+            return rel_def.get("inverse")
+        return None

--- a/engine/scout/kb/paths.py
+++ b/engine/scout/kb/paths.py
@@ -1,0 +1,33 @@
+"""Resolve the KB schema and entity paths.
+
+Engine ships scout/kb/schema.yaml as a default; users may override
+by placing their own schema at $SCOUT_DATA_DIR/knowledge-base/ontology/schema.yaml.
+"""
+
+from __future__ import annotations
+
+from importlib.resources import as_file, files
+from pathlib import Path
+
+from scout import paths
+
+
+def resolve_schema_path(data: Path | None = None) -> Path:
+    """Return the path to the active KB schema.
+
+    Precedence: user override at
+    $SCOUT_DATA_DIR/knowledge-base/ontology/schema.yaml, else the
+    packaged default in scout/kb/schema.yaml extracted via
+    importlib.resources.
+
+    Caller is responsible for not mutating the returned path; under a
+    wheel install the packaged copy may sit inside an importlib.resources
+    extraction directory, but with a filesystem-installed wheel it is a
+    real on-disk path.
+    """
+    user = paths.kb_dir(data) / "ontology" / "schema.yaml"
+    if user.exists():
+        return user
+    resource = files("scout") / "kb" / "schema.yaml"
+    with as_file(resource) as p:
+        return Path(p)

--- a/engine/scout/kb/schema.yaml
+++ b/engine/scout/kb/schema.yaml
@@ -1,0 +1,215 @@
+# SCOUT Knowledge Graph — Ontology Schema
+# Defines valid entity types, properties, and relationship types.
+# The parser validates all entity files against this schema.
+
+entity_types:
+  person:
+    properties:
+      required: [name, type]
+      optional: [email, slack_id, github, birthday, role, team, employer, phone]
+    relationships:
+      - works_with
+      - manages
+      - managed_by
+      - reports_to
+      - partner_of
+      - family_of
+      - owner_of
+      - works_on
+      - employed_by
+      - interviewed_by
+      - candidate_for
+  pet:
+    properties:
+      required: [name, type, species]
+      optional: [breed, birthday]
+    relationships:
+      - owned_by
+      - has_vet
+  project:
+    properties:
+      required: [name, type, status, priority]
+      optional: [linear_id, repo, team]
+    relationships:
+      - worked_on_by
+      - depends_on
+      - dependency_of
+      - blocks
+      - blocked_by
+  task:
+    properties:
+      required: [name, type, status]
+      optional: [deadline, priority, domain, completion_signal, created_date, completed_date]
+    relationships:
+      - assigned_to
+      - about
+      - blocked_by
+  organization:
+    properties:
+      required: [name, type]
+      optional: [domain, industry, address, phone, website, hours, category, founded, headquarters, employees, funding]
+    relationships:
+      - employs
+      - employed_by
+      - owns
+      - serves
+      - served_by
+      - uses_technology
+      - competes_with
+      - partners_with
+  technology:
+    properties:
+      required: [name, type]
+      optional: [domain, category, license, language, latest_version]
+    relationships:
+      - used_by
+      - forked_from
+      - depends_on
+      - dependency_of
+  invoice-review:
+    properties:
+      required: [name, type]
+      optional: [person, billing_period, hours_billed, amount_billed_czk, hourly_rate_czk, created, sources, status]
+    relationships:
+      - about
+      - details
+  invoice-line-item-review:
+    properties:
+      required: [name, type]
+      optional: [person, parent_review, billing_period, scope, created, sources]
+    relationships:
+      - details
+      - about
+  event:
+    properties:
+      required: [name, type]
+      optional: [domain, date, location, status, created_date, completed_date, attendees]
+    relationships:
+      - attended_by
+      - hosted_by
+      - constrains
+      - mentioned_in
+      - about
+  design:
+    properties:
+      required: [name, type]
+      optional: [domain, project, status, created_date, author, sources]
+    relationships:
+      - about
+      - feeds
+      - lives_in
+      - authored_by
+      - reviewed_by
+
+relationship_types:
+  works_with:
+    inverse: works_with
+    symmetric: true
+  manages:
+    inverse: managed_by
+  managed_by:
+    inverse: manages
+  reports_to:
+    inverse: manages
+  partner_of:
+    inverse: partner_of
+    symmetric: true
+  family_of:
+    inverse: family_of
+    symmetric: true
+  owner_of:
+    inverse: owned_by
+  owned_by:
+    inverse: owner_of
+  works_on:
+    inverse: worked_on_by
+  worked_on_by:
+    inverse: works_on
+  depends_on:
+    inverse: dependency_of
+  dependency_of:
+    inverse: depends_on
+  blocks:
+    inverse: blocked_by
+  blocked_by:
+    inverse: blocks
+  assigned_to:
+    inverse: assignee_of
+  assignee_of:
+    inverse: assigned_to
+  about:
+    inverse: referenced_by
+  referenced_by:
+    inverse: about
+  employs:
+    inverse: employed_by
+  employed_by:
+    inverse: employs
+  owns:
+    inverse: owned_by
+  serves:
+    inverse: served_by
+  served_by:
+    inverse: serves
+  has_vet:
+    inverse: vet_of
+  vet_of:
+    inverse: has_vet
+  uses_technology:
+    inverse: used_by
+  used_by:
+    inverse: uses_technology
+  forked_from:
+    inverse: forked_to
+  forked_to:
+    inverse: forked_from
+  competes_with:
+    inverse: competes_with
+    symmetric: true
+  partners_with:
+    inverse: partners_with
+    symmetric: true
+  details:
+    inverse: detailed_by
+  detailed_by:
+    inverse: details
+  interviewed_by:
+    inverse: interviewed
+  interviewed:
+    inverse: interviewed_by
+  candidate_for:
+    inverse: considering_candidate
+  considering_candidate:
+    inverse: candidate_for
+  attended_by:
+    inverse: attends
+  attends:
+    inverse: attended_by
+  hosted_by:
+    inverse: hosts
+  hosts:
+    inverse: hosted_by
+  constrains:
+    inverse: constrained_by
+  constrained_by:
+    inverse: constrains
+  mentioned_in:
+    inverse: mentions
+  mentions:
+    inverse: mentioned_in
+  feeds:
+    inverse: fed_by
+  fed_by:
+    inverse: feeds
+  lives_in:
+    inverse: houses
+  houses:
+    inverse: lives_in
+  authored_by:
+    inverse: authored
+  authored:
+    inverse: authored_by
+  reviewed_by:
+    inverse: reviewed
+  reviewed:
+    inverse: reviewed_by

--- a/engine/scout/manifest.py
+++ b/engine/scout/manifest.py
@@ -61,11 +61,11 @@ def build_manifest() -> EngineManifest:
         version=__version__,
         schema_version=1,
         features={
-            "session_tokens_v1": False,
-            "connector_health_v1": False,
-            "action_items_cli_v1": False,
-            "kb_ontology_v1": False,
-            "tui_v1": False,
+            "session_tokens_v1": False,  # Plan 3
+            "connector_health_v1": False,  # Plan 3
+            "action_items_cli_v1": True,  # Plan 2
+            "kb_ontology_v1": True,  # Plan 2
+            "tui_v1": True,  # Plan 2
         },
         subcommands=_list_subcommands(),
     )

--- a/engine/scout/paths.py
+++ b/engine/scout/paths.py
@@ -5,6 +5,7 @@ All paths are expanded (~) and resolved (symlinks, relative segments).
 
 from __future__ import annotations
 
+import datetime as _dt
 import os
 from pathlib import Path
 
@@ -70,3 +71,18 @@ def require_data_dir(data: Path | None = None) -> Path:
     if not d.is_dir():
         raise DataDirError(f"Scout data dir is not a directory: {d}")
     return d
+
+
+def _today() -> _dt.date:
+    """Indirection so tests can monkeypatch the date without freezing time."""
+    return _dt.date.today()
+
+
+def action_items_daily_path(data: Path | None = None, date: _dt.date | None = None) -> Path:
+    """Return the daily action-items markdown path for `date` (default today).
+
+    Filename format matches the existing ~/Scout convention:
+    `action-items-YYYY-MM-DD.md` under the data dir's `action-items/`.
+    """
+    d = date or _today()
+    return action_items_dir(data) / f"action-items-{d.isoformat()}.md"

--- a/engine/scout/tui/app.py
+++ b/engine/scout/tui/app.py
@@ -32,8 +32,3 @@ class ScoutApp(App):
         screen = self.screen
         if isinstance(screen, DashboardScreen):
             screen.refresh_items()
-
-
-def main() -> None:
-    app = ScoutApp()
-    app.run()

--- a/engine/scout/tui/app.py
+++ b/engine/scout/tui/app.py
@@ -1,0 +1,39 @@
+"""Scout TUI — Terminal UI for managing action items.
+
+Run with: scoutctl tui
+Or: textual run scout/tui/app.py
+"""
+
+from textual.app import App
+
+from scout.tui.screens.dashboard import DashboardScreen
+
+
+class ScoutApp(App):
+    """The main Scout TUI application."""
+
+    TITLE = "SCOUT Action Items"
+    CSS = """
+    Screen {
+        background: $surface;
+    }
+    """
+
+    BINDINGS = [
+        ("q", "quit", "Quit"),
+        ("r", "refresh", "Refresh"),
+    ]
+
+    def on_mount(self) -> None:
+        self.push_screen(DashboardScreen())
+
+    def action_refresh(self) -> None:
+        """Reload action items from disk."""
+        screen = self.screen
+        if isinstance(screen, DashboardScreen):
+            screen.refresh_items()
+
+
+def main() -> None:
+    app = ScoutApp()
+    app.run()

--- a/engine/scout/tui/config.py
+++ b/engine/scout/tui/config.py
@@ -1,0 +1,37 @@
+"""Scout TUI configuration — paths, keybindings, defaults."""
+
+import datetime
+from pathlib import Path
+
+SCOUT_DIR = Path.home() / "Scout"
+KB_DIR = SCOUT_DIR / "knowledge-base"
+
+ACTION_ITEMS_DIR = SCOUT_DIR / "action-items"
+
+
+def action_items_path(date: datetime.date | None = None) -> Path:
+    """Return the action items file path for a given date (defaults to today)."""
+    if date is None:
+        date = datetime.date.today()
+    filename = f"action-items-{date.isoformat()}.md"
+    return ACTION_ITEMS_DIR / filename
+
+
+def latest_action_items_path() -> Path:
+    """Return the most recent action items file."""
+    if not ACTION_ITEMS_DIR.exists():
+        return action_items_path()
+    files = sorted(ACTION_ITEMS_DIR.glob("action-items-*.md"), reverse=True)
+    return files[0] if files else action_items_path()
+
+
+# Keybindings (Textual action names)
+KEYBINDINGS = {
+    "mark_done": "d",
+    "add_note": "n",
+    "open_context": "o",
+    "spawn_session": "s",
+    "refresh": "r",
+    "filter": "f",
+    "quit": "q",
+}

--- a/engine/scout/tui/screens/context.py
+++ b/engine/scout/tui/screens/context.py
@@ -1,0 +1,13 @@
+"""Context links panel — shows related URLs for an action item."""
+
+from __future__ import annotations
+
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+
+class ContextPanel(ModalScreen):
+    """Shows context links (Linear, GitHub, Slack) for the selected action item."""
+
+    def compose(self):
+        yield Static("Context panel — implementation in next run", id="placeholder")

--- a/engine/scout/tui/screens/dashboard.py
+++ b/engine/scout/tui/screens/dashboard.py
@@ -1,0 +1,302 @@
+"""Dashboard screen — main action items list with keyboard navigation."""
+
+from __future__ import annotations
+
+import datetime as _dt
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.reactive import reactive
+from textual.screen import Screen
+from textual.widgets import Footer, Header, Label, ListItem, ListView, Static
+
+from scout.action_items.parser import ActionItem, filter_actionable, parse_action_items
+from scout.tui.config import latest_action_items_path
+
+# Priority display
+PRIORITY_DISPLAY = {
+    "🔴": ("🔴", "urgent"),
+    "🟡": ("🟡", "medium"),
+    "🟢": ("🟢", "low"),
+    "": ("  ", "none"),
+}
+
+STATUS_DISPLAY = {
+    "open": "[ ]",
+    "done": "[x]",
+    "in_progress": "[~]",
+    "watching": "[?]",
+}
+
+FILTER_OPTIONS = ["all", "🔴", "🟡", "🟢", "open", "done"]
+
+
+def _make_tui_note_line(note_text: str) -> str:
+    """Format a TUI note line with a local timestamp.
+
+    Preserves the same format that the old tui/writer.py add_note used:
+      - **[TUI note, YYYY-MM-DD HH:MM AM/PM ET]:** <text>
+    The timezone is fixed to UTC-4 (EDT) to match the original behaviour.
+    """
+    tz = _dt.timezone(_dt.timedelta(hours=-4))
+    now = _dt.datetime.now(tz)
+    timestamp = now.strftime("%Y-%m-%d %I:%M %p ET")
+    return f"  - **[TUI note, {timestamp}]:** {note_text}"
+
+
+class ActionItemWidget(ListItem):
+    """A single action item in the list."""
+
+    def __init__(self, item: ActionItem) -> None:
+        super().__init__()
+        self.item = item
+
+    def compose(self) -> ComposeResult:
+        priority, _ = PRIORITY_DISPLAY.get(self.item.priority, ("  ", "none"))
+        status = STATUS_DISPLAY.get(self.item.status, "[ ]")
+        title = self.item.title[:80]
+        section = self.item.section[:30] if self.item.section else ""
+
+        if self.item.status == "done":
+            label_text = f"{priority} {status} ~~{title}~~"
+        else:
+            label_text = f"{priority} {status} {title}"
+
+        if section:
+            label_text += f"  ({section})"
+
+        yield Label(label_text)
+
+
+class DashboardScreen(Screen):
+    """Displays action items with keyboard navigation."""
+
+    BINDINGS = [
+        Binding("d", "mark_done", "Done"),
+        Binding("n", "add_note", "Note"),
+        Binding("o", "open_context", "Open"),
+        Binding("s", "spawn", "Spawn"),
+        Binding("f", "cycle_filter", "Filter"),
+    ]
+
+    CSS = """
+    #item-list {
+        height: 1fr;
+    }
+    #status-bar {
+        height: 1;
+        background: $accent;
+        color: $text;
+        padding: 0 1;
+    }
+    #detail-panel {
+        height: 8;
+        border-top: solid $accent;
+        padding: 0 1;
+        overflow-y: auto;
+    }
+    ActionItemWidget {
+        height: 1;
+    }
+    ActionItemWidget:hover {
+        background: $boost;
+    }
+    ListView > ActionItemWidget.-highlight {
+        background: $accent 30%;
+    }
+    """
+
+    filter_mode: reactive[str] = reactive("all")
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.all_items: list[ActionItem] = []
+        self.filepath = latest_action_items_path()
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Vertical(
+            Static(f"Loading from: {self.filepath.name}", id="status-bar"),
+            ListView(id="item-list"),
+            Static("", id="detail-panel"),
+        )
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.refresh_items()
+
+    def refresh_items(self) -> None:
+        """Reload items from disk and update the list."""
+        try:
+            self.filepath = latest_action_items_path()
+            self.all_items = parse_action_items(self.filepath)
+        except FileNotFoundError:
+            self.all_items = []
+            self.notify("No action items file found", severity="warning")
+        except Exception as e:
+            self.all_items = []
+            self.notify(f"Error loading items: {e}", severity="error")
+        self._update_list()
+
+    def _update_list(self) -> None:
+        """Apply current filter and populate the list view."""
+        items = self._filtered_items()
+        list_view = self.query_one("#item-list", ListView)
+        list_view.clear()
+
+        for item in items:
+            list_view.append(ActionItemWidget(item))
+
+        actionable = len(filter_actionable(self.all_items))
+        total = len(self.all_items)
+        showing = len(items)
+        status_text = (
+            f"📋 {self.filepath.name} — "
+            f"{showing} shown, {actionable} actionable, {total} total "
+            f"| Filter: {self.filter_mode}"
+        )
+        self.query_one("#status-bar", Static).update(status_text)
+
+    def _filtered_items(self) -> list[ActionItem]:
+        """Return items matching the current filter."""
+        if self.filter_mode == "all":
+            return self.all_items
+        if self.filter_mode in ("🔴", "🟡", "🟢"):
+            return [i for i in self.all_items if i.priority == self.filter_mode]
+        if self.filter_mode == "open":
+            return filter_actionable(self.all_items)
+        if self.filter_mode == "done":
+            return [i for i in self.all_items if i.status == "done"]
+        return self.all_items
+
+    def watch_filter_mode(self, _old: str, _new: str) -> None:
+        self._update_list()
+
+    def _selected_item(self) -> ActionItem | None:
+        """Get the currently highlighted action item."""
+        list_view = self.query_one("#item-list", ListView)
+        if list_view.highlighted_child is not None:
+            widget = list_view.highlighted_child
+            if isinstance(widget, ActionItemWidget):
+                return widget.item
+        return None
+
+    def on_list_view_highlighted(self, event: ListView.Highlighted) -> None:
+        """Update detail panel when selection changes."""
+        detail = self.query_one("#detail-panel", Static)
+        if event.item and isinstance(event.item, ActionItemWidget):
+            item = event.item.item
+            lines = []
+            if item.details:
+                lines.extend(item.details[:3])
+            if item.context_links:
+                links = ", ".join(item.context_links[:4])
+                lines.append(f"Links: {links}")
+            if item.notes:
+                lines.append(f"Notes: {len(item.notes)}")
+            detail.update("\n".join(lines) if lines else "No details")
+        else:
+            detail.update("")
+
+    def action_cycle_filter(self) -> None:
+        """Cycle through filter options."""
+        idx = FILTER_OPTIONS.index(self.filter_mode)
+        self.filter_mode = FILTER_OPTIONS[(idx + 1) % len(FILTER_OPTIONS)]
+
+    def action_mark_done(self) -> None:
+        """Mark the selected item as done."""
+        item = self._selected_item()
+        if item and item.status != "done" and item.line_number > 0:
+            from scout.action_items.writer import flip_checkbox
+
+            flip_checkbox(self.filepath, line_number=item.line_number, to_done=True)
+            self.refresh_items()
+            self.notify(f"Marked done: {item.title[:40]}")
+
+    def action_add_note(self) -> None:
+        """Open note input for the selected item."""
+        item = self._selected_item()
+        if item:
+            self.app.push_screen(NoteInputScreen(item, self.filepath))
+
+    def on_screen_resume(self) -> None:
+        """Refresh when returning from note screen."""
+        self.refresh_items()
+
+    def action_open_context(self) -> None:
+        """Open context links for the selected item in the browser."""
+        item = self._selected_item()
+        if item and item.context_links:
+            import webbrowser
+
+            for link in item.context_links:
+                if link.startswith("http"):
+                    webbrowser.open(link)
+                    break
+            self.notify(f"Opened link for: {item.title[:40]}")
+        elif item:
+            self.notify("No links for this item")
+
+    def action_spawn(self) -> None:
+        """Spawn a Claude Code session for the selected item."""
+        item = self._selected_item()
+        if item:
+            from scout.tui.screens.spawn import SpawnConfirmScreen
+
+            def on_spawn(result: bool | None) -> None:
+                if result:
+                    self.notify(f"Session launched for: {item.title[:40]}")
+
+            self.app.push_screen(SpawnConfirmScreen(item), on_spawn)
+
+
+class NoteInputScreen(Screen):
+    """Modal for adding a note to an action item."""
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    CSS = """
+    NoteInputScreen {
+        align: center middle;
+    }
+    #note-container {
+        width: 60;
+        height: 12;
+        border: solid $accent;
+        background: $surface;
+        padding: 1;
+    }
+    #note-title {
+        height: 1;
+        margin-bottom: 1;
+    }
+    """
+
+    def __init__(self, item: ActionItem, filepath) -> None:
+        super().__init__()
+        self.item = item
+        self.filepath = filepath
+
+    def compose(self) -> ComposeResult:
+        from textual.widgets import Input
+
+        with Vertical(id="note-container"):
+            yield Label(f"Note for: {self.item.title[:50]}", id="note-title")
+            yield Input(placeholder="Type your note here...", id="note-input")
+            yield Label("[Enter] Save  [Esc] Cancel")
+
+    def on_input_submitted(self, event) -> None:
+        if event.value.strip():
+            from scout.action_items.writer import insert_below
+
+            note_line = _make_tui_note_line(event.value.strip())
+            insert_below(self.filepath, line_number=self.item.line_number, text=note_line)
+            self.dismiss(True)
+        else:
+            self.dismiss(False)
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)

--- a/engine/scout/tui/screens/dashboard.py
+++ b/engine/scout/tui/screens/dashboard.py
@@ -37,10 +37,13 @@ def _make_tui_note_line(note_text: str) -> str:
 
     Preserves the same format that the old tui/writer.py add_note used:
       - **[TUI note, YYYY-MM-DD HH:MM AM/PM ET]:** <text>
-    The timezone is fixed to UTC-4 (EDT) to match the original behaviour.
+    Uses ZoneInfo("America/New_York") so DST transitions track correctly
+    (the source script's hardcoded UTC-4 silently drifted by one hour
+    November–March).
     """
-    tz = _dt.timezone(_dt.timedelta(hours=-4))
-    now = _dt.datetime.now(tz)
+    from zoneinfo import ZoneInfo
+
+    now = _dt.datetime.now(ZoneInfo("America/New_York"))
     timestamp = now.strftime("%Y-%m-%d %I:%M %p ET")
     return f"  - **[TUI note, {timestamp}]:** {note_text}"
 

--- a/engine/scout/tui/screens/note_modal.py
+++ b/engine/scout/tui/screens/note_modal.py
@@ -1,0 +1,13 @@
+"""Note input modal for adding notes to action items."""
+
+from __future__ import annotations
+
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+
+class NoteModal(ModalScreen):
+    """Modal dialog for entering a note on an action item."""
+
+    def compose(self):
+        yield Static("Note modal — implementation in next run", id="placeholder")

--- a/engine/scout/tui/screens/spawn.py
+++ b/engine/scout/tui/screens/spawn.py
@@ -1,0 +1,123 @@
+"""Session spawner — launches Claude Code sessions for action items."""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Label, Static
+
+from scout.action_items.parser import ActionItem
+
+
+def build_prompt(item: ActionItem) -> str:
+    """Build a Claude Code session prompt from an action item."""
+    parts = [f"Work on: {item.title}"]
+
+    if item.section:
+        parts.append(f"Context: From the {item.section!r} section of today's action items.")
+
+    if item.details:
+        parts.append("Details:")
+        for d in item.details[:5]:
+            parts.append(f"  {d}")
+
+    # Extract useful links
+    linear_links = [link for link in item.context_links if "linear.app" in link]
+    github_links = [link for link in item.context_links if "github.com" in link]
+    kb_links = [link for link in item.context_links if link.startswith("kb://")]
+
+    if linear_links:
+        parts.append(f"Linear: {linear_links[0]}")
+    if github_links:
+        parts.append(f"GitHub: {github_links[0]}")
+    if kb_links:
+        kb_names = [link.replace("kb://", "") for link in kb_links[:3]]
+        parts.append(f"KB files: {', '.join(kb_names)}")
+
+    return "\n".join(parts)
+
+
+def spawn_session(item: ActionItem) -> str:
+    """Spawn a Claude Code session in a new terminal window.
+
+    Returns the command that was launched.
+    """
+    prompt = build_prompt(item)
+    safe_title = item.title[:50].replace('"', '\\"')
+
+    # Use osascript to open a new Terminal.app window with claude
+    cmd = f'claude --name "scout-action-{safe_title[:30]}" -p {shlex.quote(prompt)}'
+
+    # Open in a new Terminal window via osascript
+    apple_script = f"""
+    tell application "Terminal"
+        activate
+        do script "cd ~/Scout && {cmd}"
+    end tell
+    """
+
+    subprocess.Popen(
+        ["osascript", "-e", apple_script],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    return cmd
+
+
+class SpawnConfirmScreen(ModalScreen[bool]):
+    """Confirmation modal before spawning a Claude Code session."""
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+        Binding("enter", "confirm", "Launch"),
+    ]
+
+    CSS = """
+    SpawnConfirmScreen {
+        align: center middle;
+    }
+    #spawn-container {
+        width: 70;
+        max-height: 20;
+        border: solid $accent;
+        background: $surface;
+        padding: 1;
+    }
+    #spawn-title {
+        height: 1;
+        margin-bottom: 1;
+    }
+    #spawn-prompt {
+        height: auto;
+        max-height: 12;
+        margin-bottom: 1;
+        color: $text-muted;
+    }
+    #spawn-hint {
+        height: 1;
+    }
+    """
+
+    def __init__(self, item: ActionItem) -> None:
+        super().__init__()
+        self.item = item
+        self.prompt = build_prompt(item)
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="spawn-container"):
+            yield Label(f"Spawn session for: {self.item.title[:50]}", id="spawn-title")
+            yield Static(self.prompt[:500], id="spawn-prompt")
+            yield Label("[Enter] Launch in new terminal  [Esc] Cancel", id="spawn-hint")
+
+    def action_confirm(self) -> None:
+        spawn_session(self.item)
+        self.dismiss(True)
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)

--- a/engine/tests/fixtures/action-items-sample.md
+++ b/engine/tests/fixtures/action-items-sample.md
@@ -1,0 +1,22 @@
+# Action Items — 2026-04-15
+
+## In Progress
+
+- [ ] 🔴 Submit Lever feedback to recruiting
+  - Context: https://example.com/lever
+  - Notes: waiting on hiring manager confirmation
+- [ ] 🟡 Send Scout plugin announcement
+- [x] 🟢 Read incident postmortem
+
+## To Do
+
+- [ ] 🔴 Reply to Q2 budget thread
+- [ ] Followup with vendor on contract redlines
+
+## Watching
+
+- [ ] Vendor SLA renegotiation (no action yet)
+
+## Completed Today
+
+- [x] 🟢 Submit weekly status

--- a/engine/tests/fixtures/kb-sample/people/jordan.md
+++ b/engine/tests/fixtures/kb-sample/people/jordan.md
@@ -1,0 +1,10 @@
+---
+type: person
+name: Jordan
+team: Engineering
+works_on: [scout, plugin-x]
+---
+
+# Jordan
+
+Test fixture entity for KB ontology tests.

--- a/engine/tests/fixtures/kb-sample/schema.yaml
+++ b/engine/tests/fixtures/kb-sample/schema.yaml
@@ -1,0 +1,215 @@
+# SCOUT Knowledge Graph — Ontology Schema
+# Defines valid entity types, properties, and relationship types.
+# The parser validates all entity files against this schema.
+
+entity_types:
+  person:
+    properties:
+      required: [name, type]
+      optional: [email, slack_id, github, birthday, role, team, employer, phone]
+    relationships:
+      - works_with
+      - manages
+      - managed_by
+      - reports_to
+      - partner_of
+      - family_of
+      - owner_of
+      - works_on
+      - employed_by
+      - interviewed_by
+      - candidate_for
+  pet:
+    properties:
+      required: [name, type, species]
+      optional: [breed, birthday]
+    relationships:
+      - owned_by
+      - has_vet
+  project:
+    properties:
+      required: [name, type, status, priority]
+      optional: [linear_id, repo, team]
+    relationships:
+      - worked_on_by
+      - depends_on
+      - dependency_of
+      - blocks
+      - blocked_by
+  task:
+    properties:
+      required: [name, type, status]
+      optional: [deadline, priority, domain, completion_signal, created_date, completed_date]
+    relationships:
+      - assigned_to
+      - about
+      - blocked_by
+  organization:
+    properties:
+      required: [name, type]
+      optional: [domain, industry, address, phone, website, hours, category, founded, headquarters, employees, funding]
+    relationships:
+      - employs
+      - employed_by
+      - owns
+      - serves
+      - served_by
+      - uses_technology
+      - competes_with
+      - partners_with
+  technology:
+    properties:
+      required: [name, type]
+      optional: [domain, category, license, language, latest_version]
+    relationships:
+      - used_by
+      - forked_from
+      - depends_on
+      - dependency_of
+  invoice-review:
+    properties:
+      required: [name, type]
+      optional: [person, billing_period, hours_billed, amount_billed_czk, hourly_rate_czk, created, sources, status]
+    relationships:
+      - about
+      - details
+  invoice-line-item-review:
+    properties:
+      required: [name, type]
+      optional: [person, parent_review, billing_period, scope, created, sources]
+    relationships:
+      - details
+      - about
+  event:
+    properties:
+      required: [name, type]
+      optional: [domain, date, location, status, created_date, completed_date, attendees]
+    relationships:
+      - attended_by
+      - hosted_by
+      - constrains
+      - mentioned_in
+      - about
+  design:
+    properties:
+      required: [name, type]
+      optional: [domain, project, status, created_date, author, sources]
+    relationships:
+      - about
+      - feeds
+      - lives_in
+      - authored_by
+      - reviewed_by
+
+relationship_types:
+  works_with:
+    inverse: works_with
+    symmetric: true
+  manages:
+    inverse: managed_by
+  managed_by:
+    inverse: manages
+  reports_to:
+    inverse: manages
+  partner_of:
+    inverse: partner_of
+    symmetric: true
+  family_of:
+    inverse: family_of
+    symmetric: true
+  owner_of:
+    inverse: owned_by
+  owned_by:
+    inverse: owner_of
+  works_on:
+    inverse: worked_on_by
+  worked_on_by:
+    inverse: works_on
+  depends_on:
+    inverse: dependency_of
+  dependency_of:
+    inverse: depends_on
+  blocks:
+    inverse: blocked_by
+  blocked_by:
+    inverse: blocks
+  assigned_to:
+    inverse: assignee_of
+  assignee_of:
+    inverse: assigned_to
+  about:
+    inverse: referenced_by
+  referenced_by:
+    inverse: about
+  employs:
+    inverse: employed_by
+  employed_by:
+    inverse: employs
+  owns:
+    inverse: owned_by
+  serves:
+    inverse: served_by
+  served_by:
+    inverse: serves
+  has_vet:
+    inverse: vet_of
+  vet_of:
+    inverse: has_vet
+  uses_technology:
+    inverse: used_by
+  used_by:
+    inverse: uses_technology
+  forked_from:
+    inverse: forked_to
+  forked_to:
+    inverse: forked_from
+  competes_with:
+    inverse: competes_with
+    symmetric: true
+  partners_with:
+    inverse: partners_with
+    symmetric: true
+  details:
+    inverse: detailed_by
+  detailed_by:
+    inverse: details
+  interviewed_by:
+    inverse: interviewed
+  interviewed:
+    inverse: interviewed_by
+  candidate_for:
+    inverse: considering_candidate
+  considering_candidate:
+    inverse: candidate_for
+  attended_by:
+    inverse: attends
+  attends:
+    inverse: attended_by
+  hosted_by:
+    inverse: hosts
+  hosts:
+    inverse: hosted_by
+  constrains:
+    inverse: constrained_by
+  constrained_by:
+    inverse: constrains
+  mentioned_in:
+    inverse: mentions
+  mentions:
+    inverse: mentioned_in
+  feeds:
+    inverse: fed_by
+  fed_by:
+    inverse: feeds
+  lives_in:
+    inverse: houses
+  houses:
+    inverse: lives_in
+  authored_by:
+    inverse: authored
+  authored:
+    inverse: authored_by
+  reviewed_by:
+    inverse: reviewed
+  reviewed:
+    inverse: reviewed_by

--- a/engine/tests/integration/test_action_items_cli.py
+++ b/engine/tests/integration/test_action_items_cli.py
@@ -1,0 +1,63 @@
+"""Integration tests for scoutctl action-items via subprocess."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _scoutctl(*args: str, env: dict[str, str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "scout.cli", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=cwd,
+    )
+
+
+def test_action_items_list_open_only(tmp_path: Path) -> None:
+    data_dir = tmp_path / "Scout"
+    items_dir = data_dir / "action-items"
+    items_dir.mkdir(parents=True)
+    fixture = Path(__file__).parent.parent / "fixtures" / "action-items-sample.md"
+    target = items_dir / "action-items-2026-04-15.md"
+    target.write_text(fixture.read_text())
+
+    env = {**os.environ, "SCOUT_DATA_DIR": str(data_dir)}
+    r = _scoutctl("action-items", "list", str(target), "--json", env=env)
+    assert r.returncode == 0, r.stderr
+    payload = json.loads(r.stdout)
+    statuses = {row["status"] for row in payload}
+    assert statuses == {"open"}
+
+
+def test_action_items_mark_done_via_cli(tmp_path: Path) -> None:
+    data_dir = tmp_path / "Scout"
+    items_dir = data_dir / "action-items"
+    items_dir.mkdir(parents=True)
+    target = items_dir / "action-items-2026-04-15.md"
+    target.write_text("- [ ] sample task\n")
+
+    env = {**os.environ, "SCOUT_DATA_DIR": str(data_dir)}
+    r = _scoutctl(
+        "action-items",
+        "mark-done",
+        "--subject",
+        "sample",
+        str(target),
+        env=env,
+    )
+    assert r.returncode == 0, r.stderr
+    assert "- [x] sample task" in target.read_text()
+
+
+def test_action_items_watch_returns_scout_error_exit_code() -> None:
+    """Plan 2 stubs `watch` with a Plan 3 placeholder."""
+    r = _scoutctl("action-items", "watch", env={**os.environ})
+    # ScoutError.exit_code == 1
+    assert r.returncode == 1
+    assert "Plan 3" in r.stderr

--- a/engine/tests/integration/test_schema_parity.py
+++ b/engine/tests/integration/test_schema_parity.py
@@ -1,0 +1,47 @@
+"""Schema-parity check: packaged engine default vs live user vault.
+
+The engine ships ``scout/kb/schema.yaml`` as a default; users may override
+by placing their own copy at
+``$SCOUT_DATA_DIR/knowledge-base/ontology/schema.yaml`` (see
+``scout.kb.paths.resolve_schema_path``). Until the vault becomes the sole
+source of truth (Plan 4+), the two copies need to match — otherwise any
+consumer that doesn't go through ``resolve_schema_path`` (e.g., a wheel
+install with no ``SCOUT_DATA_DIR`` set) silently reads a stale schema.
+
+This test is gated on ``SCOUT_DATA_DIR``: skipped in CI (where it's unset),
+runs locally and against any environment with a real vault. ~/Scout's
+launchd runners export ``SCOUT_DATA_DIR=$HOME/Scout``, so wiring this into
+a pre-session hook there catches drift before it bites.
+"""
+
+from __future__ import annotations
+
+import os
+from importlib.resources import as_file, files
+from pathlib import Path
+
+import pytest
+
+
+def test_packaged_schema_matches_vault() -> None:
+    data_dir = os.environ.get("SCOUT_DATA_DIR")
+    if not data_dir:
+        pytest.skip("SCOUT_DATA_DIR not set — parity test only runs against a real vault")
+
+    vault_schema = Path(data_dir) / "knowledge-base" / "ontology" / "schema.yaml"
+    if not vault_schema.exists():
+        pytest.skip(f"No vault schema at {vault_schema}")
+
+    resource = files("scout") / "kb" / "schema.yaml"
+    with as_file(resource) as p:
+        packaged_schema = Path(p)
+        packaged_text = packaged_schema.read_text(encoding="utf-8")
+
+    vault_text = vault_schema.read_text(encoding="utf-8")
+
+    assert vault_text == packaged_text, (
+        "Schema drift detected between vault and packaged engine default.\n"
+        f"  vault:    {vault_schema}\n"
+        f"  packaged: {packaged_schema}\n"
+        "Reconcile the two, or document the divergence and update this test."
+    )

--- a/engine/tests/perf/test_no_heavy_imports.py
+++ b/engine/tests/perf/test_no_heavy_imports.py
@@ -1,8 +1,9 @@
 """Static import-graph test: forbids heavy imports at scoutctl startup.
 
-Scout-app invokes scoutctl on every user action. If scout.cli imports
-textual / rich / jinja2 / watchdog / scout.kb.*, startup balloons past
-the latency budget. This test parses scout/cli.py's AST and fails on
+Scout-app invokes scoutctl on every user action. If scout.cli (or any
+sub-CLI module imported transitively at startup) imports textual / rich /
+jinja2 / watchdog / scout.kb.* / scout.tui.*, startup balloons past the
+latency budget. This test parses each scanned file's AST and fails on
 top-level imports of the banned modules.
 """
 
@@ -20,7 +21,15 @@ BANNED_TOP_LEVEL = {
     "watchdog",
     "scout.kb",
     "scout.tui",
-    "scout.action_items",
+    # scout.action_items.cli is allowed since it only imports typer + stdlib
+    # at top; its heavy submodules are inside function bodies.
+    "scout.action_items.parser",
+    "scout.action_items.writer",
+    "scout.action_items.mark_done",
+    "scout.action_items.snooze",
+    "scout.action_items.add_comment",
+    "scout.action_items.render",
+    "scout.action_items.list",
     "scout.runners",
     "scout.hooks",
     "scout.scripts",
@@ -42,15 +51,19 @@ def _top_level_imports(source: str) -> set[str]:
     return names
 
 
-CLI_PATH = Path(__file__).parent.parent.parent / "scout" / "cli.py"
+SCANNED_FILES = [
+    Path(__file__).parent.parent.parent / "scout" / "cli.py",
+    Path(__file__).parent.parent.parent / "scout" / "action_items" / "cli.py",
+]
 
 
 @pytest.mark.perf
-def test_cli_has_no_banned_top_level_imports() -> None:
-    source = CLI_PATH.read_text()
+@pytest.mark.parametrize("source_file", SCANNED_FILES, ids=lambda p: p.name)
+def test_cli_has_no_banned_top_level_imports(source_file: Path) -> None:
+    source = source_file.read_text()
     imports = _top_level_imports(source)
     offenders = imports & BANNED_TOP_LEVEL
     assert not offenders, (
-        f"scout/cli.py has banned top-level imports: {offenders}. "
+        f"{source_file} has banned top-level imports: {offenders}. "
         f"Move them inside subcommand functions to preserve startup latency."
     )

--- a/engine/tests/unit/test_action_items_add_comment.py
+++ b/engine/tests/unit/test_action_items_add_comment.py
@@ -1,0 +1,82 @@
+"""Unit tests for scout.action_items.add_comment."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scout.action_items.add_comment import add_comment
+from scout.errors import ActionItemError
+
+
+def _seed(tmp_path: Path, body: str) -> Path:
+    f = tmp_path / "action-items-2026-04-15.md"
+    f.write_text(body)
+    return f
+
+
+def test_adds_comment_below_matched_task(tmp_path: Path) -> None:
+    f = _seed(tmp_path, "- [ ] Task A\n- [ ] Task B\n")
+    add_comment(f, subject="Task A", text="checked with vendor", timestamp=False)
+    body = f.read_text()
+    assert "checked with vendor" in body
+    # The comment appears between Task A and Task B.
+    assert body.index("Task A") < body.index("checked with vendor") < body.index("Task B")
+
+
+def test_adds_comment_with_timestamp(tmp_path: Path) -> None:
+    f = _seed(tmp_path, "- [ ] Task A\n")
+    add_comment(f, subject="Task A", text="vendor confirmed", timestamp=True, author="jordan")
+    body = f.read_text()
+    # Comment should contain the author name, text, and a date-like pattern.
+    assert "jordan" in body
+    assert "vendor confirmed" in body
+    # Should be formatted as blockquote: > author (YYYY-MM-DD HH:MM AM/PM ET): text
+    assert "> jordan" in body
+
+
+def test_comment_appended_after_existing_comments(tmp_path: Path) -> None:
+    f = _seed(tmp_path, "- [ ] Task A\n  > scott (2026-04-15 10:00 AM ET): first comment\n- [ ] Task B\n")
+    add_comment(f, subject="Task A", text="second comment", timestamp=False)
+    body = f.read_text()
+    # Both comments should be present.
+    assert "first comment" in body
+    assert "second comment" in body
+    # second_comment comes after first_comment
+    assert body.index("first comment") < body.index("second comment")
+    # Both come before Task B
+    assert body.index("second comment") < body.index("Task B")
+
+
+def test_no_match_raises(tmp_path: Path) -> None:
+    f = _seed(tmp_path, "- [ ] Task\n")
+    with pytest.raises(ActionItemError, match="no match"):
+        add_comment(f, subject="other", text="x")
+
+
+def test_ambiguous_match_raises(tmp_path: Path) -> None:
+    f = _seed(tmp_path, "- [ ] vendor A\n- [ ] vendor B\n")
+    with pytest.raises(ActionItemError, match="ambiguous|multiple"):
+        add_comment(f, subject="vendor", text="x")
+
+
+def test_case_insensitive_matching(tmp_path: Path) -> None:
+    f = _seed(tmp_path, "- [ ] Submit LEVER Feedback\n")
+    add_comment(f, subject="lever", text="done", timestamp=False)
+    body = f.read_text()
+    assert "done" in body
+
+
+def test_resolves_today_when_path_omitted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import datetime as dt
+
+    from scout import paths
+
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    (tmp_path / "action-items").mkdir()
+    monkeypatch.setattr(paths, "_today", lambda: dt.date(2026, 4, 15))
+    f = _seed(tmp_path / "action-items", "- [ ] task X\n")
+    # No `path` argument → resolves via paths.action_items_daily_path()
+    add_comment(None, subject="task X", text="done", timestamp=False)
+    assert "done" in f.read_text()

--- a/engine/tests/unit/test_action_items_list.py
+++ b/engine/tests/unit/test_action_items_list.py
@@ -1,0 +1,32 @@
+"""Unit tests for scout.action_items.list."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scout.action_items.list import list_items
+
+FIXTURE = Path(__file__).parent.parent / "fixtures" / "action-items-sample.md"
+
+
+def test_list_open_only_default() -> None:
+    items = list_items(FIXTURE)
+    statuses = {i.status for i in items}
+    assert statuses == {"open"}
+
+
+def test_list_all_includes_done() -> None:
+    items = list_items(FIXTURE, include_done=True)
+    statuses = {i.status for i in items}
+    assert "done" in statuses
+    assert "open" in statuses
+
+
+def test_list_filter_priority_high() -> None:
+    items = list_items(FIXTURE, priority="high")
+    assert all(i.priority == "🔴" for i in items)
+
+
+def test_list_filter_section() -> None:
+    items = list_items(FIXTURE, section="Watching")
+    assert all(i.section == "Watching" for i in items)

--- a/engine/tests/unit/test_action_items_mark_done.py
+++ b/engine/tests/unit/test_action_items_mark_done.py
@@ -1,0 +1,57 @@
+"""Unit tests for scout.action_items.mark_done."""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import pytest
+
+from scout.action_items.mark_done import mark_done
+from scout.errors import ActionItemError
+
+
+def _seed(tmp_path: Path, body: str) -> Path:
+    f = tmp_path / "action-items-2026-04-15.md"
+    f.write_text(body)
+    return f
+
+
+def test_marks_open_task_done_by_subject(tmp_path: Path) -> None:
+    f = _seed(tmp_path, "- [ ] Submit Lever feedback\n- [ ] Other task\n")
+    mark_done(f, subject="Lever feedback")
+    assert "- [x] Submit Lever feedback" in f.read_text()
+    assert "- [ ] Other task" in f.read_text()  # unchanged
+
+
+def test_no_match_raises(tmp_path: Path) -> None:
+    f = _seed(tmp_path, "- [ ] Existing task\n")
+    with pytest.raises(ActionItemError, match="no match"):
+        mark_done(f, subject="missing keyword")
+
+
+def test_ambiguous_match_raises_listing_candidates(tmp_path: Path) -> None:
+    f = _seed(tmp_path, "- [ ] Lever feedback A\n- [ ] Lever feedback B\n")
+    with pytest.raises(ActionItemError, match="ambiguous|multiple") as exc:
+        mark_done(f, subject="lever feedback")
+    msg = str(exc.value)
+    assert "Lever feedback A" in msg
+    assert "Lever feedback B" in msg
+
+
+def test_undo_flips_done_back_to_open(tmp_path: Path) -> None:
+    f = _seed(tmp_path, "- [x] Done thing\n")
+    mark_done(f, subject="Done thing", undo=True)
+    assert "- [ ] Done thing" in f.read_text()
+
+
+def test_resolves_today_when_path_omitted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from scout import paths
+
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    (tmp_path / "action-items").mkdir()
+    monkeypatch.setattr(paths, "_today", lambda: dt.date(2026, 4, 15))
+    f = _seed(tmp_path / "action-items", "- [ ] task X\n")
+    # No `path` argument → resolves via paths.action_items_daily_path()
+    mark_done(None, subject="task X")
+    assert "- [x] task X" in f.read_text()

--- a/engine/tests/unit/test_action_items_parser.py
+++ b/engine/tests/unit/test_action_items_parser.py
@@ -1,0 +1,66 @@
+"""Unit tests for scout.action_items.parser.
+
+Drives all assertions off engine/tests/fixtures/action-items-sample.md
+so behavior remains anchored to a real, version-controlled document.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scout.action_items.parser import ActionItem, parse_file
+
+FIXTURE = Path(__file__).parent.parent / "fixtures" / "action-items-sample.md"
+
+
+@pytest.fixture
+def items() -> list[ActionItem]:
+    return parse_file(FIXTURE)
+
+
+def test_parses_all_items(items: list[ActionItem]) -> None:
+    assert len(items) == 7  # 3 in progress + 2 to do + 1 watching + 1 completed
+
+
+def test_open_vs_done_status(items: list[ActionItem]) -> None:
+    open_titles = [i.title for i in items if i.status == "open"]
+    done_titles = [i.title for i in items if i.status == "done"]
+    assert "Submit Lever feedback to recruiting" in open_titles
+    assert "Read incident postmortem" in done_titles
+
+
+def test_priority_extraction(items: list[ActionItem]) -> None:
+    by_title = {i.title: i for i in items}
+    assert by_title["Submit Lever feedback to recruiting"].priority == "🔴"
+    assert by_title["Send Scout plugin announcement"].priority == "🟡"
+    assert by_title["Read incident postmortem"].priority == "🟢"
+    assert by_title["Followup with vendor on contract redlines"].priority == ""
+
+
+def test_section_attribution(items: list[ActionItem]) -> None:
+    by_title = {i.title: i for i in items}
+    assert by_title["Submit Lever feedback to recruiting"].section == "In Progress"
+    assert by_title["Reply to Q2 budget thread"].section == "To Do"
+    assert by_title["Vendor SLA renegotiation (no action yet)"].section == "Watching"
+    assert by_title["Submit weekly status"].section == "Completed Today"
+
+
+def test_sub_bullets_collected(items: list[ActionItem]) -> None:
+    by_title = {i.title: i for i in items}
+    lever = by_title["Submit Lever feedback to recruiting"]
+    # context_links comes from "Context: <url>" sub-bullet
+    assert any("example.com/lever" in link for link in lever.context_links)
+    # details from all sub-bullets (including "Notes: ..." sub-bullet)
+    assert any("hiring manager" in detail for detail in lever.details)
+
+
+def test_raw_line_preserved_for_substring_lookup(items: list[ActionItem]) -> None:
+    """Writer modules locate items by full-line substring match;
+    `raw_line` must be the exact original source line."""
+    by_title = {i.title: i for i in items}
+    raw = by_title["Reply to Q2 budget thread"].raw_line
+    assert "[ ]" in raw
+    assert "🔴" in raw
+    assert "Reply to Q2 budget thread" in raw

--- a/engine/tests/unit/test_action_items_render.py
+++ b/engine/tests/unit/test_action_items_render.py
@@ -1,0 +1,36 @@
+"""Unit tests for scout.action_items.render.
+
+Smoke-level: render a fixture file and verify the output references the
+tasks the parser extracted. Pixel-perfect Rich output is intentionally
+not asserted — that would be brittle.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scout.action_items.render import render
+
+FIXTURE = Path(__file__).parent.parent / "fixtures" / "action-items-sample.md"
+
+
+def test_render_runs_on_fixture_without_error() -> None:
+    out = render(FIXTURE)
+    assert isinstance(out, str)
+    assert len(out) > 0
+
+
+def test_render_includes_open_task_titles() -> None:
+    out = render(FIXTURE)
+    assert "Submit Lever feedback" in out
+    assert "Reply to Q2 budget thread" in out
+
+
+def test_render_missing_file_raises(tmp_path: Path) -> None:
+    from scout.errors import ActionItemError
+
+    missing = tmp_path / "no-such-file.md"
+    with pytest.raises(ActionItemError, match="not found"):
+        render(missing)

--- a/engine/tests/unit/test_action_items_snooze.py
+++ b/engine/tests/unit/test_action_items_snooze.py
@@ -1,0 +1,135 @@
+"""Unit tests for scout.action_items.snooze.
+
+Source contract (from ~/Scout/action-items/snooze.py):
+- Source line is REMOVED entirely (not replaced with a marker).
+- A carry-in entry is appended to a '## 🛌 Snoozed' section in the target file:
+    - [ ] {task body} _(carried in from {source_date})_
+- Matching scans ALL tasks regardless of checkbox state (open and closed).
+- until must be strictly after today (raises ActionItemError with 'past' substring).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import pytest
+
+from scout.action_items.snooze import snooze
+from scout.errors import ActionItemError
+
+
+def test_moves_task_to_future_daily_file(tmp_path: Path) -> None:
+    src = tmp_path / "action-items-2026-04-15.md"
+    src.write_text("## To Do\n\n- [ ] Reply to vendor\n- [ ] Other thing\n")
+    dst = snooze(src, subject="Reply to vendor", until=dt.date(2026, 5, 1))
+    assert dst == tmp_path / "action-items-2026-05-01.md"
+    assert dst.exists()
+    assert "Reply to vendor" in dst.read_text()
+    # Source line is removed.
+    src_after = src.read_text()
+    assert "Reply to vendor" not in src_after
+    # Unrelated task is untouched.
+    assert "- [ ] Other thing" in src_after
+
+
+def test_carry_in_annotation_in_dest(tmp_path: Path) -> None:
+    src = tmp_path / "action-items-2026-04-15.md"
+    src.write_text("- [ ] Call mechanic\n")
+    dst = snooze(src, subject="Call mechanic", until=dt.date(2026, 5, 1))
+    content = dst.read_text()
+    assert "Call mechanic" in content
+    assert "carried in from 2026-04-15" in content
+
+
+def test_dest_has_snoozed_section(tmp_path: Path) -> None:
+    src = tmp_path / "action-items-2026-04-15.md"
+    src.write_text("- [ ] Buy milk\n")
+    dst = snooze(src, subject="Buy milk", until=dt.date(2026, 5, 1))
+    content = dst.read_text()
+    assert "🛌 Snoozed" in content
+
+
+def test_appends_to_existing_dest_file(tmp_path: Path) -> None:
+    src = tmp_path / "action-items-2026-04-15.md"
+    src.write_text("- [ ] New task\n")
+    dst_path = tmp_path / "action-items-2026-05-01.md"
+    dst_path.write_text("# Action Items — 2026-05-01\n\n## To Do\n\n- [ ] Pre-existing\n")
+    dst = snooze(src, subject="New task", until=dt.date(2026, 5, 1))
+    content = dst.read_text()
+    assert "Pre-existing" in content
+    assert "New task" in content
+
+
+def test_removes_continuation_lines(tmp_path: Path) -> None:
+    """Task block removal includes indented sub-items."""
+    src = tmp_path / "action-items-2026-04-15.md"
+    src.write_text("- [ ] Big task\n  - sub item A\n  - sub item B\n- [ ] Other task\n")
+    snooze(src, subject="Big task", until=dt.date(2026, 5, 1))
+    src_after = src.read_text()
+    assert "Big task" not in src_after
+    assert "sub item" not in src_after
+    assert "- [ ] Other task" in src_after
+
+
+def test_no_match_raises(tmp_path: Path) -> None:
+    src = tmp_path / "action-items-2026-04-15.md"
+    src.write_text("- [ ] something\n")
+    with pytest.raises(ActionItemError, match="no match"):
+        snooze(src, subject="missing", until=dt.date(2026, 5, 1))
+
+
+def test_ambiguous_match_raises(tmp_path: Path) -> None:
+    src = tmp_path / "action-items-2026-04-15.md"
+    src.write_text("- [ ] vendor A\n- [ ] vendor B\n")
+    with pytest.raises(ActionItemError, match="ambiguous|multiple"):
+        snooze(src, subject="vendor", until=dt.date(2026, 5, 1))
+
+
+def test_until_in_the_past_raises(tmp_path: Path) -> None:
+    src = tmp_path / "action-items-2026-04-15.md"
+    src.write_text("- [ ] task\n")
+    with pytest.raises(ActionItemError, match="past"):
+        snooze(src, subject="task", until=dt.date(2026, 4, 14))
+
+
+def test_case_insensitive_match(tmp_path: Path) -> None:
+    src = tmp_path / "action-items-2026-04-15.md"
+    src.write_text("- [ ] Reply To Vendor\n")
+    dst = snooze(src, subject="reply to vendor", until=dt.date(2026, 5, 1))
+    assert "Reply To Vendor" in dst.read_text()
+
+
+def test_matches_closed_tasks_too(tmp_path: Path) -> None:
+    """Snooze can act on an already-closed task (source matches regardless of mark)."""
+    src = tmp_path / "action-items-2026-04-15.md"
+    src.write_text("- [x] Finished but reschedule\n")
+    dst = snooze(src, subject="Finished but reschedule", until=dt.date(2026, 5, 1))
+    assert "Finished but reschedule" in dst.read_text()
+
+
+def test_returns_dest_path(tmp_path: Path) -> None:
+    src = tmp_path / "action-items-2026-04-15.md"
+    src.write_text("- [ ] task\n")
+    result = snooze(src, subject="task", until=dt.date(2026, 5, 1))
+    assert result == tmp_path / "action-items-2026-05-01.md"
+
+
+def test_dedup_does_not_double_append(tmp_path: Path) -> None:
+    """Re-snoozing skips if exact same subject already present in target section.
+
+    Dedup compares the plain-text subject of existing entries.  An entry with
+    an identical rest (no carry-in annotation yet) is treated as a duplicate.
+    Note: entries that already carry a '_(carried in from …)_' annotation will
+    NOT be detected as duplicates because the annotation changes the subject
+    text — this matches the source's behaviour verbatim.
+    """
+    src = tmp_path / "action-items-2026-04-15.md"
+    src.write_text("- [ ] task\n")
+    dst_path = tmp_path / "action-items-2026-05-01.md"
+    # Pre-existing entry has the SAME subject (no annotation yet).
+    dst_path.write_text("## 🛌 Snoozed\n\n- [ ] task\n")
+    snooze(src, subject="task", until=dt.date(2026, 5, 1))
+    count = dst_path.read_text().count("task")
+    # Only one mention — dedup prevented a second append.
+    assert count == 1

--- a/engine/tests/unit/test_action_items_writer.py
+++ b/engine/tests/unit/test_action_items_writer.py
@@ -1,0 +1,68 @@
+"""Unit tests for scout.action_items.writer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scout.action_items.writer import (
+    atomic_write_lines,
+    flip_checkbox,
+    insert_below,
+)
+
+
+def test_atomic_write_replaces_file_contents(tmp_path: Path) -> None:
+    target = tmp_path / "f.md"
+    target.write_text("old\n")
+    atomic_write_lines(target, ["new line 1", "new line 2"])
+    assert target.read_text() == "new line 1\nnew line 2\n"
+
+
+def test_atomic_write_uses_temp_then_rename(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Failure between tmp write and replace must leave original intact."""
+    target = tmp_path / "f.md"
+    target.write_text("original\n")
+    real_replace = __import__("os").replace
+
+    def boom(_src: str, _dst: str) -> None:
+        raise OSError("simulated rename failure")
+
+    import os
+
+    monkeypatch.setattr(os, "replace", boom)
+    with pytest.raises(OSError):
+        atomic_write_lines(target, ["new"])
+    assert target.read_text() == "original\n"  # untouched
+    monkeypatch.setattr(os, "replace", real_replace)
+
+
+def test_flip_checkbox_open_to_done(tmp_path: Path) -> None:
+    target = tmp_path / "f.md"
+    target.write_text("- [ ] task A\n- [ ] task B\n")
+    flip_checkbox(target, line_number=1, to_done=True)
+    assert target.read_text() == "- [x] task A\n- [ ] task B\n"
+
+
+def test_flip_checkbox_done_to_open(tmp_path: Path) -> None:
+    target = tmp_path / "f.md"
+    target.write_text("- [x] task A\n")
+    flip_checkbox(target, line_number=1, to_done=False)
+    assert target.read_text() == "- [ ] task A\n"
+
+
+def test_insert_below_appends_after_target_line(tmp_path: Path) -> None:
+    target = tmp_path / "f.md"
+    target.write_text("line 1\nline 2\nline 3\n")
+    insert_below(target, line_number=2, text="  - inserted note")
+    assert target.read_text() == "line 1\nline 2\n  - inserted note\nline 3\n"
+
+
+def test_flip_checkbox_out_of_range_raises(tmp_path: Path) -> None:
+    target = tmp_path / "f.md"
+    target.write_text("- [ ] task\n")
+    from scout.errors import ActionItemError
+
+    with pytest.raises(ActionItemError, match="line"):
+        flip_checkbox(target, line_number=99, to_done=True)

--- a/engine/tests/unit/test_kb_ontology.py
+++ b/engine/tests/unit/test_kb_ontology.py
@@ -32,3 +32,22 @@ def test_knowledge_graph_query_unknown_type_returns_empty() -> None:
     )
     g.load()
     assert g.query(type="nonexistent") == []
+
+
+def test_knowledge_graph_validate_returns_structured_errors() -> None:
+    # Locks in the library-side validate() surface ahead of the Plan 4
+    # `scoutctl kb validate` CLI port. ~/Scout users today reach this via
+    # `python3 knowledge-base/ontology/parser.py validate`; once the engine
+    # is the source of truth, that capability must stay reachable from the
+    # library.
+    g = KnowledgeGraph(
+        schema_path=str(FIXTURE_DIR / "schema.yaml"),
+        kb_root=str(FIXTURE_DIR),
+    )
+    g.load()
+    errors = g.validate()
+    assert isinstance(errors, list)
+    for err in errors:
+        assert set(err.keys()) >= {"entity", "message"}
+        assert isinstance(err["entity"], str)
+        assert isinstance(err["message"], str)

--- a/engine/tests/unit/test_kb_ontology.py
+++ b/engine/tests/unit/test_kb_ontology.py
@@ -1,0 +1,34 @@
+"""Unit tests for scout.kb.ontology."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scout.kb.ontology import KnowledgeGraph
+
+FIXTURE_DIR = Path(__file__).parent.parent / "fixtures" / "kb-sample"
+
+
+def test_knowledge_graph_loads_fixture() -> None:
+    g = KnowledgeGraph(
+        schema_path=str(FIXTURE_DIR / "schema.yaml"),
+        kb_root=str(FIXTURE_DIR),
+    )
+    g.load()
+    results = g.query(type="person", name="Jordan")
+    assert len(results) == 1
+    # Adapt assertion shape to what query() returns (dict vs object).
+    first = results[0]
+    if hasattr(first, "name"):
+        assert first.name == "Jordan"
+    else:
+        assert first["name"] == "Jordan"
+
+
+def test_knowledge_graph_query_unknown_type_returns_empty() -> None:
+    g = KnowledgeGraph(
+        schema_path=str(FIXTURE_DIR / "schema.yaml"),
+        kb_root=str(FIXTURE_DIR),
+    )
+    g.load()
+    assert g.query(type="nonexistent") == []

--- a/engine/tests/unit/test_manifest.py
+++ b/engine/tests/unit/test_manifest.py
@@ -86,3 +86,14 @@ def test_build_manifest_enumerates_subcommands_from_typer_app(
 def test_build_manifest_subcommands_sorted_for_stability() -> None:
     m = build_manifest()
     assert m.subcommands == sorted(m.subcommands)
+
+
+def test_action_items_kb_tui_features_enabled() -> None:
+    """Plan 2 lights these three. Other Plan 1 placeholders remain False."""
+    m = build_manifest()
+    assert m.features["action_items_cli_v1"] is True
+    assert m.features["kb_ontology_v1"] is True
+    assert m.features["tui_v1"] is True
+    # Plan 3 lights these — still False after Plan 2.
+    assert m.features["session_tokens_v1"] is False
+    assert m.features["connector_health_v1"] is False

--- a/engine/tests/unit/test_paths.py
+++ b/engine/tests/unit/test_paths.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 from pathlib import Path
 
 import pytest
@@ -61,3 +62,16 @@ def test_derived_paths_under_data_dir(tmp_path: Path) -> None:
     assert paths.config_path(tmp_path) == tmp_path / ".scout-config.yaml"
     assert paths.kb_dir(tmp_path) == tmp_path / "knowledge-base"
     assert paths.action_items_dir(tmp_path) == tmp_path / "action-items"
+
+
+def test_action_items_daily_path_default_today(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    today = dt.date(2026, 4, 24)
+    monkeypatch.setattr(paths, "_today", lambda: today)
+    p = paths.action_items_daily_path(data=fake_data_dir)
+    assert p.name == "action-items-2026-04-24.md"
+    assert p.parent == fake_data_dir / "action-items"
+
+
+def test_action_items_daily_path_explicit_date(fake_data_dir: Path) -> None:
+    p = paths.action_items_daily_path(data=fake_data_dir, date=dt.date(2026, 4, 15))
+    assert p.name == "action-items-2026-04-15.md"

--- a/engine/tests/unit/test_tui_smoke.py
+++ b/engine/tests/unit/test_tui_smoke.py
@@ -1,0 +1,40 @@
+"""Smoke tests for the TUI port: confirm imports work and the
+Textual App class is constructable without actually running the UI.
+
+A full UI test requires Textual's pilot framework. Plan 2 keeps
+testing minimal — Plan 6 (scout-app) is where TUI wins matter.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        "scout.tui",
+        "scout.tui.app",
+        "scout.tui.config",
+        "scout.tui.screens.dashboard",
+        "scout.tui.screens.context",
+        "scout.tui.screens.note_modal",
+        "scout.tui.screens.spawn",
+    ],
+)
+def test_tui_module_imports(module: str) -> None:
+    pytest.importorskip("textual")  # skip whole test if textual is not installed
+    importlib.import_module(module)
+
+
+def test_tui_app_class_exists() -> None:
+    """Sanity-check that scout.tui.app exposes the Textual App subclass
+    that scoutctl tui will instantiate."""
+    pytest.importorskip("textual")
+    mod = importlib.import_module("scout.tui.app")
+    # Class name varies — read tui/app.py to confirm. Accept either name pattern.
+    classes = [n for n in dir(mod) if not n.startswith("_")]
+    has_app = any(n.endswith("App") or n in {"ScoutTUI", "ScoutApp", "App"} for n in classes)
+    assert has_app, f"scout.tui.app must expose a Textual App subclass. Found: {sorted(classes)}"


### PR DESCRIPTION
## Summary

Plan 2 of 7 for Scout unification. Ports the existing Python subsystems from \`~/Scout\` into \`scout-plugin/engine/scout/\`:

- **\`scout.action_items\`** — shared parser + atomic-write writer (factored out of TUI), plus \`mark_done\`, \`snooze\`, \`add_comment\`, \`render\`, and a new \`list\` module. All wired behind \`scoutctl action-items {mark-done,snooze,add-comment,render,list,watch}\`. \`watch\` is stubbed pending Plan 3.
- **\`scout.kb\`** — \`KnowledgeGraph\` ontology parser; \`schema.yaml\` ships packaged via \`importlib.resources\`, with user override at \`\$SCOUT_DATA_DIR/knowledge-base/ontology/schema.yaml\`. CLI query wiring lands in Plan 4.
- **\`scout.tui\`** — Textual app + screens, ported as-is, retargeted to import from \`scout.action_items.{parser,writer}\`. \`scoutctl tui\` imports \`textual\` lazily; remains opt-in via \`.[full]\` extra.

Manifest flags flipped: \`action_items_cli_v1\`, \`kb_ontology_v1\`, \`tui_v1\` → \`true\`.

## Personal-data discipline

Two scrubs applied while porting:
- \`add_comment.py\` defaulted \`author=\"jordan\"\`; changed to \`\"scout\"\` (commit \`97340c3\`).
- \`render.py\` docstring + regex comment had \`> jordan ...\` placeholders; changed to \`> scout ...\` (commit \`74388a2\`).
- KB \`entities/\` directory NOT copied — \`keboola.md\` referenced ~12 employee names. Engine ships only the schema metadata; user KB content stays in \`\$SCOUT_DATA_DIR\`.

## Tests

99 tests pass (Plan 1 baseline 39 + 60 new):
- 9 manifest, 8 paths, 10 cli, 6 config, 3 errors (Plan 1 + polish)
- 6 parser, 6 writer, 5 mark_done, 12 snooze, 7 add_comment, 3 render, 4 list, 2 kb, 8 tui smoke (Plan 2)
- 3 integration (subprocess via \`scoutctl action-items\`)
- 3 perf + 2 wheel smoke

## Test plan

- [ ] CI test workflow green on macOS + Linux × py3.11/3.12
- [ ] CI lint workflow green
- [x] Manual: \`scoutctl action-items list --json\` returns the expected shape against a fixture daily file (3 statuses == {\"open\"})
- [x] Manual: \`scoutctl action-items mark-done --subject \"...\"\` flips a checkbox atomically (subprocess integration test)
- [x] Manual: \`scoutctl action-items watch\` exits 1 with \"Plan 3\" stub message
- [x] Manual: \`scoutctl manifest show\` reflects flipped flags + new subcommands

## Refs

- \`docs/superpowers/specs/2026-04-24-scout-unification-design.md\` (in scout-app repo)
- \`docs/superpowers/plans/2026-04-24-scout-unification-plan-2-port-existing-python.md\` (in scout-app repo)