### PR TITLE
feat(engine): Plan 3 — scoutctl action-items watch

### DIFF
--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -12,13 +12,13 @@ dependencies = [
     "pyyaml>=6.0",
     "jinja2>=3.1",
     "python-ulid>=2.2",
+    "rich>=13.7",
+    "watchdog>=4.0",
 ]
 
 [project.optional-dependencies]
 full = [
     "textual>=0.63",
-    "rich>=13.7",
-    "watchdog>=4.0",
 ]
 dev = [
     "pytest>=8.0",
@@ -63,6 +63,12 @@ warn_unused_ignores = true
 # extra just for type-checking.
 [[tool.mypy.overrides]]
 module = ["textual", "textual.*"]
+ignore_missing_imports = true
+
+# watchdog ships no PEP 561 type stubs (no `types-watchdog` exists on PyPI as
+# of 2026-04). Treat as untyped — same pattern as textual.
+[[tool.mypy.overrides]]
+module = ["watchdog", "watchdog.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/engine/scout/action_items/cli.py
+++ b/engine/scout/action_items/cli.py
@@ -160,7 +160,7 @@ def cli_list(
 
 @app.command("watch")
 def cli_watch(
-    target: str = typer.Argument(
+    target: str | None = typer.Argument(
         None,
         metavar="[DATE_OR_PATH]",
         help="YYYY-MM-DD for that day's file, an explicit path, or omit for today.",

--- a/engine/scout/action_items/cli.py
+++ b/engine/scout/action_items/cli.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import typer
 
-from scout.errors import ActionItemError, ScoutError
+from scout.errors import ActionItemError
 
 app = typer.Typer(help="Action-items operations.", no_args_is_help=True)
 
@@ -159,5 +159,32 @@ def cli_list(
 
 
 @app.command("watch")
-def cli_watch() -> None:
-    raise ScoutError("scoutctl action-items watch is implemented in Plan 3")
+def cli_watch(
+    target: str = typer.Argument(
+        None,
+        metavar="[DATE_OR_PATH]",
+        help="YYYY-MM-DD for that day's file, an explicit path, or omit for today.",
+    ),
+    no_color: bool = typer.Option(False, "--no-color", help="Disable ANSI color (auto when stdout is not a TTY)."),
+) -> None:
+    """Stream changes to today's action items as they happen."""
+    import datetime as dt
+    import re
+    import sys
+    from pathlib import Path
+
+    from scout import paths
+    from scout.action_items.watch import run_watch_loop
+
+    if target is None:
+        target_path = paths.action_items_daily_path()
+    elif re.fullmatch(r"\d{4}-\d{2}-\d{2}", target):
+        target_path = paths.action_items_daily_path(date=dt.date.fromisoformat(target))
+    else:
+        target_path = Path(target).expanduser().resolve()
+
+    if not target_path.exists():
+        raise ActionItemError(f"target does not exist: {target_path}")
+
+    color = not no_color and sys.stdout.isatty()
+    run_watch_loop(target_path, color=color)

--- a/engine/scout/action_items/cli.py
+++ b/engine/scout/action_items/cli.py
@@ -168,10 +168,7 @@ def cli_watch(
     no_color: bool = typer.Option(False, "--no-color", help="Disable ANSI color (auto when stdout is not a TTY)."),
 ) -> None:
     """Stream changes to today's action items as they happen."""
-    import datetime as dt
     import re
-    import sys
-    from pathlib import Path
 
     from scout import paths
     from scout.action_items.watch import run_watch_loop
@@ -179,7 +176,7 @@ def cli_watch(
     if target is None:
         target_path = paths.action_items_daily_path()
     elif re.fullmatch(r"\d{4}-\d{2}-\d{2}", target):
-        target_path = paths.action_items_daily_path(date=dt.date.fromisoformat(target))
+        target_path = paths.action_items_daily_path(date=_dt.date.fromisoformat(target))
     else:
         target_path = Path(target).expanduser().resolve()
 

--- a/engine/scout/action_items/diff.py
+++ b/engine/scout/action_items/diff.py
@@ -1,0 +1,142 @@
+"""Pure diff over ActionItem snapshots.
+
+Returns a list of ChangeEvent records describing what changed between
+two parses of the same action-items file. Designed to be the v0.5
+event-store subscriber's projection target as well — same shape,
+different source.
+
+Match priority:
+1. By short_prefix (the [#XXXX] surface form from §13.1) — only matches
+   when *both* prev and curr items carry the same prefix.
+2. By (section, title) tuple — fallback for legacy unprefixed lines.
+
+This means a line that gains a prefix in curr is not matched to its
+unprefixed prev — it appears as a `removed` (the unprefixed version
+disappeared) plus an `added` (the prefixed version appeared). That's
+intentional: the watcher's `prev_state` will be re-seeded on the next
+diff cycle, and the v0.5 event store will see the assignment as a
+distinct event.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from scout.action_items.parser import ActionItem
+
+
+@dataclass(frozen=True)
+class ChangeEvent:
+    kind: str  # "added" | "removed" | "completed" | "reopened" | "title_changed"
+    item_id: str  # short_prefix, or "" for unprefixed lines
+    title: str  # display title (curr title for title_changed)
+    section: str  # display section
+    extras: dict[str, Any] = field(default_factory=dict)
+
+
+def _index_by_prefix(items: list[ActionItem]) -> dict[str, ActionItem]:
+    return {i.short_prefix: i for i in items if i.short_prefix}
+
+
+def _index_by_section_title(items: list[ActionItem]) -> dict[tuple[str, str], ActionItem]:
+    # Skip items that have a prefix — those match by prefix path only.
+    return {(i.section, i.title): i for i in items if not i.short_prefix}
+
+
+def diff(*, prev: list[ActionItem], curr: list[ActionItem]) -> list[ChangeEvent]:
+    """Return the list of changes from `prev` to `curr`."""
+    events: list[ChangeEvent] = []
+
+    prev_by_prefix = _index_by_prefix(prev)
+    prev_by_st = _index_by_section_title(prev)
+
+    matched_prev_prefix: set[str] = set()
+    matched_prev_st: set[tuple[str, str]] = set()
+
+    # Walk curr in input order so the emitted events are in display order.
+    for item in curr:
+        if item.short_prefix:
+            prev_match = prev_by_prefix.get(item.short_prefix)
+            if prev_match is not None:
+                matched_prev_prefix.add(item.short_prefix)
+                events.extend(_compare(prev_match, item))
+                continue
+            # New prefix in curr that wasn't in prev → "added".
+            events.append(
+                ChangeEvent(
+                    kind="added",
+                    item_id=item.short_prefix,
+                    title=item.title,
+                    section=item.section,
+                )
+            )
+            continue
+
+        # Unprefixed line: match by (section, title).
+        key = (item.section, item.title)
+        prev_match = prev_by_st.get(key)
+        if prev_match is not None:
+            matched_prev_st.add(key)
+            events.extend(_compare(prev_match, item))
+            continue
+
+        events.append(
+            ChangeEvent(
+                kind="added",
+                item_id="",
+                title=item.title,
+                section=item.section,
+            )
+        )
+
+    # Anything in prev that wasn't matched is removed.
+    for prefix, item in prev_by_prefix.items():
+        if prefix not in matched_prev_prefix:
+            events.append(
+                ChangeEvent(
+                    kind="removed",
+                    item_id=prefix,
+                    title=item.title,
+                    section=item.section,
+                )
+            )
+    for key, item in prev_by_st.items():
+        if key not in matched_prev_st:
+            events.append(
+                ChangeEvent(
+                    kind="removed",
+                    item_id="",
+                    title=item.title,
+                    section=item.section,
+                )
+            )
+
+    return events
+
+
+def _compare(prev: ActionItem, curr: ActionItem) -> list[ChangeEvent]:
+    """Compare two matched items; emit zero or more events."""
+    out: list[ChangeEvent] = []
+    item_id = curr.short_prefix or ""
+    if prev.status != curr.status:
+        kind = "completed" if curr.status == "done" else "reopened"
+        out.append(
+            ChangeEvent(
+                kind=kind,
+                item_id=item_id,
+                title=curr.title,
+                section=curr.section,
+            )
+        )
+    if prev.title != curr.title:
+        out.append(
+            ChangeEvent(
+                kind="title_changed",
+                item_id=item_id,
+                title=curr.title,
+                section=curr.section,
+                extras={"old_title": prev.title, "new_title": curr.title},
+            )
+        )
+    return out

--- a/engine/scout/action_items/render.py
+++ b/engine/scout/action_items/render.py
@@ -19,12 +19,17 @@ parse(md_path: Path) -> tuple[str, list[str], list[Section]]
 
 from __future__ import annotations
 
+import datetime as dt
 import html
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from scout.errors import ActionItemError
+
+if TYPE_CHECKING:
+    from scout.action_items.diff import ChangeEvent
 
 # ---------------------------------------------------------------------------
 # Parsing
@@ -1061,3 +1066,70 @@ document.addEventListener('click', function(e) {
   }
 });
 """
+
+
+# ---------------------------------------------------------------------------
+# Change-event line formatter (Plan 3, Task 2)
+# ---------------------------------------------------------------------------
+
+
+# Symbol + label + Rich style per kind.
+# Defined here (module level) so render_changes doesn't rebuild it per call.
+_SYMBOL_STYLE: dict[str, tuple[str, str, str]] = {
+    "added": ("+", "added", "green"),
+    "removed": ("-", "removed", "red"),
+    "completed": ("✓", "completed", "green"),
+    "reopened": ("↻", "reopened", "yellow"),
+    "title_changed": ("✎", "renamed", "yellow"),
+}
+
+
+def render_changes(
+    events: list[ChangeEvent],
+    *,
+    now: dt.datetime,
+    color: bool,
+) -> list[str]:
+    """Format ChangeEvent records as one line each.
+
+    Returns a list of strings; caller is responsible for emitting them
+    (typically `for line in lines: print(line)`).
+
+    `color=True` injects ANSI escapes via Rich. `color=False` is plain
+    text — use this when stdout is not a TTY or the user passed `--no-color`.
+    """
+    # Local imports keep render_html's stdlib-only top-level imports intact;
+    # rich is in the [full] optional-dependencies, not core.
+    from io import StringIO
+
+    from rich.console import Console
+    from rich.text import Text
+
+    out: list[str] = []
+    ts = now.strftime("[%H:%M:%S]")
+    # 9-char-wide kind column so all rows align.
+    KIND_WIDTH = 9
+    for ev in events:
+        symbol, kind_label, style = _SYMBOL_STYLE.get(ev.kind, ("?", ev.kind, "white"))
+        prefix_part = f"[#{ev.item_id}] " if ev.item_id else ""
+        if ev.kind == "title_changed":
+            body = f'{prefix_part}"{ev.extras["old_title"]}" → "{ev.extras["new_title"]}"'
+        else:
+            body = f"{prefix_part}{ev.title} ({ev.section})"
+        plain = f"{ts} {symbol} {kind_label.ljust(KIND_WIDTH)} {body}"
+        if not color:
+            out.append(plain)
+            continue
+        # Use a temporary Console capturing into a StringIO so we get
+        # ANSI escapes regardless of the surrounding stdout's TTY status.
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True, color_system="truecolor", legacy_windows=False)
+        console.print(
+            Text(f"{ts} ", style="dim")
+            + Text(symbol + " ", style=style)
+            + Text(kind_label.ljust(KIND_WIDTH), style=style)
+            + Text(" " + body),
+            end="",
+        )
+        out.append(buf.getvalue())
+    return out

--- a/engine/scout/action_items/watch.py
+++ b/engine/scout/action_items/watch.py
@@ -1,0 +1,113 @@
+"""scoutctl action-items watch — projection-consumer over today's action items.
+
+Public CLI contract per spec §13.3: this command *streams changes to
+today's action items as they happen*. The v0.4 implementation watches
+the underlying markdown file via `watchdog`; v0.5 will substitute an
+event-store subscriber. The CLI surface and stdout shape are stable.
+
+Heavy imports (watchdog, rich) live inside function bodies so
+`scoutctl --help` and other subcommands stay under the latency budget
+(spec §4).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import sys
+from pathlib import Path
+
+from scout.action_items.diff import diff
+from scout.action_items.parser import ActionItem
+from scout.action_items.render import render_changes
+
+
+def process_change(
+    *,
+    prev_text: str,
+    curr_text: str,
+    now: dt.datetime,
+    color: bool,
+) -> list[str]:
+    """Pure core of the watcher: text → text → list of formatted lines.
+
+    Used directly by tests; called from `_handle_modified_event` in the
+    real watcher loop.
+    """
+    prev_items = _parse_text(prev_text)
+    curr_items = _parse_text(curr_text)
+    events = diff(prev=prev_items, curr=curr_items)
+    return render_changes(events, now=now, color=color)
+
+
+def _parse_text(text: str) -> list[ActionItem]:
+    """Run the parser over an in-memory string by writing to a tempfile."""
+    # parser.parse_file expects a Path. The watcher always has a real
+    # path; this helper exists so process_change() can be tested with
+    # arbitrary strings without hitting the real filesystem.
+    import tempfile
+
+    from scout.action_items.parser import parse_file
+
+    if not text:
+        return []
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False, encoding="utf-8") as f:
+        f.write(text)
+        tmp = Path(f.name)
+    try:
+        return parse_file(tmp)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def run_watch_loop(target: Path, *, color: bool) -> None:
+    """Block until SIGINT, emitting one line per detected change.
+
+    Heavy imports inside the body — `scoutctl action-items watch` is
+    interactive (a long-running process), so the cost is paid once.
+    """
+    from watchdog.events import FileModifiedEvent, FileSystemEventHandler
+    from watchdog.observers import Observer
+
+    if not target.exists():
+        raise FileNotFoundError(target)
+
+    state = {"prev_text": target.read_text(encoding="utf-8")}
+
+    def on_modified(event: FileModifiedEvent) -> None:
+        src_path = event.src_path
+        if isinstance(src_path, bytes):
+            src_path = src_path.decode()
+        if Path(src_path) != target:
+            return
+        try:
+            curr_text = target.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return  # mid-rename; the next event will deliver the new contents
+        if curr_text == state["prev_text"]:
+            return
+        lines = process_change(
+            prev_text=state["prev_text"],
+            curr_text=curr_text,
+            now=dt.datetime.now(),
+            color=color,
+        )
+        for line in lines:
+            print(line, flush=True)
+        state["prev_text"] = curr_text
+
+    class _Handler(FileSystemEventHandler):
+        def on_modified(self, event: FileModifiedEvent) -> None:  # type: ignore[override]
+            on_modified(event)
+
+    observer = Observer()
+    observer.schedule(_Handler(), str(target.parent), recursive=False)
+    observer.start()
+    print(
+        f"Watching {target.name} for changes — Ctrl-C to stop.",
+        file=sys.stderr,
+    )
+    try:
+        observer.join()
+    except KeyboardInterrupt:
+        observer.stop()
+        observer.join()

--- a/engine/scout/action_items/watch.py
+++ b/engine/scout/action_items/watch.py
@@ -96,6 +96,9 @@ def run_watch_loop(target: Path, *, color: bool) -> None:
         state["prev_text"] = curr_text
 
     class _Handler(FileSystemEventHandler):
+        # watchdog stubs widen `event` to FileSystemEvent — narrowing here
+        # is safe because watchdog only dispatches FileModifiedEvent to
+        # on_modified, but mypy correctly flags the Liskov narrowing.
         def on_modified(self, event: FileModifiedEvent) -> None:  # type: ignore[override]
             on_modified(event)
 

--- a/engine/tests/integration/test_action_items_cli.py
+++ b/engine/tests/integration/test_action_items_cli.py
@@ -55,14 +55,6 @@ def test_action_items_mark_done_via_cli(tmp_path: Path) -> None:
     assert "- [x] sample task" in target.read_text()
 
 
-def test_action_items_watch_returns_scout_error_exit_code() -> None:
-    """Plan 2 stubs `watch` with a Plan 3 placeholder."""
-    r = _scoutctl("action-items", "watch", env={**os.environ})
-    # ScoutError.exit_code == 1
-    assert r.returncode == 1
-    assert "Plan 3" in r.stderr
-
-
 def test_action_items_mark_done_by_id_via_cli(tmp_path: Path) -> None:
     """Smoke test: scoutctl action-items mark-done --by-id A3F7 flips the matching line."""
     data_dir = tmp_path / "Scout"

--- a/engine/tests/integration/test_action_items_watch.py
+++ b/engine/tests/integration/test_action_items_watch.py
@@ -1,0 +1,83 @@
+"""Integration test for scoutctl action-items watch.
+
+Spawns the CLI as a subprocess, mutates the watched file, asserts a
+diff line is printed within a small timeout. Marked `slow` so default
+unit-test runs skip it; CI runs it explicitly.
+"""
+
+from __future__ import annotations
+
+import os
+import select
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.slow
+
+
+def _scoutctl_path() -> str:
+    """Resolve the scoutctl entry point inside the engine venv."""
+    venv_bin = Path(__file__).parent.parent.parent / ".venv" / "bin"
+    candidate = venv_bin / "scoutctl"
+    if candidate.exists():
+        return str(candidate)
+    return "scoutctl"  # fall back to PATH lookup
+
+
+def _read_until(proc: subprocess.Popen[str], substring: str, timeout: float) -> str:
+    """Read stdout until `substring` appears or `timeout` elapses.
+
+    Returns accumulated stdout. Uses `select` so a wedged subprocess
+    doesn't hang the test.
+    """
+    deadline = time.monotonic() + timeout
+    buf: list[str] = []
+    assert proc.stdout is not None
+    while time.monotonic() < deadline:
+        ready, _, _ = select.select([proc.stdout], [], [], 0.2)
+        if proc.stdout in ready:
+            line = proc.stdout.readline()
+            if not line:
+                break
+            buf.append(line)
+            if substring in line:
+                return "".join(buf)
+    return "".join(buf)
+
+
+def test_watch_emits_completed_line_on_checkbox_flip(tmp_path: Path) -> None:
+    daily = tmp_path / "action-items-2026-04-26.md"
+    daily.write_text(
+        "## In Progress\n\n- [ ] [#A3F7] Submit Lever feedback\n",
+    )
+
+    env = {**os.environ, "NO_COLOR": "1"}  # ensure plain output even on TTY-emulating CI
+    proc = subprocess.Popen(
+        [_scoutctl_path(), "action-items", "watch", str(daily), "--no-color"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+
+    try:
+        # Give the watcher ~500ms to register its filesystem hook.
+        time.sleep(0.5)
+
+        # Mutate the file: flip the checkbox.
+        daily.write_text(
+            "## In Progress\n\n- [x] [#A3F7] Submit Lever feedback\n",
+        )
+
+        out = _read_until(proc, "completed", timeout=10.0)
+        assert "completed" in out
+        assert "[#A3F7]" in out
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()

--- a/engine/tests/unit/test_action_items_cli.py
+++ b/engine/tests/unit/test_action_items_cli.py
@@ -1,0 +1,32 @@
+"""Unit tests for the action-items Typer sub-app's per-command surface.
+
+Subprocess-style coverage of the same commands lives in
+tests/integration/test_action_items_cli.py.
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+
+def test_cli_watch_help_text_is_projection_consumer_contract() -> None:
+    """Per spec §13.3, watch's help text describes a stream of changes,
+    not a file-watcher. This test pins that wording."""
+    from scout.action_items.cli import app
+
+    result = CliRunner().invoke(app, ["watch", "--help"])
+    assert result.exit_code == 0
+    assert "stream" in result.stdout.lower()
+    assert "changes" in result.stdout.lower()
+
+
+def test_cli_watch_rejects_missing_target(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    from scout.action_items.cli import app
+
+    # No daily file exists in tmp_path/action-items/, and we pass no target.
+    result = CliRunner().invoke(app, ["watch"])
+    assert result.exit_code != 0
+    # The ActionItemError message surfaces via the exception or stderr/stdout.
+    err_text = (str(result.exception) if result.exception else "") + result.output
+    assert "does not exist" in err_text.lower()

--- a/engine/tests/unit/test_action_items_diff.py
+++ b/engine/tests/unit/test_action_items_diff.py
@@ -1,0 +1,130 @@
+"""Unit tests for scout.action_items.diff."""
+
+from __future__ import annotations
+
+from scout.action_items.diff import diff
+from scout.action_items.parser import ActionItem
+
+
+def _item(
+    *,
+    title: str,
+    short_prefix: str | None = None,
+    status: str = "open",
+    section: str = "In Progress",
+    priority: str = "",
+) -> ActionItem:
+    checkbox = "x" if status == "done" else " "
+    prefix_token = f"[#{short_prefix}] " if short_prefix else ""
+    return ActionItem(
+        priority=priority,
+        title=title,
+        status=status,
+        section=section,
+        context_links=[],
+        notes=[],
+        details=[],
+        raw_line=f"- [{checkbox}] {prefix_token}{title}",
+        short_prefix=short_prefix,
+    )
+
+
+def test_no_changes_yields_empty_list() -> None:
+    items = [_item(title="task A", short_prefix="A3F7")]
+    assert diff(prev=items, curr=items) == []
+
+
+def test_added_item_emits_added_event() -> None:
+    prev: list[ActionItem] = []
+    curr = [_item(title="task A", short_prefix="A3F7")]
+    events = diff(prev=prev, curr=curr)
+    assert len(events) == 1
+    assert events[0].kind == "added"
+    assert events[0].item_id == "A3F7"
+    assert events[0].title == "task A"
+
+
+def test_removed_item_emits_removed_event() -> None:
+    prev = [_item(title="task A", short_prefix="A3F7")]
+    curr: list[ActionItem] = []
+    events = diff(prev=prev, curr=curr)
+    assert len(events) == 1
+    assert events[0].kind == "removed"
+    assert events[0].item_id == "A3F7"
+
+
+def test_status_open_to_done_emits_completed() -> None:
+    prev = [_item(title="task A", short_prefix="A3F7", status="open")]
+    curr = [_item(title="task A", short_prefix="A3F7", status="done")]
+    events = diff(prev=prev, curr=curr)
+    assert len(events) == 1
+    assert events[0].kind == "completed"
+    assert events[0].item_id == "A3F7"
+
+
+def test_status_done_to_open_emits_reopened() -> None:
+    prev = [_item(title="task A", short_prefix="A3F7", status="done")]
+    curr = [_item(title="task A", short_prefix="A3F7", status="open")]
+    events = diff(prev=prev, curr=curr)
+    assert events[0].kind == "reopened"
+
+
+def test_title_changed_emits_title_changed_event() -> None:
+    prev = [_item(title="old title", short_prefix="A3F7")]
+    curr = [_item(title="new title", short_prefix="A3F7")]
+    events = diff(prev=prev, curr=curr)
+    assert len(events) == 1
+    assert events[0].kind == "title_changed"
+    assert events[0].item_id == "A3F7"
+    assert events[0].extras == {"old_title": "old title", "new_title": "new title"}
+
+
+def test_match_falls_back_to_section_and_title_for_unprefixed_lines() -> None:
+    """Legacy lines without [#XXXX] match by (section, title) tuple."""
+    prev = [_item(title="legacy task", short_prefix=None, status="open")]
+    curr = [_item(title="legacy task", short_prefix=None, status="done")]
+    events = diff(prev=prev, curr=curr)
+    assert events[0].kind == "completed"
+    assert events[0].item_id == ""  # no prefix → empty id
+
+
+def test_unprefixed_line_in_different_sections_treated_as_separate() -> None:
+    prev = [_item(title="dup", short_prefix=None, section="In Progress")]
+    curr = [_item(title="dup", short_prefix=None, section="To Do")]
+    # Same title, different sections → first removed, second added.
+    events = diff(prev=prev, curr=curr)
+    kinds = {e.kind for e in events}
+    assert kinds == {"removed", "added"}
+
+
+def test_multiple_changes_emitted_in_input_order() -> None:
+    prev = [
+        _item(title="A", short_prefix="AAAA", status="open"),
+        _item(title="B", short_prefix="BBBB", status="open"),
+    ]
+    curr = [
+        _item(title="A", short_prefix="AAAA", status="done"),  # completed
+        _item(title="B", short_prefix="BBBB", status="open"),  # unchanged
+        _item(title="C", short_prefix="CCCC", status="open"),  # added
+    ]
+    events = diff(prev=prev, curr=curr)
+    assert len(events) == 2
+    assert events[0].kind == "completed" and events[0].item_id == "AAAA"
+    assert events[1].kind == "added" and events[1].item_id == "CCCC"
+
+
+def test_prefix_match_wins_over_title_match() -> None:
+    """If prefixes match but titles differ, that's a title_changed — not remove+add."""
+    prev = [_item(title="original", short_prefix="A3F7")]
+    curr = [_item(title="renamed", short_prefix="A3F7")]
+    events = diff(prev=prev, curr=curr)
+    assert len(events) == 1
+    assert events[0].kind == "title_changed"
+
+
+def test_change_event_has_section_for_display() -> None:
+    """Renderers need the section for context — verify it survives diffing."""
+    prev: list[ActionItem] = []
+    curr = [_item(title="task", short_prefix="A3F7", section="To Do")]
+    events = diff(prev=prev, curr=curr)
+    assert events[0].section == "To Do"

--- a/engine/tests/unit/test_action_items_render_changes.py
+++ b/engine/tests/unit/test_action_items_render_changes.py
@@ -1,0 +1,76 @@
+"""Unit tests for scout.action_items.render.render_changes."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+from scout.action_items.diff import ChangeEvent
+from scout.action_items.render import render_changes
+
+_NOW = dt.datetime(2026, 4, 26, 14, 32, 15)
+
+
+def test_added_line_format() -> None:
+    e = ChangeEvent(kind="added", item_id="A3F7", title="task A", section="To Do")
+    lines = render_changes([e], now=_NOW, color=False)
+    assert len(lines) == 1
+    assert lines[0] == "[14:32:15] + added     [#A3F7] task A (To Do)"
+
+
+def test_removed_line_format() -> None:
+    e = ChangeEvent(kind="removed", item_id="A3F7", title="task A", section="To Do")
+    lines = render_changes([e], now=_NOW, color=False)
+    assert lines[0] == "[14:32:15] - removed   [#A3F7] task A (To Do)"
+
+
+def test_completed_line_format() -> None:
+    e = ChangeEvent(kind="completed", item_id="A3F7", title="task A", section="In Progress")
+    lines = render_changes([e], now=_NOW, color=False)
+    assert lines[0] == "[14:32:15] ✓ completed [#A3F7] task A (In Progress)"
+
+
+def test_reopened_line_format() -> None:
+    e = ChangeEvent(kind="reopened", item_id="A3F7", title="task A", section="In Progress")
+    lines = render_changes([e], now=_NOW, color=False)
+    assert lines[0] == "[14:32:15] ↻ reopened  [#A3F7] task A (In Progress)"
+
+
+def test_title_changed_line_format() -> None:
+    e = ChangeEvent(
+        kind="title_changed",
+        item_id="A3F7",
+        title="new title",
+        section="In Progress",
+        extras={"old_title": "old title", "new_title": "new title"},
+    )
+    lines = render_changes([e], now=_NOW, color=False)
+    assert lines[0] == '[14:32:15] ✎ renamed   [#A3F7] "old title" → "new title"'
+
+
+def test_unprefixed_item_id_omits_brackets() -> None:
+    e = ChangeEvent(kind="added", item_id="", title="legacy task", section="To Do")
+    lines = render_changes([e], now=_NOW, color=False)
+    assert lines[0] == "[14:32:15] + added     legacy task (To Do)"
+
+
+def test_color_output_includes_ansi_codes() -> None:
+    e = ChangeEvent(kind="completed", item_id="A3F7", title="task", section="In Progress")
+    lines = render_changes([e], now=_NOW, color=True)
+    # Rich emits ANSI escapes for colored text. We don't pin the exact codes
+    # but assert the line contains an ANSI escape introducer.
+    assert "\x1b[" in lines[0]
+
+
+def test_multiple_events_render_in_order() -> None:
+    events = [
+        ChangeEvent(kind="completed", item_id="A3F7", title="A", section="In Progress"),
+        ChangeEvent(kind="added", item_id="B5K2", title="B", section="To Do"),
+    ]
+    lines = render_changes(events, now=_NOW, color=False)
+    assert len(lines) == 2
+    assert "completed" in lines[0]
+    assert "added" in lines[1]
+
+
+def test_empty_events_yields_empty_list() -> None:
+    assert render_changes([], now=_NOW, color=False) == []

--- a/engine/tests/unit/test_action_items_watch.py
+++ b/engine/tests/unit/test_action_items_watch.py
@@ -1,0 +1,44 @@
+"""Unit tests for the pure core of scout.action_items.watch.
+
+The watchdog wiring is tested in tests/integration/test_action_items_watch.py.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+from scout.action_items.watch import process_change
+
+_NOW = dt.datetime(2026, 4, 26, 14, 32, 15)
+
+
+def test_process_change_emits_no_lines_when_text_identical() -> None:
+    text = "## In Progress\n\n- [ ] [#A3F7] task A\n"
+    lines = process_change(prev_text=text, curr_text=text, now=_NOW, color=False)
+    assert lines == []
+
+
+def test_process_change_emits_completed_line_when_checkbox_flipped() -> None:
+    prev = "## In Progress\n\n- [ ] [#A3F7] task A\n"
+    curr = "## In Progress\n\n- [x] [#A3F7] task A\n"
+    lines = process_change(prev_text=prev, curr_text=curr, now=_NOW, color=False)
+    assert len(lines) == 1
+    assert "completed" in lines[0]
+    assert "[#A3F7]" in lines[0]
+
+
+def test_process_change_emits_added_line_when_new_item_appears() -> None:
+    prev = "## In Progress\n\n- [ ] [#A3F7] task A\n"
+    curr = "## In Progress\n\n- [ ] [#A3F7] task A\n- [ ] [#B5K2] task B\n"
+    lines = process_change(prev_text=prev, curr_text=curr, now=_NOW, color=False)
+    assert len(lines) == 1
+    assert "added" in lines[0]
+    assert "[#B5K2]" in lines[0]
+
+
+def test_process_change_handles_unparseable_prev_gracefully() -> None:
+    """Initial seed (empty file) shouldn't crash the watcher."""
+    lines = process_change(prev_text="", curr_text="- [ ] [#A3F7] task\n", now=_NOW, color=False)
+    # Single added event for the new task.
+    assert len(lines) == 1
+    assert "added" in lines[0]


### PR DESCRIPTION
## Summary

Implements `scoutctl action-items watch [DATE_OR_PATH] [--no-color]` per [Plan 3](https://github.com/jordanrburger/scout-app/blob/main/docs/superpowers/plans/2026-04-26-scout-unification-plan-3-action-items-watch.md).

Output is one human-readable line per change to today's action-items file:

```
[14:32:15] ✓ completed [#A3F7] Submit Lever feedback (In Progress)
[14:32:18] + added     [#B5K2] Reply to Q2 budget thread (To Do)
[14:32:22] - removed   [#C9N4] Followup with vendor (To Do)
[14:32:30] ✎ renamed   [#A3F7] "old title" → "new title"
```

Color when stdout is a TTY (Rich-emitted ANSI), plain text when piped or `--no-color`.

### Architecture

Three pure modules + watcher driver + CLI wiring, each tested in isolation:

1. **`scout.action_items.diff`** (new) — pure `diff(prev, curr) → list[ChangeEvent]` over `ActionItem` snapshots. Matches by `short_prefix` first (the `[#XXXX]` surface form from §13.1), falls back to `(section, title)` for legacy unprefixed lines. Emits `added` / `removed` / `completed` / `reopened` / `title_changed` events.

2. **`scout.action_items.render.render_changes`** (added alongside the existing HTML renderer) — TTY-aware one-line-per-change formatter via Rich. The HTML renderer is untouched.

3. **`scout.action_items.watch`** (new) — file-watcher driver. Pure `process_change(prev_text, curr_text, now, color) → list[str]` core (testable without a real watcher) plus `run_watch_loop(target, color)` wrapping it in a `watchdog.observers.Observer`. Heavy imports (`watchdog`, `rich`) live inside function bodies per spec §4 startup-latency rules.

4. **`scout.action_items.cli.cli_watch`** — replaces the Plan 2 stub. Lazy-imports the watch module so `scoutctl --help` startup latency is unaffected when the user doesn't invoke `watch`.

### Projection-consumer contract (forward compat for v0.5)

Per [v0.4 spec §13.3](https://github.com/jordanrburger/scout-app/blob/main/docs/superpowers/specs/2026-04-24-scout-unification-design.md#133-watch-and-kb-refresh-summary-are-projection-consumer-contracts), the public CLI contract is *"stream changes to today's action items as they happen"* — file-watching is an implementation detail. The [v0.5+ event architecture spec](https://github.com/jordanrburger/scout-app/blob/main/docs/superpowers/specs/2026-04-25-scout-event-architecture-design.md) substitutes an event-store subscriber under the same `run_watch_loop`-equivalent surface; `ChangeEvent`, `render_changes`, and `process_change` need zero changes for the swap.

The help-text test (`test_cli_watch_help_text_is_projection_consumer_contract`) pins the §13.3 wording.

## Test plan

- [x] **Unit:** 11 diff cases (kinds, match-priority, ordering, section preservation), 9 render cases (each kind's exact byte-level format pinned, ANSI presence, ordering, empty), 4 watch-pure cases including empty-prev seed, 2 CLI surface cases (help-text contract + missing-target rejection)
- [x] **Integration:** subprocess + file mutation test asserts a `completed` line appears in stdout within timeout; passes in 0.55s on macOS, ran 5 extra times — no flakiness
- [x] **Manual smoke test:** `SCOUT_DATA_DIR=/tmp/test .venv/bin/scoutctl action-items watch --no-color` against a real daily file confirms the omitted-target branch (which the integration test doesn't exercise — it passes an explicit path)
- [x] **Import discipline:** `tests/perf/test_no_heavy_imports.py` confirms `watchdog` / `rich` stay out of `scoutctl` startup
- [x] **Full suite:** 171 passed / 1 skipped (regular) + 3 passed (slow); ruff check + format clean; mypy clean

## Followups captured

Code reviews surfaced six minor items (no blockers); all filed at [`scout-app/docs/superpowers/FOLLOWUPS.md`](https://github.com/jordanrburger/scout-app/blob/main/docs/superpowers/FOLLOWUPS.md):

- `diff._compare` collapses non-`done` status transitions into `reopened` (important — decide before v0.5)
- `ChangeEvent.item_id` uses `""` sentinel; `str | None` would be more honest
- `render_changes` allocates a fresh `Console` per event in color mode (fine at personal scale)
- `watch._parse_text` writes a tempfile per diff (cleanup if parser grows `parse_text(str)`)
- `watch._Handler`'s `# type: ignore[override]` could use a 1-word inline comment
- Integration test's `_read_until` doesn't check `proc.poll()` — silent-crash failure mode is uninformative

## Refs

- Plan: `docs/superpowers/plans/2026-04-26-scout-unification-plan-3-action-items-watch.md`
- v0.4 unification spec §13.3 (projection-consumer contract)
- v0.5+ event architecture spec (substitution target)
- Plan 2 supplement (provides `ActionItem.short_prefix` and ID-aware mutators) — required dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)