### PR TITLE
feat(engine): §13 stable IDs + Events (Plan 2 supplement)

### DIFF
--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "typer>=0.12",
     "pyyaml>=6.0",
     "jinja2>=3.1",
+    "python-ulid>=2.2",
 ]
 
 [project.optional-dependencies]

--- a/engine/scout/action_items/_common.py
+++ b/engine/scout/action_items/_common.py
@@ -1,0 +1,73 @@
+"""Shared helpers for action-item mutators.
+
+Factored out of mark_done/snooze/add_comment so each mutator's public
+function is a thin wrapper around resolution + the actual mutation +
+Event construction.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scout.action_items.parser import ActionItem
+from scout.errors import ActionItemError
+from scout.id_map import IdMap
+
+
+def find_line_number(path: Path, raw_line: str) -> int:
+    """1-indexed line number where `raw_line` first appears as a complete line."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    for n, line in enumerate(lines, start=1):
+        if line == raw_line:
+            return n
+    raise ActionItemError(f"could not locate line in {path.name}: {raw_line!r}")
+
+
+def resolve_target(
+    *,
+    items: list[ActionItem],
+    data_dir: Path,
+    by_id: str | None,
+    by_subject: str | None,
+) -> tuple[ActionItem, str, str]:
+    """Resolve which `ActionItem` a mutator should act on.
+
+    Returns `(target, item_ulid, via)` where `via` is `"id"` or
+    `"subject"`. `item_ulid` may be empty string if a `--by-subject` lookup
+    matched a legacy unprefixed line and no IdMap entry exists for it.
+
+    Raises `ActionItemError` on bad arguments, unknown prefix, no match,
+    or ambiguous match.
+    """
+    if (by_id is None) == (by_subject is None):
+        raise ActionItemError("resolve_target requires exactly one of by_id or by_subject")
+
+    id_map = IdMap.load(data_dir)
+
+    if by_id is not None:
+        entry = id_map.lookup_by_prefix(by_id)
+        if entry is None:
+            raise ActionItemError(
+                f"prefix [#{by_id}] not found in id-map; if this is a legacy line, retry with --by-subject"
+            )
+        match = next((i for i in items if i.short_prefix == by_id), None)
+        if match is None:
+            raise ActionItemError(f"prefix [#{by_id}] is in id-map but not present in this file")
+        return match, entry.ulid, "id"
+
+    # by_subject path
+    assert by_subject is not None  # enforced by the exactly-one-of check above
+    matches = [i for i in items if i.status == "open" and by_subject.lower() in i.raw_line.lower()]
+    if len(matches) == 0:
+        raise ActionItemError(f"no open task matched subject: {by_subject!r}")
+    if len(matches) > 1:
+        raise ActionItemError(
+            f"ambiguous subject {by_subject!r}; matched:\n" + "\n".join(f"  - {m.title}" for m in matches)
+        )
+    match = matches[0]
+    item_ulid = ""
+    if match.short_prefix:
+        sub_entry = id_map.lookup_by_prefix(match.short_prefix)
+        if sub_entry is not None:
+            item_ulid = sub_entry.ulid
+    return match, item_ulid, "subject"

--- a/engine/scout/action_items/add_comment.py
+++ b/engine/scout/action_items/add_comment.py
@@ -1,205 +1,72 @@
-"""Insert a comment under a matched task in daily action-items markdown.
+"""Append a comment beneath an action item.
 
-Comments are written as indented blockquote lines directly under the matched
-task bullet:
+Inserts a ``  - <comment>`` sub-bullet directly beneath the matched task
+line. The task itself stays in place — the sub-bullet is the comment.
 
-    - [ ] Task subject — body
-      > scout (2026-04-18 10:20 AM ET): text here
-      > scout (2026-04-18 11:00 AM ET): reply
-
-This mirrors the schema parsed by the action-items parser.
+Returns an `Event` describing the mutation. v0.4 mutators emit Events
+but nothing persists them yet; v0.5 will add the SQLite event store.
+See v0.4 spec §13.2.
 """
 
 from __future__ import annotations
 
 import datetime as dt
-import re
 from pathlib import Path
-from zoneinfo import ZoneInfo
 
 from scout import paths
-from scout.action_items.writer import atomic_write_lines
-from scout.errors import ActionItemError
-
-EASTERN = ZoneInfo("America/New_York")
-TASK_RE = re.compile(r"^(?P<indent>\s*)- \[(?P<mark>[ xX])\]\s+(?P<rest>.+?)\s*$")
-
-
-def _timestamp() -> str:
-    """Return current timestamp in Eastern time (YYYY-MM-DD HH:MM AM/PM ET format)."""
-    return dt.datetime.now(EASTERN).strftime("%Y-%m-%d %-I:%M %p ET")
+from scout.action_items._common import find_line_number, resolve_target
+from scout.action_items.parser import parse_file
+from scout.action_items.writer import insert_below
+from scout.events import Event, now_iso
+from scout.ids import new_ulid
 
 
-def _strip_markdown_tokens(text: str) -> str:
-    """Collapse a task subject to plain text for matching."""
-    text = re.sub(r"~~(.+?)~~", r"\1", text)
-    text = re.sub(r"\*\*(.+?)\*\*", r"\1", text)
-    text = re.sub(r"`([^`]+)`", r"\1", text)
-    text = re.sub(r"\[\[([^\]|]+?)(?:\|[^\]]+)?\]\]", r"\1", text)
-    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
-    return text
-
-
-def _first_separator_outside_tokens(text: str, separators: tuple[str, ...]) -> int:
-    """Return the earliest offset where any of ``separators`` starts outside
-    markdown tokens (bold, strike, code, wiki links, links). -1 if none found.
-    """
-    in_bold = in_strike = in_code = False
-    bracket_depth = 0
-    i = 0
-    n = len(text)
-    while i < n:
-        two = text[i : i + 2]
-        ch = text[i]
-        if ch == "`" and not in_bold and not in_strike:
-            in_code = not in_code
-            i += 1
-            continue
-        if in_code:
-            i += 1
-            continue
-        if two == "**":
-            in_bold = not in_bold
-            i += 2
-            continue
-        if two == "~~":
-            in_strike = not in_strike
-            i += 2
-            continue
-        if two == "[[":
-            bracket_depth += 1
-            i += 2
-            continue
-        if two == "]]" and bracket_depth > 0:
-            bracket_depth -= 1
-            i += 2
-            continue
-        if ch == "[" and bracket_depth == 0:
-            bracket_depth = 1
-            i += 1
-            continue
-        if ch == "]" and bracket_depth > 0 and two != "]]":
-            bracket_depth = 0
-            i += 1
-            continue
-        if not in_bold and not in_strike and bracket_depth == 0:
-            for sep in separators:
-                if text[i : i + len(sep)] == sep:
-                    return i
-        i += 1
-    return -1
-
-
-def _task_subject(rest: str) -> str:
-    """Extract the subject (title) part of a task line."""
-    idx = _first_separator_outside_tokens(rest, (" — ", " – ", " - "))
-    if idx != -1:
-        return rest[:idx]
-    idx = _first_separator_outside_tokens(rest, (": ",))
-    if idx != -1:
-        return rest[:idx]
-    return rest
-
-
-def _matching_lines(lines: list[str], subject: str) -> list[tuple[int, str]]:
-    """Find all task lines whose subject contains the substring (case-insensitive).
-
-    Returns list of (1-indexed line number, line text) tuples.
-    """
-    needle = subject.casefold()
-    out: list[tuple[int, str]] = []
-    for i, line in enumerate(lines, start=1):
-        m = TASK_RE.match(line)
-        if not m:
-            continue
-        subject_plain = _strip_markdown_tokens(_task_subject(m.group("rest"))).lower()
-        if needle in subject_plain:
-            out.append((i, line))
-    return out
-
-
-def _insert_comment_line(
-    lines: list[str],
-    task_idx: int,
-    author: str,
-    text: str,
-    timestamp: str,
-) -> list[str]:
-    """Insert a comment line after the task and its existing comment block.
-
-    Args:
-        lines: List of markdown lines.
-        task_idx: 0-indexed line number of the task.
-        author: Author name for the comment.
-        text: Comment body.
-        timestamp: Timestamp string.
-
-    Returns: modified lines list.
-    """
-    task_indent = TASK_RE.match(lines[task_idx]).group("indent")  # type: ignore[union-attr]
-    comment_indent = task_indent + "  "
-    insert_at = task_idx + 1
-
-    # Skip continuation lines that belong to this task: comment lines
-    # (blockquotes starting with >) or indented non-bullet prose.
-    # Stop at blank line, new bullet at same/shallower indent, or header.
-    while insert_at < len(lines):
-        cur = lines[insert_at]
-        if not cur.strip():
-            break
-        if cur.lstrip().startswith("#"):
-            break
-        m = TASK_RE.match(cur)
-        if m and len(m.group("indent")) <= len(task_indent):
-            break
-        if re.match(r"^\s*-\s+", cur) and len(cur) - len(cur.lstrip()) <= len(task_indent):
-            break
-        insert_at += 1
-
-    new_line = f"{comment_indent}> {author} ({timestamp}): {text}"
-    return lines[:insert_at] + [new_line] + lines[insert_at:]
+def _today() -> dt.date:
+    """Indirection so tests can monkeypatch the date without freezing time."""
+    return dt.date.today()
 
 
 def add_comment(
-    path: Path | None,
     *,
-    subject: str,
-    text: str,
-    author: str = "scout",
-    timestamp: bool = True,
-) -> Path:
-    """Insert a comment beneath the unique matching task.
+    comment: str,
+    by_id: str | None = None,
+    by_subject: str | None = None,
+    date: dt.date | None = None,
+    data_dir: Path | None = None,
+) -> Event:
+    """Append `  - <comment>` beneath today's (or `date`'s) action item.
 
-    Args:
-        path: Daily markdown file. None resolves to today's file in SCOUT_DATA_DIR.
-        subject: Case-insensitive substring of the task title.
-        text: Comment body.
-        author: Author name for the comment (default: "scout"). The CLI
-            wrapper or caller should pass the resolved user display name
-            from `.scout-config.yaml` (`user.display_name`); the generic
-            default here keeps the engine free of personal identity.
-        timestamp: If True, prepend a timestamp decoration (default: True).
-
-    Returns: the file modified.
-
-    Raises ActionItemError on no-match or ambiguous match.
+    Exactly one of `by_id` or `by_subject` must be provided. `by_id` is
+    a 4-char Crockford prefix; `by_subject` is a case-insensitive
+    substring match against open-status raw lines (legacy fallback for
+    lines that haven't been prefixed yet).
     """
-    target = path or paths.action_items_daily_path()
-    if not target.exists():
-        raise ActionItemError(f"add_comment: no daily file at {target}")
+    target_path = paths.action_items_daily_path(data=data_dir, date=date or _today())
 
-    lines = target.read_text(encoding="utf-8").splitlines()
-    matches = _matching_lines(lines, subject)
+    # Parse if file exists; otherwise pass empty items list and let
+    # resolve_target produce the right error (unknown prefix for by_id,
+    # no-match for by_subject). This preserves the by_id-unknown-prefix
+    # contract: that error fires before any file existence check.
+    items = parse_file(target_path) if target_path.exists() else []
+    match, item_ulid, via = resolve_target(
+        items=items,
+        data_dir=data_dir if data_dir is not None else paths.data_dir(),
+        by_id=by_id,
+        by_subject=by_subject,
+    )
 
-    if not matches:
-        raise ActionItemError(f"add_comment: no match for subject '{subject}' in {target.name}")
-    if len(matches) > 1:
-        listing = "\n".join(f"  {ln}: {ln_text}" for ln, ln_text in matches)
-        raise ActionItemError(f"add_comment: ambiguous match for '{subject}' ({len(matches)} candidates):\n{listing}")
+    line_number = find_line_number(target_path, match.raw_line)
+    insert_below(target_path, line_number=line_number, text=f"  - {comment}")
 
-    line_number, _ = matches[0]
-    task_idx = line_number - 1
-    ts = _timestamp() if timestamp else ""
-    new_lines = _insert_comment_line(lines, task_idx, author, text, ts)
-    atomic_write_lines(target, new_lines)
-    return target
+    return Event(
+        id=new_ulid(),
+        ts=now_iso(),
+        kind="action_item.commented",
+        source="cli:add_comment",
+        payload={
+            "item_id": item_ulid,
+            "via": via,
+            "title": match.title,
+            "comment": comment,
+        },
+    )

--- a/engine/scout/action_items/cli.py
+++ b/engine/scout/action_items/cli.py
@@ -53,17 +53,38 @@ def cli_mark_done(
 
 @app.command("snooze")
 def cli_snooze(
-    subject: str = typer.Option(..., "--subject"),
     until: str = typer.Option(..., "--until", help="YYYY-MM-DD"),
-    path: Path | None = typer.Argument(None),
+    subject: str | None = typer.Option(None, "--subject", help="Substring of task title (legacy fallback)."),
+    by_id: str | None = typer.Option(None, "--by-id", help="4-char Crockford prefix from `[#XXXX]`."),
+    path: Path | None = typer.Argument(
+        None,
+        help="Daily markdown file (default: today). When given, its grandparent is the data dir.",
+    ),
 ) -> None:
     from scout.action_items.snooze import snooze
+
+    if (subject is None) == (by_id is None):
+        raise ActionItemError("snooze requires exactly one of --subject or --by-id")
 
     try:
         target_date = _dt.date.fromisoformat(until)
     except ValueError as e:
         raise ActionItemError(f"--until: invalid date {until!r}") from e
-    snooze(path, subject=subject, until=target_date)
+
+    # Backward compat: if a path argument is given, its grandparent serves as
+    # the data dir (path lives at <data_dir>/action-items/<file>.md). The
+    # filename's date is used to pin which daily file to operate on.
+    data_dir: Path | None = None
+    date: _dt.date | None = None
+    if path is not None:
+        data_dir = path.parent.parent
+        stem = path.stem  # e.g. action-items-2026-04-15
+        try:
+            date = _dt.date.fromisoformat(stem.removeprefix("action-items-"))
+        except ValueError as e:
+            raise ActionItemError(f"unrecognized daily filename: {path.name}") from e
+
+    snooze(by_id=by_id, by_subject=subject, until=target_date, date=date, data_dir=data_dir)
 
 
 @app.command("add-comment")

--- a/engine/scout/action_items/cli.py
+++ b/engine/scout/action_items/cli.py
@@ -22,13 +22,33 @@ app = typer.Typer(help="Action-items operations.", no_args_is_help=True)
 
 @app.command("mark-done")
 def cli_mark_done(
-    subject: str = typer.Option(..., "--subject", help="Substring of task title."),
-    path: Path | None = typer.Argument(None, help="Daily markdown file (default: today)."),
-    undo: bool = typer.Option(False, "--undo", help="Flip [x] back to [ ]."),
+    subject: str | None = typer.Option(None, "--subject", help="Substring of task title (legacy fallback)."),
+    by_id: str | None = typer.Option(None, "--by-id", help="4-char Crockford prefix from `[#XXXX]`."),
+    path: Path | None = typer.Argument(
+        None,
+        help="Daily markdown file (default: today). When given, its grandparent is the data dir.",
+    ),
 ) -> None:
     from scout.action_items.mark_done import mark_done
 
-    mark_done(path, subject=subject, undo=undo)
+    if (subject is None) == (by_id is None):
+        raise ActionItemError("mark-done requires exactly one of --subject or --by-id")
+
+    # Backward compat: if a path argument is given, its grandparent serves as
+    # the data dir (path lives at <data_dir>/action-items/<file>.md). The
+    # filename's date is used to pin which daily file to operate on.
+    data_dir: Path | None = None
+    date: _dt.date | None = None
+    if path is not None:
+        data_dir = path.parent.parent
+        # Filename: action-items-YYYY-MM-DD.md
+        stem = path.stem  # e.g. action-items-2026-04-15
+        try:
+            date = _dt.date.fromisoformat(stem.removeprefix("action-items-"))
+        except ValueError as e:
+            raise ActionItemError(f"unrecognized daily filename: {path.name}") from e
+
+    mark_done(by_id=by_id, by_subject=subject, date=date, data_dir=data_dir)
 
 
 @app.command("snooze")

--- a/engine/scout/action_items/cli.py
+++ b/engine/scout/action_items/cli.py
@@ -138,7 +138,7 @@ def cli_list(
     json_out: bool = typer.Option(False, "--json"),
 ) -> None:
     from scout import paths
-    from scout.action_items.list import list_items
+    from scout.action_items.list import format_items, list_items
 
     target = path or paths.action_items_daily_path()
     items = list_items(target, include_done=include_done, priority=priority, section=section)
@@ -149,13 +149,13 @@ def cli_list(
                 "priority": i.priority,
                 "status": i.status,
                 "section": i.section,
+                "short_prefix": i.short_prefix,
             }
             for i in items
         ]
         sys.stdout.write(_json.dumps(payload) + "\n")
     else:
-        for i in items:
-            sys.stdout.write(f"{i.priority} [{i.status}] {i.title}\n")
+        sys.stdout.write(format_items(items))
 
 
 @app.command("watch")

--- a/engine/scout/action_items/cli.py
+++ b/engine/scout/action_items/cli.py
@@ -89,13 +89,33 @@ def cli_snooze(
 
 @app.command("add-comment")
 def cli_add_comment(
-    subject: str = typer.Option(..., "--subject"),
-    text: str = typer.Option(..., "--text"),
-    path: Path | None = typer.Argument(None),
+    comment: str = typer.Option(..., "--comment", help="Comment text to append beneath the task."),
+    subject: str | None = typer.Option(None, "--subject", help="Substring of task title (legacy fallback)."),
+    by_id: str | None = typer.Option(None, "--by-id", help="4-char Crockford prefix from `[#XXXX]`."),
+    path: Path | None = typer.Argument(
+        None,
+        help="Daily markdown file (default: today). When given, its grandparent is the data dir.",
+    ),
 ) -> None:
     from scout.action_items.add_comment import add_comment
 
-    add_comment(path, subject=subject, text=text)
+    if (subject is None) == (by_id is None):
+        raise ActionItemError("add-comment requires exactly one of --subject or --by-id")
+
+    # Backward compat: if a path argument is given, its grandparent serves as
+    # the data dir (path lives at <data_dir>/action-items/<file>.md). The
+    # filename's date is used to pin which daily file to operate on.
+    data_dir: Path | None = None
+    date: _dt.date | None = None
+    if path is not None:
+        data_dir = path.parent.parent
+        stem = path.stem  # e.g. action-items-2026-04-15
+        try:
+            date = _dt.date.fromisoformat(stem.removeprefix("action-items-"))
+        except ValueError as e:
+            raise ActionItemError(f"unrecognized daily filename: {path.name}") from e
+
+    add_comment(by_id=by_id, by_subject=subject, comment=comment, date=date, data_dir=data_dir)
 
 
 @app.command("render")

--- a/engine/scout/action_items/list.py
+++ b/engine/scout/action_items/list.py
@@ -38,3 +38,17 @@ def list_items(
     if section is not None:
         items = [i for i in items if i.section == section]
     return items
+
+
+def format_items(items: list[ActionItem]) -> str:
+    """Format a list of ActionItems for plain-text CLI output.
+
+    Each line shows `<priority> [<status>] [#XXXX] <title>` when the item has
+    a short prefix; the bracketed prefix is omitted entirely (no extra space)
+    when no prefix is present. This is the v0.4 surface form for stable IDs.
+    """
+    lines: list[str] = []
+    for i in items:
+        prefix_part = f"[#{i.short_prefix}] " if i.short_prefix else ""
+        lines.append(f"{i.priority} [{i.status}] {prefix_part}{i.title}")
+    return "\n".join(lines) + ("\n" if lines else "")

--- a/engine/scout/action_items/mark_done.py
+++ b/engine/scout/action_items/mark_done.py
@@ -11,11 +11,10 @@ import datetime as dt
 from pathlib import Path
 
 from scout import paths
+from scout.action_items._common import find_line_number, resolve_target
 from scout.action_items.parser import parse_file
 from scout.action_items.writer import flip_checkbox
-from scout.errors import ActionItemError
 from scout.events import Event, now_iso
-from scout.id_map import IdMap
 from scout.ids import new_ulid
 
 
@@ -38,53 +37,21 @@ def mark_done(
     substring match against open-status raw lines (legacy fallback for
     lines that haven't been prefixed yet).
     """
-    if (by_id is None) == (by_subject is None):
-        raise ActionItemError("mark_done requires exactly one of by_id or by_subject")
-
-    resolved_data_dir = data_dir if data_dir is not None else paths.data_dir()
-
-    if by_id is not None:
-        # ID path: look up the entity ULID via IdMap up front; this gives
-        # a clear "prefix not found" error before we read the daily file.
-        id_map = IdMap.load(resolved_data_dir)
-        entry = id_map.lookup_by_prefix(by_id)
-        if entry is None:
-            raise ActionItemError(
-                f"prefix [#{by_id}] not found in id-map; if this is a legacy line, retry with --by-subject"
-            )
-
     target_path = paths.action_items_daily_path(data=data_dir, date=date or _today())
-    if not target_path.exists():
-        raise ActionItemError(f"no action items file: {target_path}")
 
-    items = parse_file(target_path)
+    # Parse if file exists; otherwise pass empty items list and let
+    # resolve_target produce the right error (unknown prefix for by_id,
+    # no-match for by_subject). This preserves the by_id-unknown-prefix
+    # contract: that error fires before any file existence check.
+    items = parse_file(target_path) if target_path.exists() else []
+    match, item_ulid, via = resolve_target(
+        items=items,
+        data_dir=data_dir if data_dir is not None else paths.data_dir(),
+        by_id=by_id,
+        by_subject=by_subject,
+    )
 
-    if by_id is not None:
-        # `entry` was resolved above
-        match = next((i for i in items if i.short_prefix == by_id), None)
-        if match is None:
-            raise ActionItemError(f"prefix [#{by_id}] is in id-map but not present in {target_path.name}")
-        item_ulid = entry.ulid  # type: ignore[union-attr]
-        via = "id"
-    else:
-        # Subject path: case-insensitive substring against open-status raw_lines.
-        assert by_subject is not None  # enforced by the exactly-one-of check above
-        matches = [i for i in items if i.status == "open" and by_subject.lower() in i.raw_line.lower()]
-        if len(matches) == 0:
-            raise ActionItemError(f"no open task matched subject: {by_subject!r}")
-        if len(matches) > 1:
-            raise ActionItemError(
-                f"ambiguous subject {by_subject!r}; matched:\n" + "\n".join(f"  - {m.title}" for m in matches)
-            )
-        match = matches[0]
-        item_ulid = ""
-        if match.short_prefix:
-            entry2 = IdMap.load(resolved_data_dir).lookup_by_prefix(match.short_prefix)
-            if entry2 is not None:
-                item_ulid = entry2.ulid
-        via = "subject"
-
-    line_number = _find_line_number(target_path, match.raw_line)
+    line_number = find_line_number(target_path, match.raw_line)
     flip_checkbox(target_path, line_number=line_number, to_done=True)
 
     return Event(
@@ -94,12 +61,3 @@ def mark_done(
         source="cli:mark_done",
         payload={"item_id": item_ulid, "via": via, "title": match.title},
     )
-
-
-def _find_line_number(path: Path, raw_line: str) -> int:
-    """1-indexed line number where `raw_line` first appears as a complete line."""
-    lines = path.read_text(encoding="utf-8").splitlines()
-    for n, line in enumerate(lines, start=1):
-        if line == raw_line:
-            return n
-    raise ActionItemError(f"could not locate line in {path.name}: {raw_line!r}")

--- a/engine/scout/action_items/mark_done.py
+++ b/engine/scout/action_items/mark_done.py
@@ -1,61 +1,105 @@
-"""Toggle a task's checkbox to done in a daily action-items markdown.
+"""Mark an action-item complete by ID prefix or by subject substring.
 
-Match is case-insensitive substring on the task title; must be unambiguous.
-Undo flips `[x]` back to `[ ]`. Atomic rewrite via scout.action_items.writer.
+Returns an `Event` describing the mutation. v0.4 mutators emit Events
+but nothing persists them yet; v0.5 will add the SQLite event store.
+See v0.4 spec §13.2.
 """
 
 from __future__ import annotations
 
-import re
+import datetime as dt
 from pathlib import Path
 
 from scout import paths
+from scout.action_items.parser import parse_file
 from scout.action_items.writer import flip_checkbox
 from scout.errors import ActionItemError
-
-TASK_RE = re.compile(r"^(?P<indent>\s*)- \[(?P<mark>[ xX])\] (?P<rest>.+?)\s*$")
-
-
-def _matching_lines(lines: list[str], subject: str, *, want_mark: str) -> list[tuple[int, str]]:
-    needle = subject.casefold()
-    out: list[tuple[int, str]] = []
-    for i, line in enumerate(lines, start=1):
-        m = TASK_RE.match(line)
-        if not m:
-            continue
-        if m.group("mark") not in want_mark:
-            continue
-        if needle in m.group("rest").casefold():
-            out.append((i, line))
-    return out
+from scout.events import Event, now_iso
+from scout.id_map import IdMap
+from scout.ids import new_ulid
 
 
-def mark_done(path: Path | None, *, subject: str, undo: bool = False) -> Path:
-    """Mark the unique matching task done (or open if undo=True).
+def _today() -> dt.date:
+    """Indirection so tests can monkeypatch the date without freezing time."""
+    return dt.date.today()
 
-    Args:
-        path: Daily markdown file. None resolves to today's file in SCOUT_DATA_DIR.
-        subject: Case-insensitive substring of the task title.
-        undo: If True, flip `[x]` back to `[ ]`.
 
-    Returns: the file actually modified (useful when `path is None`).
+def mark_done(
+    *,
+    by_id: str | None = None,
+    by_subject: str | None = None,
+    date: dt.date | None = None,
+    data_dir: Path | None = None,
+) -> Event:
+    """Mark today's (or `date`'s) action item done.
 
-    Raises ActionItemError on no-match or ambiguous match.
+    Exactly one of `by_id` or `by_subject` must be provided. `by_id` is
+    a 4-char Crockford prefix; `by_subject` is a case-insensitive
+    substring match against open-status raw lines (legacy fallback for
+    lines that haven't been prefixed yet).
     """
-    target = path or paths.action_items_daily_path()
-    if not target.exists():
-        raise ActionItemError(f"no daily file at {target}")
+    if (by_id is None) == (by_subject is None):
+        raise ActionItemError("mark_done requires exactly one of by_id or by_subject")
 
-    lines = target.read_text(encoding="utf-8").splitlines()
-    want_mark = "x X" if undo else " "
-    matches = _matching_lines(lines, subject, want_mark=want_mark)
+    resolved_data_dir = data_dir if data_dir is not None else paths.data_dir()
 
-    if not matches:
-        raise ActionItemError(f"mark_done: no match for subject '{subject}' in {target.name}")
-    if len(matches) > 1:
-        listing = "\n".join(f"  {ln}: {ln_text}" for ln, ln_text in matches)
-        raise ActionItemError(f"mark_done: ambiguous match for '{subject}' ({len(matches)} candidates):\n{listing}")
+    if by_id is not None:
+        # ID path: look up the entity ULID via IdMap up front; this gives
+        # a clear "prefix not found" error before we read the daily file.
+        id_map = IdMap.load(resolved_data_dir)
+        entry = id_map.lookup_by_prefix(by_id)
+        if entry is None:
+            raise ActionItemError(
+                f"prefix [#{by_id}] not found in id-map; if this is a legacy line, retry with --by-subject"
+            )
 
-    line_number, _ = matches[0]
-    flip_checkbox(target, line_number=line_number, to_done=not undo)
-    return target
+    target_path = paths.action_items_daily_path(data=data_dir, date=date or _today())
+    if not target_path.exists():
+        raise ActionItemError(f"no action items file: {target_path}")
+
+    items = parse_file(target_path)
+
+    if by_id is not None:
+        # `entry` was resolved above
+        match = next((i for i in items if i.short_prefix == by_id), None)
+        if match is None:
+            raise ActionItemError(f"prefix [#{by_id}] is in id-map but not present in {target_path.name}")
+        item_ulid = entry.ulid  # type: ignore[union-attr]
+        via = "id"
+    else:
+        # Subject path: case-insensitive substring against open-status raw_lines.
+        assert by_subject is not None  # enforced by the exactly-one-of check above
+        matches = [i for i in items if i.status == "open" and by_subject.lower() in i.raw_line.lower()]
+        if len(matches) == 0:
+            raise ActionItemError(f"no open task matched subject: {by_subject!r}")
+        if len(matches) > 1:
+            raise ActionItemError(
+                f"ambiguous subject {by_subject!r}; matched:\n" + "\n".join(f"  - {m.title}" for m in matches)
+            )
+        match = matches[0]
+        item_ulid = ""
+        if match.short_prefix:
+            entry2 = IdMap.load(resolved_data_dir).lookup_by_prefix(match.short_prefix)
+            if entry2 is not None:
+                item_ulid = entry2.ulid
+        via = "subject"
+
+    line_number = _find_line_number(target_path, match.raw_line)
+    flip_checkbox(target_path, line_number=line_number, to_done=True)
+
+    return Event(
+        id=new_ulid(),
+        ts=now_iso(),
+        kind="action_item.completed",
+        source="cli:mark_done",
+        payload={"item_id": item_ulid, "via": via, "title": match.title},
+    )
+
+
+def _find_line_number(path: Path, raw_line: str) -> int:
+    """1-indexed line number where `raw_line` first appears as a complete line."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    for n, line in enumerate(lines, start=1):
+        if line == raw_line:
+            return n
+    raise ActionItemError(f"could not locate line in {path.name}: {raw_line!r}")

--- a/engine/scout/action_items/parser.py
+++ b/engine/scout/action_items/parser.py
@@ -15,6 +15,8 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from scout.ids import short_prefix_pattern
+
 
 @dataclass
 class ActionItem:
@@ -29,6 +31,7 @@ class ActionItem:
     details: list[str] = field(default_factory=list)
     raw_line: str = ""
     line_number: int = 0
+    short_prefix: str | None = None
 
 
 PRIORITY_MAP = {
@@ -177,6 +180,16 @@ def _parse_item_line(
     title = title.lstrip("- ")
     # Remove status emojis at start
     title = STATUS_EMOJI.sub("", title).strip()
+    # Extract `[#XXXX]` short prefix (if present) and strip from title.
+    # raw_line is preserved untouched so substring matching still works.
+    _short_prefix: str | None = None
+    _prefix_match = short_prefix_pattern().search(title)
+    if _prefix_match is not None:
+        _short_prefix = _prefix_match.group(1)
+        # Remove the bracketed prefix from the title.
+        title = title[: _prefix_match.start()] + title[_prefix_match.end() :]
+        # Collapse any double-space left behind, then strip outer whitespace.
+        title = title.replace("  ", " ").strip()
     # Remove strikethrough markers but keep text for context
     title = STRIKETHROUGH.sub(r"\1", title)
     # Remove bold markers
@@ -201,6 +214,7 @@ def _parse_item_line(
         context_links=context_links,
         raw_line=line,
         line_number=line_number,
+        short_prefix=_short_prefix,
     )
 
 

--- a/engine/scout/action_items/render.py
+++ b/engine/scout/action_items/render.py
@@ -628,15 +628,16 @@ def _render_task_actions(t: Task, date_slug: str) -> str:
     needle = _plain_subject(t.subject).strip().replace('"', r"\"")
     if len(needle) > 40:
         needle = needle[:40].rstrip()
-    date_arg = f"{date_slug} " if date_slug else ""
     if t.done:
-        cmd = f'./action-items/mark_done.py {date_arg}--subject "{needle}" --undo'
-        chips = [("Reopen", cmd)]
-    else:
-        mark_cmd = f'./action-items/mark_done.py {date_arg}--subject "{needle}"'
-        snooze_tmpl = f'./action-items/snooze.py {date_arg}--subject "{needle}" --until +1d'
-        launch_cmd = f'cd ~/Scout && claude "Help me make progress on this action item: {needle}"'
-        chips = [("Mark done", mark_cmd), ("Snooze", snooze_tmpl), ("Launch Claude", launch_cmd)]
+        # No actionable affordances for completed tasks; reopen flow is not
+        # part of the v0.4 CLI surface. Editing the source markdown remains
+        # the canonical way to reopen a task.
+        return ""
+    date_arg = f"{date_slug} " if date_slug else ""
+    mark_cmd = f'./action-items/mark_done.py {date_arg}--subject "{needle}"'
+    snooze_tmpl = f'./action-items/snooze.py {date_arg}--subject "{needle}" --until +1d'
+    launch_cmd = f'cd ~/Scout && claude "Help me make progress on this action item: {needle}"'
+    chips = [("Mark done", mark_cmd), ("Snooze", snooze_tmpl), ("Launch Claude", launch_cmd)]
     buttons = "".join(
         f'<button type="button" class="task-action" data-cmd="{html.escape(cmd, quote=True)}" '
         f'title="Click to copy: {html.escape(cmd, quote=True)}">{html.escape(label)}</button>'

--- a/engine/scout/action_items/snooze.py
+++ b/engine/scout/action_items/snooze.py
@@ -1,282 +1,78 @@
-"""Snooze a task to a future-dated daily action-items file.
+"""Snooze an action item until a future date.
 
-Two complementary writes happen:
+Inserts a ``  - snoozed-until: YYYY-MM-DD`` sub-bullet directly beneath
+the matched task line. The task itself stays in place — the sub-bullet
+is the snooze marker. v0.5+ list/render layers may filter out items
+whose snooze marker is in the future.
 
-1.  The task in the source file is **removed entirely** (along with any
-    immediately-following indented continuation lines).  No marker is left
-    on the source side — git history and the destination carry-in annotation
-    provide full traceability.
-2.  The task is appended (as an open ``[ ]`` item) to a ``## 🛌 Snoozed``
-    section in the target day's file.  The file and section are created on
-    demand.  A ``_(carried in from YYYY-MM-DD)_`` annotation is appended so
-    the origin date is visible.
-
-Ported from ~/Scout/action-items/snooze.py (362 lines).
-argparse / __main__ block removed; public surface is the ``snooze()`` function.
+Returns an `Event` describing the mutation. v0.4 mutators emit Events
+but nothing persists them yet; v0.5 will add the SQLite event store.
+See v0.4 spec §13.2.
 """
 
 from __future__ import annotations
 
 import datetime as dt
-import re
 from pathlib import Path
 
 from scout import paths
-from scout.action_items.writer import atomic_write_lines
-from scout.errors import ActionItemError
-
-# ---------------------------------------------------------------------------
-# Regex helpers
-# ---------------------------------------------------------------------------
-
-TASK_RE = re.compile(r"^(?P<indent>\s*)- \[(?P<mark>[ xX])\] (?P<rest>.+?)\s*$")
-SNOOZE_SUFFIX_RE = re.compile(r"\s*(?:—|–|-)\s*🛌 Snoozed until \d{4}-\d{2}-\d{2}$")
+from scout.action_items._common import find_line_number, resolve_target
+from scout.action_items.parser import parse_file
+from scout.action_items.writer import insert_below
+from scout.events import Event, now_iso
+from scout.ids import new_ulid
 
 
-# ---------------------------------------------------------------------------
-# Matching
-#
-# NOTE: the source snooze.py matches on ALL tasks regardless of checkbox mark
-# (open [ ], done [x], or [X]).  This intentionally differs from
-# mark_done._matching_lines, which filters by want_mark.  A local helper is
-# kept here rather than importing from mark_done to avoid coupling to the
-# want_mark contract.  The subject comparison uses plain .lower() (not
-# .casefold()) to match the source's original behaviour.
-# ---------------------------------------------------------------------------
+def _today() -> dt.date:
+    """Indirection so tests can monkeypatch the date without freezing time."""
+    return dt.date.today()
 
 
-def _strip_markdown_tokens(text: str) -> str:
-    text = re.sub(r"~~(.+?)~~", r"\1", text)
-    text = re.sub(r"\*\*(.+?)\*\*", r"\1", text)
-    text = re.sub(r"`([^`]+)`", r"\1", text)
-    text = re.sub(r"\[\[([^\]|]+?)(?:\|[^\]]+)?\]\]", r"\1", text)
-    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
-    return text
+def snooze(
+    *,
+    until: dt.date,
+    by_id: str | None = None,
+    by_subject: str | None = None,
+    date: dt.date | None = None,
+    data_dir: Path | None = None,
+) -> Event:
+    """Snooze today's (or `date`'s) action item until `until`.
 
-
-def _first_separator_outside_tokens(text: str, separators: tuple[str, ...]) -> int:
-    """Return the earliest offset where any separator starts outside Markdown
-    inline tokens (bold, strike, code, wiki-links, hyperlinks).  -1 if none."""
-    in_bold = in_strike = in_code = False
-    bracket_depth = 0
-    i = 0
-    n = len(text)
-    while i < n:
-        two = text[i : i + 2]
-        ch = text[i]
-        if ch == "`" and not in_bold and not in_strike:
-            in_code = not in_code
-            i += 1
-            continue
-        if in_code:
-            i += 1
-            continue
-        if two == "**":
-            in_bold = not in_bold
-            i += 2
-            continue
-        if two == "~~":
-            in_strike = not in_strike
-            i += 2
-            continue
-        if two == "[[":
-            bracket_depth += 1
-            i += 2
-            continue
-        if two == "]]" and bracket_depth > 0:
-            bracket_depth -= 1
-            i += 2
-            continue
-        if ch == "[" and bracket_depth == 0:
-            bracket_depth = 1
-            i += 1
-            continue
-        if ch == "]" and bracket_depth > 0 and two != "]]":
-            bracket_depth = 0
-            i += 1
-            continue
-        if not in_bold and not in_strike and bracket_depth == 0:
-            for sep in separators:
-                if text[i : i + len(sep)] == sep:
-                    return i
-        i += 1
-    return -1
-
-
-def _task_subject(rest: str) -> str:
-    idx = _first_separator_outside_tokens(rest, (" — ", " – ", " - "))
-    if idx != -1:
-        return rest[:idx]
-    idx = _first_separator_outside_tokens(rest, (": ",))
-    if idx != -1:
-        return rest[:idx]
-    return rest
-
-
-def _find_task_lines(lines: list[str], needle: str) -> list[int]:
-    """Return 0-based indices of lines whose task subject contains *needle*.
-
-    Matches all tasks regardless of checkbox state (open, done, or X-done).
-    Case-insensitive substring match on the plain-text subject (markdown tokens
-    stripped).
+    Exactly one of `by_id` or `by_subject` must be provided. `by_id` is
+    a 4-char Crockford prefix; `by_subject` is a case-insensitive
+    substring match against open-status raw lines (legacy fallback for
+    lines that haven't been prefixed yet).
     """
-    needle_norm = needle.lower().strip()
-    hits: list[int] = []
-    for i, line in enumerate(lines):
-        m = TASK_RE.match(line)
-        if not m:
-            continue
-        subject_plain = _strip_markdown_tokens(_task_subject(m.group("rest"))).lower()
-        if needle_norm in subject_plain:
-            hits.append(i)
-    return hits
+    target_path = paths.action_items_daily_path(data=data_dir, date=date or _today())
 
+    # Parse if file exists; otherwise pass empty items list and let
+    # resolve_target produce the right error (unknown prefix for by_id,
+    # no-match for by_subject). This preserves the by_id-unknown-prefix
+    # contract: that error fires before any file existence check.
+    items = parse_file(target_path) if target_path.exists() else []
+    match, item_ulid, via = resolve_target(
+        items=items,
+        data_dir=data_dir if data_dir is not None else paths.data_dir(),
+        by_id=by_id,
+        by_subject=by_subject,
+    )
 
-# ---------------------------------------------------------------------------
-# Source-file mutation
-# ---------------------------------------------------------------------------
+    line_number = find_line_number(target_path, match.raw_line)
+    insert_below(
+        target_path,
+        line_number=line_number,
+        text=f"  - snoozed-until: {until.isoformat()}",
+    )
 
-
-def _remove_task_block(lines: list[str], task_idx: int) -> list[str]:
-    """Return lines with the task at task_idx and its indented continuation
-    lines removed.
-
-    The source removes the task entirely rather than leaving a snooze-marker
-    stub.  See remove_task_block() in ~/Scout/action-items/snooze.py for the
-    original rationale (git history + destination carry-in provide traceability).
-    """
-    m = TASK_RE.match(lines[task_idx])
-    task_indent_len = len(m.group("indent")) if m else 0
-    end = task_idx + 1
-    while end < len(lines):
-        line = lines[end]
-        if not line.strip():
-            break
-        line_indent_len = len(line) - len(line.lstrip())
-        if line_indent_len > task_indent_len:
-            end += 1
-        else:
-            break
-    return lines[:task_idx] + lines[end:]
-
-
-# ---------------------------------------------------------------------------
-# Destination-file mutation
-# ---------------------------------------------------------------------------
-
-
-def _append_to_target(target_path: Path, task_line: str, source_date: str) -> None:
-    """Append the task to a ## 🛌 Snoozed section in target_path.
-
-    Creates the file (with a minimal header + section) if it does not exist.
-    Flips the checkbox back to open [ ] and drops any snooze suffix; the
-    carry-in annotation _(carried in from <source_date>)_ replaces it.
-    Deduplicates: if the same subject is already present in the section, skips.
-    """
-    m = TASK_RE.match(task_line)
-    rest = m.group("rest") if m else task_line.strip()
-    rest = SNOOZE_SUFFIX_RE.sub("", rest)
-    indent = m.group("indent") if m else ""
-    subject_key = _strip_markdown_tokens(_task_subject(rest)).strip().lower()
-    carry_line = f"{indent}- [ ] {rest} _(carried in from {source_date})_"
-
-    if target_path.exists():
-        text = target_path.read_text(encoding="utf-8")
-        lines = text.splitlines()
-        section_idx = next(
-            (i for i, ln in enumerate(lines) if ln.strip().lower().startswith("## 🛌 snoozed")),
-            None,
-        )
-        if section_idx is None:
-            if lines and lines[-1].strip():
-                lines.append("")
-            lines.append("## 🛌 Snoozed")
-            lines.append("")
-            lines.append(carry_line)
-        else:
-            section_end = len(lines)
-            for j in range(section_idx + 1, len(lines)):
-                if lines[j].startswith("## "):
-                    section_end = j
-                    break
-            # Dedupe: skip if same subject already present.
-            for j in range(section_idx + 1, section_end):
-                mt = TASK_RE.match(lines[j])
-                if not mt:
-                    continue
-                existing_subject = _strip_markdown_tokens(_task_subject(mt.group("rest"))).strip().lower()
-                if existing_subject == subject_key:
-                    return
-            insert_at = section_end
-            while insert_at > section_idx + 1 and not lines[insert_at - 1].strip():
-                insert_at -= 1
-            lines.insert(insert_at, carry_line)
-        atomic_write_lines(target_path, lines)
-        return
-
-    # Fresh target file: minimal header + snoozed section.
-    date_label = target_path.stem.replace("action-items-", "")
-    header_lines = [
-        f"# Action Items — {date_label}",
-        "",
-        "## 🛌 Snoozed",
-        "",
-        carry_line,
-    ]
-    atomic_write_lines(target_path, header_lines)
-
-
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
-
-
-def snooze(src: Path | None, *, subject: str, until: dt.date) -> Path:
-    """Snooze the uniquely matching task to a future daily file.
-
-    Args:
-        src:     Source daily markdown file.  None resolves to today's file.
-        subject: Case-insensitive substring of the task subject to snooze.
-        until:   Target date (must be strictly after today).
-
-    Returns:
-        Path to the destination daily file the task was moved into.
-
-    Raises:
-        ActionItemError: no match, ambiguous match, or until is in the past.
-    """
-    today = dt.date.today()
-    if until <= today:
-        raise ActionItemError(
-            f"until date {until.isoformat()} is in the past or today "
-            f"(today is {today.isoformat()}); must be a future date"
-        )
-
-    source_path = src if src is not None else paths.action_items_daily_path()
-    if not source_path.exists():
-        raise ActionItemError(f"snooze: source file not found: {source_path}")
-
-    # Extract the date label from the filename (e.g. "action-items-2026-04-15.md" → "2026-04-15").
-    source_date = source_path.stem.replace("action-items-", "")
-
-    lines = source_path.read_text(encoding="utf-8").splitlines()
-    hits = _find_task_lines(lines, subject)
-
-    if not hits:
-        raise ActionItemError(f"snooze: no match for subject {subject!r} in {source_path.name}")
-    if len(hits) > 1:
-        listing = "\n".join(f"  line {i + 1}: {lines[i].strip()}" for i in hits)
-        raise ActionItemError(f"snooze: ambiguous match for {subject!r} ({len(hits)} candidates):\n{listing}")
-
-    task_idx = hits[0]
-    original_line = lines[task_idx]
-
-    # Remove the task (and any continuation lines) from the source file.
-    new_lines = _remove_task_block(lines, task_idx)
-    atomic_write_lines(source_path, new_lines)
-
-    # Write the carry-in entry to the target daily file.
-    target_path = source_path.parent / f"action-items-{until.isoformat()}.md"
-    _append_to_target(target_path, original_line, source_date)
-
-    return target_path
+    return Event(
+        id=new_ulid(),
+        ts=now_iso(),
+        kind="action_item.snoozed",
+        source="cli:snooze",
+        payload={
+            "item_id": item_ulid,
+            "via": via,
+            "title": match.title,
+            "until": until.isoformat(),
+        },
+    )

--- a/engine/scout/action_items/snooze.py
+++ b/engine/scout/action_items/snooze.py
@@ -19,6 +19,7 @@ from scout import paths
 from scout.action_items._common import find_line_number, resolve_target
 from scout.action_items.parser import parse_file
 from scout.action_items.writer import insert_below
+from scout.errors import ActionItemError
 from scout.events import Event, now_iso
 from scout.ids import new_ulid
 
@@ -38,11 +39,17 @@ def snooze(
 ) -> Event:
     """Snooze today's (or `date`'s) action item until `until`.
 
+    Past dates for `until` are accepted intentionally — the v0.5 event-store
+    filtering layer is the canonical place for "is this still relevant?" logic.
+    Callers may want to pre-validate `until > today` themselves.
+
     Exactly one of `by_id` or `by_subject` must be provided. `by_id` is
     a 4-char Crockford prefix; `by_subject` is a case-insensitive
     substring match against open-status raw lines (legacy fallback for
     lines that haven't been prefixed yet).
     """
+    if not isinstance(until, dt.date):
+        raise ActionItemError(f"snooze: until must be a date, got {type(until).__name__}")
     target_path = paths.action_items_daily_path(data=data_dir, date=date or _today())
 
     # Parse if file exists; otherwise pass empty items list and let

--- a/engine/scout/action_items/writer.py
+++ b/engine/scout/action_items/writer.py
@@ -61,3 +61,28 @@ def insert_below(target: Path, *, line_number: int, text: str) -> None:
         raise ActionItemError(f"insert_below: line {line_number} out of range (1..{len(lines)})")
     lines.insert(idx + 1, text)
     atomic_write_lines(target, lines)
+
+
+def add_prefix_to_line(target: Path, *, line_number: int, prefix: str) -> None:
+    """Insert `[#PREFIX] ` after the checkbox marker on the 1-indexed line.
+
+    Refuses if the line already carries a `[#XXXX]` prefix — the caller
+    should not be asking to add one if scout.id_map already has a record.
+    """
+    from scout.ids import short_prefix_pattern  # local import — keeps writer light
+
+    lines = _read_lines(target)
+    idx = line_number - 1
+    if not 0 <= idx < len(lines):
+        raise ActionItemError(f"add_prefix_to_line: line {line_number} out of range (1..{len(lines)})")
+    line = lines[idx]
+    if short_prefix_pattern().search(line):
+        raise ActionItemError(f"add_prefix_to_line: line {line_number} already has prefix")
+    # Find the checkbox marker (`- [ ]` or `- [x]`) and insert after it.
+    for marker in ("- [ ] ", "- [x] "):
+        if line.startswith(marker):
+            lines[idx] = marker + f"[#{prefix}] " + line[len(marker) :]
+            break
+    else:
+        raise ActionItemError(f"add_prefix_to_line: line {line_number} doesn't start with a checkbox marker")
+    atomic_write_lines(target, lines)

--- a/engine/scout/action_items/writer.py
+++ b/engine/scout/action_items/writer.py
@@ -12,6 +12,7 @@ import tempfile
 from pathlib import Path
 
 from scout.errors import ActionItemError
+from scout.ids import short_prefix_pattern
 
 
 def atomic_write_lines(target: Path, lines: list[str]) -> None:
@@ -69,8 +70,6 @@ def add_prefix_to_line(target: Path, *, line_number: int, prefix: str) -> None:
     Refuses if the line already carries a `[#XXXX]` prefix — the caller
     should not be asking to add one if scout.id_map already has a record.
     """
-    from scout.ids import short_prefix_pattern  # local import — keeps writer light
-
     lines = _read_lines(target)
     idx = line_number - 1
     if not 0 <= idx < len(lines):

--- a/engine/scout/events.py
+++ b/engine/scout/events.py
@@ -1,0 +1,41 @@
+"""Event dataclass returned by mutators.
+
+In v0.4, mutators return an `Event` but nothing persists it. v0.5 will
+add an `emit()` function that appends to the SQLite event store; the
+shape defined here is its wire format. See v0.4 spec §13.2 and the v0.5+
+event-architecture vision spec.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Event:
+    """A single mutation event.
+
+    Fields:
+        id: ULID for the event itself (distinct from any entity ULID
+            referenced in the payload).
+        ts: ISO 8601 UTC timestamp with millisecond precision and 'Z'
+            suffix, e.g. "2026-04-26T12:34:56.789Z".
+        kind: Flat namespace, e.g. "action_item.completed".
+        source: Origin tag, e.g. "cli:mark_done", "hook:connector-log".
+        payload: Arbitrary JSON-compatible dict. Per-kind schemas are
+            documented in the v0.5+ event-architecture spec.
+    """
+
+    id: str
+    ts: str
+    kind: str
+    source: str
+    payload: dict[str, Any]
+
+
+def now_iso() -> str:
+    """ISO 8601 UTC string with millisecond precision and 'Z' suffix."""
+    n = dt.datetime.now(tz=dt.UTC)
+    return n.strftime("%Y-%m-%dT%H:%M:%S.") + f"{n.microsecond // 1000:03d}Z"

--- a/engine/scout/id_map.py
+++ b/engine/scout/id_map.py
@@ -1,15 +1,27 @@
 """Prefix↔ULID map persisted at $SCOUT_DATA_DIR/.scout-state/id-map.json.
 
-Read-modify-write semantics use `flock(LOCK_EX)` per spec §6. The map
-holds last-known position metadata so the diff engine can fuzzy-reattach
-a markdown line whose `[#XXXX]` prefix was accidentally deleted.
+Writes are atomic-rename: serialise to a tempfile, fsync, then
+`os.replace` over the target. Concurrent writers see last-writer-wins —
+two `save()` calls that overlap leave only one entry visible, but the
+JSON file itself is never torn. Readers see either the old or the new
+file, never a half-written state.
+
+The plan's spec §6 phrase "read-modify-write under flock(LOCK_EX)" is
+the v0.5 invariant: when SQLite WAL replaces this JSON file, real
+serialisation is provided by the database. For v0.4, action-item
+registration is single-digit-per-day so LWW is acceptable; the
+concurrency test's `len(found) >= 1` assertion encodes this contract
+honestly.
+
+The map holds last-known position metadata so the diff engine can
+fuzzy-reattach a markdown line whose `[#XXXX]` prefix was accidentally
+deleted.
 
 See v0.4 spec §13.1.
 """
 
 from __future__ import annotations
 
-import fcntl
 import json
 import os
 import tempfile
@@ -42,11 +54,10 @@ class IdMap:
         if not path.exists():
             return cls(data_dir, entries={})
         with path.open("r", encoding="utf-8") as f:
-            fcntl.flock(f.fileno(), fcntl.LOCK_SH)
-            try:
-                raw = json.load(f)
-            finally:
-                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+            raw = json.load(f)
+        schema_version = raw.get("schema_version")
+        if schema_version != 1:
+            raise ValueError(f"id-map.json has unknown schema_version {schema_version!r}; expected 1")
         entries = {ulid: IdMapEntry(**meta) for ulid, meta in raw.get("entries", {}).items()}
         return cls(data_dir, entries)
 
@@ -57,19 +68,17 @@ class IdMap:
             "schema_version": 1,
             "entries": {ulid: asdict(entry) for ulid, entry in self._entries.items()},
         }
-        # Write under exclusive lock + atomic rename.
+        # Atomic-rename write: tempfile in the same directory, fsync, then
+        # os.replace. Concurrent writes are last-writer-wins (see module
+        # docstring); v0.5's SQLite migration provides real RMW.
         fd, tmp = tempfile.mkstemp(prefix=".id-map.", suffix=".json.tmp", dir=str(path.parent))
         tmp_path = Path(tmp)
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
-                fcntl.flock(f.fileno(), fcntl.LOCK_EX)
-                try:
-                    json.dump(payload, f, indent=2, sort_keys=True)
-                    f.write("\n")
-                    f.flush()
-                    os.fsync(f.fileno())
-                finally:
-                    fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+                json.dump(payload, f, indent=2, sort_keys=True)
+                f.write("\n")
+                f.flush()
+                os.fsync(f.fileno())
             os.replace(tmp_path, path)
         except BaseException:
             if tmp_path.exists():

--- a/engine/scout/id_map.py
+++ b/engine/scout/id_map.py
@@ -1,0 +1,111 @@
+"""Prefix↔ULID map persisted at $SCOUT_DATA_DIR/.scout-state/id-map.json.
+
+Read-modify-write semantics use `flock(LOCK_EX)` per spec §6. The map
+holds last-known position metadata so the diff engine can fuzzy-reattach
+a markdown line whose `[#XXXX]` prefix was accidentally deleted.
+
+See v0.4 spec §13.1.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import tempfile
+from collections.abc import Iterator
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from scout import paths
+
+
+@dataclass(frozen=True)
+class IdMapEntry:
+    ulid: str
+    short_prefix: str
+    last_title: str
+    last_file: str
+    last_line: int
+
+
+class IdMap:
+    """Owns the prefix↔ULID JSON file. Construct via `IdMap.load(data_dir)`."""
+
+    def __init__(self, data_dir: Path, entries: dict[str, IdMapEntry]) -> None:
+        self._data_dir = data_dir
+        self._entries: dict[str, IdMapEntry] = entries  # keyed by ULID
+
+    @classmethod
+    def load(cls, data_dir: Path) -> IdMap:
+        path = paths.id_map_path(data_dir)
+        if not path.exists():
+            return cls(data_dir, entries={})
+        with path.open("r", encoding="utf-8") as f:
+            fcntl.flock(f.fileno(), fcntl.LOCK_SH)
+            try:
+                raw = json.load(f)
+            finally:
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+        entries = {ulid: IdMapEntry(**meta) for ulid, meta in raw.get("entries", {}).items()}
+        return cls(data_dir, entries)
+
+    def save(self) -> None:
+        path = paths.id_map_path(self._data_dir)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "schema_version": 1,
+            "entries": {ulid: asdict(entry) for ulid, entry in self._entries.items()},
+        }
+        # Write under exclusive lock + atomic rename.
+        fd, tmp = tempfile.mkstemp(prefix=".id-map.", suffix=".json.tmp", dir=str(path.parent))
+        tmp_path = Path(tmp)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+                try:
+                    json.dump(payload, f, indent=2, sort_keys=True)
+                    f.write("\n")
+                    f.flush()
+                    os.fsync(f.fileno())
+                finally:
+                    fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+            os.replace(tmp_path, path)
+        except BaseException:
+            if tmp_path.exists():
+                tmp_path.unlink()
+            raise
+
+    def register(self, entry: IdMapEntry) -> None:
+        """Insert or update an entry. Caller is responsible for `save()`."""
+        self._entries[entry.ulid] = entry
+
+    def lookup_by_prefix(self, prefix: str) -> IdMapEntry | None:
+        for entry in self._entries.values():
+            if entry.short_prefix == prefix:
+                return entry
+        return None
+
+    def lookup_by_ulid(self, ulid: str) -> IdMapEntry | None:
+        return self._entries.get(ulid)
+
+    def in_use_prefixes(self) -> set[str]:
+        return {entry.short_prefix for entry in self._entries.values()}
+
+    def iter_entries(self) -> Iterator[IdMapEntry]:
+        return iter(self._entries.values())
+
+    def reattach(self, *, title: str, file: str) -> IdMapEntry | None:
+        """Fuzzy-match an entry by title; prefer same-file matches.
+
+        Used when a markdown line lost its `[#XXXX]` prefix. Title
+        comparison is exact (case-sensitive); future enhancement could
+        Levenshtein-fuzz this.
+        """
+        candidates = [e for e in self._entries.values() if e.last_title == title]
+        if not candidates:
+            return None
+        same_file = [e for e in candidates if e.last_file == file]
+        if same_file:
+            return same_file[0]
+        return candidates[0]

--- a/engine/scout/ids.py
+++ b/engine/scout/ids.py
@@ -1,0 +1,57 @@
+"""ULID generation and Crockford base32 short prefixes.
+
+Short prefixes are the human-friendly surface form for action-item IDs in
+markdown; the full ULID is the canonical storage form. See v0.4 spec §13.1.
+
+The Crockford alphabet excludes 0/O and 1/I/L visual confusables (and
+also U) so that hand-typed prefixes are unambiguous.
+"""
+
+from __future__ import annotations
+
+import re
+import secrets
+
+from ulid import ULID
+
+# Crockford base32 alphabet: 0-9 + uppercase A-Z minus I, L, O, U.
+CROCKFORD_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+SHORT_PREFIX_LEN = 4
+
+_DEFAULT_MAX_ATTEMPTS = 64  # plenty for any realistic in-use set
+
+_PREFIX_REGEX = re.compile(r"\[#(" + f"[{re.escape(CROCKFORD_ALPHABET)}]" + r"{" + str(SHORT_PREFIX_LEN) + r"})\]")
+
+
+def new_ulid() -> str:
+    """Mint a fresh 26-character ULID (sortable, time-ordered)."""
+    return str(ULID())
+
+
+def new_short_prefix(
+    exclude: set[str] | None = None,
+    max_attempts: int = _DEFAULT_MAX_ATTEMPTS,
+) -> str:
+    """Generate a fresh 4-char Crockford base32 prefix not in `exclude`.
+
+    `exclude` is the set of currently-in-use short prefixes (typically
+    sourced from `scout.id_map.IdMap.in_use_prefixes()`). Raises
+    `RuntimeError` if `max_attempts` retries all hit the exclude set —
+    indicates the prefix space is approaching saturation, which would
+    require widening to 5 chars (out of scope for v0.4).
+    """
+    exclude = exclude or set()
+    for _ in range(max_attempts + 1):
+        candidate = "".join(secrets.choice(CROCKFORD_ALPHABET) for _ in range(SHORT_PREFIX_LEN))
+        if candidate not in exclude:
+            return candidate
+    raise RuntimeError(f"prefix space exhausted after {max_attempts} attempts (exclude size {len(exclude)})")
+
+
+def short_prefix_pattern() -> re.Pattern[str]:
+    """Regex matching `[#XXXX]` where XXXX is 4 Crockford chars.
+
+    `match.group(0)` returns the full bracketed prefix; `match.group(1)`
+    returns the bare 4-char prefix.
+    """
+    return _PREFIX_REGEX

--- a/engine/scout/ids.py
+++ b/engine/scout/ids.py
@@ -41,7 +41,7 @@ def new_short_prefix(
     require widening to 5 chars (out of scope for v0.4).
     """
     exclude = exclude or set()
-    for _ in range(max_attempts + 1):
+    for _ in range(max_attempts):
         candidate = "".join(secrets.choice(CROCKFORD_ALPHABET) for _ in range(SHORT_PREFIX_LEN))
         if candidate not in exclude:
             return candidate

--- a/engine/scout/paths.py
+++ b/engine/scout/paths.py
@@ -86,3 +86,14 @@ def action_items_daily_path(data: Path | None = None, date: _dt.date | None = No
     """
     d = date or _today()
     return action_items_dir(data) / f"action-items-{d.isoformat()}.md"
+
+
+def id_map_path(data: Path | None = None) -> Path:
+    """Return the path to the prefix↔ULID map JSON file.
+
+    Lives under `$SCOUT_DATA_DIR/.scout-state/id-map.json`. Parent dir
+    is created on first write; readers may find it absent and treat
+    that as an empty map.
+    """
+    target = data if data is not None else data_dir()
+    return target / ".scout-state" / "id-map.json"

--- a/engine/tests/concurrency/test_id_map_concurrent.py
+++ b/engine/tests/concurrency/test_id_map_concurrent.py
@@ -1,0 +1,44 @@
+"""Concurrency tests for scout.id_map — multiple processes registering entries.
+
+Per spec §6: stateful JSON files use read-modify-write under flock(LOCK_EX).
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+from pathlib import Path
+
+import pytest
+
+from scout.id_map import IdMap, IdMapEntry
+
+
+def _register_one(args: tuple[Path, str, str]) -> None:
+    data_dir, ulid, prefix = args
+    m = IdMap.load(data_dir)
+    m.register(IdMapEntry(ulid, prefix, f"task {prefix}", "today.md", 1))
+    m.save()
+
+
+@pytest.mark.concurrency
+def test_parallel_registers_are_not_lost(fake_data_dir: Path) -> None:
+    """N processes register N distinct entries.
+
+    Note: this test is read-modify-write — last writer wins on the JSON file.
+    The file lock guarantees no torn JSON, but two processes registering at
+    the exact same moment may produce a final file with only one of them.
+
+    For action items, registration is rare and scout-app + CLI rarely race.
+    For high-write-rate cases, see the v0.5 SQLite migration.
+    """
+    n = 8
+    args = [(fake_data_dir, f"01HX{i:022d}", f"P{i:03X}") for i in range(n)]
+    with mp.get_context("fork").Pool(processes=4) as pool:
+        pool.map(_register_one, args)
+
+    m = IdMap.load(fake_data_dir)
+    found = m.in_use_prefixes()
+    # We can't assert all 8 land due to last-writer-wins, but we MUST
+    # assert the file is parseable (no JSON corruption) and at least one entry persists.
+    assert isinstance(found, set)
+    assert len(found) >= 1

--- a/engine/tests/fixtures/action-items-with-prefixes.md
+++ b/engine/tests/fixtures/action-items-with-prefixes.md
@@ -1,0 +1,17 @@
+# Action Items — 2026-04-26
+
+## In Progress
+
+- [ ] [#A3F7] 🔴 Submit Lever feedback to recruiting
+  - Context: https://example.com/lever
+- [ ] 🟡 Send Scout plugin announcement
+- [x] [#B5K2] 🟢 Read incident postmortem
+
+## To Do
+
+- [ ] [#C9N4] 🔴 Reply to Q2 budget thread
+- [ ] Followup with vendor on contract redlines
+
+## Completed Today
+
+- [x] [#D7P1] 🟢 Submit weekly status

--- a/engine/tests/fixtures/action-items-with-prefixes.md
+++ b/engine/tests/fixtures/action-items-with-prefixes.md
@@ -11,6 +11,7 @@
 
 - [ ] [#C9N4] 🔴 Reply to Q2 budget thread
 - [ ] Followup with vendor on contract redlines
+- [ ] [#E1Q2] Plain prefixed task without priority
 
 ## Completed Today
 

--- a/engine/tests/integration/test_action_items_cli.py
+++ b/engine/tests/integration/test_action_items_cli.py
@@ -61,3 +61,67 @@ def test_action_items_watch_returns_scout_error_exit_code() -> None:
     # ScoutError.exit_code == 1
     assert r.returncode == 1
     assert "Plan 3" in r.stderr
+
+
+def test_action_items_mark_done_by_id_via_cli(tmp_path: Path) -> None:
+    """Smoke test: scoutctl action-items mark-done --by-id A3F7 flips the matching line."""
+    data_dir = tmp_path / "Scout"
+    items_dir = data_dir / "action-items"
+    items_dir.mkdir(parents=True)
+    state_dir = data_dir / ".scout-state"
+    state_dir.mkdir(parents=True)
+    target = items_dir / "action-items-2026-04-15.md"
+    target.write_text(
+        "## In Progress\n\n- [ ] [#A3F7] 🔴 Test mark-done by id\n",
+    )
+    # Register the prefix↔ULID mapping so --by-id can look it up.
+    id_map_path = state_dir / "id-map.json"
+    id_map_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "entries": {
+                    "01HXAAA0000000000000000000": {
+                        "ulid": "01HXAAA0000000000000000000",
+                        "short_prefix": "A3F7",
+                        "last_title": "Test mark-done by id",
+                        "last_file": "action-items-2026-04-15.md",
+                        "last_line": 3,
+                    }
+                },
+            }
+        )
+        + "\n"
+    )
+
+    env = {**os.environ, "SCOUT_DATA_DIR": str(data_dir)}
+    r = _scoutctl(
+        "action-items",
+        "mark-done",
+        "--by-id",
+        "A3F7",
+        str(target),
+        env=env,
+    )
+    assert r.returncode == 0, r.stderr
+    assert "- [x] [#A3F7] 🔴 Test mark-done by id" in target.read_text()
+
+
+def test_action_items_list_surfaces_short_prefix(tmp_path: Path) -> None:
+    """`scoutctl action-items list` surfaces `[#XXXX]` in the plain output."""
+    data_dir = tmp_path / "Scout"
+    items_dir = data_dir / "action-items"
+    items_dir.mkdir(parents=True)
+    fixture = Path(__file__).parent.parent / "fixtures" / "action-items-with-prefixes.md"
+    target = items_dir / "action-items-2026-04-15.md"
+    target.write_text(fixture.read_text())
+
+    env = {**os.environ, "SCOUT_DATA_DIR": str(data_dir)}
+    r = _scoutctl("action-items", "list", str(target), env=env)
+    assert r.returncode == 0, r.stderr
+    assert "[#A3F7]" in r.stdout
+    assert "[#C9N4]" in r.stdout
+    # An unprefixed open item: the line containing "announcement" must not
+    # contain "[#" — otherwise the formatter is leaking an empty bracket.
+    sent_line = [ln for ln in r.stdout.splitlines() if "announcement" in ln]
+    assert sent_line and "[#" not in sent_line[0]

--- a/engine/tests/unit/test_action_items_add_comment.py
+++ b/engine/tests/unit/test_action_items_add_comment.py
@@ -1,82 +1,88 @@
-"""Unit tests for scout.action_items.add_comment."""
+"""Unit tests for scout.action_items.add_comment.
+
+New contract (Plan 2 supplement, Task 20):
+- add_comment(*, comment, by_id|by_subject, date=None, data_dir=None) -> Event
+- Inserts a ``  - <comment>`` sub-bullet beneath the matched task line.
+- Returns Event(kind="action_item.commented", source="cli:add_comment") with
+  payload {item_id, via, title, comment}.
+- Resolution by_id/by_subject is delegated to scout.action_items._common.
+"""
 
 from __future__ import annotations
 
+import datetime as dt
+import re
 from pathlib import Path
 
 import pytest
 
 from scout.action_items.add_comment import add_comment
 from scout.errors import ActionItemError
+from scout.events import Event
+from scout.id_map import IdMap, IdMapEntry
 
 
-def _seed(tmp_path: Path, body: str) -> Path:
-    f = tmp_path / "action-items-2026-04-15.md"
-    f.write_text(body)
-    return f
+def test_add_comment_by_id_inserts_subbullet(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    m = IdMap.load(fake_data_dir)
+    m.register(
+        IdMapEntry(
+            "01HXAAA",
+            "A3F7",
+            "Submit Lever feedback",
+            "action-items-2026-04-26.md",
+            5,
+        )
+    )
+    m.save()
+    daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
+    daily.parent.mkdir(parents=True, exist_ok=True)
+    daily.write_text("## In Progress\n\n- [ ] [#A3F7] 🔴 Submit Lever feedback\n- [ ] 🟡 Other unrelated task\n")
+    monkeypatch.setattr("scout.action_items.add_comment._today", lambda: dt.date(2026, 4, 26))
+
+    event = add_comment(by_id="A3F7", comment="Hiring manager confirmed", data_dir=fake_data_dir)
+
+    text = daily.read_text()
+    assert "- [ ] [#A3F7] 🔴 Submit Lever feedback\n  - Hiring manager confirmed" in text
+    assert "Other unrelated task" in text  # untouched
+    assert isinstance(event, Event)
+    assert event.kind == "action_item.commented"
+    assert event.source == "cli:add_comment"
+    assert event.payload["item_id"] == "01HXAAA"
+    assert event.payload["via"] == "id"
+    assert event.payload["comment"] == "Hiring manager confirmed"
 
 
-def test_adds_comment_below_matched_task(tmp_path: Path) -> None:
-    f = _seed(tmp_path, "- [ ] Task A\n- [ ] Task B\n")
-    add_comment(f, subject="Task A", text="checked with vendor", timestamp=False)
-    body = f.read_text()
-    assert "checked with vendor" in body
-    # The comment appears between Task A and Task B.
-    assert body.index("Task A") < body.index("checked with vendor") < body.index("Task B")
+def test_add_comment_by_subject_fallback(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
+    daily.parent.mkdir(parents=True, exist_ok=True)
+    daily.write_text("## To Do\n\n- [ ] 🔴 Followup with vendor on contract\n")
+    monkeypatch.setattr("scout.action_items.add_comment._today", lambda: dt.date(2026, 4, 26))
+
+    event = add_comment(by_subject="vendor", comment="Email sent 4/26", data_dir=fake_data_dir)
+    assert "- Email sent 4/26" in daily.read_text()
+    assert event.payload["via"] == "subject"
+    assert event.payload["comment"] == "Email sent 4/26"
 
 
-def test_adds_comment_with_timestamp(tmp_path: Path) -> None:
-    f = _seed(tmp_path, "- [ ] Task A\n")
-    add_comment(f, subject="Task A", text="vendor confirmed", timestamp=True, author="jordan")
-    body = f.read_text()
-    # Comment should contain the author name, text, and a date-like pattern.
-    assert "jordan" in body
-    assert "vendor confirmed" in body
-    # Should be formatted as blockquote: > author (YYYY-MM-DD HH:MM AM/PM ET): text
-    assert "> jordan" in body
+def test_add_comment_by_id_unknown_prefix_raises(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
+    daily.parent.mkdir(parents=True, exist_ok=True)
+    daily.write_text("- [ ] x\n")
+    monkeypatch.setattr("scout.action_items.add_comment._today", lambda: dt.date(2026, 4, 26))
+
+    with pytest.raises(ActionItemError, match="prefix.*not found"):
+        add_comment(by_id="ZZZZ", comment="x", data_dir=fake_data_dir)
 
 
-def test_comment_appended_after_existing_comments(tmp_path: Path) -> None:
-    f = _seed(tmp_path, "- [ ] Task A\n  > scott (2026-04-15 10:00 AM ET): first comment\n- [ ] Task B\n")
-    add_comment(f, subject="Task A", text="second comment", timestamp=False)
-    body = f.read_text()
-    # Both comments should be present.
-    assert "first comment" in body
-    assert "second comment" in body
-    # second_comment comes after first_comment
-    assert body.index("first comment") < body.index("second comment")
-    # Both come before Task B
-    assert body.index("second comment") < body.index("Task B")
+def test_add_comment_event_id_and_ts_well_formed(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    m = IdMap.load(fake_data_dir)
+    m.register(IdMapEntry("01HX", "A3F7", "task", "action-items-2026-04-26.md", 1))
+    m.save()
+    daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
+    daily.parent.mkdir(parents=True, exist_ok=True)
+    daily.write_text("- [ ] [#A3F7] task\n")
+    monkeypatch.setattr("scout.action_items.add_comment._today", lambda: dt.date(2026, 4, 26))
 
-
-def test_no_match_raises(tmp_path: Path) -> None:
-    f = _seed(tmp_path, "- [ ] Task\n")
-    with pytest.raises(ActionItemError, match="no match"):
-        add_comment(f, subject="other", text="x")
-
-
-def test_ambiguous_match_raises(tmp_path: Path) -> None:
-    f = _seed(tmp_path, "- [ ] vendor A\n- [ ] vendor B\n")
-    with pytest.raises(ActionItemError, match="ambiguous|multiple"):
-        add_comment(f, subject="vendor", text="x")
-
-
-def test_case_insensitive_matching(tmp_path: Path) -> None:
-    f = _seed(tmp_path, "- [ ] Submit LEVER Feedback\n")
-    add_comment(f, subject="lever", text="done", timestamp=False)
-    body = f.read_text()
-    assert "done" in body
-
-
-def test_resolves_today_when_path_omitted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    import datetime as dt
-
-    from scout import paths
-
-    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
-    (tmp_path / "action-items").mkdir()
-    monkeypatch.setattr(paths, "_today", lambda: dt.date(2026, 4, 15))
-    f = _seed(tmp_path / "action-items", "- [ ] task X\n")
-    # No `path` argument → resolves via paths.action_items_daily_path()
-    add_comment(None, subject="task X", text="done", timestamp=False)
-    assert "done" in f.read_text()
+    event = add_comment(by_id="A3F7", comment="x", data_dir=fake_data_dir)
+    assert len(event.id) == 26
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", event.ts)

--- a/engine/tests/unit/test_action_items_common.py
+++ b/engine/tests/unit/test_action_items_common.py
@@ -122,3 +122,17 @@ def test_resolve_target_ambiguous_subject_raises(fake_data_dir: Path) -> None:
     ]
     with pytest.raises(ActionItemError, match="ambiguous"):
         resolve_target(items=items, data_dir=fake_data_dir, by_id=None, by_subject="reply")
+
+
+def test_resolve_target_prefix_in_idmap_but_missing_from_items_raises(
+    fake_data_dir: Path,
+) -> None:
+    """If the IdMap knows a prefix but the parsed items list doesn't include it
+    (e.g., user passed `--by-id A3F7` while looking at the wrong day's file),
+    raise a clear error rather than silently no-op."""
+    m = IdMap.load(fake_data_dir)
+    m.register(IdMapEntry("01HXAAA", "A3F7", "task X", "today.md", 5))
+    m.save()
+    # Items list is empty — simulates the wrong-file case.
+    with pytest.raises(ActionItemError, match="is in id-map but not present"):
+        resolve_target(items=[], data_dir=fake_data_dir, by_id="A3F7", by_subject=None)

--- a/engine/tests/unit/test_action_items_common.py
+++ b/engine/tests/unit/test_action_items_common.py
@@ -1,0 +1,124 @@
+"""Unit tests for scout.action_items._common — shared mutator helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scout.action_items._common import find_line_number, resolve_target
+from scout.action_items.parser import ActionItem
+from scout.errors import ActionItemError
+from scout.id_map import IdMap, IdMapEntry
+
+
+def test_find_line_number_returns_1_indexed(tmp_path: Path) -> None:
+    f = tmp_path / "x.md"
+    f.write_text("alpha\nbeta\ngamma\n")
+    assert find_line_number(f, "beta") == 2
+    assert find_line_number(f, "alpha") == 1
+
+
+def test_find_line_number_raises_when_missing(tmp_path: Path) -> None:
+    f = tmp_path / "x.md"
+    f.write_text("only line\n")
+    with pytest.raises(ActionItemError, match="could not locate"):
+        find_line_number(f, "missing line")
+
+
+def test_resolve_target_by_id_returns_entry_and_match(fake_data_dir: Path) -> None:
+    m = IdMap.load(fake_data_dir)
+    m.register(IdMapEntry("01HXAAA", "A3F7", "task X", "today.md", 5))
+    m.save()
+    items = [
+        ActionItem(
+            priority="🔴",
+            title="task X",
+            status="open",
+            section="In Progress",
+            context_links=[],
+            notes=[],
+            details=[],
+            raw_line="- [ ] [#A3F7] 🔴 task X",
+            short_prefix="A3F7",
+        ),
+        ActionItem(
+            priority="",
+            title="other",
+            status="open",
+            section="In Progress",
+            context_links=[],
+            notes=[],
+            details=[],
+            raw_line="- [ ] other",
+            short_prefix=None,
+        ),
+    ]
+    target, ulid, via = resolve_target(items=items, data_dir=fake_data_dir, by_id="A3F7", by_subject=None)
+    assert target.title == "task X"
+    assert ulid == "01HXAAA"
+    assert via == "id"
+
+
+def test_resolve_target_by_subject_substring(fake_data_dir: Path) -> None:
+    items = [
+        ActionItem(
+            priority="🔴",
+            title="Reply to vendor on contract",
+            status="open",
+            section="To Do",
+            context_links=[],
+            notes=[],
+            details=[],
+            raw_line="- [ ] 🔴 Reply to vendor on contract",
+            short_prefix=None,
+        ),
+    ]
+    target, ulid, via = resolve_target(items=items, data_dir=fake_data_dir, by_id=None, by_subject="vendor")
+    assert target.title == "Reply to vendor on contract"
+    assert ulid == ""
+    assert via == "subject"
+
+
+def test_resolve_target_rejects_both_args_unset(fake_data_dir: Path) -> None:
+    with pytest.raises(ActionItemError, match="exactly one"):
+        resolve_target(items=[], data_dir=fake_data_dir, by_id=None, by_subject=None)
+
+
+def test_resolve_target_rejects_both_args_set(fake_data_dir: Path) -> None:
+    with pytest.raises(ActionItemError, match="exactly one"):
+        resolve_target(items=[], data_dir=fake_data_dir, by_id="A3F7", by_subject="x")
+
+
+def test_resolve_target_unknown_id_raises(fake_data_dir: Path) -> None:
+    with pytest.raises(ActionItemError, match="prefix.*not found"):
+        resolve_target(items=[], data_dir=fake_data_dir, by_id="ZZZZ", by_subject=None)
+
+
+def test_resolve_target_ambiguous_subject_raises(fake_data_dir: Path) -> None:
+    items = [
+        ActionItem(
+            priority="",
+            title="Reply to alice",
+            status="open",
+            section="To Do",
+            context_links=[],
+            notes=[],
+            details=[],
+            raw_line="- [ ] Reply to alice",
+            short_prefix=None,
+        ),
+        ActionItem(
+            priority="",
+            title="Reply to bob",
+            status="open",
+            section="To Do",
+            context_links=[],
+            notes=[],
+            details=[],
+            raw_line="- [ ] Reply to bob",
+            short_prefix=None,
+        ),
+    ]
+    with pytest.raises(ActionItemError, match="ambiguous"):
+        resolve_target(items=items, data_dir=fake_data_dir, by_id=None, by_subject="reply")

--- a/engine/tests/unit/test_action_items_list.py
+++ b/engine/tests/unit/test_action_items_list.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from scout.action_items.list import list_items
+from scout.action_items.list import format_items, list_items
 
 FIXTURE = Path(__file__).parent.parent / "fixtures" / "action-items-sample.md"
+PREFIX_FIXTURE = Path(__file__).parent.parent / "fixtures" / "action-items-with-prefixes.md"
 
 
 def test_list_open_only_default() -> None:
@@ -30,3 +31,20 @@ def test_list_filter_priority_high() -> None:
 def test_list_filter_section() -> None:
     items = list_items(FIXTURE, section="Watching")
     assert all(i.section == "Watching" for i in items)
+
+
+def test_list_includes_short_prefix_when_present() -> None:
+    """The list output prefixes each item with `[#XXXX]` when one exists."""
+    items = list_items(PREFIX_FIXTURE, include_done=True)
+    output = format_items(items)
+    assert "[#A3F7]" in output
+    assert "[#B5K2]" in output
+
+
+def test_list_omits_prefix_for_unprefixed_lines() -> None:
+    """Unprefixed items render without any `[#` substring on their line."""
+    items = list_items(PREFIX_FIXTURE, include_done=True)
+    output = format_items(items)
+    # "Send Scout plugin announcement" is unprefixed in the fixture.
+    sent_line = [ln for ln in output.splitlines() if "announcement" in ln]
+    assert sent_line and "[#" not in sent_line[0]

--- a/engine/tests/unit/test_action_items_mark_done.py
+++ b/engine/tests/unit/test_action_items_mark_done.py
@@ -3,55 +3,155 @@
 from __future__ import annotations
 
 import datetime as dt
+import re
 from pathlib import Path
 
 import pytest
 
 from scout.action_items.mark_done import mark_done
 from scout.errors import ActionItemError
+from scout.events import Event
+from scout.id_map import IdMap, IdMapEntry
+
+# -----------------------------------------------------------------------
+# Plan 2 legacy contract — adapted to the new by_subject= kwarg.
+# `mark_done(path, subject=..., undo=...)` no longer exists. The new API
+# resolves the daily file via `data_dir` + `_today()`, so each test seeds
+# a daily file at the expected path and pins `_today()` via monkeypatch.
+# The Plan 2 `undo` flag is dropped (no caller exercises it post-Task 18).
+# -----------------------------------------------------------------------
 
 
-def _seed(tmp_path: Path, body: str) -> Path:
-    f = tmp_path / "action-items-2026-04-15.md"
+def _seed_daily(data_dir: Path, body: str, *, date: dt.date) -> Path:
+    items_dir = data_dir / "action-items"
+    items_dir.mkdir(parents=True, exist_ok=True)
+    f = items_dir / f"action-items-{date.isoformat()}.md"
     f.write_text(body)
     return f
 
 
-def test_marks_open_task_done_by_subject(tmp_path: Path) -> None:
-    f = _seed(tmp_path, "- [ ] Submit Lever feedback\n- [ ] Other task\n")
-    mark_done(f, subject="Lever feedback")
+def test_marks_open_task_done_by_subject(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    today = dt.date(2026, 4, 15)
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: today)
+    f = _seed_daily(
+        fake_data_dir,
+        "- [ ] Submit Lever feedback\n- [ ] Other task\n",
+        date=today,
+    )
+    mark_done(by_subject="Lever feedback", data_dir=fake_data_dir)
     assert "- [x] Submit Lever feedback" in f.read_text()
     assert "- [ ] Other task" in f.read_text()  # unchanged
 
 
-def test_no_match_raises(tmp_path: Path) -> None:
-    f = _seed(tmp_path, "- [ ] Existing task\n")
-    with pytest.raises(ActionItemError, match="no match"):
-        mark_done(f, subject="missing keyword")
+def test_no_match_raises(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    today = dt.date(2026, 4, 15)
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: today)
+    _seed_daily(fake_data_dir, "- [ ] Existing task\n", date=today)
+    with pytest.raises(ActionItemError, match="no open task matched"):
+        mark_done(by_subject="missing keyword", data_dir=fake_data_dir)
 
 
-def test_ambiguous_match_raises_listing_candidates(tmp_path: Path) -> None:
-    f = _seed(tmp_path, "- [ ] Lever feedback A\n- [ ] Lever feedback B\n")
+def test_ambiguous_match_raises_listing_candidates(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    today = dt.date(2026, 4, 15)
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: today)
+    _seed_daily(
+        fake_data_dir,
+        "- [ ] Lever feedback A\n- [ ] Lever feedback B\n",
+        date=today,
+    )
     with pytest.raises(ActionItemError, match="ambiguous|multiple") as exc:
-        mark_done(f, subject="lever feedback")
+        mark_done(by_subject="lever feedback", data_dir=fake_data_dir)
     msg = str(exc.value)
     assert "Lever feedback A" in msg
     assert "Lever feedback B" in msg
 
 
-def test_undo_flips_done_back_to_open(tmp_path: Path) -> None:
-    f = _seed(tmp_path, "- [x] Done thing\n")
-    mark_done(f, subject="Done thing", undo=True)
-    assert "- [ ] Done thing" in f.read_text()
-
-
-def test_resolves_today_when_path_omitted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    from scout import paths
-
+def test_resolves_today_when_data_dir_via_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No `data_dir` argument resolves via SCOUT_DATA_DIR env var."""
     monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
-    (tmp_path / "action-items").mkdir()
-    monkeypatch.setattr(paths, "_today", lambda: dt.date(2026, 4, 15))
-    f = _seed(tmp_path / "action-items", "- [ ] task X\n")
-    # No `path` argument → resolves via paths.action_items_daily_path()
-    mark_done(None, subject="task X")
+    today = dt.date(2026, 4, 15)
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: today)
+    f = _seed_daily(tmp_path, "- [ ] task X\n", date=today)
+    mark_done(by_subject="task X")
     assert "- [x] task X" in f.read_text()
+
+
+# -----------------------------------------------------------------------
+# Task 18 new contract — by_id + by_subject + Event return.
+# -----------------------------------------------------------------------
+
+
+def test_mark_done_by_id_flips_correct_line(fake_data_dir, monkeypatch):
+    # Set up: register prefix↔ULID in the id-map, write a markdown file with that prefix.
+    m = IdMap.load(fake_data_dir)
+    m.register(
+        IdMapEntry(
+            "01HXAAA0000000000000000000",
+            "A3F7",
+            "Submit Lever feedback",
+            "action-items-2026-04-26.md",
+            5,
+        )
+    )
+    m.save()
+    daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
+    daily.parent.mkdir(parents=True, exist_ok=True)
+    daily.write_text(
+        "# Action Items — 2026-04-26\n\n"
+        "## In Progress\n\n"
+        "- [ ] [#A3F7] 🔴 Submit Lever feedback\n"
+        "- [ ] 🟡 Other unrelated task\n"
+    )
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: dt.date(2026, 4, 26))
+
+    from scout.action_items.mark_done import mark_done
+
+    event = mark_done(by_id="A3F7", data_dir=fake_data_dir)
+
+    assert "- [x] [#A3F7]" in daily.read_text()
+    assert "- [ ] 🟡 Other" in daily.read_text()  # unrelated line untouched
+    assert isinstance(event, Event)
+    assert event.kind == "action_item.completed"
+    assert event.source == "cli:mark_done"
+    assert event.payload["item_id"] == "01HXAAA0000000000000000000"
+    assert event.payload["via"] == "id"
+
+
+def test_mark_done_by_subject_fallback_for_unprefixed_line(fake_data_dir, monkeypatch):
+    daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
+    daily.parent.mkdir(parents=True, exist_ok=True)
+    daily.write_text("## In Progress\n\n- [ ] 🔴 Followup with vendor on contract\n")
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: dt.date(2026, 4, 26))
+
+    from scout.action_items.mark_done import mark_done
+
+    event = mark_done(by_subject="vendor", data_dir=fake_data_dir)
+    assert "- [x] 🔴 Followup with vendor" in daily.read_text()
+    assert event.payload["via"] == "subject"
+    # No prefix on the line means no entity ULID — payload uses the event's own ULID derivation.
+    assert "item_id" in event.payload  # may be None or empty; assert key present
+
+
+def test_mark_done_by_id_unknown_prefix_raises(fake_data_dir, monkeypatch):
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: dt.date(2026, 4, 26))
+    from scout.action_items.mark_done import mark_done
+    from scout.errors import ActionItemError
+
+    with pytest.raises(ActionItemError, match="prefix.*not found"):
+        mark_done(by_id="ZZZZ", data_dir=fake_data_dir)
+
+
+def test_mark_done_event_id_and_ts_well_formed(fake_data_dir, monkeypatch):
+    m = IdMap.load(fake_data_dir)
+    m.register(IdMapEntry("01HX", "A3F7", "task", "action-items-2026-04-26.md", 1))
+    m.save()
+    daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
+    daily.parent.mkdir(parents=True, exist_ok=True)
+    daily.write_text("- [ ] [#A3F7] task\n")
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: dt.date(2026, 4, 26))
+
+    from scout.action_items.mark_done import mark_done
+
+    event = mark_done(by_id="A3F7", data_dir=fake_data_dir)
+    assert len(event.id) == 26
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", event.ts)

--- a/engine/tests/unit/test_action_items_parser.py
+++ b/engine/tests/unit/test_action_items_parser.py
@@ -64,3 +64,35 @@ def test_raw_line_preserved_for_substring_lookup(items: list[ActionItem]) -> Non
     assert "[ ]" in raw
     assert "🔴" in raw
     assert "Reply to Q2 budget thread" in raw
+
+
+PREFIX_FIXTURE = Path(__file__).parent.parent / "fixtures" / "action-items-with-prefixes.md"
+
+
+def test_parser_extracts_short_prefix_when_present() -> None:
+    items = parse_file(PREFIX_FIXTURE)
+    by_title = {i.title: i for i in items}
+    assert by_title["Submit Lever feedback to recruiting"].short_prefix == "A3F7"
+    assert by_title["Read incident postmortem"].short_prefix == "B5K2"
+    assert by_title["Reply to Q2 budget thread"].short_prefix == "C9N4"
+
+
+def test_parser_short_prefix_is_none_for_unprefixed_line() -> None:
+    items = parse_file(PREFIX_FIXTURE)
+    by_title = {i.title: i for i in items}
+    assert by_title["Send Scout plugin announcement"].short_prefix is None
+    assert by_title["Followup with vendor on contract redlines"].short_prefix is None
+
+
+def test_parser_strips_prefix_from_title() -> None:
+    """Title field should not include `[#XXXX]` — that's what short_prefix is for."""
+    items = parse_file(PREFIX_FIXTURE)
+    titles = [i.title for i in items]
+    assert all("[#" not in t for t in titles)
+
+
+def test_parser_raw_line_preserves_prefix() -> None:
+    """raw_line is the unmodified source line; substring fallback uses it."""
+    items = parse_file(PREFIX_FIXTURE)
+    by_title = {i.title: i for i in items}
+    assert "[#A3F7]" in by_title["Submit Lever feedback to recruiting"].raw_line

--- a/engine/tests/unit/test_action_items_parser.py
+++ b/engine/tests/unit/test_action_items_parser.py
@@ -96,3 +96,30 @@ def test_parser_raw_line_preserves_prefix() -> None:
     items = parse_file(PREFIX_FIXTURE)
     by_title = {i.title: i for i in items}
     assert "[#A3F7]" in by_title["Submit Lever feedback to recruiting"].raw_line
+
+
+def test_parser_handles_prefix_and_priority_emoji_together() -> None:
+    """A prefixed line with a priority emoji must produce all three fields correctly:
+    short_prefix from [#XXXX], priority from the emoji, title with neither.
+    Pins the interaction Tasks 18-20 will rely on.
+    """
+    items = parse_file(PREFIX_FIXTURE)
+    by_title = {i.title: i for i in items}
+    item = by_title["Submit Lever feedback to recruiting"]
+    assert item.short_prefix == "A3F7"
+    assert item.priority == "🔴"
+    assert item.title == "Submit Lever feedback to recruiting"
+    assert "[#A3F7]" not in item.title
+    assert "🔴" not in item.title
+
+
+def test_parser_handles_prefix_without_priority_emoji() -> None:
+    """A prefixed line with no priority emoji must produce short_prefix populated,
+    priority empty, title clean of any prefix marker.
+    """
+    items = parse_file(PREFIX_FIXTURE)
+    by_title = {i.title: i for i in items}
+    item = by_title["Plain prefixed task without priority"]
+    assert item.short_prefix == "E1Q2"
+    assert item.priority == ""
+    assert item.title == "Plain prefixed task without priority"

--- a/engine/tests/unit/test_action_items_snooze.py
+++ b/engine/tests/unit/test_action_items_snooze.py
@@ -90,3 +90,12 @@ def test_snooze_event_id_and_ts_well_formed(fake_data_dir: Path, monkeypatch: py
     event = snooze(by_id="A3F7", until=dt.date(2026, 5, 1), data_dir=fake_data_dir)
     assert len(event.id) == 26
     assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", event.ts)
+
+
+def test_snooze_rejects_non_date_until(fake_data_dir: Path) -> None:
+    """A string accidentally passed for `until` must fail loudly at the boundary,
+    not silently AttributeError mid-mutation."""
+    from scout.action_items.snooze import snooze
+
+    with pytest.raises(ActionItemError, match="until must be a date"):
+        snooze(by_subject="x", until="2026-05-01", data_dir=fake_data_dir)  # type: ignore[arg-type]

--- a/engine/tests/unit/test_action_items_snooze.py
+++ b/engine/tests/unit/test_action_items_snooze.py
@@ -1,135 +1,92 @@
 """Unit tests for scout.action_items.snooze.
 
-Source contract (from ~/Scout/action-items/snooze.py):
-- Source line is REMOVED entirely (not replaced with a marker).
-- A carry-in entry is appended to a '## 🛌 Snoozed' section in the target file:
-    - [ ] {task body} _(carried in from {source_date})_
-- Matching scans ALL tasks regardless of checkbox state (open and closed).
-- until must be strictly after today (raises ActionItemError with 'past' substring).
+New contract (Plan 2 supplement, Task 19):
+- snooze(*, until, by_id|by_subject, date=None, data_dir=None) -> Event
+- Inserts a ``  - snoozed-until: YYYY-MM-DD`` sub-bullet beneath the
+  matched task line. The task itself stays in place.
+- Returns Event(kind="action_item.snoozed", source="cli:snooze") with
+  payload {item_id, via, title, until}.
+- Resolution by_id/by_subject is delegated to scout.action_items._common.
+
+The earlier "move to future-dated daily file with carry-in annotation"
+contract was dropped in this rewrite (see task spec).
 """
 
 from __future__ import annotations
 
 import datetime as dt
+import re
 from pathlib import Path
 
 import pytest
 
 from scout.action_items.snooze import snooze
 from scout.errors import ActionItemError
+from scout.events import Event
+from scout.id_map import IdMap, IdMapEntry
 
 
-def test_moves_task_to_future_daily_file(tmp_path: Path) -> None:
-    src = tmp_path / "action-items-2026-04-15.md"
-    src.write_text("## To Do\n\n- [ ] Reply to vendor\n- [ ] Other thing\n")
-    dst = snooze(src, subject="Reply to vendor", until=dt.date(2026, 5, 1))
-    assert dst == tmp_path / "action-items-2026-05-01.md"
-    assert dst.exists()
-    assert "Reply to vendor" in dst.read_text()
-    # Source line is removed.
-    src_after = src.read_text()
-    assert "Reply to vendor" not in src_after
-    # Unrelated task is untouched.
-    assert "- [ ] Other thing" in src_after
+def test_snooze_by_id_inserts_until_subbullet(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    m = IdMap.load(fake_data_dir)
+    m.register(
+        IdMapEntry(
+            "01HXAAA",
+            "A3F7",
+            "Submit Lever feedback",
+            "action-items-2026-04-26.md",
+            5,
+        )
+    )
+    m.save()
+    daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
+    daily.parent.mkdir(parents=True, exist_ok=True)
+    daily.write_text("## In Progress\n\n- [ ] [#A3F7] 🔴 Submit Lever feedback\n- [ ] 🟡 Other unrelated task\n")
+    monkeypatch.setattr("scout.action_items.snooze._today", lambda: dt.date(2026, 4, 26))
+
+    event = snooze(by_id="A3F7", until=dt.date(2026, 5, 1), data_dir=fake_data_dir)
+
+    text = daily.read_text()
+    assert "- [ ] [#A3F7] 🔴 Submit Lever feedback\n  - snoozed-until: 2026-05-01" in text
+    assert "Other unrelated task" in text  # untouched
+    assert isinstance(event, Event)
+    assert event.kind == "action_item.snoozed"
+    assert event.source == "cli:snooze"
+    assert event.payload["item_id"] == "01HXAAA"
+    assert event.payload["via"] == "id"
+    assert event.payload["until"] == "2026-05-01"
 
 
-def test_carry_in_annotation_in_dest(tmp_path: Path) -> None:
-    src = tmp_path / "action-items-2026-04-15.md"
-    src.write_text("- [ ] Call mechanic\n")
-    dst = snooze(src, subject="Call mechanic", until=dt.date(2026, 5, 1))
-    content = dst.read_text()
-    assert "Call mechanic" in content
-    assert "carried in from 2026-04-15" in content
+def test_snooze_by_subject_fallback(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
+    daily.parent.mkdir(parents=True, exist_ok=True)
+    daily.write_text("## To Do\n\n- [ ] 🔴 Followup with vendor on contract\n")
+    monkeypatch.setattr("scout.action_items.snooze._today", lambda: dt.date(2026, 4, 26))
+
+    event = snooze(by_subject="vendor", until=dt.date(2026, 5, 1), data_dir=fake_data_dir)
+    assert "- snoozed-until: 2026-05-01" in daily.read_text()
+    assert event.payload["via"] == "subject"
+    assert event.payload["until"] == "2026-05-01"
 
 
-def test_dest_has_snoozed_section(tmp_path: Path) -> None:
-    src = tmp_path / "action-items-2026-04-15.md"
-    src.write_text("- [ ] Buy milk\n")
-    dst = snooze(src, subject="Buy milk", until=dt.date(2026, 5, 1))
-    content = dst.read_text()
-    assert "🛌 Snoozed" in content
+def test_snooze_by_id_unknown_prefix_raises(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
+    daily.parent.mkdir(parents=True, exist_ok=True)
+    daily.write_text("- [ ] x\n")
+    monkeypatch.setattr("scout.action_items.snooze._today", lambda: dt.date(2026, 4, 26))
+
+    with pytest.raises(ActionItemError, match="prefix.*not found"):
+        snooze(by_id="ZZZZ", until=dt.date(2026, 5, 1), data_dir=fake_data_dir)
 
 
-def test_appends_to_existing_dest_file(tmp_path: Path) -> None:
-    src = tmp_path / "action-items-2026-04-15.md"
-    src.write_text("- [ ] New task\n")
-    dst_path = tmp_path / "action-items-2026-05-01.md"
-    dst_path.write_text("# Action Items — 2026-05-01\n\n## To Do\n\n- [ ] Pre-existing\n")
-    dst = snooze(src, subject="New task", until=dt.date(2026, 5, 1))
-    content = dst.read_text()
-    assert "Pre-existing" in content
-    assert "New task" in content
+def test_snooze_event_id_and_ts_well_formed(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    m = IdMap.load(fake_data_dir)
+    m.register(IdMapEntry("01HX", "A3F7", "task", "action-items-2026-04-26.md", 1))
+    m.save()
+    daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
+    daily.parent.mkdir(parents=True, exist_ok=True)
+    daily.write_text("- [ ] [#A3F7] task\n")
+    monkeypatch.setattr("scout.action_items.snooze._today", lambda: dt.date(2026, 4, 26))
 
-
-def test_removes_continuation_lines(tmp_path: Path) -> None:
-    """Task block removal includes indented sub-items."""
-    src = tmp_path / "action-items-2026-04-15.md"
-    src.write_text("- [ ] Big task\n  - sub item A\n  - sub item B\n- [ ] Other task\n")
-    snooze(src, subject="Big task", until=dt.date(2026, 5, 1))
-    src_after = src.read_text()
-    assert "Big task" not in src_after
-    assert "sub item" not in src_after
-    assert "- [ ] Other task" in src_after
-
-
-def test_no_match_raises(tmp_path: Path) -> None:
-    src = tmp_path / "action-items-2026-04-15.md"
-    src.write_text("- [ ] something\n")
-    with pytest.raises(ActionItemError, match="no match"):
-        snooze(src, subject="missing", until=dt.date(2026, 5, 1))
-
-
-def test_ambiguous_match_raises(tmp_path: Path) -> None:
-    src = tmp_path / "action-items-2026-04-15.md"
-    src.write_text("- [ ] vendor A\n- [ ] vendor B\n")
-    with pytest.raises(ActionItemError, match="ambiguous|multiple"):
-        snooze(src, subject="vendor", until=dt.date(2026, 5, 1))
-
-
-def test_until_in_the_past_raises(tmp_path: Path) -> None:
-    src = tmp_path / "action-items-2026-04-15.md"
-    src.write_text("- [ ] task\n")
-    with pytest.raises(ActionItemError, match="past"):
-        snooze(src, subject="task", until=dt.date(2026, 4, 14))
-
-
-def test_case_insensitive_match(tmp_path: Path) -> None:
-    src = tmp_path / "action-items-2026-04-15.md"
-    src.write_text("- [ ] Reply To Vendor\n")
-    dst = snooze(src, subject="reply to vendor", until=dt.date(2026, 5, 1))
-    assert "Reply To Vendor" in dst.read_text()
-
-
-def test_matches_closed_tasks_too(tmp_path: Path) -> None:
-    """Snooze can act on an already-closed task (source matches regardless of mark)."""
-    src = tmp_path / "action-items-2026-04-15.md"
-    src.write_text("- [x] Finished but reschedule\n")
-    dst = snooze(src, subject="Finished but reschedule", until=dt.date(2026, 5, 1))
-    assert "Finished but reschedule" in dst.read_text()
-
-
-def test_returns_dest_path(tmp_path: Path) -> None:
-    src = tmp_path / "action-items-2026-04-15.md"
-    src.write_text("- [ ] task\n")
-    result = snooze(src, subject="task", until=dt.date(2026, 5, 1))
-    assert result == tmp_path / "action-items-2026-05-01.md"
-
-
-def test_dedup_does_not_double_append(tmp_path: Path) -> None:
-    """Re-snoozing skips if exact same subject already present in target section.
-
-    Dedup compares the plain-text subject of existing entries.  An entry with
-    an identical rest (no carry-in annotation yet) is treated as a duplicate.
-    Note: entries that already carry a '_(carried in from …)_' annotation will
-    NOT be detected as duplicates because the annotation changes the subject
-    text — this matches the source's behaviour verbatim.
-    """
-    src = tmp_path / "action-items-2026-04-15.md"
-    src.write_text("- [ ] task\n")
-    dst_path = tmp_path / "action-items-2026-05-01.md"
-    # Pre-existing entry has the SAME subject (no annotation yet).
-    dst_path.write_text("## 🛌 Snoozed\n\n- [ ] task\n")
-    snooze(src, subject="task", until=dt.date(2026, 5, 1))
-    count = dst_path.read_text().count("task")
-    # Only one mention — dedup prevented a second append.
-    assert count == 1
+    event = snooze(by_id="A3F7", until=dt.date(2026, 5, 1), data_dir=fake_data_dir)
+    assert len(event.id) == 26
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", event.ts)

--- a/engine/tests/unit/test_action_items_writer.py
+++ b/engine/tests/unit/test_action_items_writer.py
@@ -66,3 +66,40 @@ def test_flip_checkbox_out_of_range_raises(tmp_path: Path) -> None:
 
     with pytest.raises(ActionItemError, match="line"):
         flip_checkbox(target, line_number=99, to_done=True)
+
+
+def test_add_prefix_to_unprefixed_line(tmp_path: Path) -> None:
+    target = tmp_path / "f.md"
+    target.write_text("- [ ] 🔴 task title\n- [ ] [#X9Y2] other\n")
+    from scout.action_items.writer import add_prefix_to_line
+
+    add_prefix_to_line(target, line_number=1, prefix="A3F7")
+    assert target.read_text() == "- [ ] [#A3F7] 🔴 task title\n- [ ] [#X9Y2] other\n"
+
+
+def test_add_prefix_handles_no_priority_emoji(tmp_path: Path) -> None:
+    target = tmp_path / "f.md"
+    target.write_text("- [ ] just a plain task\n")
+    from scout.action_items.writer import add_prefix_to_line
+
+    add_prefix_to_line(target, line_number=1, prefix="A3F7")
+    assert target.read_text() == "- [ ] [#A3F7] just a plain task\n"
+
+
+def test_add_prefix_refuses_if_line_already_prefixed(tmp_path: Path) -> None:
+    target = tmp_path / "f.md"
+    target.write_text("- [ ] [#X9Y2] already prefixed\n")
+    from scout.action_items.writer import add_prefix_to_line
+    from scout.errors import ActionItemError
+
+    with pytest.raises(ActionItemError, match="already has prefix"):
+        add_prefix_to_line(target, line_number=1, prefix="A3F7")
+
+
+def test_flip_checkbox_preserves_existing_prefix(tmp_path: Path) -> None:
+    target = tmp_path / "f.md"
+    target.write_text("- [ ] [#A3F7] task\n")
+    from scout.action_items.writer import flip_checkbox
+
+    flip_checkbox(target, line_number=1, to_done=True)
+    assert target.read_text() == "- [x] [#A3F7] task\n"

--- a/engine/tests/unit/test_action_items_writer.py
+++ b/engine/tests/unit/test_action_items_writer.py
@@ -103,3 +103,36 @@ def test_flip_checkbox_preserves_existing_prefix(tmp_path: Path) -> None:
 
     flip_checkbox(target, line_number=1, to_done=True)
     assert target.read_text() == "- [x] [#A3F7] task\n"
+
+
+def test_add_prefix_refuses_when_line_number_out_of_range(tmp_path: Path) -> None:
+    target = tmp_path / "f.md"
+    target.write_text("- [ ] only line\n")
+    from scout.action_items.writer import add_prefix_to_line
+    from scout.errors import ActionItemError
+
+    with pytest.raises(ActionItemError, match="out of range"):
+        add_prefix_to_line(target, line_number=99, prefix="A3F7")
+
+
+def test_add_prefix_refuses_when_line_is_not_a_checkbox(tmp_path: Path) -> None:
+    target = tmp_path / "f.md"
+    target.write_text("plain text without checkbox\n")
+    from scout.action_items.writer import add_prefix_to_line
+    from scout.errors import ActionItemError
+
+    with pytest.raises(ActionItemError, match="doesn't start with a checkbox marker"):
+        add_prefix_to_line(target, line_number=1, prefix="A3F7")
+
+
+def test_add_prefix_to_specific_line_in_multi_line_file(tmp_path: Path) -> None:
+    """Pin 1-indexed semantics — line 3 in a multi-line file mutates only line 3."""
+    target = tmp_path / "f.md"
+    target.write_text("# Header\n\n- [ ] 🔴 first task\n- [ ] 🟡 second task\n- [ ] 🟢 third task\n")
+    from scout.action_items.writer import add_prefix_to_line
+
+    add_prefix_to_line(target, line_number=4, prefix="B5K2")
+
+    assert target.read_text() == (
+        "# Header\n\n- [ ] 🔴 first task\n- [ ] [#B5K2] 🟡 second task\n- [ ] 🟢 third task\n"
+    )

--- a/engine/tests/unit/test_events.py
+++ b/engine/tests/unit/test_events.py
@@ -1,0 +1,56 @@
+"""Unit tests for scout.events.Event."""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime as dt
+import re
+
+import pytest
+
+from scout.events import Event, now_iso
+
+
+def test_event_is_frozen() -> None:
+    e = Event(
+        id="01HXABC0000000000000000000",
+        ts="2026-04-26T12:00:00.000Z",
+        kind="action_item.completed",
+        source="cli:mark_done",
+        payload={"item_id": "01HXAAA0000000000000000000"},
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        e.kind = "action_item.snoozed"  # type: ignore[misc]
+
+
+def test_event_has_required_fields() -> None:
+    e = Event(
+        id="01HXABC0000000000000000000",
+        ts="2026-04-26T12:00:00.000Z",
+        kind="action_item.completed",
+        source="cli:mark_done",
+        payload={},
+    )
+    assert e.id and e.ts and e.kind and e.source
+    assert e.payload == {}
+
+
+def test_now_iso_returns_iso8601_z() -> None:
+    s = now_iso()
+    # Match: YYYY-MM-DDTHH:MM:SS.mmmZ
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", s)
+    # Round-trip via fromisoformat (Python 3.11+ handles 'Z' as +00:00 only since 3.12;
+    # we use the explicit Z stripper to keep 3.11 compat).
+    parsed = dt.datetime.fromisoformat(s.replace("Z", "+00:00"))
+    assert parsed.tzinfo is not None
+
+
+def test_event_payload_supports_arbitrary_json_compatible_dict() -> None:
+    e = Event(
+        id="01HX",
+        ts="2026-04-26T00:00:00.000Z",
+        kind="x.y.z",
+        source="test",
+        payload={"a": 1, "b": "two", "c": [3, 4], "d": {"e": True}},
+    )
+    assert e.payload["d"]["e"] is True

--- a/engine/tests/unit/test_id_map.py
+++ b/engine/tests/unit/test_id_map.py
@@ -1,0 +1,110 @@
+"""Unit tests for scout.id_map.IdMap."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scout.id_map import IdMap, IdMapEntry
+
+
+def test_load_missing_file_returns_empty_map(fake_data_dir: Path) -> None:
+    m = IdMap.load(fake_data_dir)
+    assert m.in_use_prefixes() == set()
+    assert list(m.iter_entries()) == []
+
+
+def test_register_writes_entry(fake_data_dir: Path) -> None:
+    m = IdMap.load(fake_data_dir)
+    entry = IdMapEntry(
+        ulid="01HXAAA0000000000000000000",
+        short_prefix="A3F7",
+        last_title="Submit Lever feedback to recruiting",
+        last_file="action-items-2026-04-26.md",
+        last_line=5,
+    )
+    m.register(entry)
+    m.save()
+
+    fresh = IdMap.load(fake_data_dir)
+    assert fresh.in_use_prefixes() == {"A3F7"}
+    found = fresh.lookup_by_prefix("A3F7")
+    assert found is not None
+    assert found.ulid == "01HXAAA0000000000000000000"
+
+
+def test_lookup_by_prefix_returns_none_for_unknown(fake_data_dir: Path) -> None:
+    m = IdMap.load(fake_data_dir)
+    assert m.lookup_by_prefix("ZZZZ") is None
+
+
+def test_lookup_by_ulid(fake_data_dir: Path) -> None:
+    m = IdMap.load(fake_data_dir)
+    entry = IdMapEntry(
+        ulid="01HXBBB0000000000000000000",
+        short_prefix="B5K2",
+        last_title="Reply to Q2 budget thread",
+        last_file="action-items-2026-04-26.md",
+        last_line=8,
+    )
+    m.register(entry)
+    found = m.lookup_by_ulid("01HXBBB0000000000000000000")
+    assert found is not None
+    assert found.short_prefix == "B5K2"
+
+
+def test_register_updates_existing_entry(fake_data_dir: Path) -> None:
+    m = IdMap.load(fake_data_dir)
+    e1 = IdMapEntry("01HX", "A3F7", "old title", "f.md", 1)
+    m.register(e1)
+    e2 = IdMapEntry("01HX", "A3F7", "new title", "f.md", 3)
+    m.register(e2)
+    m.save()
+
+    fresh = IdMap.load(fake_data_dir)
+    found = fresh.lookup_by_ulid("01HX")
+    assert found is not None
+    assert found.last_title == "new title"
+    assert found.last_line == 3
+
+
+def test_reattach_finds_match_by_title_and_file(fake_data_dir: Path) -> None:
+    m = IdMap.load(fake_data_dir)
+    m.register(IdMapEntry("01HXAAA", "A3F7", "Submit Lever feedback", "today.md", 5))
+    m.register(IdMapEntry("01HXBBB", "B5K2", "Reply to budget thread", "today.md", 8))
+
+    # Line lost its prefix but title is still "Submit Lever feedback"
+    found = m.reattach(title="Submit Lever feedback", file="today.md")
+    assert found is not None
+    assert found.short_prefix == "A3F7"
+
+
+def test_reattach_returns_none_for_unknown_title(fake_data_dir: Path) -> None:
+    m = IdMap.load(fake_data_dir)
+    m.register(IdMapEntry("01HXAAA", "A3F7", "Existing", "today.md", 1))
+    assert m.reattach(title="Brand new task", file="today.md") is None
+
+
+def test_reattach_prefers_same_file_match(fake_data_dir: Path) -> None:
+    """Same title in two files — reattach should prefer the file argument."""
+    m = IdMap.load(fake_data_dir)
+    m.register(IdMapEntry("01HX111", "AAAA", "Daily standup", "monday.md", 1))
+    m.register(IdMapEntry("01HX222", "BBBB", "Daily standup", "tuesday.md", 1))
+    found = m.reattach(title="Daily standup", file="tuesday.md")
+    assert found is not None
+    assert found.short_prefix == "BBBB"
+
+
+def test_save_creates_parent_directory(fake_data_dir: Path) -> None:
+    # The fake_data_dir fixture pre-creates .scout-state, so remove it first
+    # to verify save() recreates it.
+    state_dir = fake_data_dir / ".scout-state"
+    if state_dir.exists():
+        for child in state_dir.iterdir():
+            child.unlink()
+        state_dir.rmdir()
+    assert not state_dir.exists()
+
+    m = IdMap.load(fake_data_dir)
+    m.register(IdMapEntry("01HX", "A3F7", "x", "y.md", 1))
+    m.save()
+    assert (state_dir / "id-map.json").exists()

--- a/engine/tests/unit/test_ids.py
+++ b/engine/tests/unit/test_ids.py
@@ -1,0 +1,78 @@
+"""Unit tests for scout.ids — ULID + short-prefix generation."""
+
+from __future__ import annotations
+
+import pytest
+
+from scout.ids import (
+    CROCKFORD_ALPHABET,
+    SHORT_PREFIX_LEN,
+    new_short_prefix,
+    new_ulid,
+    short_prefix_pattern,
+)
+
+
+def test_new_ulid_returns_26_char_string() -> None:
+    val = new_ulid()
+    assert isinstance(val, str)
+    assert len(val) == 26
+
+
+def test_new_ulid_is_unique_across_calls() -> None:
+    seen: set[str] = set()
+    for _ in range(100):
+        seen.add(new_ulid())
+    assert len(seen) == 100
+
+
+def test_new_short_prefix_is_4_crockford_chars() -> None:
+    p = new_short_prefix()
+    assert len(p) == SHORT_PREFIX_LEN == 4
+    assert all(c in CROCKFORD_ALPHABET for c in p)
+
+
+def test_new_short_prefix_excludes_ambiguous_chars() -> None:
+    # Crockford base32 excludes I, L, O, U to avoid 0/O and 1/I/L visual collisions.
+    for c in "ILOU":
+        assert c not in CROCKFORD_ALPHABET
+
+
+def test_short_prefix_pattern_matches_well_formed_prefix() -> None:
+    rx = short_prefix_pattern()
+    assert rx.fullmatch("[#A3F7]")
+    assert rx.fullmatch("[#0000]")
+    # Hyphens and lowercase are not allowed.
+    assert not rx.fullmatch("[#a3f7]")
+    assert not rx.fullmatch("[#A-37]")
+    # Wrong length.
+    assert not rx.fullmatch("[#A3F]")
+    assert not rx.fullmatch("[#A3F7E]")
+
+
+def test_short_prefix_pattern_finds_prefix_in_line() -> None:
+    rx = short_prefix_pattern()
+    line = "- [ ] [#A3F7] Submit Lever feedback"
+    m = rx.search(line)
+    assert m is not None
+    assert m.group(0) == "[#A3F7]"
+    assert m.group(1) == "A3F7"
+
+
+def test_new_short_prefix_excludes_set_member() -> None:
+    """Caller passes an in-use set; generator retries until it lands outside."""
+    in_use = {new_short_prefix() for _ in range(5)}
+    # With ~1M space and 5 used prefixes, this lands in one try almost surely;
+    # the test asserts the contract, not the retry count.
+    p = new_short_prefix(exclude=in_use)
+    assert p not in in_use
+
+
+def test_new_short_prefix_raises_when_exhausted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When all retries hit `exclude`, the generator raises instead of looping forever."""
+    import secrets
+
+    # Force every generated prefix to be "AAAA" so it deterministically hits the exclude set.
+    monkeypatch.setattr(secrets, "choice", lambda _: "A")
+    with pytest.raises(RuntimeError, match="prefix space exhausted"):
+        new_short_prefix(exclude={"AAAA"}, max_attempts=3)

--- a/engine/tests/unit/test_ids.py
+++ b/engine/tests/unit/test_ids.py
@@ -68,11 +68,43 @@ def test_new_short_prefix_excludes_set_member() -> None:
     assert p not in in_use
 
 
+def test_new_short_prefix_with_explicit_none_exclude() -> None:
+    """exclude=None is the documented default; verify it's accepted explicitly."""
+    p = new_short_prefix(exclude=None)
+    assert len(p) == SHORT_PREFIX_LEN
+    assert all(c in CROCKFORD_ALPHABET for c in p)
+
+
+def test_new_short_prefix_max_attempts_zero_raises_immediately(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """max_attempts=0 means no tries — raise without invoking the RNG."""
+    call_count = {"n": 0}
+
+    def _spy(_alphabet: str) -> str:
+        call_count["n"] += 1
+        return "A"
+
+    monkeypatch.setattr("scout.ids.secrets.choice", _spy)
+    with pytest.raises(RuntimeError, match="prefix space exhausted"):
+        new_short_prefix(exclude={"AAAA"}, max_attempts=0)
+    assert call_count["n"] == 0
+
+
+def test_new_short_prefix_max_attempts_one_succeeds_when_no_collision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single try is enough when the candidate is fresh."""
+    monkeypatch.setattr("scout.ids.secrets.choice", lambda _: "B")
+    p = new_short_prefix(exclude=set(), max_attempts=1)
+    assert p == "BBBB"
+
+
 def test_new_short_prefix_raises_when_exhausted(monkeypatch: pytest.MonkeyPatch) -> None:
     """When all retries hit `exclude`, the generator raises instead of looping forever."""
-    import secrets
-
     # Force every generated prefix to be "AAAA" so it deterministically hits the exclude set.
-    monkeypatch.setattr(secrets, "choice", lambda _: "A")
+    # Patch the symbol where it's used (scout.ids.secrets.choice), not the global secrets module —
+    # this remains correct even if ids.py ever switches to `from secrets import choice`.
+    monkeypatch.setattr("scout.ids.secrets.choice", lambda _: "A")
     with pytest.raises(RuntimeError, match="prefix space exhausted"):
         new_short_prefix(exclude={"AAAA"}, max_attempts=3)

--- a/engine/tests/unit/test_paths.py
+++ b/engine/tests/unit/test_paths.py
@@ -75,3 +75,8 @@ def test_action_items_daily_path_default_today(fake_data_dir: Path, monkeypatch:
 def test_action_items_daily_path_explicit_date(fake_data_dir: Path) -> None:
     p = paths.action_items_daily_path(data=fake_data_dir, date=dt.date(2026, 4, 15))
     assert p.name == "action-items-2026-04-15.md"
+
+
+def test_id_map_path_returns_state_subdir(fake_data_dir: Path) -> None:
+    p = paths.id_map_path(data=fake_data_dir)
+    assert p == fake_data_dir / ".scout-state" / "id-map.json"


### PR DESCRIPTION
## Summary

Implements the §13 forward-compatibility commitments from the v0.4 unification spec on top of the just-merged Plan 2 work (PR #7). 15 commits, ~5 new modules, ~30 new tests; existing behavior preserved.

The action items system now learns about stable IDs without changing the user-visible markdown except for an optional `[#XXXX]` prefix on each line. v0.5 will swap out the file-watcher implementation under `watch` and substitute a SQLite event store behind `emit()` — both hidden behind the contracts this PR establishes.

### What's new

**Three leaf modules:**
- `scout.ids` — ULID generation + 4-character Crockford base32 short prefix (`[#A3F7]`-style). Collision-safe via per-call retry. Pattern regex exposed for parsers and writers.
- `scout.events` — frozen `Event` dataclass `(id, ts, kind, source, payload)`. v0.5's wire format. Mutators return these; nothing persists them yet.
- `scout.id_map` — file-backed prefix↔ULID map at `\$SCOUT_DATA_DIR/.scout-state/id-map.json`. Atomic-rename writes, schema_version validation, fuzzy reattachment by title+file when a prefix is accidentally deleted.

**Parser learns prefixes:**
- `ActionItem.short_prefix: str | None` — extracted from `[#XXXX]` in the line, stripped from the visible title; `raw_line` preserved unchanged so substring fallback still works.

**Writer gains `add_prefix_to_line`:**
- Inserts `[#XXXX] ` after the checkbox marker on a 1-indexed line. Refuses if the line is already prefixed, out of range, or doesn't start with a checkbox.

**Mutators (mark_done / snooze / add_comment) get a uniform shape:**
- New API: `--by-id PREFIX` (default for ID-aware lines) or `--subject SUBSTRING` (legacy fallback). Exactly-one-of validation.
- All three return an `Event` (action_item.completed / .snoozed / .commented) with payload `{item_id, via, title, ...}`.
- Resolution logic factored into `scout.action_items._common.resolve_target` — IdMap loaded once, error messages centralized.

**Behavior changes worth flagging:**
- `snooze` no longer moves tasks to a future-dated daily file. It now inserts `  - snoozed-until: YYYY-MM-DD` as a sub-bullet beneath the task. Past-date guard removed; the v0.5 event-store filtering layer is the canonical place for "is this still relevant?" logic.
- `add_comment` no longer emits timestamped blockquotes (`  > author (date): text`). It now inserts plain `  - <comment>` sub-bullets. The Event captures `ts`; future versions of `source` can carry author info.
- `mark_done --undo` is gone. The render.py "Reopen" chip that emitted the broken command was also removed.

These align with the v0.5+ direction: markdown is one projection, the event store is canonical for metadata.

**CLI:** `mark-done`, `snooze`, `add-comment` all accept both `--by-id` and `--subject` flags with exactly-one-of validation. Legacy positional path argument preserved by inferring `data_dir` from the path.

**list_items:** new `format_items()` helper renders `[#XXXX]` prefixes inline; `cli list --json` includes `short_prefix`.

### Cost vs. v0.5 unlock

| Commitment | v0.4 cost | v0.5+ unlock |
|---|---|---|
| Stable IDs + 4-char prefix | new \`scout.ids\` + \`scout.id_map\` + parser/writer field | external sources have a stable join key for sync |
| Event-shaped mutations | new \`scout.events\` + 3 mutator return values | one-line \`emit()\` substitution lights up the event store |
| Projection-consumer wording on \`watch\` / \`kb refresh-summary\` | docstring/help-text only | transparent substitution to event-store subscriber |

### Test plan

- [x] 145 passing, 1 skipped (the unrelated SCOUT_DATA_DIR parity test). Unit + integration + concurrency markers all green.
- [x] ruff check, ruff format --check, mypy all clean.
- [x] Manual smoke test: temp data dir, daily file with one prefixed and one unprefixed task, exercise both \`--by-id A3F7\` and \`--subject "by subject"\` — both lines flip from \`[ ]\` to \`[x]\`.
- [x] Concurrency: 8-process race against \`IdMap.save()\` produces parseable JSON (LWW under contention, atomic rename guarantees no torn writes).
- [x] Spec compliance + code quality reviewed per task; one off-by-one in scout.ids and one misleading flock pattern in id_map were caught and fixed in the same branch.

### Refs

- v0.4 unification spec §13 (\`scout-app/docs/superpowers/specs/2026-04-24-scout-unification-design.md\`) — forward-compatibility commitments
- v0.5+ event architecture vision (\`scout-app/docs/superpowers/specs/2026-04-25-scout-event-architecture-design.md\`) — substitution targets
- Plan 2 supplement (\`scout-app/docs/superpowers/plans/2026-04-26-scout-unification-plan-2-supplement-stable-ids-and-events.md\`) — task list this PR implements
- Followups: \`~/scout-app/docs/superpowers/FOLLOWUPS.md\` §scout.ids, §scout.action_items.writer

🤖 Generated with [Claude Code](https://claude.com/claude-code)