### PR TITLE
Plan 5: Schedule v2 + mode rename (engine)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,9 @@ jobs:
         # here checks the canonical file is in sync with the YAML — drift =
         # someone edited connectors.yaml and forgot to regenerate.
         run: .venv/bin/python -m scout.scripts.connectors_snapshot --check --target scout/connectors.snapshot.json
+      - name: Verify schedule.snapshot.json drift
+        # The canonical snapshot lives at engine/scout/schedule.snapshot.json
+        # (Plan 5 Task 8). scout-app's bundled fixture is a synced copy. CI
+        # here checks the canonical file is in sync with the YAML — drift =
+        # someone edited schedule.yaml and forgot to regenerate.
+        run: .venv/bin/python -m scout.scripts.schedule_snapshot --check --target scout/schedule.snapshot.json

--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -389,6 +389,37 @@ def _register_schedule() -> None:
             typer.echo(f"plist already exists at {e}; use --force to overwrite", err=True)
             raise typer.Exit(code=1) from e
 
+    @schedule_app.command("install-wake-schedule")
+    def cli_schedule_install_wake_schedule(
+        uninstall: bool = typer.Option(False, "--uninstall"),
+        dry_run: bool = typer.Option(False, "--dry-run"),
+    ) -> None:
+        """Install (or remove) a pmset repeat rule that wakes the Mac for the earliest weekday slot.
+
+        AC-only: macOS standby suppresses wake timers when on battery + lid closed.
+        Keep the laptop plugged in if you need guaranteed live firing.
+        """
+        from scout import paths as _paths
+        from scout.schedule import load_default_schedule, load_schedule
+        from scout.scripts.install_wake_schedule import (
+            install_wake_schedule as _i,
+        )
+        from scout.scripts.install_wake_schedule import (
+            uninstall_wake_schedule as _u,
+        )
+
+        if uninstall:
+            typer.echo(_u(dry_run=dry_run))
+            return
+        vault = _paths.data_dir() / ".scout-state" / "schedule.yaml"
+        sched = load_schedule(vault) if vault.exists() else load_default_schedule()
+        typer.echo(
+            "Note: pmset wake-schedule is AC-only. On battery + lid closed, "
+            "Apple Silicon laptops enter standby and ignore wake timers. "
+            "Keep the laptop plugged in if you need guaranteed live firing."
+        )
+        typer.echo(_i(sched, dry_run=dry_run))
+
 
 _register_schedule()
 

--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -147,6 +147,7 @@ def _register_connectors() -> None:
             "tier": c.tier.value,
             "capabilities": [cap.value for cap in c.capabilities],
             "required_in": "all" if c.required_in == "all" else list(c.required_in),
+            "required_in_types": [t.value for t in c.required_in_types],
             "remediation": {
                 "first_fix": c.remediation.first_fix,
                 "detail": c.remediation.detail,

--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -358,6 +358,37 @@ def _register_schedule() -> None:
             raise typer.Exit(code=1)
         typer.echo(f"fired: {slot_key}")
 
+    @schedule_app.command("install-plist")
+    def cli_schedule_install_plist(
+        force: bool = typer.Option(False, "--force", "-f"),
+        bootstrap: bool = typer.Option(
+            True,
+            "--bootstrap/--no-bootstrap",
+            help="Run launchctl bootstrap to load the job after writing the plist.",
+        ),
+        uninstall: bool = typer.Option(
+            False,
+            "--uninstall",
+            help="Remove the plist (and bootout the job) instead of installing.",
+        ),
+    ) -> None:
+        """Install or remove com.scout.schedule-tick.plist in ~/Library/LaunchAgents/."""
+        from pathlib import Path as _Path
+
+        from scout.scripts.install_schedule_plist import install_plist as _i
+        from scout.scripts.install_schedule_plist import uninstall_plist as _u
+
+        if uninstall:
+            _u(bootout=bootstrap)
+            typer.echo("uninstalled com.scout.schedule-tick.plist")
+            return
+        try:
+            target = _i(home=_Path.home(), force=force, bootstrap=bootstrap)
+            typer.echo(f"installed: {target}")
+        except FileExistsError as e:
+            typer.echo(f"plist already exists at {e}; use --force to overwrite", err=True)
+            raise typer.Exit(code=1) from e
+
 
 _register_schedule()
 

--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -421,6 +421,83 @@ def _register_schedule() -> None:
         )
         typer.echo(_i(sched, dry_run=dry_run))
 
+    @schedule_app.command("snapshot")
+    def cli_schedule_snapshot(
+        target: Path | None = typer.Option(
+            None,
+            "--target",
+            "-t",
+            help=(
+                "Where to write the snapshot. Defaults to scout-plugin's "
+                "canonical engine/scout/schedule.snapshot.json (the file "
+                "CI verifies)."
+            ),
+        ),
+        check: bool = typer.Option(
+            False,
+            "--check",
+            help="Exit 1 if on-disk differs from would-write; print unified diff.",
+        ),
+        also_write_app_fixture: bool = typer.Option(
+            True,
+            "--also-write-app-fixture/--no-also-write-app-fixture",
+            help=(
+                "Also write the scout-app bundled fixture at "
+                "~/scout-app/ScoutTests/Fixtures/schedule.snapshot.json. "
+                "Best-effort: silently skipped (with a warning) if the path "
+                "doesn't exist on this machine. Default: enabled."
+            ),
+        ),
+    ) -> None:
+        """Write or verify schedule.snapshot.json (consumed by scout-app).
+
+        Default behavior writes BOTH the canonical snapshot in scout-plugin
+        AND the scout-app bundled fixture, so a single invocation keeps both
+        repos in sync after a schedule.yaml edit. Pass
+        --no-also-write-app-fixture on a build agent that doesn't have
+        scout-app checked out.
+        """
+        from scout.scripts.schedule_snapshot import (
+            app_fixture_snapshot_path,
+            canonical_snapshot_path,
+            check_snapshot,
+            write_snapshot,
+        )
+
+        resolved_target = target if target is not None else canonical_snapshot_path()
+
+        if check:
+            ok, diff = check_snapshot(resolved_target)
+            if ok:
+                typer.echo(f"schedule snapshot OK: {resolved_target}")
+                return
+            typer.echo(diff, err=True)
+            typer.echo(
+                f"Drift detected: regenerate with `scoutctl schedule snapshot --target {resolved_target}`.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+
+        write_snapshot(resolved_target)
+        typer.echo(f"Wrote: {resolved_target}")
+
+        # Best-effort dual-write so a single invocation keeps both repos in sync.
+        if also_write_app_fixture:
+            app_fixture = app_fixture_snapshot_path()
+            if app_fixture == resolved_target:
+                # Operator pointed --target at the app fixture; primary write covered it.
+                pass
+            elif app_fixture.parent.is_dir():
+                write_snapshot(app_fixture)
+                typer.echo(f"Wrote: {app_fixture}")
+            else:
+                typer.echo(
+                    f"warning: skipped scout-app fixture write — {app_fixture.parent} "
+                    "is not a directory on this machine. Pass --no-also-write-app-fixture "
+                    "to silence.",
+                    err=True,
+                )
+
 
 _register_schedule()
 

--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -244,6 +244,106 @@ def _register_connectors() -> None:
 _register_connectors()
 
 
+def _register_schedule() -> None:
+    """scoutctl schedule {list,show,validate,init,reload} — vault schedule operations.
+
+    Tasks 3 (tick, fire-now), 4 (install-plist), 5 (install-wake-schedule),
+    and 8 (snapshot, list-upcoming) extend this same sub-app with more
+    commands. Keep this function open for extension.
+    """
+
+    schedule_app = typer.Typer(help="Schedule operations (vault schedule.yaml).")
+    app.add_typer(schedule_app, name="schedule")
+
+    @schedule_app.command("list")
+    def cli_schedule_list() -> None:
+        """List the registered schedule slots."""
+        from scout import paths as _paths
+        from scout.schedule import load_default_schedule, load_schedule
+
+        vault_path = _paths.data_dir() / ".scout-state" / "schedule.yaml"
+        sched = load_schedule(vault_path) if vault_path.exists() else load_default_schedule()
+        for key in sorted(sched.keys()):
+            slot = sched[key]
+            typer.echo(
+                f"{key}\t{slot.type.value}\t{slot.fires_at_local}\t{','.join(slot.weekdays)}\t{slot.on_miss.value}"
+            )
+
+    @schedule_app.command("show")
+    def cli_schedule_show(key: str) -> None:
+        """Show one slot's full record as JSON."""
+        import json as _json
+
+        from scout import paths as _paths
+        from scout.schedule import load_default_schedule, load_schedule
+
+        vault_path = _paths.data_dir() / ".scout-state" / "schedule.yaml"
+        sched = load_schedule(vault_path) if vault_path.exists() else load_default_schedule()
+        if key not in sched:
+            typer.echo(f"unknown slot: {key}", err=True)
+            raise typer.Exit(code=1)
+        slot = sched[key]
+        record = {
+            "key": slot.key,
+            "type": slot.type.value,
+            "runner": slot.runner,
+            "fires_at_local": slot.fires_at_local,
+            "weekdays": list(slot.weekdays),
+            "missed_window_hours": slot.missed_window_hours,
+            "on_miss": slot.on_miss.value,
+            "cooldown_minutes": slot.cooldown_minutes,
+            "budget_usd": slot.budget_usd,
+            "tz": slot.tz,
+        }
+        typer.echo(_json.dumps(record, indent=2))
+
+    @schedule_app.command("validate")
+    def cli_schedule_validate() -> None:
+        """Re-load the schedule (canonical + overlay if present); exit 0 on success."""
+        from scout import paths as _paths
+        from scout.schedule import load_default_schedule, load_schedule
+
+        vault_path = _paths.data_dir() / ".scout-state" / "schedule.yaml"
+        if vault_path.exists():
+            load_schedule(vault_path)
+            typer.echo(f"schedule OK: {vault_path}")
+        else:
+            load_default_schedule()
+            typer.echo("schedule OK: (no vault file; using plugin defaults)")
+
+    @schedule_app.command("init")
+    def cli_schedule_init(
+        force: bool = typer.Option(False, "--force", "-f", help="Overwrite existing vault file."),
+    ) -> None:
+        """Seed the vault schedule.yaml from plugin defaults."""
+        import shutil
+
+        from scout import paths as _paths
+
+        target = _paths.data_dir() / ".scout-state" / "schedule.yaml"
+        if target.exists() and not force:
+            typer.echo(
+                f"{target} exists; refusing to overwrite. Use --force to replace.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        source = Path(__file__).parent / "defaults" / "schedule.yaml"
+        shutil.copy2(source, target)
+        typer.echo(f"wrote: {target}")
+
+    @schedule_app.command("reload")
+    def cli_schedule_reload() -> None:
+        """Force-reload the schedule (forward-compat signal; loader has no cache in v0.5)."""
+        from scout.schedule import load_default_schedule
+
+        load_default_schedule()
+        typer.echo("reloaded")
+
+
+_register_schedule()
+
+
 def _register_notify() -> None:
     """scoutctl notify {telegram} — outbound notification commands.
 

--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -340,6 +340,24 @@ def _register_schedule() -> None:
         load_default_schedule()
         typer.echo("reloaded")
 
+    @schedule_app.command("tick")
+    def cli_schedule_tick() -> None:
+        """Run a single dispatch tick. Invoked by com.scout.schedule-tick.plist every 5 min."""
+        from scout.scripts.schedule_tick import main as _main
+
+        raise typer.Exit(code=_main())
+
+    @schedule_app.command("fire-now")
+    def cli_schedule_fire_now(slot_key: str) -> None:
+        """Manually fire a slot, bypassing the dispatcher's policy logic."""
+        from scout.scripts.schedule_tick import fire_now as _fire_now
+
+        ev = _fire_now(slot_key)
+        if ev.kind == "slot.fire_failed":
+            typer.echo(f"failed: {(ev.payload or {}).get('error', 'unknown')}", err=True)
+            raise typer.Exit(code=1)
+        typer.echo(f"fired: {slot_key}")
+
 
 _register_schedule()
 

--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -435,31 +435,23 @@ def _register_schedule() -> None:
         Slots whose next fire falls outside the window are omitted.
         """
         import json as _json
-        import os
         from datetime import UTC
-        from pathlib import Path as _Path
+        from datetime import datetime as _datetime
         from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
         from scout import paths as _paths
         from scout.schedule import load_default_schedule, load_schedule, next_fires
+        from scout.scripts.schedule_tick import _local_tz_name
 
         vault_path = _paths.data_dir() / ".scout-state" / "schedule.yaml"
         sched = load_schedule(vault_path) if vault_path.exists() else load_default_schedule()
 
-        # Determine local timezone (mirror schedule_tick._now / _local_tz_name pattern)
-        localtime = _Path("/etc/localtime")
-        tz_name = "UTC"
-        if localtime.is_symlink():
-            target_link = os.readlink(str(localtime))
-            marker = "zoneinfo/"
-            if marker in target_link:
-                tz_name = target_link.split(marker, 1)[1]
+        # Reuse the canonical local-tz resolver from schedule_tick — keeps
+        # CLI and dispatcher in lockstep if the helper grows fallbacks.
         try:
-            local_tz = ZoneInfo(tz_name)
+            local_tz: ZoneInfo = ZoneInfo(_local_tz_name())
         except ZoneInfoNotFoundError:
             local_tz = ZoneInfo("UTC")
-
-        from datetime import datetime as _datetime
 
         now = _datetime.now(tz=local_tz)
 

--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -421,6 +421,71 @@ def _register_schedule() -> None:
         )
         typer.echo(_i(sched, dry_run=dry_run))
 
+    @schedule_app.command("list-upcoming")
+    def cli_schedule_list_upcoming(
+        window: float = typer.Option(24.0, "--window", help="Look-ahead window in hours."),
+        use_json: bool = typer.Option(
+            True, "--json/--no-json", help="Emit JSON array (default) or tab-separated rows."
+        ),
+    ) -> None:
+        """List the next scheduled fire time for each slot within the given window.
+
+        JSON output (default) is an array sorted by scheduled_at_utc:
+            [{slot_key, slot_type, scheduled_at_local, scheduled_at_utc}, ...]
+        Slots whose next fire falls outside the window are omitted.
+        """
+        import json as _json
+        import os
+        from datetime import UTC
+        from pathlib import Path as _Path
+        from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+        from scout import paths as _paths
+        from scout.schedule import load_default_schedule, load_schedule, next_fires
+
+        vault_path = _paths.data_dir() / ".scout-state" / "schedule.yaml"
+        sched = load_schedule(vault_path) if vault_path.exists() else load_default_schedule()
+
+        # Determine local timezone (mirror schedule_tick._now / _local_tz_name pattern)
+        localtime = _Path("/etc/localtime")
+        tz_name = "UTC"
+        if localtime.is_symlink():
+            target_link = os.readlink(str(localtime))
+            marker = "zoneinfo/"
+            if marker in target_link:
+                tz_name = target_link.split(marker, 1)[1]
+        try:
+            local_tz = ZoneInfo(tz_name)
+        except ZoneInfoNotFoundError:
+            local_tz = ZoneInfo("UTC")
+
+        from datetime import datetime as _datetime
+
+        now = _datetime.now(tz=local_tz)
+
+        fires = next_fires(sched, now=now, window_hours=window)
+
+        if use_json:
+            records = []
+            for key, fire_dt in sorted(fires, key=lambda x: (x[0],)):
+                slot = sched[key]
+                utc_dt = fire_dt.astimezone(UTC)
+                records.append(
+                    {
+                        "slot_key": key,
+                        "slot_type": slot.type.value,
+                        "scheduled_at_local": fire_dt.isoformat(),
+                        "scheduled_at_utc": utc_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    }
+                )
+            # Sort by slot_key alphabetically per spec
+            records.sort(key=lambda r: r["slot_key"])
+            typer.echo(_json.dumps(records))
+        else:
+            for key, fire_dt in sorted(fires, key=lambda x: x[0]):
+                slot = sched[key]
+                typer.echo(f"{key}\t{slot.type.value}\t{fire_dt.isoformat()}")
+
     @schedule_app.command("snapshot")
     def cli_schedule_snapshot(
         target: Path | None = typer.Option(

--- a/engine/scout/connectors.py
+++ b/engine/scout/connectors.py
@@ -19,6 +19,7 @@ import yaml
 
 from scout import paths
 from scout.errors import ConfigError
+from scout.schedule import SlotType
 
 
 class Tier(enum.Enum):
@@ -45,14 +46,36 @@ class Connector:
     display_name: str
     tier: Tier
     capabilities: tuple[Capability, ...]
-    required_in: tuple[str, ...] | str  # tuple of mode strings, or "all"
+    # DEPRECATED (kept for one transitional version): tuple of mode strings, or
+    # "all". Plan 5 Task 6 introduced ``required_in_types`` as the canonical
+    # vocabulary; ``required_in`` is now empty for new YAML rows and only
+    # populated when an overlay still uses the old shape. Prefer
+    # ``required_in_type(slot_type)`` over ``required_in_mode(mode)``.
+    required_in: tuple[str, ...] | str
+    # v0.5+ canonical: which slot TYPES this connector is required for.
+    # Replaces ``required_in`` (which keyed on slot KEY names — fragile when
+    # users rename slots). Outbound-only connectors keep this empty.
+    required_in_types: tuple[SlotType, ...]
     remediation: Remediation
     notes: str = ""
 
     def required_in_mode(self, mode: str) -> bool:
+        """DEPRECATED: keyed on slot key. Prefer ``required_in_type``.
+
+        Retained for one transitional version so any caller still passing
+        slot-key strings keeps working. Returns True iff ``mode`` matches
+        the legacy ``required_in`` field.
+        """
         if self.required_in == "all":
             return True
         return mode in self.required_in
+
+    def required_in_type(self, slot_type: SlotType) -> bool:
+        """v0.5+ canonical: is this connector required in any slot of the given type?
+
+        Returns False for outbound-only connectors (empty ``required_in_types``).
+        """
+        return slot_type in self.required_in_types
 
 
 class ConnectorRegistry:
@@ -80,8 +103,19 @@ class ConnectorRegistry:
         return self._connectors.values()
 
     def critical_in_mode(self, mode: str) -> list[str]:
-        """Connector keys that are required in `mode` (i.e., outage = alert)."""
+        """DEPRECATED: keyed on slot key. Prefer ``critical_for_slot_type``.
+
+        Returns connector keys that are required in `mode` per the legacy
+        ``required_in`` field. After Plan 5 Task 6 rewrote connectors.yaml
+        to use ``required_in_types`` exclusively, this returns an empty list
+        for the seed YAML — only overlays still using the old shape can
+        produce non-empty results here.
+        """
         return [key for key, c in self._connectors.items() if c.required_in_mode(mode)]
+
+    def critical_for_slot_type(self, slot_type: SlotType) -> list[str]:
+        """Connector keys that are required for any slot of the given type."""
+        return [key for key, c in self._connectors.items() if c.required_in_type(slot_type)]
 
 
 def load_registry(data_dir: Path | None = None) -> ConnectorRegistry:
@@ -143,6 +177,11 @@ def _build_connector(key: str, raw: dict[str, Any]) -> Connector:
             required_in = "all"
         else:
             required_in = tuple(required_in_raw)
+        rit_raw = raw.get("required_in_types")
+        if rit_raw is None:
+            required_in_types: tuple[SlotType, ...] = ()
+        else:
+            required_in_types = tuple(SlotType(t) for t in rit_raw)
         rem_raw = raw.get("remediation", {})
         remediation = Remediation(
             first_fix=rem_raw.get("first_fix", ""),
@@ -154,6 +193,7 @@ def _build_connector(key: str, raw: dict[str, Any]) -> Connector:
             tier=tier,
             capabilities=capabilities,
             required_in=required_in,
+            required_in_types=required_in_types,
             remediation=remediation,
             notes=raw.get("notes", "") or "",
         )

--- a/engine/scout/connectors.snapshot.json
+++ b/engine/scout/connectors.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_from": "scout-plugin@15bbe4c",
+  "generated_from": "scout-plugin@fa60703",
   "connectors": [
     {
       "key": "mcp:claude_ai_Slack",

--- a/engine/scout/connectors.yaml
+++ b/engine/scout/connectors.yaml
@@ -7,7 +7,7 @@
 #       display_name: string
 #       tier: official | auto_discovered | community
 #       capabilities: [inbound, outbound, ...]   # see §"Capabilities" below
-#       required_in: all | [mode, mode, ...]     # which scheduled-run modes this connector is critical for
+#       required_in_types: [slot_type, ...]      # which slot TYPES this connector is critical for
 #       remediation:
 #         first_fix: string  (≤180 chars; goes into Slack/Telegram DMs)
 #         detail:    string  (multi-line allowed; goes into connector-health.md)
@@ -22,10 +22,13 @@
 #   outbound   — the connector pushes signals OUT of Scout (Slack DM, Telegram bot DM)
 #   meta       — the connector reports about Scout itself (e.g. github via gh CLI for PR queue)
 #
-# Modes vocabulary (must match the runner's $SCOUT_MODE values):
-#   morning-briefing, weekend-briefing
-#   consolidation-11am, consolidation-1pm, consolidation-5pm, consolidation-7pm
-#   manual, weekend-manual
+# Slot type vocabulary (must be one of the fixed plugin slot types in
+# scout.schedule.SlotType — i.e. references the TYPE not the user-renameable
+# slot key):
+#   briefing | consolidation | dreaming | research | manual
+#
+# `manual` is intentionally excluded from required_in_types lists — manual
+# sessions are ad-hoc and no connector is REQUIRED for them.
 
 schema_version: 1
 
@@ -34,7 +37,7 @@ connectors:
     display_name: Slack
     tier: official
     capabilities: [inbound, outbound]
-    required_in: all
+    required_in_types: [briefing, consolidation, dreaming, research]
     remediation:
       first_fix: "Reconnect Slack at https://claude.ai/settings/connectors — claude.ai Slack OAuth likely expired."
       detail: |
@@ -48,7 +51,7 @@ connectors:
     display_name: Linear
     tier: official
     capabilities: [inbound]
-    required_in: all
+    required_in_types: [briefing, consolidation, dreaming, research]
     remediation:
       first_fix: "Reconnect Linear at https://claude.ai/settings/connectors — claude.ai Linear OAuth likely expired."
       detail: |
@@ -60,7 +63,7 @@ connectors:
     display_name: Gmail
     tier: official
     capabilities: [inbound]
-    required_in: all
+    required_in_types: [briefing, consolidation]
     remediation:
       first_fix: "Reconnect Gmail at https://claude.ai/settings/connectors — Google OAuth likely needs refresh."
       detail: |
@@ -73,7 +76,7 @@ connectors:
     display_name: Google Calendar
     tier: official
     capabilities: [inbound]
-    required_in: all
+    required_in_types: [briefing, consolidation]
     remediation:
       first_fix: "Reconnect Google Calendar at https://claude.ai/settings/connectors (same Google auth as Gmail)."
       detail: |
@@ -85,14 +88,12 @@ connectors:
     display_name: Granola
     tier: official
     capabilities: [inbound]
-    required_in:
-      # Skip on weekends — meeting transcripts are work-week-only.
-      - morning-briefing
-      - consolidation-11am
-      - consolidation-1pm
-      - consolidation-5pm
-      - consolidation-7pm
-      - manual
+    # Skip on weekends — meeting transcripts are work-week-only. Briefing +
+    # consolidation slot types cover both weekday and weekend briefings; the
+    # weekend briefing's `runner` is responsible for not calling Granola on
+    # Sat/Sun. (The "required" list is the safety net — if it WERE called and
+    # failed, alerting still fires.)
+    required_in_types: [briefing, consolidation]
     remediation:
       first_fix: "Reconnect Granola at https://claude.ai/settings/connectors — Granola tokens expire periodically."
       detail: |
@@ -103,14 +104,8 @@ connectors:
     display_name: Google Drive
     tier: official
     capabilities: [inbound]
-    required_in:
-      # Same weekday-only scope as Granola — Phase 1e weekday-mandatory.
-      - morning-briefing
-      - consolidation-11am
-      - consolidation-1pm
-      - consolidation-5pm
-      - consolidation-7pm
-      - manual
+    # Same weekday-oriented scope as Granola — Phase 1e weekday-mandatory.
+    required_in_types: [briefing, consolidation]
     remediation:
       first_fix: "Reconnect Google Drive at https://claude.ai/settings/connectors."
       detail: "Google Drive connector — same reconnect flow as Gmail at https://claude.ai/settings/connectors."
@@ -119,7 +114,9 @@ connectors:
     display_name: GitHub (gh CLI)
     tier: official
     capabilities: [inbound, meta]
-    required_in: all
+    # Used in briefing + consolidation for PR queue review and in research for
+    # deep PR/issue dives. Not required for dreaming (introspection-only).
+    required_in_types: [briefing, consolidation, research]
     remediation:
       first_fix: "Run `gh auth status`; if expired, `gh auth login` to re-auth. Token lives in macOS keychain."
       detail: |
@@ -131,15 +128,9 @@ connectors:
     display_name: Chrome (Google Messages)
     tier: official
     capabilities: [inbound]
-    required_in:
-      # Required only when the briefing scans personal-context surfaces.
-      - morning-briefing
-      - weekend-briefing
-      - consolidation-11am
-      - consolidation-1pm
-      - consolidation-5pm
-      - consolidation-7pm
-      - manual
+    # Required only when the run scans personal-context surfaces (briefings +
+    # consolidations). Dreaming and research don't touch Google Messages.
+    required_in_types: [briefing, consolidation]
     remediation:
       first_fix: "Make sure Chrome is running with the Claude-in-Chrome extension enabled at chrome://extensions. If the Mac was asleep, waking it is enough."
       detail: |
@@ -157,11 +148,9 @@ connectors:
     display_name: WhatsApp
     tier: official
     capabilities: [inbound]
-    required_in:
-      # Personal-context scans are briefing-time only — consolidation runs
-      # are work-focused. Adjust per user preference via the v0.8 overlay.
-      - morning-briefing
-      - weekend-briefing
+    # Personal-context scans run during briefings + consolidations. Adjust per
+    # user preference via the v0.8 overlay.
+    required_in_types: [briefing, consolidation]
     remediation:
       first_fix: "Check the WhatsApp MCP bridge: `launchctl list | grep com.scout.whatsapp-bridge`. Restart with `launchctl kickstart -k gui/$UID/com.scout.whatsapp-bridge` if the bridge is down."
       detail: |
@@ -182,7 +171,7 @@ connectors:
     display_name: Telegram (outbound)
     tier: official
     capabilities: [outbound]
-    required_in: []   # never required — outbound notifications never make a run "fail"
+    required_in_types: []   # outbound notifier — never required for any slot type
     remediation:
       first_fix: "Check `~/.scout-secrets/telegram-bot-token` exists (mode 600); test with `scoutctl notify telegram --tier info --body 'health check'`."
       detail: |

--- a/engine/scout/defaults/com.scout.schedule-tick.plist
+++ b/engine/scout/defaults/com.scout.schedule-tick.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.scout.schedule-tick.plist — runs `scoutctl schedule tick` every 5 min.
+
+  Installed by `scoutctl schedule install-plist`, which fills __USER_HOME__
+  at install time. Replaces the 7 per-slot legacy plists deleted in Task 11.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.scout.schedule-tick</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__USER_HOME__/scout-plugin/.venv/bin/scoutctl</string>
+        <string>schedule</string>
+        <string>tick</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>__USER_HOME__/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>__USER_HOME__</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>__USER_HOME__/Scout/.scout-logs/launchd-schedule-tick-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>__USER_HOME__/Scout/.scout-logs/launchd-schedule-tick-stderr.log</string>
+</dict>
+</plist>

--- a/engine/scout/defaults/schedule.yaml
+++ b/engine/scout/defaults/schedule.yaml
@@ -1,0 +1,104 @@
+# engine/scout/defaults/schedule.yaml — Scout default schedule.
+#
+# This file is the plugin's seed schedule. `scoutctl schedule init`
+# copies it to `~/Scout/.scout-state/schedule.yaml` on first run.
+# Users edit the vault copy after that; this file is not modified.
+#
+# Slot keys are user-renameable. Slot types are a fixed plugin
+# vocabulary (briefing | consolidation | dreaming | research | manual)
+# that aggregation surfaces (connectors.yaml `required_in_types`,
+# alert routing) reference. See:
+#   ~/scout-app/docs/superpowers/specs/2026-05-04-schedule-v2-design.md
+
+schema_version: 1
+
+slots:
+  morning-briefing:
+    type: briefing
+    runner: run-scout.sh
+    fires_at_local: "08:00"
+    weekdays: [Mon, Tue, Wed, Thu, Fri]
+    missed_window_hours: 4
+    on_miss: fire
+    cooldown_minutes: 60
+
+  weekend-briefing:
+    type: briefing
+    runner: run-scout.sh
+    fires_at_local: "08:30"
+    weekdays: [Sat, Sun]
+    missed_window_hours: 6
+    on_miss: fire
+    cooldown_minutes: 60
+
+  morning-consolidation:
+    type: consolidation
+    runner: run-scout.sh
+    fires_at_local: "11:00"
+    weekdays: [Mon, Tue, Wed, Thu, Fri]
+    missed_window_hours: 2
+    on_miss: collapse
+    cooldown_minutes: 90
+
+  midday-consolidation:
+    type: consolidation
+    runner: run-scout.sh
+    fires_at_local: "13:00"
+    weekdays: [Mon, Tue, Wed, Thu, Fri]
+    missed_window_hours: 2
+    on_miss: collapse
+    cooldown_minutes: 90
+
+  afternoon-consolidation:
+    type: consolidation
+    runner: run-scout.sh
+    fires_at_local: "17:00"
+    weekdays: [Mon, Tue, Wed, Thu, Fri]
+    missed_window_hours: 3
+    on_miss: collapse
+    cooldown_minutes: 90
+
+  evening-consolidation:
+    type: consolidation
+    runner: run-scout.sh
+    fires_at_local: "19:00"
+    weekdays: [Mon, Tue, Wed, Thu, Fri]
+    missed_window_hours: 4
+    on_miss: collapse
+    cooldown_minutes: 90
+
+  dreaming-evening:
+    type: dreaming
+    runner: run-dreaming.sh
+    fires_at_local: "18:30"
+    weekdays: [Mon, Tue, Wed, Thu, Fri, Sat, Sun]
+    missed_window_hours: 4
+    on_miss: skip
+    cooldown_minutes: 120
+
+  dreaming-nightly:
+    type: dreaming
+    runner: run-dreaming.sh
+    fires_at_local: "22:00"
+    weekdays: [Mon, Tue, Wed, Thu, Fri, Sat, Sun]
+    missed_window_hours: 6
+    on_miss: skip
+    cooldown_minutes: 120
+
+  dreaming-weekend-morning:
+    type: dreaming
+    runner: run-dreaming.sh
+    fires_at_local: "07:00"
+    weekdays: [Sat, Sun]
+    missed_window_hours: 4
+    on_miss: skip
+    cooldown_minutes: 120
+
+  research:
+    type: research
+    runner: run-research.sh
+    fires_at_local: "14:00"
+    weekdays: [Mon, Tue, Wed, Thu, Fri]
+    missed_window_hours: 4
+    on_miss: skip
+    cooldown_minutes: 240

--- a/engine/scout/manifest.py
+++ b/engine/scout/manifest.py
@@ -66,6 +66,7 @@ def build_manifest() -> EngineManifest:
             "action_items_cli_v1": True,  # Plan 2
             "kb_ontology_v1": True,  # Plan 2
             "tui_v1": True,  # Plan 2
+            "schedule_v2": True,  # Plan 5
         },
         subcommands=_list_subcommands(),
     )

--- a/engine/scout/schedule.py
+++ b/engine/scout/schedule.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import enum
 from collections.abc import Iterator
 from dataclasses import dataclass
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -230,3 +230,56 @@ def _build_slot(key: str, raw: dict[str, Any]) -> Slot:
         )
     except (KeyError, ValueError) as e:
         raise ConfigError(f"slot {key}: malformed entry: {e}") from e
+
+
+_WEEKDAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+
+def next_fires(
+    schedule: Schedule,
+    *,
+    now: datetime,
+    window_hours: float = 24.0,
+) -> list[tuple[str, datetime]]:
+    """Return (slot_key, next_fire_datetime) pairs for slots firing within window.
+
+    For each slot, finds the soonest fire time strictly in the future that
+    falls within ``now + window_hours``. Results are sorted chronologically.
+    Does NOT consult the tracker — this is pure forward-looking schema math.
+
+    Args:
+        schedule: The loaded Schedule to scan.
+        now: Timezone-aware datetime representing the current moment.
+        window_hours: How many hours ahead to look (default 24).
+
+    Returns:
+        List of (slot_key, fire_datetime) tuples, sorted by fire_datetime.
+    """
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+
+    cutoff = now + timedelta(hours=window_hours)
+    results: list[tuple[str, datetime]] = []
+
+    for key, slot in schedule.items():
+        slot_tz = ZoneInfo(slot.tz) if slot.tz else now.tzinfo
+        hh, mm = slot.fires_at_local.split(":")
+        hour = int(hh)
+        minute = int(mm)
+
+        for day_offset in range(8):
+            candidate_day = (now + timedelta(days=day_offset)).astimezone(slot_tz)
+            weekday_name = _WEEKDAY_NAMES[candidate_day.weekday()]
+            if weekday_name not in slot.weekdays:
+                continue
+            # Build the target datetime on that calendar day in the slot's tz
+            target = candidate_day.replace(hour=hour, minute=minute, second=0, microsecond=0)
+            if target <= now:
+                continue
+            # Found the next eligible fire for this slot
+            if target <= cutoff:
+                results.append((key, target))
+            break  # whether inside or outside window, this slot is done
+
+    results.sort(key=lambda x: x[1])
+    return results

--- a/engine/scout/schedule.py
+++ b/engine/scout/schedule.py
@@ -152,9 +152,15 @@ def load_schedule(
     connectors overlay pattern). Validation runs after the merge.
     """
     seed = _load_yaml(canonical_path)
+    version = seed.get("schema_version", 1)
+    if version != 1:
+        raise ConfigError(f"schedule.yaml at {canonical_path} has schema_version {version}; engine supports 1")
     merged: dict[str, Any] = dict(seed.get("slots", {}))
     if overlay is not None and overlay.exists():
         ov = _load_yaml(overlay)
+        ov_version = ov.get("schema_version", 1)
+        if ov_version != 1:
+            raise ConfigError(f"schedule.yaml at {overlay} has schema_version {ov_version}; engine supports 1")
         for key, override in ov.get("slots", {}).items():
             if key in merged:
                 merged[key] = {**merged[key], **override}
@@ -201,15 +207,24 @@ def _build_slot(key: str, raw: dict[str, Any]) -> Slot:
                 ZoneInfo(tz)
             except ZoneInfoNotFoundError as e:
                 raise ConfigError(f"slot {key}: unknown tz {tz!r}") from e
+        runner = raw["runner"]
+        if not isinstance(runner, str) or not runner.strip():
+            raise ConfigError(f"slot {key}: runner must be a non-empty string")
+        mw = int(raw["missed_window_hours"])
+        if mw <= 0:
+            raise ConfigError(f"slot {key}: missed_window_hours must be > 0, got {mw}")
+        cd = int(raw["cooldown_minutes"])
+        if cd < 0:
+            raise ConfigError(f"slot {key}: cooldown_minutes must be >= 0, got {cd}")
         return Slot(
             key=key,
             type=slot_type,
-            runner=raw["runner"],
+            runner=runner,
             fires_at_local=fires_at_raw,
             weekdays=tuple(weekdays_raw),
-            missed_window_hours=int(raw["missed_window_hours"]),
+            missed_window_hours=mw,
             on_miss=on_miss,
-            cooldown_minutes=int(raw["cooldown_minutes"]),
+            cooldown_minutes=cd,
             budget_usd=raw.get("budget_usd"),
             tz=tz,
         )

--- a/engine/scout/schedule.py
+++ b/engine/scout/schedule.py
@@ -1,0 +1,217 @@
+"""Schedule registry: vault-canonical schedule.yaml loader + slot semantics.
+
+Schedule definition lives at `~/Scout/.scout-state/schedule.yaml`; the engine
+ships defaults at `engine/scout/defaults/schedule.yaml` that `scoutctl schedule
+init` copies on first run. The vault file is the single source of truth at
+runtime.
+
+Slot wall-clock times are interpreted in the system's current local timezone
+by default (TZ-aware by construction — travel ET → CEST and the schedule moves
+with you). Optional per-slot `tz: <iana-zone>` field pins a slot to a fixed
+zone if needed.
+
+See ~/scout-app/docs/superpowers/specs/2026-05-04-schedule-v2-design.md.
+"""
+
+from __future__ import annotations
+
+import enum
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import datetime, time
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+import yaml
+
+from scout.errors import ConfigError
+
+
+class SlotType(enum.Enum):
+    BRIEFING = "briefing"
+    CONSOLIDATION = "consolidation"
+    DREAMING = "dreaming"
+    RESEARCH = "research"
+    MANUAL = "manual"
+
+
+class OnMissPolicy(enum.Enum):
+    FIRE = "fire"
+    SKIP = "skip"
+    COLLAPSE = "collapse"
+
+
+class SlotPriority(enum.IntEnum):
+    """Priority order for single-fire-per-tick selection.
+
+    Higher integer = fires first when multiple slots are eligible at the
+    same tick. Hardcoded; not user-configurable. See design doc §4 step 6.
+    """
+
+    BRIEFING = 50
+    CONSOLIDATION = 40
+    DREAMING = 30
+    RESEARCH = 20
+    MANUAL = 10
+
+
+_VALID_WEEKDAYS = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"}
+
+
+@dataclass(frozen=True)
+class Slot:
+    """One scheduled slot. Frozen — load_schedule rebuilds; never mutated."""
+
+    key: str  # user-chosen kebab-case identifier
+    type: SlotType  # fixed plugin vocabulary
+    runner: str  # script name relative to vault root
+    fires_at_local: str  # "HH:MM" 24-hour
+    weekdays: tuple[str, ...]  # subset of _VALID_WEEKDAYS
+    missed_window_hours: int
+    on_miss: OnMissPolicy
+    cooldown_minutes: int
+    budget_usd: float | None = None  # optional; not load-bearing in v0.5
+    tz: str | None = None  # optional IANA zone; absent → system local
+
+    @property
+    def priority(self) -> SlotPriority:
+        """Map slot type to its priority for single-fire-per-tick selection."""
+        return _PRIORITY_BY_TYPE[self.type]
+
+    def target_today(self, *, now: datetime) -> datetime | None:
+        """Return today's target datetime for this slot, or None if today's weekday is excluded.
+
+        `now` must be tz-aware. Slot's tz override (or system local) is honored.
+        """
+        if now.tzinfo is None:
+            raise ValueError("now must be timezone-aware")
+        slot_tz = ZoneInfo(self.tz) if self.tz else now.tzinfo
+        local_today = now.astimezone(slot_tz)
+        weekday_name = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"][local_today.weekday()]
+        if weekday_name not in self.weekdays:
+            return None
+        hh, mm = self.fires_at_local.split(":")
+        return local_today.replace(hour=int(hh), minute=int(mm), second=0, microsecond=0)
+
+
+_PRIORITY_BY_TYPE: dict[SlotType, SlotPriority] = {
+    SlotType.BRIEFING: SlotPriority.BRIEFING,
+    SlotType.CONSOLIDATION: SlotPriority.CONSOLIDATION,
+    SlotType.DREAMING: SlotPriority.DREAMING,
+    SlotType.RESEARCH: SlotPriority.RESEARCH,
+    SlotType.MANUAL: SlotPriority.MANUAL,
+}
+
+
+class Schedule:
+    """Indexed view over loaded slots. Use load_schedule() / load_default_schedule()."""
+
+    def __init__(self, slots: dict[str, Slot]) -> None:
+        self._slots = slots
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._slots
+
+    def __getitem__(self, key: str) -> Slot:
+        return self._slots[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._slots)
+
+    def keys(self):
+        return self._slots.keys()
+
+    def values(self):
+        return self._slots.values()
+
+    def items(self):
+        return self._slots.items()
+
+    def by_type(self, slot_type: SlotType) -> list[Slot]:
+        return [s for s in self._slots.values() if s.type == slot_type]
+
+
+def load_default_schedule() -> Schedule:
+    """Load the plugin-shipped default schedule.
+
+    Used by tests, `scoutctl schedule init` (to seed the vault), and
+    fallback loaders when the vault file is absent.
+    """
+    return load_schedule(Path(__file__).parent / "defaults" / "schedule.yaml")
+
+
+def load_schedule(
+    canonical_path: Path,
+    *,
+    overlay: Path | None = None,
+) -> Schedule:
+    """Load a schedule.yaml. Optionally layer an overlay file on top.
+
+    The overlay is shallow-merged into each slot key (matches Plan 4's
+    connectors overlay pattern). Validation runs after the merge.
+    """
+    seed = _load_yaml(canonical_path)
+    merged: dict[str, Any] = dict(seed.get("slots", {}))
+    if overlay is not None and overlay.exists():
+        ov = _load_yaml(overlay)
+        for key, override in ov.get("slots", {}).items():
+            if key in merged:
+                merged[key] = {**merged[key], **override}
+            else:
+                merged[key] = override
+    slots: dict[str, Slot] = {}
+    for key, raw in merged.items():
+        slots[key] = _build_slot(key, raw)
+    return Schedule(slots)
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except FileNotFoundError as e:
+        raise ConfigError(f"schedule yaml at {path} not found") from e
+    except yaml.YAMLError as e:
+        raise ConfigError(f"schedule yaml at {path} is malformed: {e}") from e
+    if not isinstance(data, dict):
+        raise ConfigError(f"schedule yaml at {path} is not a mapping")
+    return data
+
+
+def _build_slot(key: str, raw: dict[str, Any]) -> Slot:
+    try:
+        slot_type = SlotType(raw["type"])
+        weekdays_raw = raw.get("weekdays", [])
+        if not weekdays_raw:
+            raise ConfigError(f"slot {key}: weekdays must be a non-empty list")
+        for wd in weekdays_raw:
+            if wd not in _VALID_WEEKDAYS:
+                raise ConfigError(f"slot {key}: invalid weekday {wd!r}; must be one of {sorted(_VALID_WEEKDAYS)}")
+        fires_at_raw = str(raw.get("fires_at_local", ""))
+        try:
+            hh, mm = fires_at_raw.split(":")
+            time(int(hh), int(mm))  # validate via stdlib
+        except (ValueError, AttributeError) as e:
+            raise ConfigError(f"slot {key}: fires_at_local {fires_at_raw!r} is not HH:MM 24-hour") from e
+        on_miss = OnMissPolicy(raw["on_miss"])
+        tz = raw.get("tz")
+        if tz is not None:
+            try:
+                ZoneInfo(tz)
+            except ZoneInfoNotFoundError as e:
+                raise ConfigError(f"slot {key}: unknown tz {tz!r}") from e
+        return Slot(
+            key=key,
+            type=slot_type,
+            runner=raw["runner"],
+            fires_at_local=fires_at_raw,
+            weekdays=tuple(weekdays_raw),
+            missed_window_hours=int(raw["missed_window_hours"]),
+            on_miss=on_miss,
+            cooldown_minutes=int(raw["cooldown_minutes"]),
+            budget_usd=raw.get("budget_usd"),
+            tz=tz,
+        )
+    except (KeyError, ValueError) as e:
+        raise ConfigError(f"slot {key}: malformed entry: {e}") from e

--- a/engine/scout/schedule.py
+++ b/engine/scout/schedule.py
@@ -247,6 +247,12 @@ def next_fires(
     falls within ``now + window_hours``. Results are sorted chronologically.
     Does NOT consult the tracker — this is pure forward-looking schema math.
 
+    DST note: on spring-forward day, a ``fires_at_local`` that lands in the
+    missing hour (e.g. '02:30' on 2026-03-08 in America/New_York) silently
+    uses the pre-shift UTC offset via ``datetime.replace``. Acceptable for
+    Scout's defaults (no slot fires in the gap); revisit if a slot ever
+    schedules in that window.
+
     Args:
         schedule: The loaded Schedule to scan.
         now: Timezone-aware datetime representing the current moment.

--- a/engine/scout/schedule.snapshot.json
+++ b/engine/scout/schedule.snapshot.json
@@ -1,0 +1,144 @@
+{
+  "schema_version": 1,
+  "generated_from": "scout-plugin@dc6ad86",
+  "slots": [
+    {
+      "key": "morning-briefing",
+      "type": "briefing",
+      "runner": "run-scout.sh",
+      "fires_at_local": "08:00",
+      "weekdays": [
+        "Mon",
+        "Tue",
+        "Wed",
+        "Thu",
+        "Fri"
+      ],
+      "on_miss": "fire"
+    },
+    {
+      "key": "weekend-briefing",
+      "type": "briefing",
+      "runner": "run-scout.sh",
+      "fires_at_local": "08:30",
+      "weekdays": [
+        "Sat",
+        "Sun"
+      ],
+      "on_miss": "fire"
+    },
+    {
+      "key": "morning-consolidation",
+      "type": "consolidation",
+      "runner": "run-scout.sh",
+      "fires_at_local": "11:00",
+      "weekdays": [
+        "Mon",
+        "Tue",
+        "Wed",
+        "Thu",
+        "Fri"
+      ],
+      "on_miss": "collapse"
+    },
+    {
+      "key": "midday-consolidation",
+      "type": "consolidation",
+      "runner": "run-scout.sh",
+      "fires_at_local": "13:00",
+      "weekdays": [
+        "Mon",
+        "Tue",
+        "Wed",
+        "Thu",
+        "Fri"
+      ],
+      "on_miss": "collapse"
+    },
+    {
+      "key": "afternoon-consolidation",
+      "type": "consolidation",
+      "runner": "run-scout.sh",
+      "fires_at_local": "17:00",
+      "weekdays": [
+        "Mon",
+        "Tue",
+        "Wed",
+        "Thu",
+        "Fri"
+      ],
+      "on_miss": "collapse"
+    },
+    {
+      "key": "evening-consolidation",
+      "type": "consolidation",
+      "runner": "run-scout.sh",
+      "fires_at_local": "19:00",
+      "weekdays": [
+        "Mon",
+        "Tue",
+        "Wed",
+        "Thu",
+        "Fri"
+      ],
+      "on_miss": "collapse"
+    },
+    {
+      "key": "dreaming-evening",
+      "type": "dreaming",
+      "runner": "run-dreaming.sh",
+      "fires_at_local": "18:30",
+      "weekdays": [
+        "Mon",
+        "Tue",
+        "Wed",
+        "Thu",
+        "Fri",
+        "Sat",
+        "Sun"
+      ],
+      "on_miss": "skip"
+    },
+    {
+      "key": "dreaming-nightly",
+      "type": "dreaming",
+      "runner": "run-dreaming.sh",
+      "fires_at_local": "22:00",
+      "weekdays": [
+        "Mon",
+        "Tue",
+        "Wed",
+        "Thu",
+        "Fri",
+        "Sat",
+        "Sun"
+      ],
+      "on_miss": "skip"
+    },
+    {
+      "key": "dreaming-weekend-morning",
+      "type": "dreaming",
+      "runner": "run-dreaming.sh",
+      "fires_at_local": "07:00",
+      "weekdays": [
+        "Sat",
+        "Sun"
+      ],
+      "on_miss": "skip"
+    },
+    {
+      "key": "research",
+      "type": "research",
+      "runner": "run-research.sh",
+      "fires_at_local": "14:00",
+      "weekdays": [
+        "Mon",
+        "Tue",
+        "Wed",
+        "Thu",
+        "Fri"
+      ],
+      "on_miss": "skip"
+    }
+  ]
+}

--- a/engine/scout/scripts/connector_health_report.py
+++ b/engine/scout/scripts/connector_health_report.py
@@ -35,6 +35,7 @@ from scout import paths
 from scout.connectors import Capability, Connector, ConnectorRegistry, load_registry
 from scout.events import Event, now_iso
 from scout.ids import new_ulid
+from scout.schedule import SlotType
 
 ET = ZoneInfo("America/New_York")
 DEFAULT_WINDOW_DAYS = 14
@@ -167,6 +168,33 @@ def compute_stats(session_list: SessionList, alertable_keys: Iterable[str]) -> S
     return stats
 
 
+def _current_slot_type(mode: str, *, data_dir: Path | None = None) -> SlotType:
+    """Look up ``mode`` (a slot key) in the active schedule and return its SlotType.
+
+    Falls back to the plugin-shipped default schedule if the vault file is
+    absent (e.g. on a fresh install or in a test fixture). Returns
+    ``SlotType.MANUAL`` for unrecognized slot keys — manual is intentionally
+    excluded from any connector's ``required_in_types``, so an unknown mode
+    never accidentally fires a chronic-skip alert.
+
+    Lazy imports (``scout.schedule``) keep this side-effect-free at module
+    import time and avoid any circular-import surprises.
+    """
+    from scout.schedule import load_default_schedule, load_schedule
+
+    target = data_dir if data_dir is not None else paths.data_dir()
+    vault_schedule = paths.state_dir(target) / "schedule.yaml"
+    try:
+        sched = load_schedule(vault_schedule) if vault_schedule.exists() else load_default_schedule()
+    except Exception:
+        # Defensive: a malformed vault schedule should not crash the health
+        # report. Fall back to defaults.
+        sched = load_default_schedule()
+    if mode in sched:
+        return sched[mode].type
+    return SlotType.MANUAL
+
+
 def _alertable_registry(registry: ConnectorRegistry) -> dict[str, Connector]:
     """Connectors that can be alerting subjects.
 
@@ -267,6 +295,8 @@ def compute_critical_alerts(
     sessions_by_id: dict[str, list[dict[str, Any]]],
     alertable: dict[str, Connector],
     records: list[dict[str, Any]],
+    *,
+    data_dir: Path | None = None,
 ) -> list[Alert]:
     """Mode-aware critical-connector rule + chronic-skip override + Pattern #48."""
     alerts: list[Alert] = []
@@ -275,6 +305,10 @@ def compute_critical_alerts(
     current_sid = session_list[-1][0]
     current_mode = sessions_by_id[current_sid][0].get("mode", "unknown")
     prior_sessions = session_list[:-1]
+
+    # Plan 5: connectors are required by SLOT TYPE, not slot key. Resolve the
+    # current run's slot type once via the schedule (vault → defaults).
+    current_slot_type = _current_slot_type(current_mode, data_dir=data_dir)
 
     for c, connector in alertable.items():
         curr_ok = _ok_count(stats, c, current_sid)
@@ -289,8 +323,9 @@ def compute_critical_alerts(
         else:
             should_alert = False
 
-        # Chronic-skip override: dark for >=3 runs in a required mode.
-        mode_required = connector.required_in_mode(current_mode)
+        # Chronic-skip override: dark for >=3 runs in a slot type that requires
+        # this connector.
+        mode_required = connector.required_in_type(current_slot_type)
         if not should_alert and gap >= DARK_GAP_THRESHOLD and mode_required:
             should_alert = True
 
@@ -569,7 +604,9 @@ def run(
     current_sid = session_list[-1][0]
     current_mode = sessions_by_id[current_sid][0].get("mode", "unknown")
 
-    critical_alerts = compute_critical_alerts(stats, session_list, dict(sessions_by_id), alertable, records)
+    critical_alerts = compute_critical_alerts(
+        stats, session_list, dict(sessions_by_id), alertable, records, data_dir=target_data
+    )
     critical_keys = {a.connector_key for a in critical_alerts}
     warning_alerts = compute_warning_alerts(stats, current_sid, alertable, records, critical_keys)
     alerts = critical_alerts + warning_alerts

--- a/engine/scout/scripts/install_schedule_plist.py
+++ b/engine/scout/scripts/install_schedule_plist.py
@@ -1,0 +1,53 @@
+"""Helper for `scoutctl schedule install-plist [--uninstall] [--force]`.
+
+Filling __USER_HOME__ in the template at install time; not at runtime, because
+launchd's plist parser doesn't expand env vars in <string> values.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+PLIST_NAME = "com.scout.schedule-tick.plist"
+TEMPLATE = Path(__file__).parent.parent / "defaults" / PLIST_NAME
+
+
+def install_plist(
+    *,
+    home: Path,
+    agents_dir: Path | None = None,
+    force: bool = False,
+    bootstrap: bool = False,
+) -> Path:
+    """Render the template into ~/Library/LaunchAgents/."""
+    agents_dir = agents_dir or (home / "Library" / "LaunchAgents")
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    target = agents_dir / PLIST_NAME
+    if target.exists() and not force:
+        raise FileExistsError(target)
+    rendered = TEMPLATE.read_text().replace("__USER_HOME__", str(home))
+    target.write_text(rendered)
+    if bootstrap:
+        # `launchctl bootstrap gui/$UID <plist>` loads the job. Best-effort.
+        uid = os.getuid()
+        subprocess.run(
+            ["launchctl", "bootstrap", f"gui/{uid}", str(target)],
+            check=False,
+        )
+    return target
+
+
+def uninstall_plist(*, agents_dir: Path | None = None, bootout: bool = False) -> None:
+    """Remove the plist (and optionally bootout the job from launchd)."""
+    agents_dir = agents_dir or (Path.home() / "Library" / "LaunchAgents")
+    target = agents_dir / PLIST_NAME
+    if bootout:
+        uid = os.getuid()
+        subprocess.run(
+            ["launchctl", "bootout", f"gui/{uid}/com.scout.schedule-tick"],
+            check=False,
+        )
+    if target.exists():
+        target.unlink()

--- a/engine/scout/scripts/install_wake_schedule.py
+++ b/engine/scout/scripts/install_wake_schedule.py
@@ -1,0 +1,64 @@
+"""scoutctl schedule install-wake-schedule [--uninstall].
+
+Wraps `pmset repeat wakeorpoweron <DAYS> <HH:MM:SS>` to wake the Mac for the
+earliest scheduled weekday slot. Documented limitation: only reliable on AC
+power; on battery + lid-closed, Apple Silicon laptops enter standby with wake
+timers suppressed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+from scout.schedule import Schedule, Slot
+
+_WEEKDAY_LETTER = {
+    "Mon": "M",
+    "Tue": "T",
+    "Wed": "W",
+    "Thu": "R",
+    "Fri": "F",
+    "Sat": "S",
+    "Sun": "U",
+}
+_WEEKDAYS = ("Mon", "Tue", "Wed", "Thu", "Fri")
+
+
+def compute_earliest_weekday_slot(sched: Schedule) -> Slot | None:
+    """Return the slot with the earliest fires_at_local that has at least one weekday.
+
+    Slots whose `weekdays` is entirely Sat/Sun are excluded — pmset's wake
+    rule only applies on weekdays we name in the day-letter argument.
+    """
+    candidates = [s for s in sched.values() if any(d in _WEEKDAYS for d in s.weekdays)]
+    if not candidates:
+        return None
+    return min(candidates, key=lambda s: s.fires_at_local)
+
+
+def install_wake_schedule(sched: Schedule, *, dry_run: bool = False) -> str:
+    """Install the pmset repeat rule. Returns the command summary string."""
+    slot = compute_earliest_weekday_slot(sched)
+    if slot is None:
+        raise ValueError("no weekday slot found in schedule; cannot compute wake time")
+    days = "".join(_WEEKDAY_LETTER[d] for d in slot.weekdays if d in _WEEKDAY_LETTER and d in _WEEKDAYS)
+    if not days:
+        raise ValueError(f"slot {slot.key} has no recognizable weekdays")
+    hhmm = slot.fires_at_local
+    cmd = ["pmset", "repeat", "wakeorpoweron", days, f"{hhmm}:00"]
+    if dry_run:
+        return f"[dry-run] would run: {' '.join(cmd)}"
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"pmset failed: {result.stderr.strip()}")
+    return f"installed: {' '.join(cmd)}"
+
+
+def uninstall_wake_schedule(*, dry_run: bool = False) -> str:
+    cmd = ["pmset", "repeat", "cancel"]
+    if dry_run:
+        return f"[dry-run] would run: {' '.join(cmd)}"
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"pmset failed: {result.stderr.strip()}")
+    return "uninstalled"

--- a/engine/scout/scripts/schedule_snapshot.py
+++ b/engine/scout/scripts/schedule_snapshot.py
@@ -1,0 +1,302 @@
+"""Schedule snapshot — JSON projection of the defaults/schedule.yaml registry,
+consumed by scout-app's schedule strip UI + dispatcher behavior labeling.
+
+This is the cross-repo sync point for Plan 5 Task 8. The Swift app cannot
+parse YAML without dragging in a dependency, and we want one canonical
+schedule contract — so scout-plugin owns the YAML and emits a stable JSON
+projection that scout-app reads as a bundled fixture.
+
+Snapshot file format (v1)::
+
+    {
+      "schema_version": 1,
+      "generated_from": "scout-plugin@<short-sha-or-unknown>",
+      "slots": [
+        {
+          "key": "morning-briefing",
+          "type": "briefing",
+          "runner": "run-scout.sh",
+          "fires_at_local": "08:00",
+          "weekdays": ["Mon", "Tue", "Wed", "Thu", "Fri"],
+          "on_miss": "fire"
+        },
+        ...
+      ]
+    }
+
+Field selection:
+  * scout-app needs key/type/runner/fires_at_local/weekdays/on_miss for the
+    schedule strip UI and dispatcher behavior labeling.
+  * Dispatcher-internal fields (missed_window_hours, cooldown_minutes,
+    budget_usd, tz) are excluded — the snapshot is intentionally lean.
+
+Ordering:
+  * The ``slots`` array preserves YAML insertion order so a YAML reordering
+    shows up as drift in ``--check`` mode (intentional — a surprise reorder
+    is a meaningful signal).
+
+Determinism:
+  * The serializer always emits ``json.dumps(snapshot, indent=2)`` followed
+    by a single trailing newline. ``--check`` does a byte-identical compare,
+    so both the writer and the verifier MUST go through ``serialize()``.
+
+Operator handoff when YAML changes
+----------------------------------
+
+When ``engine/scout/defaults/schedule.yaml`` is edited, two snapshot files
+must stay in sync (one in each repo) and both must be committed:
+
+  1. **Edit** ``engine/scout/defaults/schedule.yaml`` (this repo,
+     ``scout-plugin``).
+  2. **Regenerate** both snapshot copies:
+        $ scoutctl schedule snapshot
+     The default invocation writes the canonical snapshot at
+     ``engine/scout/schedule.snapshot.json`` AND, best-effort, the
+     scout-app fixture at ``~/scout-app/ScoutTests/Fixtures/
+     schedule.snapshot.json``. Pass ``--no-also-write-app-fixture`` to
+     skip the cross-repo write (e.g. on a build agent without scout-app
+     checked out). If scout-app isn't checked out, the cross-repo write
+     is skipped with a warning rather than failing.
+  3. **Commit BOTH** repos. CI in scout-plugin verifies (1)+(2)
+     consistency on the canonical snapshot via ``--check``. Nothing
+     auto-verifies that scout-app's bundled fixture matches; cross-repo
+     drift between the two committed copies is detectable only by
+     re-running this command and noticing a non-empty git diff in
+     scout-app.
+  4. (CI) Scout-plugin's ``test`` workflow runs::
+        python -m scout.scripts.schedule_snapshot --check \\
+            --target scout/schedule.snapshot.json
+     This guards step (1)+(2) for the canonical file only.
+
+The ``--target`` flag overrides the canonical destination. CI passes an
+explicit ``--target`` so the resolution is independent of cwd. Tests pass
+``--target tmp_path/...`` to avoid touching either repo.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from scout.schedule import load_default_schedule
+
+SCHEMA_VERSION = 1
+
+
+def canonical_snapshot_path() -> Path:
+    """Return the canonical snapshot path inside scout-plugin.
+
+    This is the file CI verifies with ``--check``. It is the source of truth
+    for the cross-repo contract: scout-app's bundled fixture must match this
+    file byte-for-byte (modulo the ``generated_from`` SHA, which is excluded
+    from comparisons — see ``check_snapshot``).
+    """
+    # engine/scout/scripts/schedule_snapshot.py -> engine/scout/scripts ->
+    # engine/scout, so parents[1] / "schedule.snapshot.json" is the canonical.
+    return Path(__file__).resolve().parents[1] / "schedule.snapshot.json"
+
+
+def app_fixture_snapshot_path() -> Path:
+    """Return scout-app's bundled fixture path.
+
+    Best-effort secondary write target. Hardcoded to Jordan's dev-machine
+    layout (``~/scout-app/...``); skipped with a warning if scout-app isn't
+    checked out at that location.
+    """
+    return Path.home() / "scout-app" / "ScoutTests" / "Fixtures" / "schedule.snapshot.json"
+
+
+def _short_sha(repo_dir: Path) -> str:
+    """Return the short SHA of HEAD in ``repo_dir``, or 'unknown' if unavailable."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return "unknown"
+    sha = result.stdout.strip()
+    return sha or "unknown"
+
+
+def build_snapshot(*, repo_dir: Path | None = None) -> dict[str, Any]:
+    """Build the in-memory snapshot dict from the default schedule.
+
+    Reflects the engine-shipped defaults/schedule.yaml (the canonical
+    contract). Iterates in YAML insertion order. Emits 6 fields per slot.
+    """
+    if repo_dir is None:
+        # Walk up from this module's location to find the scout-plugin repo root.
+        # engine/scout/scripts/schedule_snapshot.py -> engine/scout/scripts ->
+        # engine/scout -> engine -> scout-plugin
+        repo_dir = Path(__file__).resolve().parents[3]
+
+    sched = load_default_schedule()
+    slots_list = []
+    for key, slot in sched.items():
+        slots_list.append(
+            {
+                "key": key,
+                "type": slot.type.value,
+                "runner": slot.runner,
+                "fires_at_local": slot.fires_at_local,
+                "weekdays": list(slot.weekdays),
+                "on_miss": slot.on_miss.value,
+            }
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_from": f"scout-plugin@{_short_sha(repo_dir)}",
+        "slots": slots_list,
+    }
+
+
+def serialize(snapshot: dict[str, Any]) -> str:
+    """Stable serialization: indent=2, no key sorting (preserve order),
+    trailing newline.
+
+    Both the writer and the ``--check`` comparator MUST go through this
+    function so byte-identical comparisons are reliable.
+    """
+    return json.dumps(snapshot, indent=2) + "\n"
+
+
+def write_snapshot(target: Path, *, repo_dir: Path | None = None) -> str:
+    """Build and write the snapshot to ``target``. Returns the serialized string."""
+    snapshot = build_snapshot(repo_dir=repo_dir)
+    text = serialize(snapshot)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(text, encoding="utf-8")
+    return text
+
+
+def check_snapshot(target: Path, *, repo_dir: Path | None = None) -> tuple[bool, str]:
+    """Verify that ``target`` matches what ``write_snapshot`` would produce.
+
+    Compares everything EXCEPT the ``generated_from`` field — that captures
+    the SHA at write time, and would always drift if the YAML has been edited
+    in a commit that has already landed. The check is "is the on-disk JSON's
+    *content* (schema + slots list) in sync with the current YAML?".
+
+    Returns ``(matches, diff_text)``. ``diff_text`` is empty on match.
+    """
+    if not target.exists():
+        return False, f"snapshot target does not exist: {target}\n"
+
+    expected_snapshot = build_snapshot(repo_dir=repo_dir)
+    expected_text = serialize(expected_snapshot)
+
+    actual_text = target.read_text(encoding="utf-8")
+
+    # Strip the generated_from line from BOTH sides for the comparison —
+    # otherwise a re-write would always "drift" against any committed snapshot
+    # because the SHA advances with each commit. The line format is stable
+    # (json.dumps with indent=2 always renders it as `  "generated_from":...`).
+    def _strip_generated_from(text: str) -> str:
+        return "\n".join(line for line in text.splitlines() if '"generated_from"' not in line)
+
+    expected_normalized = _strip_generated_from(expected_text)
+    actual_normalized = _strip_generated_from(actual_text)
+
+    if expected_normalized == actual_normalized:
+        return True, ""
+
+    diff = difflib.unified_diff(
+        actual_text.splitlines(keepends=True),
+        expected_text.splitlines(keepends=True),
+        fromfile=f"{target} (on disk)",
+        tofile=f"{target} (would write)",
+    )
+    return False, "".join(diff)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Standalone entry point — `python -m scout.scripts.schedule_snapshot`.
+
+    The Typer CLI wrapper in scout.cli forwards through here for parity.
+    """
+    parser = argparse.ArgumentParser(
+        prog="schedule-snapshot",
+        description="Write or verify schedule.snapshot.json for scout-app sync.",
+    )
+    parser.add_argument(
+        "--target",
+        "-t",
+        type=Path,
+        default=canonical_snapshot_path(),
+        help=(
+            "Where to write the snapshot. Defaults to scout-plugin's canonical "
+            "engine/scout/schedule.snapshot.json (the file CI verifies)."
+        ),
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit 1 if on-disk file differs from what would be written.",
+    )
+    parser.add_argument(
+        "--also-write-app-fixture",
+        dest="also_write_app_fixture",
+        action="store_true",
+        default=True,
+        help=(
+            "Also write the scout-app bundled fixture at "
+            "~/scout-app/ScoutTests/Fixtures/schedule.snapshot.json. "
+            "Best-effort: silently skipped (with a warning) if the path "
+            "doesn't exist on this machine. Default: enabled."
+        ),
+    )
+    parser.add_argument(
+        "--no-also-write-app-fixture",
+        dest="also_write_app_fixture",
+        action="store_false",
+        help="Disable the secondary write to scout-app's bundled fixture.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.check:
+        ok, diff = check_snapshot(args.target)
+        if ok:
+            print(f"schedule snapshot OK: {args.target}")
+            return 0
+        sys.stderr.write(diff)
+        sys.stderr.write(f"\nDrift detected: regenerate with `scoutctl schedule snapshot --target {args.target}`.\n")
+        return 1
+
+    write_snapshot(args.target)
+    print(f"Wrote: {args.target}")
+
+    # Best-effort dual-write to the scout-app fixture so a single invocation
+    # keeps both repos' copies in sync. Skip silently (with a warning) if the
+    # secondary path isn't a viable destination on this machine.
+    if args.also_write_app_fixture:
+        app_fixture = app_fixture_snapshot_path()
+        if app_fixture == args.target:
+            # The operator passed --target pointing at the app fixture; the
+            # primary write already covered it. No-op to avoid double-writes.
+            pass
+        elif app_fixture.parent.is_dir():
+            write_snapshot(app_fixture)
+            print(f"Wrote: {app_fixture}")
+        else:
+            sys.stderr.write(
+                f"warning: skipped scout-app fixture write — {app_fixture.parent} "
+                "is not a directory on this machine. Pass --no-also-write-app-fixture "
+                "to silence.\n"
+            )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/engine/scout/scripts/schedule_tick.py
+++ b/engine/scout/scripts/schedule_tick.py
@@ -1,0 +1,687 @@
+"""Engine-canonical schedule dispatcher (`scoutctl schedule tick`).
+
+Invoked every 5 minutes by ``com.scout.schedule-tick.plist``. Per the
+design spec at
+``~/scout-app/docs/superpowers/specs/2026-05-04-schedule-v2-design.md``
+§4, this module owns the per-tick algorithm:
+
+  1. Load the vault ``schedule.yaml`` (or plugin defaults).
+  2. Read ``usage-tracker.jsonl`` to build per-slot ``last_fire_ts`` index.
+  3. Compute due slots: weekday match + target time passed + last fire older
+     than today's target + not within cooldown.
+  4. Apply per-slot ``on_miss`` policy (fire / skip / collapse-within-type).
+  5. Pre-spawn TCP probe of ``api.anthropic.com:443`` to guard against
+     wake-from-sleep races where Wi-Fi has not reconnected yet.
+  6. Single-fire-per-tick (priority-ordered): briefing > consolidation >
+     dreaming > research > manual. Non-winners stay eligible for the
+     next tick (no ``slot.skipped`` event).
+  7. Spawn the runner with ``SCOUT_FORCE_MODE=<slot_key>``; record fire
+     timestamp; emit ``slot.fired``.
+  8. Emit ``schedule.tick.completed`` summarizing the tick.
+
+Concurrency is guarded by an ``fcntl.flock`` on
+``.scout-state/.schedule-tick.lock``. A held lock causes the second
+tick to emit ``schedule.tick.skipped`` and exit cleanly.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import datetime as _dt
+import fcntl
+import json
+import os
+import socket
+import subprocess
+import time as _time
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from scout import paths
+from scout.events import Event, now_iso
+from scout.ids import new_ulid
+from scout.schedule import (
+    OnMissPolicy,
+    Schedule,
+    Slot,
+    SlotPriority,
+    SlotType,
+    load_default_schedule,
+    load_schedule,
+)
+
+# ----- module-level constants ---------------------------------------------
+
+NETWORK_PROBE_HOST = "api.anthropic.com"
+NETWORK_PROBE_PORT = 443
+NETWORK_PROBE_TIMEOUT_SECONDS = 3
+NETWORK_PROBE_RETRIES = 6
+NETWORK_PROBE_SLEEP_SECONDS = 5
+
+LOCK_FILENAME = ".schedule-tick.lock"
+TRACKER_FILENAME = "usage-tracker.jsonl"
+EVENT_LOG_PREFIX = "schedule-events-"
+
+
+# ----- data structures ----------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SlotCandidate:
+    """A slot whose target time has passed today (pre-policy classification)."""
+
+    slot_key: str
+    slot: Slot
+    target: _dt.datetime  # today's target as tz-aware datetime
+    last_fire: _dt.datetime | None  # tz-aware; None if never fired
+
+
+@dataclass(frozen=True)
+class Decision:
+    """Policy outcome for one slot this tick."""
+
+    action: str  # "fire" | "skip"
+    reason: str = ""  # populated on skip
+
+
+# ----- clock / locale seams -----------------------------------------------
+
+
+def _now() -> _dt.datetime:
+    """Return ``datetime.now()`` in the system's local timezone.
+
+    Module-level seam so tests can ``patch("scout.scripts.schedule_tick._now", ...)``.
+    """
+    tz_name = _local_tz_name()
+    tz: _dt.tzinfo
+    try:
+        tz = ZoneInfo(tz_name)
+    except ZoneInfoNotFoundError:
+        tz = _dt.UTC
+    return _dt.datetime.now(tz=tz)
+
+
+def _local_tz_name() -> str:
+    """Best-effort read of the system's local IANA zone.
+
+    Reads the ``/etc/localtime`` symlink target (the convention on macOS and
+    most Linux distros). Falls back to ``UTC`` if the symlink is missing or
+    points somewhere unrecognized.
+    """
+    localtime = Path("/etc/localtime")
+    if localtime.is_symlink():
+        target = os.readlink(localtime)
+        # Typical: /var/db/timezone/zoneinfo/America/New_York or
+        # /usr/share/zoneinfo/America/New_York. Take the trailing
+        # area/zone segments.
+        marker = "zoneinfo/"
+        if marker in target:
+            return target.split(marker, 1)[1]
+    return "UTC"
+
+
+# ----- tracker (usage-tracker.jsonl) reading ------------------------------
+
+
+def _parse_iso_z(ts: str) -> _dt.datetime:
+    """Parse an ISO 8601 string with optional ``Z`` suffix into a tz-aware datetime."""
+    if ts.endswith("Z"):
+        ts = ts[:-1] + "+00:00"
+    return _dt.datetime.fromisoformat(ts)
+
+
+def _read_last_fire_index(tracker_path: Path) -> dict[str, _dt.datetime]:
+    """Build a per-slot ``last_fire_ts`` index from the usage tracker JSONL.
+
+    Returns a dict keyed by ``scout_mode`` (the slot key) → most recent
+    fire timestamp seen in the file. Robust to malformed rows: a JSON
+    decode error or missing field skips that row silently.
+    """
+    if not tracker_path.exists():
+        return {}
+    out: dict[str, _dt.datetime] = {}
+    with tracker_path.open("r", encoding="utf-8") as f:
+        for raw_line in f:
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(row, dict):
+                continue
+            slot_key = row.get("scout_mode")
+            ts_str = row.get("ts")
+            if not slot_key or not ts_str or not isinstance(ts_str, str):
+                continue
+            try:
+                ts = _parse_iso_z(ts_str)
+            except ValueError:
+                continue
+            prev = out.get(slot_key)
+            if prev is None or ts > prev:
+                out[slot_key] = ts
+    return out
+
+
+def _record_fire(tracker_path: Path, slot_key: str, slot: Slot, now: _dt.datetime) -> None:
+    """Append a JSONL row to the usage tracker recording this slot's fire.
+
+    Schema is compatible with ``scout.hooks.session_tokens`` writes — both
+    write ``ts`` (UTC ISO), ``type``, and ``scout_mode``. The dispatcher
+    writes the bare minimum; later session_tokens entries enrich the same
+    file with token usage.
+    """
+    tracker_path.parent.mkdir(parents=True, exist_ok=True)
+    row = {
+        "ts": now.astimezone(_dt.UTC).strftime("%Y-%m-%dT%H:%M:%S.")
+        + f"{now.astimezone(_dt.UTC).microsecond // 1000:03d}Z",
+        "type": slot.type.value,
+        "scout_mode": slot_key,
+        "source": "schedule.tick",
+    }
+    with tracker_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(row) + "\n")
+
+
+# ----- candidate computation ----------------------------------------------
+
+
+def _weekday_name(dt: _dt.datetime) -> str:
+    return ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"][dt.weekday()]
+
+
+def _compute_due_slots(
+    schedule: Schedule,
+    last_fire: dict[str, _dt.datetime],
+    now: _dt.datetime,
+) -> list[SlotCandidate]:
+    """Return slots whose target has passed today and aren't blocked by cooldown."""
+    candidates: list[SlotCandidate] = []
+    for key, slot in schedule.items():
+        target = slot.target_today(now=now)
+        if target is None:
+            continue  # weekday excluded
+        if target > now:
+            continue  # target in the future
+        prev_fire = last_fire.get(key)
+        # Cooldown: don't fire if last fire is within cooldown_minutes.
+        if prev_fire is not None and slot.cooldown_minutes > 0:
+            cooldown = _dt.timedelta(minutes=slot.cooldown_minutes)
+            if now - prev_fire < cooldown:
+                continue
+        # Already fired today (last_fire >= today's target) → not a candidate.
+        if prev_fire is not None and prev_fire >= target:
+            continue
+        candidates.append(SlotCandidate(slot_key=key, slot=slot, target=target, last_fire=prev_fire))
+    return candidates
+
+
+def candidates_by_key(
+    candidates: Iterable[SlotCandidate],
+) -> dict[str, SlotCandidate]:
+    """Index a sequence of candidates by their slot_key."""
+    return {c.slot_key: c for c in candidates}
+
+
+# ----- on_miss / collapse policy ------------------------------------------
+
+
+def _apply_miss_rules(candidates: list[SlotCandidate], *, now: _dt.datetime) -> dict[str, Decision]:
+    """Apply per-slot ``on_miss`` policy and collapse-within-type semantics.
+
+    Returns a dict ``slot_key -> Decision``. Decisions are either ``fire``
+    (the slot will be considered for the priority filter) or ``skip``
+    (carries a reason; the dispatcher will emit ``slot.skipped``).
+    """
+    if not candidates:
+        return {}
+
+    # Group collapse candidates by slot type so we can pick the latest target
+    # within each group.
+    by_type: dict[SlotType, list[SlotCandidate]] = {}
+    for c in candidates:
+        if c.slot.on_miss is OnMissPolicy.COLLAPSE:
+            by_type.setdefault(c.slot.type, []).append(c)
+
+    collapse_winner: dict[SlotType, str] = {}
+    for slot_type, group in by_type.items():
+        latest = max(group, key=lambda c: c.target)
+        collapse_winner[slot_type] = latest.slot_key
+
+    decisions: dict[str, Decision] = {}
+    for c in candidates:
+        policy = c.slot.on_miss
+        window = _dt.timedelta(hours=c.slot.missed_window_hours)
+        within_window = (now - c.target) <= window
+
+        if policy is OnMissPolicy.SKIP:
+            decisions[c.slot_key] = Decision(action="skip", reason="on_miss=skip")
+            continue
+
+        if policy is OnMissPolicy.FIRE:
+            if within_window:
+                decisions[c.slot_key] = Decision(action="fire")
+            else:
+                decisions[c.slot_key] = Decision(action="skip", reason="stale-after-window")
+            continue
+
+        if policy is OnMissPolicy.COLLAPSE:
+            winner_key = collapse_winner.get(c.slot.type)
+            if c.slot_key == winner_key:
+                if within_window:
+                    decisions[c.slot_key] = Decision(action="fire")
+                else:
+                    decisions[c.slot_key] = Decision(action="skip", reason="stale-after-window")
+            else:
+                decisions[c.slot_key] = Decision(
+                    action="skip",
+                    reason=f"collapsed-into={winner_key}",
+                )
+            continue
+
+        # Unreachable — exhaustive over OnMissPolicy.
+        decisions[c.slot_key] = Decision(action="skip", reason=f"unknown-policy={policy.value}")
+    return decisions
+
+
+# ----- priority filter ----------------------------------------------------
+
+
+def _filter_winner_by_priority(schedule: Schedule, decisions: dict[str, Decision]) -> str | None:
+    """Pick the single highest-priority slot among the fire decisions.
+
+    Priority order is hardcoded by slot type: briefing > consolidation >
+    dreaming > research > manual. Within a type tier, a stable tie-break
+    by slot_key keeps the choice deterministic. Returns ``None`` when no
+    slot has ``action == "fire"``.
+    """
+    fire_keys = [k for k, d in decisions.items() if d.action == "fire"]
+    if not fire_keys:
+        return None
+    fire_keys.sort(key=lambda k: (-int(schedule[k].priority), k))
+    return fire_keys[0]
+
+
+# ----- network readiness probe --------------------------------------------
+
+
+def _network_ready(
+    *,
+    host: str = NETWORK_PROBE_HOST,
+    port: int = NETWORK_PROBE_PORT,
+    timeout_seconds: float = NETWORK_PROBE_TIMEOUT_SECONDS,
+    retries: int = NETWORK_PROBE_RETRIES,
+    sleep_seconds: float = NETWORK_PROBE_SLEEP_SECONDS,
+) -> bool:
+    """TCP-probe the Anthropic API endpoint with retries.
+
+    Set ``SCOUT_SCHEDULE_TICK_SKIP_NETWORK_PROBE=1`` to short-circuit
+    (used by the bats parity test so it doesn't depend on real network).
+    """
+    if os.environ.get("SCOUT_SCHEDULE_TICK_SKIP_NETWORK_PROBE") == "1":
+        return True
+    attempts = max(1, int(retries))
+    for i in range(attempts):
+        try:
+            with socket.create_connection((host, port), timeout=timeout_seconds):
+                return True
+        except OSError:
+            pass
+        if i < attempts - 1 and sleep_seconds > 0:
+            _time.sleep(sleep_seconds)
+    return False
+
+
+# ----- runner spawn -------------------------------------------------------
+
+
+def _spawn_runner(vault: Path, slot_key: str, slot: Slot) -> int:
+    """Spawn the runner for ``slot_key``. Returns the child PID.
+
+    Raises ``FileNotFoundError`` if the runner script is missing — that
+    propagates from ``subprocess.Popen`` when the file does not exist on
+    disk. We deliberately do NOT pre-check existence so that mocked
+    Popen calls in tests still see the call.
+    """
+    runner_path = vault / slot.runner
+    env = os.environ.copy()
+    env["SCOUT_FORCE_MODE"] = slot_key
+    env["SCOUT_DATA_DIR"] = str(vault)
+    proc = subprocess.Popen(
+        [str(runner_path)],
+        cwd=str(vault),
+        env=env,
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return proc.pid
+
+
+# ----- event emission -----------------------------------------------------
+
+
+def _emit_event(
+    log_dir: Path,
+    *,
+    kind: str,
+    source: str,
+    payload: dict[str, Any],
+) -> Event:
+    """Append an event JSONL row and return the matching Event object.
+
+    The file name is ``schedule-events-<UTC-date>.jsonl`` — UTC-dated
+    intentionally (event timestamps are UTC; the file name follows).
+    """
+    log_dir.mkdir(parents=True, exist_ok=True)
+    ev = Event(
+        id=new_ulid(),
+        ts=now_iso(),
+        kind=kind,
+        source=source,
+        payload=payload,
+    )
+    utc_date = _dt.datetime.now(tz=_dt.UTC).date().isoformat()
+    log_path = log_dir / f"{EVENT_LOG_PREFIX}{utc_date}.jsonl"
+    row = {
+        "id": ev.id,
+        "ts": ev.ts,
+        "kind": ev.kind,
+        "source": ev.source,
+        "payload": ev.payload,
+    }
+    with log_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(row) + "\n")
+    return ev
+
+
+# ----- concurrency lock ---------------------------------------------------
+
+
+@contextlib.contextmanager
+def _try_lock(lock_path: Path) -> Iterator[bool]:
+    """Acquire an exclusive non-blocking flock on ``lock_path``.
+
+    Yields ``True`` if the lock was acquired (and releases it on exit),
+    ``False`` if another process is holding it.
+    """
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            yield False
+            return
+        try:
+            yield True
+        finally:
+            with contextlib.suppress(OSError):
+                fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(fd)
+
+
+# ----- main entry points --------------------------------------------------
+
+
+def _load_or_default(vault: Path) -> Schedule:
+    sched_path = vault / ".scout-state" / "schedule.yaml"
+    if sched_path.exists():
+        return load_schedule(sched_path)
+    return load_default_schedule()
+
+
+@dataclass
+class _TickResult:
+    fired: list[str] = field(default_factory=list)
+    skipped: list[dict[str, str]] = field(default_factory=list)
+    deferred: list[str] = field(default_factory=list)
+
+
+def run() -> Event:
+    """Run a single dispatch tick. Always returns an Event.
+
+    Possible return ``kind`` values:
+      - ``schedule.tick.completed`` — normal exit (regardless of whether a
+        slot fired).
+      - ``schedule.tick.skipped`` — concurrency lock was held by another
+        process; this tick exited without doing work.
+    """
+    started_at = _time.monotonic()
+    vault = paths.data_dir()
+    state = paths.state_dir(vault)
+    log_dir = paths.logs_dir(vault)
+    lock_path = state / LOCK_FILENAME
+    tracker_path = log_dir / TRACKER_FILENAME
+
+    with _try_lock(lock_path) as acquired:
+        if not acquired:
+            return _emit_event(
+                log_dir,
+                kind="schedule.tick.skipped",
+                source="schedule.tick",
+                payload={"reason": "lock_held"},
+            )
+        return _do_tick(
+            vault=vault,
+            log_dir=log_dir,
+            tracker_path=tracker_path,
+            started_at=started_at,
+        )
+
+
+def _do_tick(
+    *,
+    vault: Path,
+    log_dir: Path,
+    tracker_path: Path,
+    started_at: float,
+) -> Event:
+    schedule = _load_or_default(vault)
+    last_fire = _read_last_fire_index(tracker_path)
+    now = _now()
+
+    candidates = _compute_due_slots(schedule, last_fire, now)
+    decisions = _apply_miss_rules(candidates, now=now)
+
+    result = _TickResult()
+
+    # Pre-spawn network check — only when at least one slot would fire.
+    fire_keys_pre = [k for k, d in decisions.items() if d.action == "fire"]
+    if fire_keys_pre and not _network_ready():
+        for k in fire_keys_pre:
+            _emit_event(
+                log_dir,
+                kind="slot.skipped",
+                source="schedule.tick",
+                payload={
+                    "slot_key": k,
+                    "reason": "network-offline",
+                },
+            )
+            result.skipped.append({"slot_key": k, "reason": "network-offline"})
+        # Per the spec: do NOT mark them fired in the tracker; the next tick
+        # will re-evaluate. Emit other "skip" decisions then exit.
+        _emit_skip_decisions(log_dir, decisions, result, exclude=set(fire_keys_pre))
+        return _finalize_tick(log_dir, result, started_at=started_at)
+
+    # Emit non-fire skip decisions (skip / collapsed / stale).
+    _emit_skip_decisions(log_dir, decisions, result)
+
+    # Pick at most one winner by priority among the fire decisions.
+    winner_key = _filter_winner_by_priority(schedule, decisions)
+    fire_keys_remaining = [k for k, d in decisions.items() if d.action == "fire" and k != winner_key]
+    result.deferred.extend(fire_keys_remaining)
+
+    if winner_key is not None:
+        winner_slot = schedule[winner_key]
+        try:
+            pid = _spawn_runner(vault, winner_key, winner_slot)
+        except (FileNotFoundError, OSError) as exc:
+            _emit_event(
+                log_dir,
+                kind="slot.fire_failed",
+                source="schedule.tick",
+                payload={
+                    "slot_key": winner_key,
+                    "error": f"{type(exc).__name__}: {exc}",
+                },
+            )
+            result.skipped.append({"slot_key": winner_key, "reason": "fire_failed"})
+        else:
+            _record_fire(tracker_path, winner_key, winner_slot, now)
+            _emit_event(
+                log_dir,
+                kind="slot.fired",
+                source="schedule.tick",
+                payload={
+                    "slot_key": winner_key,
+                    "type": winner_slot.type.value,
+                    "pid": pid,
+                    "target": _candidate_target_iso(candidates, winner_key),
+                },
+            )
+            result.fired.append(winner_key)
+
+    return _finalize_tick(log_dir, result, started_at=started_at)
+
+
+def _candidate_target_iso(candidates: list[SlotCandidate], slot_key: str) -> str | None:
+    for c in candidates:
+        if c.slot_key == slot_key:
+            return c.target.isoformat()
+    return None
+
+
+def _emit_skip_decisions(
+    log_dir: Path,
+    decisions: dict[str, Decision],
+    result: _TickResult,
+    *,
+    exclude: set[str] | None = None,
+) -> None:
+    """Emit ``slot.skipped`` events for every Decision with action='skip'."""
+    excluded = exclude or set()
+    for k, d in decisions.items():
+        if d.action != "skip" or k in excluded:
+            continue
+        _emit_event(
+            log_dir,
+            kind="slot.skipped",
+            source="schedule.tick",
+            payload={
+                "slot_key": k,
+                "reason": d.reason,
+            },
+        )
+        result.skipped.append({"slot_key": k, "reason": d.reason})
+
+
+def _finalize_tick(log_dir: Path, result: _TickResult, *, started_at: float) -> Event:
+    duration_ms = int((_time.monotonic() - started_at) * 1000)
+    return _emit_event(
+        log_dir,
+        kind="schedule.tick.completed",
+        source="schedule.tick",
+        payload={
+            "fired": list(result.fired),
+            "skipped": list(result.skipped),
+            "deferred": list(result.deferred),
+            "duration_ms": duration_ms,
+        },
+    )
+
+
+def fire_now(slot_key: str) -> Event:
+    """Manually fire a slot, bypassing the dispatcher's policy logic.
+
+    Acquires the same lock as ``run()`` so a manual fire and a tick can't
+    race. Used by Scout.app's "Run now" buttons via
+    ``scoutctl schedule fire-now <slot-key>``.
+    """
+    vault = paths.data_dir()
+    state = paths.state_dir(vault)
+    log_dir = paths.logs_dir(vault)
+    lock_path = state / LOCK_FILENAME
+    tracker_path = log_dir / TRACKER_FILENAME
+
+    with _try_lock(lock_path) as acquired:
+        if not acquired:
+            return _emit_event(
+                log_dir,
+                kind="slot.fire_failed",
+                source="schedule.fire-now",
+                payload={
+                    "slot_key": slot_key,
+                    "error": "lock_held",
+                },
+            )
+        schedule = _load_or_default(vault)
+        if slot_key not in schedule:
+            return _emit_event(
+                log_dir,
+                kind="slot.fire_failed",
+                source="schedule.fire-now",
+                payload={
+                    "slot_key": slot_key,
+                    "error": f"unknown slot: {slot_key}",
+                },
+            )
+        slot = schedule[slot_key]
+        try:
+            pid = _spawn_runner(vault, slot_key, slot)
+        except (FileNotFoundError, OSError) as exc:
+            return _emit_event(
+                log_dir,
+                kind="slot.fire_failed",
+                source="schedule.fire-now",
+                payload={
+                    "slot_key": slot_key,
+                    "error": f"{type(exc).__name__}: {exc}",
+                },
+            )
+        now = _now()
+        _record_fire(tracker_path, slot_key, slot, now)
+        return _emit_event(
+            log_dir,
+            kind="slot.fired",
+            source="schedule.fire-now",
+            payload={
+                "slot_key": slot_key,
+                "type": slot.type.value,
+                "pid": pid,
+                "manual": True,
+            },
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns 0 on success, 1 on unhandled error."""
+    try:
+        run()
+    except Exception:
+        return 1
+    return 0
+
+
+__all__ = [
+    "Decision",
+    "SlotCandidate",
+    "SlotPriority",
+    "_apply_miss_rules",
+    "_compute_due_slots",
+    "_filter_winner_by_priority",
+    "_network_ready",
+    "_read_last_fire_index",
+    "candidates_by_key",
+    "fire_now",
+    "main",
+    "run",
+]

--- a/engine/scout/scripts/schedule_tick.py
+++ b/engine/scout/scripts/schedule_tick.py
@@ -63,7 +63,25 @@ NETWORK_PROBE_SLEEP_SECONDS = 5
 
 LOCK_FILENAME = ".schedule-tick.lock"
 TRACKER_FILENAME = "usage-tracker.jsonl"
+SESSION_TOKENS_FILENAME = "session-tokens.jsonl"
 EVENT_LOG_PREFIX = "schedule-events-"
+
+# Mode-name rename map applied when reading legacy session-tokens.jsonl rows.
+# Ships in Plan 5 to bridge pre-rename JSONL data through to post-rename slot
+# keys. Once Task 7's tools/migrate-mode-names.py runs against the live vault,
+# the rename will be persisted and this map becomes idempotent (old names
+# already rewritten). Kept in code so the dispatcher works even if
+# migrate-mode-names hasn't been run yet.
+_LEGACY_MODE_RENAME: dict[str, str] = {
+    "consolidation-11am": "morning-consolidation",
+    "consolidation-1pm": "midday-consolidation",
+    "consolidation-5pm": "afternoon-consolidation",
+    "consolidation-7pm": "evening-consolidation",
+    "dreaming-nightly-10pm": "dreaming-nightly",
+    "dreaming-weekend-6am": "dreaming-weekend-morning",
+    "dreaming-weekend-7am": "dreaming-weekend-morning",
+    # morning-briefing, weekend-briefing, manual unchanged.
+}
 
 
 # ----- data structures ----------------------------------------------------
@@ -134,37 +152,53 @@ def _parse_iso_z(ts: str) -> _dt.datetime:
 
 
 def _read_last_fire_index(tracker_path: Path) -> dict[str, _dt.datetime]:
-    """Build a per-slot ``last_fire_ts`` index from the usage tracker JSONL.
+    """Build a ``{slot_key: latest_ts}`` index from the run-tracker JSONL files.
 
-    Returns a dict keyed by ``scout_mode`` (the slot key) → most recent
-    fire timestamp seen in the file. Robust to malformed rows: a JSON
-    decode error or missing field skips that row silently.
+    Reads BOTH ``usage-tracker.jsonl`` (Plan 4-supplement-era; rows from
+    write-session-cost.sh / heartbeat.sh / budget-check.sh that may lack
+    ``scout_mode``) AND ``session-tokens.jsonl`` (Plan 4 hook; has
+    ``scout_mode`` populated, but with the OLD mode names that we rename
+    inline via ``_LEGACY_MODE_RENAME``).
+
+    Robust to malformed rows: a JSON decode error or missing field skips
+    that row silently. Rows that lack a usable slot key (legacy
+    budget/heartbeat entries with no ``scout_mode``) are silently dropped
+    — they don't carry slot identity.
     """
-    if not tracker_path.exists():
-        return {}
     out: dict[str, _dt.datetime] = {}
-    with tracker_path.open("r", encoding="utf-8") as f:
-        for raw_line in f:
-            line = raw_line.strip()
-            if not line:
-                continue
-            try:
-                row = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if not isinstance(row, dict):
-                continue
-            slot_key = row.get("scout_mode")
-            ts_str = row.get("ts")
-            if not slot_key or not ts_str or not isinstance(ts_str, str):
-                continue
-            try:
-                ts = _parse_iso_z(ts_str)
-            except ValueError:
-                continue
-            prev = out.get(slot_key)
-            if prev is None or ts > prev:
-                out[slot_key] = ts
+    log_dir = tracker_path.parent
+    candidates = [tracker_path, log_dir / SESSION_TOKENS_FILENAME]
+    for path in candidates:
+        if not path.exists():
+            continue
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                for raw_line in f:
+                    line = raw_line.strip()
+                    if not line:
+                        continue
+                    try:
+                        row = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(row, dict):
+                        continue
+                    raw_key = row.get("scout_mode") or row.get("slot_key")
+                    if not isinstance(raw_key, str) or not raw_key:
+                        continue
+                    slot_key = _LEGACY_MODE_RENAME.get(raw_key, raw_key)
+                    ts_str = row.get("ts")
+                    if not isinstance(ts_str, str) or not ts_str:
+                        continue
+                    try:
+                        ts = _parse_iso_z(ts_str)
+                    except ValueError:
+                        continue
+                    prev = out.get(slot_key)
+                    if prev is None or ts > prev:
+                        out[slot_key] = ts
+        except OSError:
+            continue
     return out
 
 
@@ -357,6 +391,7 @@ def _spawn_runner(vault: Path, slot_key: str, slot: Slot) -> int:
         cwd=str(vault),
         env=env,
         start_new_session=True,
+        stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
@@ -377,6 +412,10 @@ def _emit_event(
 
     The file name is ``schedule-events-<UTC-date>.jsonl`` — UTC-dated
     intentionally (event timestamps are UTC; the file name follows).
+
+    The UTC date is derived from ``_now()`` (not ``datetime.now``) so that
+    a single ``patch("scout.scripts.schedule_tick._now", ...)`` in tests
+    sets both the event clock and the file name consistently.
     """
     log_dir.mkdir(parents=True, exist_ok=True)
     ev = Event(
@@ -386,7 +425,7 @@ def _emit_event(
         source=source,
         payload=payload,
     )
-    utc_date = _dt.datetime.now(tz=_dt.UTC).date().isoformat()
+    utc_date = _now().astimezone(_dt.UTC).date().isoformat()
     log_path = log_dir / f"{EVENT_LOG_PREFIX}{utc_date}.jsonl"
     row = {
         "id": ev.id,
@@ -466,7 +505,7 @@ def run() -> Event:
             return _emit_event(
                 log_dir,
                 kind="schedule.tick.skipped",
-                source="schedule.tick",
+                source="cli:schedule_tick",
                 payload={"reason": "lock_held"},
             )
         return _do_tick(
@@ -489,6 +528,7 @@ def _do_tick(
     now = _now()
 
     candidates = _compute_due_slots(schedule, last_fire, now)
+    cand_index = candidates_by_key(candidates)
     decisions = _apply_miss_rules(candidates, now=now)
 
     result = _TickResult()
@@ -500,20 +540,17 @@ def _do_tick(
             _emit_event(
                 log_dir,
                 kind="slot.skipped",
-                source="schedule.tick",
-                payload={
-                    "slot_key": k,
-                    "reason": "network-offline",
-                },
+                source="cli:schedule_tick",
+                payload=_skipped_payload(cand_index, k, "network-offline"),
             )
             result.skipped.append({"slot_key": k, "reason": "network-offline"})
         # Per the spec: do NOT mark them fired in the tracker; the next tick
         # will re-evaluate. Emit other "skip" decisions then exit.
-        _emit_skip_decisions(log_dir, decisions, result, exclude=set(fire_keys_pre))
+        _emit_skip_decisions(log_dir, decisions, cand_index, result, exclude=set(fire_keys_pre))
         return _finalize_tick(log_dir, result, started_at=started_at)
 
     # Emit non-fire skip decisions (skip / collapsed / stale).
-    _emit_skip_decisions(log_dir, decisions, result)
+    _emit_skip_decisions(log_dir, decisions, cand_index, result)
 
     # Pick at most one winner by priority among the fire decisions.
     winner_key = _filter_winner_by_priority(schedule, decisions)
@@ -522,15 +559,18 @@ def _do_tick(
 
     if winner_key is not None:
         winner_slot = schedule[winner_key]
+        winner_target = cand_index[winner_key].target
         try:
             pid = _spawn_runner(vault, winner_key, winner_slot)
         except (FileNotFoundError, OSError) as exc:
             _emit_event(
                 log_dir,
                 kind="slot.fire_failed",
-                source="schedule.tick",
+                source="cli:schedule_tick",
                 payload={
                     "slot_key": winner_key,
+                    "slot_type": winner_slot.type.value,
+                    "target_local": winner_target.isoformat(),
                     "error": f"{type(exc).__name__}: {exc}",
                 },
             )
@@ -540,12 +580,14 @@ def _do_tick(
             _emit_event(
                 log_dir,
                 kind="slot.fired",
-                source="schedule.tick",
+                source="cli:schedule_tick",
                 payload={
                     "slot_key": winner_key,
-                    "type": winner_slot.type.value,
-                    "pid": pid,
-                    "target": _candidate_target_iso(candidates, winner_key),
+                    "slot_type": winner_slot.type.value,
+                    "target_local": winner_target.isoformat(),
+                    "target_utc": _target_utc_iso(winner_target),
+                    "runner": winner_slot.runner,
+                    "pid_spawned": pid,
                 },
             )
             result.fired.append(winner_key)
@@ -560,9 +602,30 @@ def _candidate_target_iso(candidates: list[SlotCandidate], slot_key: str) -> str
     return None
 
 
+def _target_utc_iso(target: _dt.datetime) -> str:
+    """Render a tz-aware target datetime as a UTC ISO string with ``Z`` suffix."""
+    utc = target.astimezone(_dt.UTC)
+    return utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _skipped_payload(
+    cand_index: dict[str, SlotCandidate],
+    slot_key: str,
+    reason: str,
+) -> dict[str, Any]:
+    """Build a v0.5+ spec-compliant ``slot.skipped`` payload."""
+    payload: dict[str, Any] = {"slot_key": slot_key, "reason": reason}
+    cand = cand_index.get(slot_key)
+    if cand is not None:
+        payload["slot_type"] = cand.slot.type.value
+        payload["target_local"] = cand.target.isoformat()
+    return payload
+
+
 def _emit_skip_decisions(
     log_dir: Path,
     decisions: dict[str, Decision],
+    cand_index: dict[str, SlotCandidate],
     result: _TickResult,
     *,
     exclude: set[str] | None = None,
@@ -575,11 +638,8 @@ def _emit_skip_decisions(
         _emit_event(
             log_dir,
             kind="slot.skipped",
-            source="schedule.tick",
-            payload={
-                "slot_key": k,
-                "reason": d.reason,
-            },
+            source="cli:schedule_tick",
+            payload=_skipped_payload(cand_index, k, d.reason),
         )
         result.skipped.append({"slot_key": k, "reason": d.reason})
 
@@ -589,7 +649,7 @@ def _finalize_tick(log_dir: Path, result: _TickResult, *, started_at: float) -> 
     return _emit_event(
         log_dir,
         kind="schedule.tick.completed",
-        source="schedule.tick",
+        source="cli:schedule_tick",
         payload={
             "fired": list(result.fired),
             "skipped": list(result.skipped),
@@ -617,7 +677,7 @@ def fire_now(slot_key: str) -> Event:
             return _emit_event(
                 log_dir,
                 kind="slot.fire_failed",
-                source="schedule.fire-now",
+                source="cli:schedule_fire_now",
                 payload={
                     "slot_key": slot_key,
                     "error": "lock_held",
@@ -628,35 +688,45 @@ def fire_now(slot_key: str) -> Event:
             return _emit_event(
                 log_dir,
                 kind="slot.fire_failed",
-                source="schedule.fire-now",
+                source="cli:schedule_fire_now",
                 payload={
                     "slot_key": slot_key,
                     "error": f"unknown slot: {slot_key}",
                 },
             )
         slot = schedule[slot_key]
+        now = _now()
+        # Manual fire-now uses "now" as the effective target for payload
+        # purposes — the spec's target_local/target_utc fields describe
+        # when the fire happened, and a manual fire has no scheduled target.
+        target_local = now.isoformat()
+        target_utc = _target_utc_iso(now)
         try:
             pid = _spawn_runner(vault, slot_key, slot)
         except (FileNotFoundError, OSError) as exc:
             return _emit_event(
                 log_dir,
                 kind="slot.fire_failed",
-                source="schedule.fire-now",
+                source="cli:schedule_fire_now",
                 payload={
                     "slot_key": slot_key,
+                    "slot_type": slot.type.value,
+                    "target_local": target_local,
                     "error": f"{type(exc).__name__}: {exc}",
                 },
             )
-        now = _now()
         _record_fire(tracker_path, slot_key, slot, now)
         return _emit_event(
             log_dir,
             kind="slot.fired",
-            source="schedule.fire-now",
+            source="cli:schedule_fire_now",
             payload={
                 "slot_key": slot_key,
-                "type": slot.type.value,
-                "pid": pid,
+                "slot_type": slot.type.value,
+                "target_local": target_local,
+                "target_utc": target_utc,
+                "runner": slot.runner,
+                "pid_spawned": pid,
                 "manual": True,
             },
         )

--- a/engine/tests/fixtures/connector-calls-pre-rename.jsonl
+++ b/engine/tests/fixtures/connector-calls-pre-rename.jsonl
@@ -1,0 +1,5 @@
+{"ts":"2026-04-30T15:03:01Z","session_id":"a1","mode":"consolidation-11am","tool":"Bash","connector":"github","error":false}
+{"ts":"2026-04-30T17:03:02Z","session_id":"a2","mode":"consolidation-1pm","tool":"Bash","connector":"github","error":false}
+{"ts":"2026-04-30T21:03:03Z","session_id":"a3","mode":"consolidation-5pm","tool":"Bash","connector":"github","error":false}
+{"ts":"2026-04-30T23:00:04Z","session_id":"a4","mode":"consolidation-7pm","tool":"Bash","connector":"github","error":false}
+{"ts":"2026-04-30T12:00:05Z","session_id":"a5","mode":"morning-briefing","tool":"Bash","connector":"github","error":false}

--- a/engine/tests/fixtures/schedule-default.yaml
+++ b/engine/tests/fixtures/schedule-default.yaml
@@ -1,0 +1,11 @@
+schema_version: 1
+
+slots:
+  morning-briefing:
+    type: briefing
+    runner: run-scout.sh
+    fires_at_local: "08:00"
+    weekdays: [Mon, Tue, Wed, Thu, Fri]
+    missed_window_hours: 4
+    on_miss: fire
+    cooldown_minutes: 60

--- a/engine/tests/fixtures/schedule-edge-cases.yaml
+++ b/engine/tests/fixtures/schedule-edge-cases.yaml
@@ -1,0 +1,11 @@
+schema_version: 1
+
+slots:
+  bad-slot:
+    type: not-real-type
+    runner: run-scout.sh
+    fires_at_local: "08:00"
+    weekdays: [Mon]
+    missed_window_hours: 4
+    on_miss: fire
+    cooldown_minutes: 60

--- a/engine/tests/integration/test_schedule_tick_e2e.py
+++ b/engine/tests/integration/test_schedule_tick_e2e.py
@@ -1,0 +1,72 @@
+"""Integration test: full tick against a tmp_path vault + fake clock."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+from scout.scripts.schedule_tick import run as tick_run
+
+
+def test_e2e_tick_fires_briefing_on_monday_morning(tmp_path, monkeypatch):
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    state = tmp_path / ".scout-state"
+    state.mkdir()
+    (tmp_path / ".scout-logs").mkdir()
+    sched = state / "schedule.yaml"
+    sched.write_text(
+        "schema_version: 1\nslots:\n  morning-briefing:\n"
+        "    type: briefing\n    runner: run-scout.sh\n    fires_at_local: '08:00'\n"
+        "    weekdays: [Mon, Tue, Wed, Thu, Fri]\n"
+        "    missed_window_hours: 4\n    on_miss: fire\n    cooldown_minutes: 60\n"
+    )
+    et = ZoneInfo("America/New_York")
+    fake_now = datetime(2026, 5, 11, 8, 5, tzinfo=et)
+    with (
+        patch("scout.scripts.schedule_tick._now", return_value=fake_now),
+        patch("scout.scripts.schedule_tick._network_ready", return_value=True),
+        patch("scout.scripts.schedule_tick.subprocess.Popen") as mock_popen,
+    ):
+        mock_popen.return_value.pid = 12345
+        ev = tick_run()
+    args, kwargs = mock_popen.call_args
+    env = kwargs["env"]
+    assert env["SCOUT_FORCE_MODE"] == "morning-briefing"
+    assert ev.kind == "schedule.tick.completed"
+    assert "morning-briefing" in (ev.payload or {}).get("fired", [])
+
+
+def test_e2e_tick_handles_wake_from_sleep_with_priority_winner(tmp_path, monkeypatch):
+    """Wake at 3pm Mon after closed-laptop morning. Briefing wins on priority."""
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    state = tmp_path / ".scout-state"
+    state.mkdir()
+    (tmp_path / ".scout-logs").mkdir()
+    sched = state / "schedule.yaml"
+    sched.write_text(
+        "schema_version: 1\nslots:\n"
+        "  morning-briefing:\n"
+        "    type: briefing\n    runner: run-scout.sh\n    fires_at_local: '08:00'\n"
+        "    weekdays: [Mon, Tue, Wed, Thu, Fri]\n"
+        "    missed_window_hours: 8\n    on_miss: fire\n    cooldown_minutes: 60\n"
+        "  morning-consolidation:\n"
+        "    type: consolidation\n    runner: run-scout.sh\n    fires_at_local: '11:00'\n"
+        "    weekdays: [Mon, Tue, Wed, Thu, Fri]\n"
+        "    missed_window_hours: 8\n    on_miss: collapse\n    cooldown_minutes: 90\n"
+    )
+    et = ZoneInfo("America/New_York")
+    fake_now = datetime(2026, 5, 11, 15, 0, tzinfo=et)
+    with (
+        patch("scout.scripts.schedule_tick._now", return_value=fake_now),
+        patch("scout.scripts.schedule_tick._network_ready", return_value=True),
+        patch("scout.scripts.schedule_tick.subprocess.Popen") as mock_popen,
+    ):
+        mock_popen.return_value.pid = 99
+        ev = tick_run()
+    assert mock_popen.call_count == 1
+    args, kwargs = mock_popen.call_args
+    assert kwargs["env"]["SCOUT_FORCE_MODE"] == "morning-briefing"
+    assert "morning-briefing" in (ev.payload or {}).get("fired", [])
+    assert "morning-consolidation" not in (ev.payload or {}).get("fired", [])
+    assert "morning-consolidation" not in (ev.payload or {}).get("skipped", [])

--- a/engine/tests/parity/test_schedule_tick_parity.bats
+++ b/engine/tests/parity/test_schedule_tick_parity.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+
+# Transitional parity test for `scoutctl schedule tick`.
+#
+# Limitation: the dispatcher only fires a slot when "now" matches an
+# allowed weekday and "now" is past the slot's fires_at_local time. If
+# this bats run happens on a weekend or before 08:00 ET, the test will
+# silently pass (no slot.fired event in the log, but no failure either —
+# the grep for slot.fired below is the only assertion that requires a
+# fire). For a deterministic test we rely on the Python unit/integration
+# suites; this bats run is a smoke test that the real CLI command exists
+# and writes events when it would naturally fire.
+
+setup() {
+    SCOUT_DATA_DIR=$(mktemp -d)
+    export SCOUT_DATA_DIR
+    PYTHON_TICK="$HOME/scout-plugin/.venv/bin/scoutctl"
+    if [ ! -x "$PYTHON_TICK" ]; then
+        skip "scoutctl not at expected path"
+    fi
+    mkdir -p "$SCOUT_DATA_DIR/.scout-state" "$SCOUT_DATA_DIR/.scout-logs"
+    cat > "$SCOUT_DATA_DIR/.scout-state/schedule.yaml" <<EOF
+schema_version: 1
+slots:
+  morning-briefing:
+    type: briefing
+    runner: run-scout.sh
+    fires_at_local: "08:00"
+    weekdays: [Mon, Tue, Wed, Thu, Fri]
+    missed_window_hours: 4
+    on_miss: fire
+    cooldown_minutes: 60
+EOF
+    cat > "$SCOUT_DATA_DIR/run-scout.sh" <<EOF
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$SCOUT_DATA_DIR/run-scout.sh"
+}
+
+teardown() {
+    rm -rf "$SCOUT_DATA_DIR"
+}
+
+@test "tick fires briefing when schedule says it should and tracker is empty" {
+    SCOUT_SCHEDULE_TICK_SKIP_NETWORK_PROBE=1 \
+        "$PYTHON_TICK" schedule tick
+
+    # The schedule-events JSONL should contain a slot.fired event for morning-briefing.
+    # If now is before 08:00 ET on a weekday or it is the weekend, the dispatcher
+    # correctly does NOT fire — these grep failures are expected then. We accept
+    # that limitation in lieu of a fake-clock injection (see file header).
+    if grep -q '"kind": "schedule.tick.completed"' "$SCOUT_DATA_DIR/.scout-logs/schedule-events-"*.jsonl; then
+        :
+    else
+        echo "expected schedule.tick.completed event in event log"
+        return 1
+    fi
+}

--- a/engine/tests/unit/test_cli_schedule_subapp.py
+++ b/engine/tests/unit/test_cli_schedule_subapp.py
@@ -1,14 +1,19 @@
-"""CLI smoke tests for `scoutctl schedule {list,show,validate,init,reload}`."""
+"""CLI smoke tests for `scoutctl schedule {list,show,validate,init,reload,list-upcoming}`."""
 
 from __future__ import annotations
 
 import json
+from datetime import datetime
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 from typer.testing import CliRunner
 
 from scout.cli import app
 
 runner = CliRunner()
+
+_ET = ZoneInfo("America/New_York")
 
 
 def test_schedule_list_shows_all_default_slots():
@@ -76,3 +81,111 @@ def test_schedule_reload_succeeds():
     result = runner.invoke(app, ["schedule", "reload"])
     assert result.exit_code == 0
     assert "reloaded" in result.stdout.lower()
+
+
+# ---------------------------------------------------------------------------
+# list-upcoming tests
+# ---------------------------------------------------------------------------
+
+# Pin "now" to Mon 2026-05-04 07:00 ET — several slots fire later that day
+_FAKE_NOW = datetime(2026, 5, 4, 7, 0, 0, tzinfo=_ET)
+
+
+def _invoke_list_upcoming(*extra_args: str):
+    """Helper: invoke list-upcoming with a pinned 'now' and default 24h window."""
+    with patch("scout.schedule.datetime") as _:
+        # We patch at the CLI level: monkeypatch the datetime.now call inside
+        # the command by patching the imported name directly.
+        pass
+    # Actually invoke without patching datetime — the test just checks shape;
+    # real time is fine since the command always returns valid future slots.
+    return runner.invoke(app, ["schedule", "list-upcoming", *extra_args])
+
+
+def test_list_upcoming_exits_zero():
+    result = runner.invoke(app, ["schedule", "list-upcoming"])
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+
+
+def test_list_upcoming_json_is_array():
+    result = runner.invoke(app, ["schedule", "list-upcoming", "--json"])
+    assert result.exit_code == 0, result.stdout
+    records = json.loads(result.stdout)
+    assert isinstance(records, list)
+
+
+def test_list_upcoming_json_has_required_fields():
+    result = runner.invoke(app, ["schedule", "list-upcoming", "--json"])
+    assert result.exit_code == 0
+    records = json.loads(result.stdout)
+    # With a 24h window there should be at least some slots (defaults fire daily)
+    # We just need at least one to validate shape; but if zero, still assert schema.
+    for rec in records:
+        assert "slot_key" in rec
+        assert "slot_type" in rec
+        assert "scheduled_at_local" in rec
+        assert "scheduled_at_utc" in rec
+
+
+def test_list_upcoming_json_slot_type_values_are_valid():
+    result = runner.invoke(app, ["schedule", "list-upcoming", "--json"])
+    assert result.exit_code == 0
+    records = json.loads(result.stdout)
+    valid_types = {"briefing", "consolidation", "dreaming", "research", "manual"}
+    for rec in records:
+        assert rec["slot_type"] in valid_types
+
+
+def test_list_upcoming_json_sorted_alphabetically_by_slot_key():
+    result = runner.invoke(app, ["schedule", "list-upcoming", "--json"])
+    assert result.exit_code == 0
+    records = json.loads(result.stdout)
+    keys = [r["slot_key"] for r in records]
+    assert keys == sorted(keys), f"Expected alphabetical order, got: {keys}"
+
+
+def test_list_upcoming_window_zero_returns_empty_array():
+    """A zero-hour window should return no upcoming slots."""
+    result = runner.invoke(app, ["schedule", "list-upcoming", "--window", "0"])
+    assert result.exit_code == 0
+    records = json.loads(result.stdout)
+    assert records == []
+
+
+def test_list_upcoming_large_window_returns_all_slots():
+    """With a 200h window (~8 days), all 10 default slots should appear."""
+    result = runner.invoke(app, ["schedule", "list-upcoming", "--window", "200"])
+    assert result.exit_code == 0
+    records = json.loads(result.stdout)
+    keys = {r["slot_key"] for r in records}
+    expected_keys = {
+        "morning-briefing",
+        "weekend-briefing",
+        "morning-consolidation",
+        "midday-consolidation",
+        "afternoon-consolidation",
+        "evening-consolidation",
+        "dreaming-evening",
+        "dreaming-nightly",
+        "dreaming-weekend-morning",
+        "research",
+    }
+    assert keys == expected_keys
+
+
+def test_list_upcoming_no_json_emits_tab_separated_lines():
+    """--no-json should emit tab-separated lines (not JSON)."""
+    result = runner.invoke(app, ["schedule", "list-upcoming", "--window", "200", "--no-json"])
+    assert result.exit_code == 0
+    # Should NOT be parseable as JSON array
+    output = result.stdout.strip()
+    if output:
+        # At least one line; each should have tab separators
+        first_line = output.splitlines()[0]
+        parts = first_line.split("\t")
+        assert len(parts) == 3, f"Expected 3 tab-separated fields, got: {parts}"
+        slot_key, slot_type, scheduled_at_local = parts
+        assert slot_key  # non-empty
+        assert slot_type in {"briefing", "consolidation", "dreaming", "research", "manual"}
+        # scheduled_at_local should look like an ISO datetime
+        assert "T" in scheduled_at_local or ":" in scheduled_at_local

--- a/engine/tests/unit/test_cli_schedule_subapp.py
+++ b/engine/tests/unit/test_cli_schedule_subapp.py
@@ -1,0 +1,78 @@
+"""CLI smoke tests for `scoutctl schedule {list,show,validate,init,reload}`."""
+
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from scout.cli import app
+
+runner = CliRunner()
+
+
+def test_schedule_list_shows_all_default_slots():
+    result = runner.invoke(app, ["schedule", "list"])
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert "morning-briefing" in result.stdout
+    assert "morning-consolidation" in result.stdout
+    assert "dreaming-evening" in result.stdout
+    assert "research" in result.stdout
+
+
+def test_schedule_show_single_slot_returns_full_record():
+    result = runner.invoke(app, ["schedule", "show", "morning-briefing"])
+    assert result.exit_code == 0, result.stdout + result.stderr
+    record = json.loads(result.stdout)
+    assert record["key"] == "morning-briefing"
+    assert record["type"] == "briefing"
+    assert record["fires_at_local"] == "08:00"
+    assert record["on_miss"] == "fire"
+
+
+def test_schedule_show_unknown_slot_exits_nonzero():
+    result = runner.invoke(app, ["schedule", "show", "no-such-slot"])
+    assert result.exit_code != 0
+    assert "no-such-slot" in (result.stdout + result.stderr)
+
+
+def test_schedule_validate_returns_zero_on_default():
+    result = runner.invoke(app, ["schedule", "validate"])
+    assert result.exit_code == 0, result.stdout + result.stderr
+
+
+def test_schedule_init_writes_vault_yaml(tmp_path, monkeypatch):
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    result = runner.invoke(app, ["schedule", "init"])
+    assert result.exit_code == 0, result.stdout + result.stderr
+    written = tmp_path / ".scout-state" / "schedule.yaml"
+    assert written.exists()
+    assert "morning-briefing" in written.read_text()
+
+
+def test_schedule_init_refuses_to_overwrite_existing_without_force(tmp_path, monkeypatch):
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    target = tmp_path / ".scout-state" / "schedule.yaml"
+    target.parent.mkdir(parents=True)
+    target.write_text("# existing user content\n")
+    result = runner.invoke(app, ["schedule", "init"])
+    assert result.exit_code != 0
+    assert "exists" in (result.stdout + result.stderr).lower()
+    # Existing content preserved.
+    assert target.read_text() == "# existing user content\n"
+
+
+def test_schedule_init_force_overwrites_existing(tmp_path, monkeypatch):
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    target = tmp_path / ".scout-state" / "schedule.yaml"
+    target.parent.mkdir(parents=True)
+    target.write_text("# old content\n")
+    result = runner.invoke(app, ["schedule", "init", "--force"])
+    assert result.exit_code == 0
+    assert "morning-briefing" in target.read_text()
+
+
+def test_schedule_reload_succeeds():
+    result = runner.invoke(app, ["schedule", "reload"])
+    assert result.exit_code == 0
+    assert "reloaded" in result.stdout.lower()

--- a/engine/tests/unit/test_cli_schedule_subapp.py
+++ b/engine/tests/unit/test_cli_schedule_subapp.py
@@ -3,17 +3,12 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
-from unittest.mock import patch
-from zoneinfo import ZoneInfo
 
 from typer.testing import CliRunner
 
 from scout.cli import app
 
 runner = CliRunner()
-
-_ET = ZoneInfo("America/New_York")
 
 
 def test_schedule_list_shows_all_default_slots():
@@ -86,20 +81,6 @@ def test_schedule_reload_succeeds():
 # ---------------------------------------------------------------------------
 # list-upcoming tests
 # ---------------------------------------------------------------------------
-
-# Pin "now" to Mon 2026-05-04 07:00 ET — several slots fire later that day
-_FAKE_NOW = datetime(2026, 5, 4, 7, 0, 0, tzinfo=_ET)
-
-
-def _invoke_list_upcoming(*extra_args: str):
-    """Helper: invoke list-upcoming with a pinned 'now' and default 24h window."""
-    with patch("scout.schedule.datetime") as _:
-        # We patch at the CLI level: monkeypatch the datetime.now call inside
-        # the command by patching the imported name directly.
-        pass
-    # Actually invoke without patching datetime — the test just checks shape;
-    # real time is fine since the command always returns valid future slots.
-    return runner.invoke(app, ["schedule", "list-upcoming", *extra_args])
 
 
 def test_list_upcoming_exits_zero():

--- a/engine/tests/unit/test_connectors_yaml.py
+++ b/engine/tests/unit/test_connectors_yaml.py
@@ -11,6 +11,7 @@ from scout.connectors import (
     Tier,
     load_registry,
 )
+from scout.schedule import SlotType
 
 
 def test_load_registry_returns_official_tier_seed():
@@ -42,28 +43,35 @@ def test_connector_fields_typed():
     assert Capability.OUTBOUND in slack.capabilities
 
 
-def test_required_in_all_means_every_mode_is_required():
+def test_slack_required_in_briefing_and_consolidation_types():
+    """Slack is required across the four operational slot types."""
     reg = load_registry()
     slack = reg["mcp:claude_ai_Slack"]
-    assert slack.required_in_mode("morning-briefing")
-    assert slack.required_in_mode("weekend-briefing")
-    assert slack.required_in_mode("consolidation-11am")
-    assert slack.required_in_mode("manual")
+    assert slack.required_in_type(SlotType.BRIEFING)
+    assert slack.required_in_type(SlotType.CONSOLIDATION)
+    assert slack.required_in_type(SlotType.DREAMING)
+    assert slack.required_in_type(SlotType.RESEARCH)
+    # Manual is never required for any connector.
+    assert not slack.required_in_type(SlotType.MANUAL)
 
 
-def test_required_in_specific_modes():
+def test_required_in_specific_types_granola_briefing_consolidation_only():
+    """Granola: briefing + consolidation only — never dreaming/research."""
     reg = load_registry()
     granola = reg["mcp:claude_ai_Granola"]
-    assert granola.required_in_mode("morning-briefing")
-    assert not granola.required_in_mode("weekend-briefing")
-    assert not granola.required_in_mode("weekend-manual")
+    assert granola.required_in_type(SlotType.BRIEFING)
+    assert granola.required_in_type(SlotType.CONSOLIDATION)
+    assert not granola.required_in_type(SlotType.DREAMING)
+    assert not granola.required_in_type(SlotType.RESEARCH)
 
 
-def test_required_in_empty_means_never_critical():
+def test_outbound_only_connector_required_in_no_type():
+    """Telegram is outbound-only — never required for any slot type."""
     reg = load_registry()
     tg = reg["notify:telegram"]
-    assert not tg.required_in_mode("morning-briefing")
-    assert not tg.required_in_mode("manual")
+    assert tg.required_in_types == ()
+    for st in SlotType:
+        assert not tg.required_in_type(st)
 
 
 def test_remediation_fields_under_180_chars():
@@ -75,12 +83,18 @@ def test_remediation_fields_under_180_chars():
         )
 
 
-def test_critical_connectors_filter():
+def test_critical_connectors_filter_by_slot_type():
     reg = load_registry()
-    critical = reg.critical_in_mode("morning-briefing")
+    critical = reg.critical_for_slot_type(SlotType.BRIEFING)
     assert "mcp:claude_ai_Slack" in critical
     assert "mcp:claude_ai_Granola" in critical
     assert "notify:telegram" not in critical  # outbound, never critical
+    # Dreaming requires a smaller set: Slack + Linear only.
+    dreaming_critical = reg.critical_for_slot_type(SlotType.DREAMING)
+    assert "mcp:claude_ai_Slack" in dreaming_critical
+    assert "mcp:claude_ai_Linear" in dreaming_critical
+    assert "mcp:claude_ai_Granola" not in dreaming_critical
+    assert "github" not in dreaming_critical  # gh used in research, not dreaming
 
 
 def test_unknown_connector_raises():

--- a/engine/tests/unit/test_install_schedule_plist.py
+++ b/engine/tests/unit/test_install_schedule_plist.py
@@ -1,0 +1,54 @@
+"""Unit tests for engine/scout/scripts/install_schedule_plist.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from scout.scripts.install_schedule_plist import install_plist, uninstall_plist
+
+
+def test_install_plist_writes_filled_template(tmp_path):
+    target_dir = tmp_path / "LaunchAgents"
+    target_dir.mkdir()
+    install_plist(home=tmp_path, agents_dir=target_dir)
+    written = target_dir / "com.scout.schedule-tick.plist"
+    assert written.exists()
+    content = written.read_text()
+    assert "__USER_HOME__" not in content  # placeholders filled
+    assert str(tmp_path) in content
+    assert "<integer>300</integer>" in content
+
+
+def test_install_plist_refuses_to_overwrite_without_force(tmp_path):
+    target_dir = tmp_path / "LaunchAgents"
+    target_dir.mkdir()
+    plist = target_dir / "com.scout.schedule-tick.plist"
+    plist.write_text("# existing\n")
+    with pytest.raises(FileExistsError):
+        install_plist(home=tmp_path, agents_dir=target_dir, force=False)
+    assert plist.read_text() == "# existing\n"
+
+
+def test_install_plist_force_overwrites(tmp_path):
+    target_dir = tmp_path / "LaunchAgents"
+    target_dir.mkdir()
+    plist = target_dir / "com.scout.schedule-tick.plist"
+    plist.write_text("# old\n")
+    install_plist(home=tmp_path, agents_dir=target_dir, force=True)
+    assert "<integer>300</integer>" in plist.read_text()
+
+
+def test_uninstall_plist_removes_file(tmp_path):
+    target_dir = tmp_path / "LaunchAgents"
+    target_dir.mkdir()
+    plist = target_dir / "com.scout.schedule-tick.plist"
+    plist.write_text("dummy\n")
+    uninstall_plist(agents_dir=target_dir)
+    assert not plist.exists()
+
+
+def test_uninstall_plist_silent_when_missing(tmp_path):
+    target_dir = tmp_path / "LaunchAgents"
+    target_dir.mkdir()
+    # No exception when target plist doesn't exist.
+    uninstall_plist(agents_dir=target_dir)

--- a/engine/tests/unit/test_install_wake_schedule.py
+++ b/engine/tests/unit/test_install_wake_schedule.py
@@ -1,0 +1,77 @@
+"""Unit tests for install_wake_schedule.py."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from scout.schedule import load_default_schedule
+from scout.scripts.install_wake_schedule import (
+    compute_earliest_weekday_slot,
+    install_wake_schedule,
+    uninstall_wake_schedule,
+)
+
+
+def test_compute_earliest_weekday_slot_filters_to_weekday_only():
+    sched = load_default_schedule()
+    slot = compute_earliest_weekday_slot(sched)
+    assert slot is not None
+    weekdays = set(slot.weekdays)
+    assert weekdays.intersection({"Mon", "Tue", "Wed", "Thu", "Fri"})
+    # Slots that are weekend-only must NOT be returned.
+    assert slot.key != "weekend-briefing"
+    assert slot.key != "dreaming-weekend-morning"
+
+
+def test_compute_earliest_weekday_slot_returns_morning_briefing_in_default():
+    sched = load_default_schedule()
+    slot = compute_earliest_weekday_slot(sched)
+    # Default schedule's earliest weekday slot is morning-briefing 08:00.
+    assert slot.key == "morning-briefing"
+    assert slot.fires_at_local == "08:00"
+
+
+def test_install_wake_schedule_invokes_pmset_repeat():
+    sched = load_default_schedule()
+    with patch("scout.scripts.install_wake_schedule.subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        install_wake_schedule(sched, dry_run=False)
+    args, kwargs = mock_run.call_args
+    cmd = args[0]
+    assert cmd[0] == "pmset"
+    assert "repeat" in cmd
+    assert "wakeorpoweron" in cmd
+    # MTWRF letter form for Mon-Fri.
+    assert "MTWRF" in cmd
+    # Hour:minute:second form.
+    assert "08:00:00" in cmd
+
+
+def test_install_wake_schedule_dry_run_doesnt_invoke_pmset():
+    sched = load_default_schedule()
+    with patch("scout.scripts.install_wake_schedule.subprocess.run") as mock_run:
+        result = install_wake_schedule(sched, dry_run=True)
+    mock_run.assert_not_called()
+    assert "dry-run" in result.lower()
+
+
+def test_install_wake_schedule_raises_when_pmset_fails():
+    sched = load_default_schedule()
+    with patch("scout.scripts.install_wake_schedule.subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stderr = "pmset: permission denied"
+        with pytest.raises(RuntimeError, match="permission denied"):
+            install_wake_schedule(sched, dry_run=False)
+
+
+def test_uninstall_wake_schedule_invokes_pmset_repeat_cancel():
+    with patch("scout.scripts.install_wake_schedule.subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        uninstall_wake_schedule()
+    args, kwargs = mock_run.call_args
+    cmd = args[0]
+    assert cmd[0] == "pmset"
+    assert "repeat" in cmd
+    assert "cancel" in cmd

--- a/engine/tests/unit/test_manifest.py
+++ b/engine/tests/unit/test_manifest.py
@@ -29,6 +29,7 @@ def test_build_manifest_exposes_known_features() -> None:
         "action_items_cli_v1",
         "kb_ontology_v1",
         "tui_v1",
+        "schedule_v2",
     }
     assert expected.issubset(m.features.keys())
 
@@ -89,7 +90,7 @@ def test_build_manifest_subcommands_sorted_for_stability() -> None:
 
 
 def test_action_items_kb_tui_features_enabled() -> None:
-    """Plan 2 lights these three; Plan 4 lights session_tokens + connector_health."""
+    """Plan 2 lights these three; Plan 4 lights session_tokens + connector_health; Plan 5 lights schedule_v2."""
     m = build_manifest()
     assert m.features["action_items_cli_v1"] is True
     assert m.features["kb_ontology_v1"] is True
@@ -97,3 +98,5 @@ def test_action_items_kb_tui_features_enabled() -> None:
     # Plan 4 lights these — flipped True after the connector subsystem + hooks port land.
     assert m.features["session_tokens_v1"] is True
     assert m.features["connector_health_v1"] is True
+    # Plan 5 lights this after schedule.yaml + dispatcher + scout-app refactor land.
+    assert m.features["schedule_v2"] is True

--- a/engine/tests/unit/test_migrate_mode_names.py
+++ b/engine/tests/unit/test_migrate_mode_names.py
@@ -1,0 +1,76 @@
+"""Unit tests for tools/migrate-mode-names.py."""
+
+from __future__ import annotations
+
+import importlib.util as _ilu
+import json
+import shutil
+import sys
+from pathlib import Path
+
+# Tools dir is outside the engine package; add to sys.path for import.
+TOOLS_DIR = Path(__file__).parent.parent.parent.parent / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+# Import the hyphen-named script via importlib (Python module names can't have
+# hyphens, but the script filename intentionally does).
+_spec = _ilu.spec_from_file_location("migrate_mode_names", TOOLS_DIR / "migrate-mode-names.py")
+assert _spec is not None and _spec.loader is not None
+migrate_mode_names = _ilu.module_from_spec(_spec)
+_spec.loader.exec_module(migrate_mode_names)
+
+MODE_RENAME_MAP = migrate_mode_names.MODE_RENAME_MAP
+migrate_jsonl_file = migrate_mode_names.migrate_jsonl_file
+migrate_data_dir = migrate_mode_names.migrate_data_dir
+
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+
+
+def test_mode_rename_map_covers_all_old_names():
+    expected = {
+        "consolidation-11am": "morning-consolidation",
+        "consolidation-1pm": "midday-consolidation",
+        "consolidation-5pm": "afternoon-consolidation",
+        "consolidation-7pm": "evening-consolidation",
+        "dreaming-nightly-10pm": "dreaming-nightly",
+        "dreaming-weekend-6am": "dreaming-weekend-morning",
+        "dreaming-weekend-7am": "dreaming-weekend-morning",
+        # Unchanged: morning-briefing, weekend-briefing, manual.
+    }
+    for old, new in expected.items():
+        assert MODE_RENAME_MAP[old] == new
+
+
+def test_migrate_jsonl_rewrites_mode_field(tmp_path):
+    src = tmp_path / "connector-calls-2026-04-30.jsonl"
+    shutil.copy(FIXTURES / "connector-calls-pre-rename.jsonl", src)
+    n_changed = migrate_jsonl_file(src, mode_field="mode")
+    assert n_changed == 4  # 4 of 5 lines had old names; morning-briefing unchanged
+    rows = [json.loads(line) for line in src.read_text().splitlines() if line.strip()]
+    modes = [r["mode"] for r in rows]
+    assert "consolidation-11am" not in modes
+    assert "morning-consolidation" in modes
+    assert "morning-briefing" in modes
+
+
+def test_migrate_jsonl_is_idempotent(tmp_path):
+    src = tmp_path / "connector-calls-2026-04-30.jsonl"
+    shutil.copy(FIXTURES / "connector-calls-pre-rename.jsonl", src)
+    migrate_jsonl_file(src, mode_field="mode")
+    n_changed_second_pass = migrate_jsonl_file(src, mode_field="mode")
+    assert n_changed_second_pass == 0
+
+
+def test_migrate_data_dir_creates_backup(tmp_path):
+    log_dir = tmp_path / ".scout-logs"
+    log_dir.mkdir()
+    shutil.copy(
+        FIXTURES / "connector-calls-pre-rename.jsonl",
+        log_dir / "connector-calls-2026-04-30.jsonl",
+    )
+    migrate_data_dir(tmp_path)
+    backup = log_dir / ".pre-plan-5-backup" / "connector-calls-2026-04-30.jsonl"
+    assert backup.exists()
+    backup_rows = [json.loads(line) for line in backup.read_text().splitlines() if line.strip()]
+    assert any(r["mode"] == "consolidation-11am" for r in backup_rows)

--- a/engine/tests/unit/test_schedule_loader.py
+++ b/engine/tests/unit/test_schedule_loader.py
@@ -11,11 +11,13 @@ import pytest
 from scout.errors import ConfigError
 from scout.schedule import (
     OnMissPolicy,
+    Schedule,
     Slot,
     SlotPriority,
     SlotType,
     load_default_schedule,
     load_schedule,
+    next_fires,
 )
 
 FIXTURES = Path(__file__).parent.parent / "fixtures"
@@ -288,3 +290,191 @@ def test_overlay_path_layered_on_seed_when_present(tmp_path, monkeypatch):
     sched = load_schedule(canonical, overlay=overlay)
     assert sched["morning-briefing"].fires_at_local == "07:00"
     assert sched["morning-briefing"].on_miss == OnMissPolicy.FIRE  # inherited
+
+
+# ---------------------------------------------------------------------------
+# next_fires() — forward-looking next-fire computation
+# ---------------------------------------------------------------------------
+
+_ET = ZoneInfo("America/New_York")
+
+
+def _make_schedule(slots: dict[str, Slot]) -> Schedule:
+    return Schedule(slots)
+
+
+def _make_slot(
+    key: str,
+    fires_at: str,
+    weekdays: list[str],
+    slot_type: SlotType = SlotType.BRIEFING,
+    tz: str | None = None,
+) -> Slot:
+    return Slot(
+        key=key,
+        type=slot_type,
+        runner="run-scout.sh",
+        fires_at_local=fires_at,
+        weekdays=tuple(weekdays),
+        missed_window_hours=4,
+        on_miss=OnMissPolicy.FIRE,
+        cooldown_minutes=60,
+        budget_usd=None,
+        tz=tz,
+    )
+
+
+def test_next_fires_today_slot_still_ahead():
+    """A slot that fires later today should appear in the results."""
+    # Mon 2026-05-04 06:00 ET — morning-briefing fires at 08:00
+    now = datetime(2026, 5, 4, 6, 0, tzinfo=_ET)
+    slot = _make_slot("morning-briefing", "08:00", ["Mon", "Tue", "Wed", "Thu", "Fri"])
+    sched = _make_schedule({"morning-briefing": slot})
+    results = next_fires(sched, now=now, window_hours=24)
+    assert len(results) == 1
+    key, fire_dt = results[0]
+    assert key == "morning-briefing"
+    assert fire_dt.hour == 8
+    assert fire_dt.minute == 0
+    assert fire_dt > now
+
+
+def test_next_fires_today_slot_already_past_gives_tomorrow():
+    """A slot whose today-target has already passed rolls to tomorrow."""
+    # Mon 2026-05-04 10:00 ET — morning-briefing was at 08:00 (already past)
+    now = datetime(2026, 5, 4, 10, 0, tzinfo=_ET)
+    slot = _make_slot("morning-briefing", "08:00", ["Mon", "Tue", "Wed", "Thu", "Fri"])
+    sched = _make_schedule({"morning-briefing": slot})
+    # 24-hour window: includes tomorrow Tue 08:00 (24h from Mon 10:00 is Tue 10:00)
+    results = next_fires(sched, now=now, window_hours=24)
+    assert len(results) == 1
+    key, fire_dt = results[0]
+    assert key == "morning-briefing"
+    # Tomorrow is Tuesday 08:00 — within the 24h window
+    assert fire_dt.weekday() == 1  # Tuesday
+    assert fire_dt.hour == 8
+
+
+def test_next_fires_weekday_filter_skips_non_matching_days():
+    """Slots with weekday exclusions should skip excluded days."""
+    # Saturday 2026-05-09 06:00 ET — morning-briefing only fires Mon-Fri
+    now = datetime(2026, 5, 9, 6, 0, tzinfo=_ET)
+    slot = _make_slot("morning-briefing", "08:00", ["Mon", "Tue", "Wed", "Thu", "Fri"])
+    sched = _make_schedule({"morning-briefing": slot})
+    # Next Mon is 2026-05-11 08:00; that's ~50h away — beyond a 24h window
+    results = next_fires(sched, now=now, window_hours=24)
+    assert results == []
+
+
+def test_next_fires_multi_day_skip_finds_next_matching_weekday():
+    """If next matching weekday is 2 days out, the result reflects that."""
+    # Friday 2026-05-08 20:00 ET — weekend-briefing fires Sat/Sun at 08:30
+    now = datetime(2026, 5, 8, 20, 0, tzinfo=_ET)
+    slot = _make_slot("weekend-briefing", "08:30", ["Sat", "Sun"])
+    sched = _make_schedule({"weekend-briefing": slot})
+    # Sat 08:30 is ~12.5h ahead — within a 24h window
+    results = next_fires(sched, now=now, window_hours=24)
+    assert len(results) == 1
+    key, fire_dt = results[0]
+    assert key == "weekend-briefing"
+    assert fire_dt.weekday() == 5  # Saturday
+    assert fire_dt.hour == 8
+    assert fire_dt.minute == 30
+
+
+def test_next_fires_window_cutoff_excludes_slots_beyond_window():
+    """Slots whose next fire is beyond the window should be excluded."""
+    # Mon 2026-05-04 09:00 ET — slot fires at 08:00 weekdays (already past)
+    # Next fire is Tue 08:00 = 23h ahead — within 24h window
+    # But if window is 12h it falls outside.
+    now = datetime(2026, 5, 4, 9, 0, tzinfo=_ET)
+    slot = _make_slot("morning-briefing", "08:00", ["Mon", "Tue", "Wed", "Thu", "Fri"])
+    sched = _make_schedule({"morning-briefing": slot})
+    # 12h window: now + 12h = Mon 21:00; Tue 08:00 is beyond that
+    results = next_fires(sched, now=now, window_hours=12)
+    assert results == []
+
+
+def test_next_fires_slot_tz_override_honored():
+    """Per-slot tz override should be used when computing next fire."""
+    # now is Mon 2026-05-04 07:00 ET (= 04:00 PT)
+    # Slot fires at 08:00 PT (= 11:00 ET) on weekdays
+    now = datetime(2026, 5, 4, 7, 0, tzinfo=_ET)
+    slot = _make_slot(
+        "pacific-standup",
+        "08:00",
+        ["Mon", "Tue", "Wed", "Thu", "Fri"],
+        tz="America/Los_Angeles",
+    )
+    sched = _make_schedule({"pacific-standup": slot})
+    results = next_fires(sched, now=now, window_hours=24)
+    assert len(results) == 1
+    key, fire_dt = results[0]
+    assert key == "pacific-standup"
+    # Should be 08:00 PT on Mon
+    assert fire_dt.tzinfo == ZoneInfo("America/Los_Angeles")
+    assert fire_dt.hour == 8
+    # In ET terms: 08:00 PT = 11:00 ET, which is ahead of 07:00 ET
+    et_equiv = fire_dt.astimezone(_ET)
+    assert et_equiv.hour == 11
+    assert fire_dt > now
+
+
+def test_next_fires_mixed_tz_schedule_returns_both_in_order():
+    """Two slots with different tz overrides should both appear, sorted by fire time."""
+    # now Mon 2026-05-04 05:00 ET
+    now = datetime(2026, 5, 4, 5, 0, tzinfo=_ET)
+    et_slot = _make_slot("et-slot", "08:00", ["Mon", "Tue", "Wed", "Thu", "Fri"])
+    pt_slot = _make_slot(
+        "pt-slot",
+        "08:00",
+        ["Mon", "Tue", "Wed", "Thu", "Fri"],
+        tz="America/Los_Angeles",
+    )
+    sched = _make_schedule({"et-slot": et_slot, "pt-slot": pt_slot})
+    results = next_fires(sched, now=now, window_hours=24)
+    assert len(results) == 2
+    keys = [k for k, _ in results]
+    # et-slot fires at 08:00 ET, pt-slot at 08:00 PT = 11:00 ET → et-slot is first
+    assert keys[0] == "et-slot"
+    assert keys[1] == "pt-slot"
+    # Check chronological order
+    assert results[0][1] < results[1][1]
+
+
+def test_next_fires_empty_schedule_returns_empty_list():
+    """Empty schedule should return an empty list, not raise."""
+    sched = _make_schedule({})
+    now = datetime(2026, 5, 4, 9, 0, tzinfo=_ET)
+    results = next_fires(sched, now=now, window_hours=24)
+    assert results == []
+
+
+def test_next_fires_single_slot_precision():
+    """Verify exact datetime values are correct for a known slot/now pair."""
+    # Mon 2026-05-04 07:30:00 ET — slot fires 08:00 ET
+    now = datetime(2026, 5, 4, 7, 30, 0, tzinfo=_ET)
+    slot = _make_slot("morning-briefing", "08:00", ["Mon", "Tue", "Wed", "Thu", "Fri"])
+    sched = _make_schedule({"morning-briefing": slot})
+    results = next_fires(sched, now=now, window_hours=24)
+    assert len(results) == 1
+    _, fire_dt = results[0]
+    expected = datetime(2026, 5, 4, 8, 0, 0, tzinfo=_ET)
+    assert fire_dt == expected
+
+
+def test_next_fires_default_schedule_returns_slots_within_24h():
+    """Smoke test against the real default schedule — should return >=1 slot for most times."""
+    # Mon 2026-05-04 07:00 ET — several slots should be in the next 24 hours
+    now = datetime(2026, 5, 4, 7, 0, tzinfo=_ET)
+    sched = load_default_schedule()
+    results = next_fires(sched, now=now, window_hours=24)
+    # Morning briefing (08:00), consolidations (11, 13, 17, 19), research (14),
+    # dreaming-evening (18:30), dreaming-nightly (22) are all ahead of 07:00
+    assert len(results) >= 5
+    # All returned fire times should be strictly in the future
+    for _, fire_dt in results:
+        assert fire_dt > now
+    # Results should be in chronological order
+    fire_times = [fire_dt for _, fire_dt in results]
+    assert fire_times == sorted(fire_times)

--- a/engine/tests/unit/test_schedule_loader.py
+++ b/engine/tests/unit/test_schedule_loader.py
@@ -184,6 +184,88 @@ def test_schedule_get_priority_for_slot_type():
     assert morning.priority > consolidation.priority
 
 
+def test_by_type_filters_to_matching_slot_type():
+    sched = load_default_schedule()
+    briefings = sched.by_type(SlotType.BRIEFING)
+    assert len(briefings) == 2  # morning-briefing + weekend-briefing
+    assert all(s.type == SlotType.BRIEFING for s in briefings)
+    consolidations = sched.by_type(SlotType.CONSOLIDATION)
+    assert len(consolidations) == 4  # morning/midday/afternoon/evening
+    assert sched.by_type(SlotType.MANUAL) == []
+
+
+def test_missed_window_hours_must_be_positive(tmp_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(
+        "schema_version: 1\n"
+        "slots:\n"
+        "  bad-slot:\n"
+        "    type: briefing\n"
+        "    runner: run-scout.sh\n"
+        "    fires_at_local: '08:00'\n"
+        "    weekdays: [Mon]\n"
+        "    missed_window_hours: 0\n"
+        "    on_miss: fire\n"
+        "    cooldown_minutes: 60\n"
+    )
+    with pytest.raises(ConfigError, match="missed_window_hours"):
+        load_schedule(bad)
+
+
+def test_negative_cooldown_minutes_raises(tmp_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(
+        "schema_version: 1\n"
+        "slots:\n"
+        "  bad-slot:\n"
+        "    type: briefing\n"
+        "    runner: run-scout.sh\n"
+        "    fires_at_local: '08:00'\n"
+        "    weekdays: [Mon]\n"
+        "    missed_window_hours: 4\n"
+        "    on_miss: fire\n"
+        "    cooldown_minutes: -5\n"
+    )
+    with pytest.raises(ConfigError, match="cooldown_minutes"):
+        load_schedule(bad)
+
+
+def test_unknown_schema_version_raises(tmp_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(
+        "schema_version: 999\n"
+        "slots:\n"
+        "  any-slot:\n"
+        "    type: briefing\n"
+        "    runner: run-scout.sh\n"
+        "    fires_at_local: '08:00'\n"
+        "    weekdays: [Mon]\n"
+        "    missed_window_hours: 4\n"
+        "    on_miss: fire\n"
+        "    cooldown_minutes: 60\n"
+    )
+    with pytest.raises(ConfigError, match="schema_version"):
+        load_schedule(bad)
+
+
+def test_empty_runner_raises(tmp_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(
+        "schema_version: 1\n"
+        "slots:\n"
+        "  bad-slot:\n"
+        "    type: briefing\n"
+        "    runner: ''\n"
+        "    fires_at_local: '08:00'\n"
+        "    weekdays: [Mon]\n"
+        "    missed_window_hours: 4\n"
+        "    on_miss: fire\n"
+        "    cooldown_minutes: 60\n"
+    )
+    with pytest.raises(ConfigError, match="runner"):
+        load_schedule(bad)
+
+
 def test_overlay_path_layered_on_seed_when_present(tmp_path, monkeypatch):
     """If <vault>/.scout-state/schedule.local.yaml exists, layer on top of the canonical."""
     canonical = tmp_path / "schedule.yaml"

--- a/engine/tests/unit/test_schedule_loader.py
+++ b/engine/tests/unit/test_schedule_loader.py
@@ -1,0 +1,208 @@
+"""Unit tests for scout.schedule — YAML loader + slot semantics."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from scout.errors import ConfigError
+from scout.schedule import (
+    OnMissPolicy,
+    Slot,
+    SlotPriority,
+    SlotType,
+    load_default_schedule,
+    load_schedule,
+)
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+
+
+def test_load_default_schedule_returns_jordan_default_slots():
+    sched = load_default_schedule()
+    keys = set(sched.keys())
+    # The 10 slot keys shipped in engine/scout/defaults/schedule.yaml.
+    assert keys >= {
+        "morning-briefing",
+        "weekend-briefing",
+        "morning-consolidation",
+        "midday-consolidation",
+        "afternoon-consolidation",
+        "evening-consolidation",
+        "dreaming-evening",
+        "dreaming-nightly",
+        "dreaming-weekend-morning",
+        "research",
+    }
+
+
+def test_slot_dataclass_has_typed_fields():
+    sched = load_default_schedule()
+    morning = sched["morning-briefing"]
+    assert isinstance(morning, Slot)
+    assert morning.type == SlotType.BRIEFING
+    assert morning.fires_at_local == "08:00"
+    assert "Mon" in morning.weekdays
+    assert morning.on_miss == OnMissPolicy.FIRE
+    assert morning.cooldown_minutes == 60
+    assert morning.runner == "run-scout.sh"
+    assert morning.budget_usd is None  # optional; absent in default
+    assert morning.tz is None  # absent → system local
+
+
+def test_slot_priority_order_is_briefing_consolidation_dreaming_research_manual():
+    assert SlotPriority.BRIEFING.value > SlotPriority.CONSOLIDATION.value
+    assert SlotPriority.CONSOLIDATION.value > SlotPriority.DREAMING.value
+    assert SlotPriority.DREAMING.value > SlotPriority.RESEARCH.value
+    assert SlotPriority.RESEARCH.value > SlotPriority.MANUAL.value
+
+
+def test_load_schedule_from_explicit_path():
+    sched = load_schedule(FIXTURES / "schedule-default.yaml")
+    assert "morning-briefing" in sched
+
+
+def test_unknown_slot_type_raises():
+    overlay = FIXTURES / "schedule-edge-cases.yaml"
+    # File has slot with `type: not-real-type`.
+    with pytest.raises(ConfigError, match="not-real-type"):
+        load_schedule(overlay)
+
+
+def test_invalid_fires_at_local_format_raises(tmp_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(
+        "schema_version: 1\n"
+        "slots:\n"
+        "  bad-slot:\n"
+        "    type: briefing\n"
+        "    runner: run-scout.sh\n"
+        "    fires_at_local: '25:99'\n"  # invalid hour
+        "    weekdays: [Mon]\n"
+        "    missed_window_hours: 4\n"
+        "    on_miss: fire\n"
+        "    cooldown_minutes: 60\n"
+    )
+    with pytest.raises(ConfigError, match="fires_at_local"):
+        load_schedule(bad)
+
+
+def test_invalid_weekday_raises(tmp_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(
+        "schema_version: 1\n"
+        "slots:\n"
+        "  bad-slot:\n"
+        "    type: briefing\n"
+        "    runner: run-scout.sh\n"
+        "    fires_at_local: '08:00'\n"
+        "    weekdays: [Funday]\n"  # not a valid weekday
+        "    missed_window_hours: 4\n"
+        "    on_miss: fire\n"
+        "    cooldown_minutes: 60\n"
+    )
+    with pytest.raises(ConfigError, match="weekday"):
+        load_schedule(bad)
+
+
+def test_empty_weekdays_raises(tmp_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(
+        "schema_version: 1\n"
+        "slots:\n"
+        "  bad-slot:\n"
+        "    type: briefing\n"
+        "    runner: run-scout.sh\n"
+        "    fires_at_local: '08:00'\n"
+        "    weekdays: []\n"  # empty
+        "    missed_window_hours: 4\n"
+        "    on_miss: fire\n"
+        "    cooldown_minutes: 60\n"
+    )
+    with pytest.raises(ConfigError, match="weekday"):
+        load_schedule(bad)
+
+
+def test_slot_target_today_in_system_local_tz_when_no_override():
+    sched = load_default_schedule()
+    morning = sched["morning-briefing"]
+    # 'Now' set to a specific datetime in local tz; target_today should match.
+    fake_now = datetime(2026, 5, 11, 6, 0, tzinfo=ZoneInfo("America/New_York"))  # Mon 6am EDT
+    target = morning.target_today(now=fake_now)
+    assert target.tzinfo is not None
+    assert target.hour == 8
+    assert target.minute == 0
+    assert target.weekday() == 0  # Monday
+
+
+def test_slot_target_today_honors_per_slot_tz_override(tmp_path):
+    bad_or_explicit = tmp_path / "with-tz.yaml"
+    bad_or_explicit.write_text(
+        "schema_version: 1\n"
+        "slots:\n"
+        "  pacific-standup:\n"
+        "    type: briefing\n"
+        "    runner: run-scout.sh\n"
+        "    fires_at_local: '08:00'\n"
+        "    weekdays: [Mon, Tue, Wed, Thu, Fri]\n"
+        "    missed_window_hours: 4\n"
+        "    on_miss: fire\n"
+        "    cooldown_minutes: 60\n"
+        "    tz: America/Los_Angeles\n"
+    )
+    sched = load_schedule(bad_or_explicit)
+    pac = sched["pacific-standup"]
+    fake_now = datetime(2026, 5, 11, 14, 0, tzinfo=ZoneInfo("Europe/Prague"))  # 2pm Prague
+    target = pac.target_today(now=fake_now)
+    # Same wall-clock day; 8am Pacific = different absolute time than 8am Prague.
+    assert target.tzinfo == ZoneInfo("America/Los_Angeles")
+    assert target.hour == 8
+
+
+def test_slot_target_today_returns_none_when_weekday_doesnt_match():
+    sched = load_default_schedule()
+    weekend = sched["weekend-briefing"]
+    fake_now = datetime(2026, 5, 11, 6, 0, tzinfo=ZoneInfo("America/New_York"))  # Monday
+    assert weekend.target_today(now=fake_now) is None
+
+
+def test_schedule_keys_iter_lookup_contains():
+    sched = load_default_schedule()
+    keys = list(sched.keys())
+    assert "morning-briefing" in keys
+    assert "morning-briefing" in sched
+    assert sched["morning-briefing"].type == SlotType.BRIEFING
+
+
+def test_schedule_get_priority_for_slot_type():
+    sched = load_default_schedule()
+    morning = sched["morning-briefing"]
+    consolidation = sched["morning-consolidation"]
+    assert morning.priority > consolidation.priority
+
+
+def test_overlay_path_layered_on_seed_when_present(tmp_path, monkeypatch):
+    """If <vault>/.scout-state/schedule.local.yaml exists, layer on top of the canonical."""
+    canonical = tmp_path / "schedule.yaml"
+    canonical.write_text(
+        "schema_version: 1\n"
+        "slots:\n"
+        "  morning-briefing:\n"
+        "    type: briefing\n"
+        "    runner: run-scout.sh\n"
+        "    fires_at_local: '08:00'\n"
+        "    weekdays: [Mon, Tue, Wed, Thu, Fri]\n"
+        "    missed_window_hours: 4\n"
+        "    on_miss: fire\n"
+        "    cooldown_minutes: 60\n"
+    )
+    overlay = tmp_path / "schedule.local.yaml"
+    overlay.write_text(
+        "slots:\n  morning-briefing:\n    fires_at_local: '07:00'\n"  # override only this field
+    )
+    sched = load_schedule(canonical, overlay=overlay)
+    assert sched["morning-briefing"].fires_at_local == "07:00"
+    assert sched["morning-briefing"].on_miss == OnMissPolicy.FIRE  # inherited

--- a/engine/tests/unit/test_schedule_snapshot.py
+++ b/engine/tests/unit/test_schedule_snapshot.py
@@ -1,0 +1,336 @@
+"""Unit tests for scout.scripts.schedule_snapshot.
+
+Plan 5 Task 8 — JSON snapshot of the default schedule registry, consumed by
+scout-app's schedule strip UI + dispatcher behavior labeling.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from scout.scripts import schedule_snapshot as snap
+
+# ----- helpers --------------------------------------------------------------
+
+_EXPECTED_SLOT_KEYS = [
+    "morning-briefing",
+    "weekend-briefing",
+    "morning-consolidation",
+    "midday-consolidation",
+    "afternoon-consolidation",
+    "evening-consolidation",
+    "dreaming-evening",
+    "dreaming-nightly",
+    "dreaming-weekend-morning",
+    "research",
+]
+
+_EXPECTED_SLOT_FIELDS = {"key", "type", "runner", "fires_at_local", "weekdays", "on_miss"}
+
+
+def _yaml_slot_keys() -> list[str]:
+    """Read schedule.yaml directly to confirm insertion order.
+
+    Tests must NOT trust scout.schedule with the same logic the snapshot
+    uses — read raw YAML so a bug in either layer fails the test, not both.
+    """
+    import yaml
+
+    yaml_path = Path(__file__).resolve().parents[2] / "scout" / "defaults" / "schedule.yaml"
+    with yaml_path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    return list(data["slots"].keys())
+
+
+# ----- tests ----------------------------------------------------------------
+
+
+def test_build_snapshot_has_v1_schema_and_all_slots():
+    s = snap.build_snapshot()
+    assert s["schema_version"] == 1
+    assert "generated_from" in s
+    assert s["generated_from"].startswith("scout-plugin@")
+    assert isinstance(s["slots"], list)
+    keys = [slot["key"] for slot in s["slots"]]
+    assert keys == _yaml_slot_keys()
+
+
+def test_build_snapshot_contains_all_10_slots():
+    """Lock in the exact 10-slot roster that scout-app must reflect."""
+    s = snap.build_snapshot()
+    keys = [slot["key"] for slot in s["slots"]]
+    assert len(s["slots"]) == 10
+    assert keys == _EXPECTED_SLOT_KEYS
+
+
+def test_build_snapshot_slot_field_shape():
+    """Each slot record must have exactly the 6 fields in the v1 contract.
+
+    The snapshot is intentionally lean: key, type, runner, fires_at_local,
+    weekdays, on_miss. Dispatcher-internal fields (missed_window_hours,
+    cooldown_minutes, budget_usd, tz) are excluded.
+    """
+    s = snap.build_snapshot()
+    for slot in s["slots"]:
+        assert set(slot.keys()) == _EXPECTED_SLOT_FIELDS, f"slot {slot['key']} has wrong fields: {set(slot.keys())}"
+
+
+def test_build_snapshot_slot_field_types():
+    """Spot-check value types for a sample slot (morning-briefing)."""
+    s = snap.build_snapshot()
+    mb = next(sl for sl in s["slots"] if sl["key"] == "morning-briefing")
+    assert isinstance(mb["key"], str)
+    assert isinstance(mb["type"], str)
+    assert isinstance(mb["runner"], str)
+    assert isinstance(mb["fires_at_local"], str)
+    assert isinstance(mb["weekdays"], list)
+    assert isinstance(mb["on_miss"], str)
+    # Weekdays should be a list of strings
+    assert all(isinstance(d, str) for d in mb["weekdays"])
+    # fires_at_local should be HH:MM format
+    assert len(mb["fires_at_local"]) == 5
+    assert mb["fires_at_local"][2] == ":"
+
+
+def test_build_snapshot_preserves_yaml_insertion_order():
+    """Order is YAML insertion order — a YAML reorder shows up as drift."""
+    s = snap.build_snapshot()
+    keys = [slot["key"] for slot in s["slots"]]
+    assert keys[0] == "morning-briefing"
+    assert keys[-1] == "research"
+    assert keys == _yaml_slot_keys()
+
+
+def test_build_snapshot_enum_values_are_strings():
+    """SlotType and OnMissPolicy enums must be serialized to their .value strings."""
+    s = snap.build_snapshot()
+    for slot in s["slots"]:
+        # type and on_miss come from enums; must be plain strings in the JSON
+        assert slot["type"] in {"briefing", "consolidation", "dreaming", "research", "manual"}
+        assert slot["on_miss"] in {"fire", "skip", "collapse"}
+
+
+def test_serialize_is_idempotent(tmp_path):
+    """Writing twice produces byte-identical output (the SHA stays the same
+    within one git state, so no false drift)."""
+    target = tmp_path / "snap.json"
+    text1 = snap.write_snapshot(target)
+    text2 = snap.write_snapshot(target)
+    assert text1 == text2
+    assert target.read_text(encoding="utf-8") == text1
+
+
+def test_serialize_format_indent_two_with_trailing_newline():
+    """Stable serialization: indent=2, terminating newline. Both writer and
+    --check rely on this exact format for byte comparisons."""
+    s = snap.build_snapshot()
+    text = snap.serialize(s)
+    assert text.endswith("\n")
+    # Spot-check indent: the second line should start with two spaces.
+    assert text.split("\n")[1].startswith('  "')
+
+
+def test_check_snapshot_passes_when_on_disk_matches(tmp_path):
+    target = tmp_path / "snap.json"
+    snap.write_snapshot(target)
+    ok, diff = snap.check_snapshot(target)
+    assert ok is True
+    assert diff == ""
+
+
+def test_check_snapshot_fails_with_diff_when_on_disk_differs(tmp_path):
+    target = tmp_path / "snap.json"
+    snap.write_snapshot(target)
+    # Tamper: rewrite with a missing slot.
+    bad = json.loads(target.read_text())
+    bad["slots"] = bad["slots"][:-1]  # drop research
+    target.write_text(json.dumps(bad, indent=2) + "\n", encoding="utf-8")
+
+    ok, diff = snap.check_snapshot(target)
+    assert ok is False
+    assert "research" in diff
+    # Unified diff format.
+    assert "@@" in diff or "---" in diff
+
+
+def test_check_snapshot_fails_when_target_missing(tmp_path):
+    target = tmp_path / "does-not-exist.json"
+    ok, diff = snap.check_snapshot(target)
+    assert ok is False
+    assert "does not exist" in diff
+
+
+def test_check_snapshot_ignores_generated_from_sha_drift(tmp_path):
+    """Two writes from different SHAs should still match content-wise.
+
+    Reasoning: the snapshot is committed in scout-plugin AND scout-app at
+    different times. If --check fails the moment anyone advances HEAD, the
+    sync workflow is unworkable. We compare schema + slot list, not the
+    embedded SHA.
+    """
+    target = tmp_path / "snap.json"
+    snap.write_snapshot(target)
+    # Simulate the file being committed at an older SHA — rewrite the
+    # generated_from line by hand.
+    text = target.read_text(encoding="utf-8")
+    munged = text.replace('"scout-plugin@', '"scout-plugin@deadbee')
+    target.write_text(munged, encoding="utf-8")
+
+    ok, diff = snap.check_snapshot(target)
+    assert ok is True, f"unexpected drift in diff:\n{diff}"
+
+
+def test_generated_from_uses_short_sha_when_in_git_repo():
+    """The `generated_from` field surfaces the SHA so downstream consumers
+    can correlate snapshots back to the plugin's git history."""
+    s = snap.build_snapshot()
+    val = s["generated_from"]
+    assert val.startswith("scout-plugin@")
+    sha = val.split("@", 1)[1]
+    # Either a real short SHA (7-12 hex chars) or the unknown sentinel.
+    assert sha == "unknown" or (len(sha) >= 4 and all(c in "0123456789abcdef" for c in sha))
+
+
+def test_generated_from_falls_back_to_unknown_outside_git(tmp_path):
+    """If the repo lookup fails (not a git repo, no git binary), fall back to 'unknown'."""
+    s = snap.build_snapshot(repo_dir=tmp_path)
+    assert s["generated_from"] == "scout-plugin@unknown"
+
+
+def test_generated_from_falls_back_to_unknown_when_git_missing():
+    """If `git` binary is missing entirely, the helper still returns unknown."""
+    with patch.object(subprocess, "run", side_effect=FileNotFoundError("git")):
+        s = snap.build_snapshot()
+    assert s["generated_from"] == "scout-plugin@unknown"
+
+
+def test_main_writes_target_with_flag(tmp_path):
+    """The `--target` flag overrides the default path."""
+    target = tmp_path / "fixtures" / "snap.json"
+    rc = snap.main(["--target", str(target), "--no-also-write-app-fixture"])
+    assert rc == 0
+    assert target.exists()
+    parsed = json.loads(target.read_text())
+    assert parsed["schema_version"] == 1
+    assert len(parsed["slots"]) == 10
+
+
+def test_main_check_mode_returns_zero_when_in_sync(tmp_path):
+    target = tmp_path / "snap.json"
+    snap.write_snapshot(target)
+    rc = snap.main(["--target", str(target), "--check"])
+    assert rc == 0
+
+
+def test_main_check_mode_returns_one_on_drift(tmp_path):
+    target = tmp_path / "snap.json"
+    snap.write_snapshot(target)
+    # Rewrite with empty slots to force drift.
+    bad = json.loads(target.read_text())
+    bad["slots"] = []
+    target.write_text(json.dumps(bad, indent=2) + "\n", encoding="utf-8")
+
+    rc = snap.main(["--target", str(target), "--check"])
+    assert rc == 1
+
+
+def test_canonical_snapshot_path_points_at_engine_scout():
+    """The canonical snapshot lives at engine/scout/schedule.snapshot.json.
+    CI verifies this exact file with `--check`."""
+    canonical = snap.canonical_snapshot_path()
+    parts = canonical.parts
+    # Last three components must be engine/scout/schedule.snapshot.json.
+    assert parts[-3:] == ("engine", "scout", "schedule.snapshot.json")
+
+
+def test_app_fixture_snapshot_path_points_at_scout_app():
+    """The scout-app fixture path lives at
+    ~/scout-app/ScoutTests/Fixtures/schedule.snapshot.json."""
+    fixture = snap.app_fixture_snapshot_path()
+    parts = fixture.parts
+    assert parts[-4:] == (
+        "scout-app",
+        "ScoutTests",
+        "Fixtures",
+        "schedule.snapshot.json",
+    )
+
+
+def test_main_default_target_is_canonical_snapshot_path(tmp_path, monkeypatch):
+    """When --target is omitted, main() writes the canonical snapshot path.
+
+    Redirect the canonical helper to tmp_path so the test doesn't actually
+    touch the repo's committed snapshot.
+    """
+    fake_canonical = tmp_path / "engine" / "scout" / "schedule.snapshot.json"
+    monkeypatch.setattr(snap, "canonical_snapshot_path", lambda: fake_canonical)
+    # Disable the dual-write so we only assert on the primary path here.
+    rc = snap.main(["--no-also-write-app-fixture"])
+    assert rc == 0
+    assert fake_canonical.exists()
+
+
+def test_main_dual_writes_when_app_fixture_dir_exists(tmp_path, monkeypatch):
+    """Default behavior: writing to --target ALSO writes to the scout-app
+    bundled fixture (best-effort) so a single invocation keeps both repos
+    in sync."""
+    fake_app_fixture = tmp_path / "scout-app" / "ScoutTests" / "Fixtures" / "schedule.snapshot.json"
+    fake_app_fixture.parent.mkdir(parents=True)
+    monkeypatch.setattr(snap, "app_fixture_snapshot_path", lambda: fake_app_fixture)
+
+    primary = tmp_path / "primary.json"
+    rc = snap.main(["--target", str(primary)])
+    assert rc == 0
+    assert primary.exists()
+    assert fake_app_fixture.exists()
+    # Both files should have identical content (same builder, same SHA).
+    assert primary.read_text(encoding="utf-8") == fake_app_fixture.read_text(encoding="utf-8")
+
+
+def test_main_skips_app_fixture_with_warning_when_dir_missing(tmp_path, monkeypatch, capsys):
+    """If the scout-app fixture parent doesn't exist, the dual-write is
+    skipped with a stderr warning rather than failing."""
+    bogus = tmp_path / "nonexistent-scout-app" / "Fixtures" / "schedule.snapshot.json"
+    monkeypatch.setattr(snap, "app_fixture_snapshot_path", lambda: bogus)
+
+    primary = tmp_path / "primary.json"
+    rc = snap.main(["--target", str(primary)])
+    assert rc == 0
+    assert primary.exists()
+    assert not bogus.exists()
+    captured = capsys.readouterr()
+    assert "skipped scout-app fixture write" in captured.err
+    assert "--no-also-write-app-fixture" in captured.err
+
+
+def test_main_no_also_write_app_fixture_skips_dual_write(tmp_path, monkeypatch):
+    """`--no-also-write-app-fixture` disables the secondary write entirely,
+    even when the path is viable."""
+    fake_app_fixture = tmp_path / "scout-app" / "ScoutTests" / "Fixtures" / "schedule.snapshot.json"
+    fake_app_fixture.parent.mkdir(parents=True)
+    monkeypatch.setattr(snap, "app_fixture_snapshot_path", lambda: fake_app_fixture)
+
+    primary = tmp_path / "primary.json"
+    rc = snap.main(["--target", str(primary), "--no-also-write-app-fixture"])
+    assert rc == 0
+    assert primary.exists()
+    assert not fake_app_fixture.exists()
+
+
+def test_main_dual_write_no_op_when_target_equals_app_fixture(tmp_path, monkeypatch, capsys):
+    """If the operator passes --target pointing at the app fixture itself,
+    the primary write covers it — no double-write, no warning."""
+    fake_app_fixture = tmp_path / "scout-app" / "ScoutTests" / "Fixtures" / "schedule.snapshot.json"
+    fake_app_fixture.parent.mkdir(parents=True)
+    monkeypatch.setattr(snap, "app_fixture_snapshot_path", lambda: fake_app_fixture)
+
+    rc = snap.main(["--target", str(fake_app_fixture)])
+    assert rc == 0
+    assert fake_app_fixture.exists()
+    captured = capsys.readouterr()
+    # Exactly one "Wrote:" line (the primary), no second one for the app fixture.
+    assert captured.out.count("Wrote:") == 1
+    assert "skipped" not in captured.err

--- a/engine/tests/unit/test_schedule_tick.py
+++ b/engine/tests/unit/test_schedule_tick.py
@@ -1,0 +1,332 @@
+"""Unit tests for scout.scripts.schedule_tick — the dispatcher brain."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+from scout.events import Event
+from scout.schedule import (
+    OnMissPolicy,
+    Slot,
+    SlotType,
+    load_default_schedule,
+)
+from scout.scripts.schedule_tick import (
+    Decision,
+    SlotCandidate,
+    _apply_miss_rules,
+    _compute_due_slots,
+    _filter_winner_by_priority,
+    _network_ready,
+    _read_last_fire_index,
+    candidates_by_key,
+)
+from scout.scripts.schedule_tick import (
+    run as tick_run,
+)
+
+
+# Helper for synthesizing slots in tests.
+def _slot(
+    key: str,
+    *,
+    type_: SlotType = SlotType.CONSOLIDATION,
+    fires_at: str = "11:00",
+    weekdays: tuple = ("Mon", "Tue", "Wed", "Thu", "Fri"),
+    missed_window_hours: int = 2,
+    on_miss: OnMissPolicy = OnMissPolicy.COLLAPSE,
+    cooldown_minutes: int = 90,
+) -> Slot:
+    return Slot(
+        key=key,
+        type=type_,
+        runner="run-scout.sh",
+        fires_at_local=fires_at,
+        weekdays=weekdays,
+        missed_window_hours=missed_window_hours,
+        on_miss=on_miss,
+        cooldown_minutes=cooldown_minutes,
+    )
+
+
+# 0. candidates_by_key: indexer used by callers to look up candidate metadata.
+
+
+def test_candidates_by_key_indexes_by_slot_key():
+    sched = load_default_schedule()
+    et = ZoneInfo("America/New_York")
+    target = datetime(2026, 5, 11, 8, 0, tzinfo=et)
+    cand = SlotCandidate(
+        slot_key="morning-briefing",
+        slot=sched["morning-briefing"],
+        target=target,
+        last_fire=None,
+    )
+    indexed = candidates_by_key([cand])
+    assert indexed["morning-briefing"].target == target
+
+
+# 1. compute_due_slots: only slots whose target time has passed and last fire is older than today's target.
+
+
+def test_compute_due_slots_includes_slot_past_target_with_no_prior_fire():
+    sched = load_default_schedule()
+    et = ZoneInfo("America/New_York")
+    now = datetime(2026, 5, 11, 11, 30, tzinfo=et)
+    last_fire = {}
+    candidates = _compute_due_slots(sched, last_fire, now)
+    keys = {c.slot_key for c in candidates}
+    assert "morning-briefing" in keys
+    assert "morning-consolidation" in keys
+    assert "midday-consolidation" not in keys
+
+
+def test_compute_due_slots_skips_slot_within_cooldown():
+    sched = load_default_schedule()
+    et = ZoneInfo("America/New_York")
+    now = datetime(2026, 5, 11, 11, 30, tzinfo=et)
+    last_fire = {"morning-consolidation": now - timedelta(minutes=30)}
+    candidates = _compute_due_slots(sched, last_fire, now)
+    assert "morning-consolidation" not in {c.slot_key for c in candidates}
+
+
+def test_compute_due_slots_excludes_slot_with_today_fire():
+    sched = load_default_schedule()
+    et = ZoneInfo("America/New_York")
+    now = datetime(2026, 5, 11, 11, 30, tzinfo=et)
+    last_fire = {"morning-consolidation": datetime(2026, 5, 11, 11, 5, tzinfo=et)}
+    candidates = _compute_due_slots(sched, last_fire, now)
+    assert "morning-consolidation" not in {c.slot_key for c in candidates}
+
+
+# 2. apply_miss_rules: on_miss policy + missed_window + collapse-within-type semantics.
+
+
+def test_apply_miss_rules_fire_within_window():
+    sched = load_default_schedule()
+    et = ZoneInfo("America/New_York")
+    now = datetime(2026, 5, 11, 11, 30, tzinfo=et)
+    candidate = SlotCandidate(
+        slot_key="morning-briefing",
+        slot=sched["morning-briefing"],
+        target=datetime(2026, 5, 11, 8, 0, tzinfo=et),
+        last_fire=None,
+    )
+    decisions = _apply_miss_rules([candidate], now=now)
+    assert decisions["morning-briefing"].action == "fire"
+
+
+def test_apply_miss_rules_fire_outside_window_skips():
+    sched = load_default_schedule()
+    et = ZoneInfo("America/New_York")
+    now = datetime(2026, 5, 11, 14, 0, tzinfo=et)
+    candidate = SlotCandidate(
+        slot_key="morning-briefing",
+        slot=sched["morning-briefing"],
+        target=datetime(2026, 5, 11, 8, 0, tzinfo=et),
+        last_fire=None,
+    )
+    decisions = _apply_miss_rules([candidate], now=now)
+    assert decisions["morning-briefing"].action == "skip"
+    assert "stale" in decisions["morning-briefing"].reason
+
+
+def test_apply_miss_rules_skip_policy_always_skips():
+    sched = load_default_schedule()
+    et = ZoneInfo("America/New_York")
+    now = datetime(2026, 5, 11, 14, 30, tzinfo=et)
+    candidate = SlotCandidate(
+        slot_key="research",
+        slot=sched["research"],
+        target=datetime(2026, 5, 11, 14, 0, tzinfo=et),
+        last_fire=None,
+    )
+    decisions = _apply_miss_rules([candidate], now=now)
+    assert decisions["research"].action == "skip"
+    assert "on_miss=skip" in decisions["research"].reason
+
+
+def test_apply_miss_rules_collapse_within_type_fires_only_latest():
+    sched = load_default_schedule()
+    et = ZoneInfo("America/New_York")
+    now = datetime(2026, 5, 11, 17, 30, tzinfo=et)
+    morning = SlotCandidate(
+        "morning-consolidation",
+        sched["morning-consolidation"],
+        target=datetime(2026, 5, 11, 11, 0, tzinfo=et),
+        last_fire=None,
+    )
+    midday = SlotCandidate(
+        "midday-consolidation",
+        sched["midday-consolidation"],
+        target=datetime(2026, 5, 11, 13, 0, tzinfo=et),
+        last_fire=None,
+    )
+    afternoon = SlotCandidate(
+        "afternoon-consolidation",
+        sched["afternoon-consolidation"],
+        target=datetime(2026, 5, 11, 17, 0, tzinfo=et),
+        last_fire=None,
+    )
+    decisions = _apply_miss_rules([morning, midday, afternoon], now=now)
+    assert decisions["afternoon-consolidation"].action == "fire"
+    assert decisions["morning-consolidation"].action == "skip"
+    assert "collapsed-into=afternoon-consolidation" in decisions["morning-consolidation"].reason
+    assert decisions["midday-consolidation"].action == "skip"
+
+
+def test_apply_miss_rules_collapse_respects_window_for_oldest():
+    sched = load_default_schedule()
+    et = ZoneInfo("America/New_York")
+    now = datetime(2026, 5, 11, 19, 30, tzinfo=et)
+    morning = SlotCandidate(
+        "morning-consolidation",
+        sched["morning-consolidation"],
+        target=datetime(2026, 5, 11, 11, 0, tzinfo=et),
+        last_fire=None,
+    )
+    evening = SlotCandidate(
+        "evening-consolidation",
+        sched["evening-consolidation"],
+        target=datetime(2026, 5, 11, 19, 0, tzinfo=et),
+        last_fire=None,
+    )
+    decisions = _apply_miss_rules([morning, evening], now=now)
+    assert decisions["evening-consolidation"].action == "fire"
+    assert decisions["morning-consolidation"].action == "skip"
+
+
+# 3. priority filter: at most one fire per tick.
+
+
+def test_filter_winner_by_priority_picks_briefing_over_consolidation():
+    sched = load_default_schedule()
+    decisions = {
+        "morning-briefing": Decision(action="fire"),
+        "afternoon-consolidation": Decision(action="fire"),
+    }
+    winner = _filter_winner_by_priority(sched, decisions)
+    assert winner == "morning-briefing"
+
+
+def test_filter_winner_by_priority_picks_consolidation_when_no_briefing():
+    sched = load_default_schedule()
+    decisions = {
+        "afternoon-consolidation": Decision(action="fire"),
+        "dreaming-evening": Decision(action="fire"),
+    }
+    winner = _filter_winner_by_priority(sched, decisions)
+    assert winner == "afternoon-consolidation"
+
+
+def test_filter_winner_returns_none_when_no_fire_decisions():
+    sched = load_default_schedule()
+    decisions = {
+        "morning-briefing": Decision(action="skip", reason="stale"),
+    }
+    assert _filter_winner_by_priority(sched, decisions) is None
+
+
+# 4. network probe.
+
+
+def test_network_ready_returns_true_when_probe_succeeds():
+    with patch("scout.scripts.schedule_tick.socket.create_connection") as mock_conn:
+        mock_conn.return_value.__enter__ = lambda s: None
+        mock_conn.return_value.__exit__ = lambda *args: None
+        assert _network_ready(retries=1, sleep_seconds=0) is True
+
+
+def test_network_ready_returns_false_after_exhausting_retries():
+    with patch("scout.scripts.schedule_tick.socket.create_connection", side_effect=OSError("dns")):
+        assert _network_ready(retries=2, sleep_seconds=0) is False
+
+
+# 5. tracker reading.
+
+
+def test_read_last_fire_index_extracts_per_slot_last_ts(tmp_path):
+    log_dir = tmp_path / ".scout-logs"
+    log_dir.mkdir()
+    tracker = log_dir / "usage-tracker.jsonl"
+    tracker.write_text(
+        '{"ts":"2026-05-11T12:00:00Z","type":"briefing","scout_mode":"morning-briefing"}\n'
+        '{"ts":"2026-05-11T15:00:00Z","type":"consolidation","scout_mode":"morning-consolidation"}\n'
+        '{"ts":"2026-05-11T17:00:00Z","type":"consolidation","scout_mode":"afternoon-consolidation"}\n'
+    )
+    index = _read_last_fire_index(tracker)
+    assert "morning-briefing" in index
+    assert "afternoon-consolidation" in index
+    assert index["morning-briefing"] < index["afternoon-consolidation"]
+
+
+def test_read_last_fire_index_is_empty_when_tracker_missing(tmp_path):
+    assert _read_last_fire_index(tmp_path / "no.jsonl") == {}
+
+
+# 6. End-to-end: run() emits Event and writes JSONL row.
+
+
+def test_run_emits_schedule_tick_completed_event(tmp_path, monkeypatch):
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    (tmp_path / ".scout-state").mkdir()
+    (tmp_path / ".scout-logs").mkdir()
+    sched_path = tmp_path / ".scout-state" / "schedule.yaml"
+    sched_path.write_text(
+        "schema_version: 1\nslots:\n  smoke-slot:\n"
+        "    type: manual\n    runner: run-scout.sh\n    fires_at_local: '00:01'\n"
+        "    weekdays: [Mon, Tue, Wed, Thu, Fri, Sat, Sun]\n"
+        "    missed_window_hours: 24\n    on_miss: skip\n    cooldown_minutes: 5\n"
+    )
+    with (
+        patch("scout.scripts.schedule_tick._network_ready", return_value=True),
+        patch("scout.scripts.schedule_tick.subprocess.Popen") as mock_popen,
+    ):
+        mock_popen.return_value.pid = 99999
+        ev = tick_run()
+    assert isinstance(ev, Event)
+    assert ev.kind == "schedule.tick.completed"
+
+
+def test_run_skips_when_network_offline(tmp_path, monkeypatch):
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    (tmp_path / ".scout-state").mkdir()
+    (tmp_path / ".scout-logs").mkdir()
+    sched_path = tmp_path / ".scout-state" / "schedule.yaml"
+    sched_path.write_text(
+        "schema_version: 1\nslots:\n  smoke-slot:\n"
+        "    type: briefing\n    runner: run-scout.sh\n    fires_at_local: '00:01'\n"
+        "    weekdays: [Mon, Tue, Wed, Thu, Fri, Sat, Sun]\n"
+        "    missed_window_hours: 24\n    on_miss: fire\n    cooldown_minutes: 5\n"
+    )
+    with (
+        patch("scout.scripts.schedule_tick._network_ready", return_value=False),
+        patch("scout.scripts.schedule_tick.subprocess.Popen") as mock_popen,
+    ):
+        ev = tick_run()
+    mock_popen.assert_not_called()
+    assert ev.kind == "schedule.tick.completed"
+    skipped_log = next((tmp_path / ".scout-logs").glob("schedule-events-*.jsonl"), None)
+    assert skipped_log is not None
+    events = [json.loads(line) for line in skipped_log.read_text().splitlines()]
+    skip_kinds = [e for e in events if e["kind"] == "slot.skipped"]
+    assert any("network-offline" in (e.get("payload") or {}).get("reason", "") for e in skip_kinds)
+
+
+def test_run_lock_held_returns_quickly(tmp_path, monkeypatch):
+    """Concurrency guard: a held flock causes the second tick to early-exit."""
+    import fcntl
+
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    (tmp_path / ".scout-state").mkdir()
+    (tmp_path / ".scout-logs").mkdir()
+    lock_path = tmp_path / ".scout-state" / ".schedule-tick.lock"
+    lock_path.touch()
+    with open(lock_path, "w") as held:
+        fcntl.flock(held.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        ev = tick_run()
+    assert ev.kind == "schedule.tick.skipped"
+    assert ev.payload.get("reason") == "lock_held"

--- a/engine/tests/unit/test_schedule_tick.py
+++ b/engine/tests/unit/test_schedule_tick.py
@@ -267,6 +267,40 @@ def test_read_last_fire_index_is_empty_when_tracker_missing(tmp_path):
     assert _read_last_fire_index(tmp_path / "no.jsonl") == {}
 
 
+def test_read_last_fire_index_applies_legacy_mode_rename(tmp_path):
+    """Legacy session-tokens.jsonl with old mode names → renamed to new slot keys."""
+    log_dir = tmp_path / ".scout-logs"
+    log_dir.mkdir()
+    session_tokens = log_dir / "session-tokens.jsonl"
+    session_tokens.write_text(
+        '{"ts":"2026-05-11T15:00:00Z","scout_mode":"consolidation-11am"}\n'
+        '{"ts":"2026-05-11T17:00:00Z","scout_mode":"consolidation-1pm"}\n'
+        '{"ts":"2026-05-11T21:00:00Z","scout_mode":"morning-briefing"}\n'
+    )
+    tracker = log_dir / "usage-tracker.jsonl"
+    tracker.write_text("")
+    index = _read_last_fire_index(tracker)
+    # Old names mapped to new keys.
+    assert "morning-consolidation" in index
+    assert "midday-consolidation" in index
+    assert "morning-briefing" in index
+    assert "consolidation-11am" not in index  # not present under old name
+
+
+def test_read_last_fire_index_falls_through_legacy_usage_tracker_rows(tmp_path):
+    """Legacy usage-tracker rows lacking scout_mode are silently skipped."""
+    log_dir = tmp_path / ".scout-logs"
+    log_dir.mkdir()
+    tracker = log_dir / "usage-tracker.jsonl"
+    tracker.write_text(
+        # Pre-Plan-5 rows from write-session-cost.sh / heartbeat.sh (no scout_mode):
+        '{"ts":"2026-05-01T12:00:00Z","type":"briefing","budget_cap":150}\n'
+        '{"ts":"2026-05-01T13:00:00Z","type":"heartbeat","source":"heartbeat"}\n'
+    )
+    index = _read_last_fire_index(tracker)
+    assert index == {}  # silently skipped; no error
+
+
 # 6. End-to-end: run() emits Event and writes JSONL row.
 
 
@@ -330,3 +364,138 @@ def test_run_lock_held_returns_quickly(tmp_path, monkeypatch):
         ev = tick_run()
     assert ev.kind == "schedule.tick.skipped"
     assert ev.payload.get("reason") == "lock_held"
+
+
+# 7. v0.5+ event-taxonomy compliance: payload fields per spec §9.
+
+
+def test_slot_fired_event_has_full_payload_per_v0_5_spec(tmp_path, monkeypatch):
+    """slot.fired payload must contain every v0.5+ spec field."""
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    (tmp_path / ".scout-state").mkdir()
+    (tmp_path / ".scout-logs").mkdir()
+    sched_path = tmp_path / ".scout-state" / "schedule.yaml"
+    sched_path.write_text(
+        "schema_version: 1\nslots:\n  smoke-slot:\n"
+        "    type: briefing\n    runner: run-scout.sh\n    fires_at_local: '00:01'\n"
+        "    weekdays: [Mon, Tue, Wed, Thu, Fri, Sat, Sun]\n"
+        "    missed_window_hours: 24\n    on_miss: fire\n    cooldown_minutes: 5\n"
+    )
+    with (
+        patch("scout.scripts.schedule_tick._network_ready", return_value=True),
+        patch("scout.scripts.schedule_tick.subprocess.Popen") as mock_popen,
+    ):
+        mock_popen.return_value.pid = 42
+        tick_run()
+    log = next((tmp_path / ".scout-logs").glob("schedule-events-*.jsonl"))
+    rows = [json.loads(line) for line in log.read_text().splitlines() if line.strip()]
+    fired_events = [r for r in rows if r["kind"] == "slot.fired"]
+    assert len(fired_events) == 1
+    payload = fired_events[0]["payload"]
+    # All v0.5+ spec fields present.
+    for f in ("slot_key", "slot_type", "target_local", "target_utc", "runner", "pid_spawned"):
+        assert f in payload, f"{f} missing from slot.fired payload: {payload}"
+    assert fired_events[0]["source"] == "cli:schedule_tick"
+
+
+def test_slot_skipped_event_has_slot_type_and_target_local(tmp_path, monkeypatch):
+    """slot.skipped payload must contain slot_type and target_local per v0.5+ spec."""
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    (tmp_path / ".scout-state").mkdir()
+    (tmp_path / ".scout-logs").mkdir()
+    sched_path = tmp_path / ".scout-state" / "schedule.yaml"
+    sched_path.write_text(
+        "schema_version: 1\nslots:\n  research-slot:\n"
+        "    type: research\n    runner: run-research.sh\n    fires_at_local: '00:01'\n"
+        "    weekdays: [Mon, Tue, Wed, Thu, Fri, Sat, Sun]\n"
+        "    missed_window_hours: 24\n    on_miss: skip\n    cooldown_minutes: 5\n"
+    )
+    with patch("scout.scripts.schedule_tick._network_ready", return_value=True):
+        tick_run()
+    log = next((tmp_path / ".scout-logs").glob("schedule-events-*.jsonl"))
+    rows = [json.loads(line) for line in log.read_text().splitlines() if line.strip()]
+    skipped = [r for r in rows if r["kind"] == "slot.skipped"]
+    assert len(skipped) >= 1
+    payload = skipped[0]["payload"]
+    for f in ("slot_key", "slot_type", "target_local", "reason"):
+        assert f in payload
+
+
+# 8. fire_now() coverage.
+
+
+def test_fire_now_unknown_slot_emits_fire_failed(tmp_path, monkeypatch):
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    (tmp_path / ".scout-state").mkdir()
+    (tmp_path / ".scout-logs").mkdir()
+    sched = tmp_path / ".scout-state" / "schedule.yaml"
+    sched.write_text(
+        "schema_version: 1\nslots:\n  any-slot:\n"
+        "    type: briefing\n    runner: run-scout.sh\n    fires_at_local: '08:00'\n"
+        "    weekdays: [Mon]\n    missed_window_hours: 4\n    on_miss: fire\n    cooldown_minutes: 60\n"
+    )
+    from scout.scripts.schedule_tick import fire_now
+
+    ev = fire_now("no-such-slot")
+    assert ev.kind == "slot.fire_failed"
+    assert "unknown" in (ev.payload.get("error") or "").lower()
+
+
+def test_fire_now_lock_held_emits_fire_failed(tmp_path, monkeypatch):
+    import fcntl
+
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    (tmp_path / ".scout-state").mkdir()
+    (tmp_path / ".scout-logs").mkdir()
+    sched = tmp_path / ".scout-state" / "schedule.yaml"
+    sched.write_text(
+        "schema_version: 1\nslots:\n  any-slot:\n"
+        "    type: briefing\n    runner: run-scout.sh\n    fires_at_local: '08:00'\n"
+        "    weekdays: [Mon]\n    missed_window_hours: 4\n    on_miss: fire\n    cooldown_minutes: 60\n"
+    )
+    lock_path = tmp_path / ".scout-state" / ".schedule-tick.lock"
+    lock_path.touch()
+    from scout.scripts.schedule_tick import fire_now
+
+    with open(lock_path, "w") as held:
+        fcntl.flock(held.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        ev = fire_now("any-slot")
+    assert ev.kind == "slot.fire_failed"
+    assert "lock" in (ev.payload.get("error") or "").lower()
+
+
+def test_fire_now_happy_path_emits_slot_fired(tmp_path, monkeypatch):
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    (tmp_path / ".scout-state").mkdir()
+    (tmp_path / ".scout-logs").mkdir()
+    sched = tmp_path / ".scout-state" / "schedule.yaml"
+    sched.write_text(
+        "schema_version: 1\nslots:\n  any-slot:\n"
+        "    type: briefing\n    runner: run-scout.sh\n    fires_at_local: '08:00'\n"
+        "    weekdays: [Mon]\n    missed_window_hours: 4\n    on_miss: fire\n    cooldown_minutes: 60\n"
+    )
+    from scout.scripts.schedule_tick import fire_now
+
+    with patch("scout.scripts.schedule_tick.subprocess.Popen") as mock_popen:
+        mock_popen.return_value.pid = 7777
+        ev = fire_now("any-slot")
+    assert ev.kind == "slot.fired"
+    assert ev.payload.get("manual") is True
+    assert ev.payload.get("pid_spawned") == 7777
+
+
+def test_fire_now_runner_missing_emits_fire_failed(tmp_path, monkeypatch):
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    (tmp_path / ".scout-state").mkdir()
+    (tmp_path / ".scout-logs").mkdir()
+    sched = tmp_path / ".scout-state" / "schedule.yaml"
+    sched.write_text(
+        "schema_version: 1\nslots:\n  any-slot:\n"
+        "    type: briefing\n    runner: nonexistent-runner.sh\n    fires_at_local: '08:00'\n"
+        "    weekdays: [Mon]\n    missed_window_hours: 4\n    on_miss: fire\n    cooldown_minutes: 60\n"
+    )
+    from scout.scripts.schedule_tick import fire_now
+
+    with patch("scout.scripts.schedule_tick.subprocess.Popen", side_effect=FileNotFoundError("nope")):
+        ev = fire_now("any-slot")
+    assert ev.kind == "slot.fire_failed"

--- a/engine/tests/unit/test_scripts_connector_health.py
+++ b/engine/tests/unit/test_scripts_connector_health.py
@@ -257,15 +257,20 @@ def test_slack_dark_two_prior_healthy_fires_critical(fake_data_dir, monkeypatch)
 # ----- Test 5: Weekend-only `gh CLI dark` → no alert if non-required -------
 
 
-def test_chronic_skip_only_in_required_mode(fake_data_dir, monkeypatch):
-    """github is required_in: all → it IS required in weekend-briefing too,
-    so the chronic-skip override should fire. To exercise the "non-required mode"
-    path, use Granola which is NOT required on weekends (weekday-only).
+def test_chronic_skip_only_in_required_slot_type(fake_data_dir, monkeypatch):
+    """Plan 5 Task 6: chronic-skip rule keys on slot TYPE, not slot key.
 
-    Set up: 3 weekend-briefing runs all dark on Granola, but the connector
-    DOES have prior OK calls (so Pattern #48 does not suppress). The
-    mode-baseline rule sees 0 of 2 prior same-mode runs healthy → no alert.
-    The chronic-skip rule sees mode_required=False → no alert.
+    Granola declares ``required_in_types: [briefing, consolidation]`` — so
+    it is required across any briefing-type slot (including weekend
+    briefings, which intentionally over-applies safety) but NOT in
+    research-type runs. Use research to exercise the "non-required slot
+    type" path.
+
+    Set up: prior morning-briefings establish total_ok_ever > 0 (Pattern
+    #48 doesn't suppress). Then 3 research runs all dark on Granola. The
+    mode-baseline rule sees 0 of 2 prior same-mode runs healthy → no
+    alert. The chronic-skip rule sees the current slot type is research,
+    Granola is NOT required for research → no alert.
     """
     monkeypatch.setattr(chr_mod, "_default_now", _frozen_now)
     log_dir = fake_data_dir / ".scout-logs"
@@ -286,13 +291,13 @@ def test_chronic_skip_only_in_required_mode(fake_data_dir, monkeypatch):
             },
         )
 
-    # Then 3 weekend-briefing runs where Granola is dark (legitimately —
-    # weekend mode doesn't call it).
+    # Then 3 research runs where Granola is dark — research-type slots don't
+    # require Granola, so the chronic-skip override must stay silent.
     for i in range(3):
         _seed_session(
             log_dir,
-            sid=f"weekend_{i}",
-            mode="weekend-briefing",
+            sid=f"research_{i}",
+            mode="research",
             ts=base + timedelta(days=5 + i),
             calls={
                 "mcp:claude_ai_Slack": (5, 0),
@@ -305,7 +310,7 @@ def test_chronic_skip_only_in_required_mode(fake_data_dir, monkeypatch):
 
     alerts = event.payload["alerts"]
     granola_alerts = [a for a in alerts if a["connector_key"] == "mcp:claude_ai_Granola"]
-    assert granola_alerts == [], "Granola is not required in weekend-briefing — should not fire chronic-skip."
+    assert granola_alerts == [], "Granola is not required in research slot type — should not fire chronic-skip."
 
 
 # ----- Test 6: WARNING rule (4 calls, 3 errors > 50% → WARNING) -----------

--- a/engine/tests/unit/test_scripts_connector_health_required_in_types.py
+++ b/engine/tests/unit/test_scripts_connector_health_required_in_types.py
@@ -1,0 +1,254 @@
+"""Plan 5 Task 6 — verify the chronic-skip rule keys on slot TYPE, not slot key.
+
+After Task 6 rewrote ``connectors.yaml`` to use ``required_in_types`` (the
+fixed plugin vocabulary: briefing | consolidation | dreaming | research |
+manual), the chronic-skip rule in ``connector_health_report.run()`` must
+resolve the current run's slot key through ``scout.schedule`` to its
+``SlotType`` and then ask the connector ``required_in_type(slot_type)``.
+
+These tests pin that mapping at the rule layer:
+
+  1. Three weekday morning-briefing runs with ``github`` dark → CRITICAL
+     alert (briefing requires github via ``required_in_types`` containing
+     ``briefing``).
+  2. Three research runs with Granola dark → no Granola alert (research
+     does not require Granola).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from scout.scripts import connector_health_report as chr_mod
+
+# ----- helpers (mirrors test_scripts_connector_health.py shape) -------------
+
+
+def _make_call(
+    ts_utc: datetime,
+    sid: str,
+    mode: str,
+    connector: str,
+    *,
+    error: bool = False,
+    err: str = "",
+    tool: str = "Bash",
+) -> dict:
+    rec: dict = {
+        "ts": ts_utc.isoformat().replace("+00:00", "Z"),
+        "session_id": sid,
+        "mode": mode,
+        "tool": tool,
+        "connector": connector,
+        "error": error,
+    }
+    if err:
+        rec["err"] = err
+    return rec
+
+
+def _seed_session(
+    log_dir: Path,
+    *,
+    sid: str,
+    mode: str,
+    ts: datetime,
+    calls: dict[str, tuple[int, int]],
+) -> None:
+    """Append a synthetic scheduled-run session to a JSONL file."""
+    records = []
+    for connector, (n_ok, n_err) in calls.items():
+        for i in range(n_ok):
+            records.append(_make_call(ts + timedelta(seconds=i), sid, mode, connector, error=False))
+        for i in range(n_err):
+            records.append(
+                _make_call(
+                    ts + timedelta(seconds=100 + i),
+                    sid,
+                    mode,
+                    connector,
+                    error=True,
+                    err=f"boom {connector}",
+                )
+            )
+    out = log_dir / f"connector-calls-{ts.date().isoformat()}.jsonl"
+    if out.exists():
+        existing = out.read_text().splitlines()
+        existing.extend(json.dumps(r) for r in records)
+        out.write_text("\n".join(existing) + "\n")
+    else:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+
+def _frozen_now() -> datetime:
+    """Deterministic 'now' inside EDT."""
+    return datetime(2026, 4, 28, 21, 0, 0, tzinfo=UTC)
+
+
+# ----- tests ----------------------------------------------------------------
+
+
+def test_chronic_skip_alert_fires_when_slot_type_requires_connector(fake_data_dir, monkeypatch):
+    """github dark in 3 weekday morning-briefing runs → CRITICAL alert.
+
+    The default schedule maps ``morning-briefing`` to ``SlotType.BRIEFING``,
+    and ``github`` declares ``required_in_types: [briefing, consolidation,
+    research]``. So the chronic-skip rule MUST resolve the slot type and
+    fire the alert.
+    """
+    monkeypatch.setattr(chr_mod, "_default_now", _frozen_now)
+    log_dir = fake_data_dir / ".scout-logs"
+
+    # Three morning-briefing runs across 3 days.
+    # Day 1 has github HEALTHY (so total_ok_ever > 0 — Pattern #48 doesn't
+    # suppress). Days 2 + 3 are dark on github but otherwise have OK Slack
+    # records, giving us valid scheduled-run sessions.
+    base = _frozen_now() - timedelta(days=3)
+
+    _seed_session(
+        log_dir,
+        sid="briefing_d1",
+        mode="morning-briefing",
+        ts=base,
+        calls={
+            "github": (3, 0),
+            "mcp:claude_ai_Slack": (5, 0),
+            "mcp:claude_ai_Linear": (4, 0),
+        },
+    )
+    for i in range(2):
+        _seed_session(
+            log_dir,
+            sid=f"briefing_d{2 + i}",
+            mode="morning-briefing",
+            ts=base + timedelta(days=1 + i),
+            calls={
+                "mcp:claude_ai_Slack": (5, 0),
+                "mcp:claude_ai_Linear": (4, 0),
+                # github intentionally absent — dark.
+            },
+        )
+    # Current run: another dark-on-github morning-briefing (so the gap is 3).
+    _seed_session(
+        log_dir,
+        sid="briefing_curr",
+        mode="morning-briefing",
+        ts=_frozen_now() - timedelta(hours=1),
+        calls={
+            "mcp:claude_ai_Slack": (5, 0),
+            "mcp:claude_ai_Linear": (4, 0),
+        },
+    )
+
+    event = chr_mod.run(data_dir=fake_data_dir)
+    assert event is not None
+
+    alert_keys = [a["connector_key"] for a in event.payload["alerts"]]
+    assert "github" in alert_keys, f"Expected github CRITICAL alert in briefing slot type; got alerts: {alert_keys}"
+
+
+def test_chronic_skip_alert_silent_when_slot_type_does_not_require_connector(fake_data_dir, monkeypatch):
+    """Granola dark in 3 research runs → no Granola alert.
+
+    Research's slot type is ``SlotType.RESEARCH``; Granola declares
+    ``required_in_types: [briefing, consolidation]`` and is NOT required
+    for research. The chronic-skip override must therefore stay silent.
+    """
+    monkeypatch.setattr(chr_mod, "_default_now", _frozen_now)
+    log_dir = fake_data_dir / ".scout-logs"
+
+    base = _frozen_now() - timedelta(days=4)
+
+    # Pre-seed: a few morning-briefing runs where Granola IS healthy, so
+    # total_ok_ever > 0 (Pattern #48 doesn't suppress) AND Granola has been
+    # observed in the window (it's wired, just not relevant in research).
+    for i in range(2):
+        _seed_session(
+            log_dir,
+            sid=f"weekday_{i}",
+            mode="morning-briefing",
+            ts=base + timedelta(days=i),
+            calls={
+                "mcp:claude_ai_Granola": (4, 0),
+                "mcp:claude_ai_Slack": (5, 0),
+            },
+        )
+
+    # Three research runs, Granola dark, github exercised heavily.
+    research_base = base + timedelta(days=3)
+    for i in range(3):
+        _seed_session(
+            log_dir,
+            sid=f"research_{i}",
+            mode="research",
+            ts=research_base + timedelta(days=i),
+            calls={
+                "github": (5, 0),
+                "mcp:claude_ai_Slack": (3, 0),
+                "mcp:claude_ai_Linear": (3, 0),
+                # Granola intentionally absent.
+            },
+        )
+
+    event = chr_mod.run(data_dir=fake_data_dir)
+    assert event is not None
+
+    alert_keys = [a["connector_key"] for a in event.payload["alerts"]]
+    assert "mcp:claude_ai_Granola" not in alert_keys, (
+        f"Granola should NOT alert in research slot type; got alerts: {alert_keys}"
+    )
+
+
+def test_unknown_mode_resolves_to_manual_slot_type(fake_data_dir, monkeypatch):
+    """A scheduled run with an unrecognized mode → SlotType.MANUAL → no chronic-skip.
+
+    Manual is intentionally excluded from every connector's
+    ``required_in_types``, so even with 3 dark runs, no alert should fire
+    from the chronic-skip override. (The mode-aware-baseline rule may still
+    fire if there are healthy prior same-mode runs, so we keep this test
+    targeted at chronic-skip by giving the unknown mode no prior healthy
+    runs.)
+    """
+    monkeypatch.setattr(chr_mod, "_default_now", _frozen_now)
+    log_dir = fake_data_dir / ".scout-logs"
+
+    base = _frozen_now() - timedelta(days=5)
+
+    # Pre-seed: a few morning-briefing runs where github IS healthy so
+    # total_ok_ever > 0.
+    for i in range(2):
+        _seed_session(
+            log_dir,
+            sid=f"weekday_{i}",
+            mode="morning-briefing",
+            ts=base + timedelta(days=i),
+            calls={
+                "github": (3, 0),
+                "mcp:claude_ai_Slack": (5, 0),
+            },
+        )
+
+    # Three runs with an unknown mode key, github dark.
+    unknown_base = base + timedelta(days=3)
+    for i in range(3):
+        _seed_session(
+            log_dir,
+            sid=f"custom_{i}",
+            mode="my-custom-slot",  # not in default schedule
+            ts=unknown_base + timedelta(days=i),
+            calls={
+                "mcp:claude_ai_Slack": (5, 0),
+                # github absent.
+            },
+        )
+
+    event = chr_mod.run(data_dir=fake_data_dir)
+    assert event is not None
+
+    alert_keys = [a["connector_key"] for a in event.payload["alerts"]]
+    assert "github" not in alert_keys, (
+        f"Unknown mode → SlotType.MANUAL → chronic-skip should not fire for github; got alerts: {alert_keys}"
+    )

--- a/tools/migrate-mode-names.py
+++ b/tools/migrate-mode-names.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""tools/migrate-mode-names.py — one-shot Plan 5 migration.
+
+Walks ~/Scout/.scout-logs/connector-calls-*.jsonl and session-tokens.jsonl,
+rewrites the mode / scout_mode field per MODE_RENAME_MAP. Backs up originals
+to .scout-logs/.pre-plan-5-backup/. Idempotent — re-runnable.
+
+Usage:
+    python3 tools/migrate-mode-names.py [--data-dir ~/Scout]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+
+MODE_RENAME_MAP: dict[str, str] = {
+    "consolidation-11am": "morning-consolidation",
+    "consolidation-1pm": "midday-consolidation",
+    "consolidation-5pm": "afternoon-consolidation",
+    "consolidation-7pm": "evening-consolidation",
+    "dreaming-nightly-10pm": "dreaming-nightly",
+    "dreaming-weekend-6am": "dreaming-weekend-morning",
+    "dreaming-weekend-7am": "dreaming-weekend-morning",
+    # morning-briefing, weekend-briefing, manual unchanged.
+}
+
+
+def migrate_jsonl_file(path: Path, *, mode_field: str = "mode") -> int:
+    """Rewrite the given JSONL file in place. Returns count of lines changed."""
+    n_changed = 0
+    new_lines: list[str] = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip():
+            new_lines.append(raw_line)
+            continue
+        try:
+            rec = json.loads(raw_line)
+        except json.JSONDecodeError:
+            new_lines.append(raw_line)
+            continue
+        old = rec.get(mode_field)
+        if isinstance(old, str) and old in MODE_RENAME_MAP:
+            rec[mode_field] = MODE_RENAME_MAP[old]
+            new_lines.append(json.dumps(rec, separators=(",", ":")))
+            n_changed += 1
+        else:
+            new_lines.append(raw_line)
+    path.write_text("\n".join(new_lines) + ("\n" if new_lines else ""))
+    return n_changed
+
+
+def migrate_data_dir(data_dir: Path) -> dict[str, int]:
+    """Migrate all JSONL files under data_dir/.scout-logs/. Returns per-file change counts."""
+    log_dir = data_dir / ".scout-logs"
+    backup_dir = log_dir / ".pre-plan-5-backup"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+
+    changes: dict[str, int] = {}
+
+    for jsonl in sorted(log_dir.glob("connector-calls-*.jsonl")):
+        backup_target = backup_dir / jsonl.name
+        if not backup_target.exists():
+            shutil.copy2(jsonl, backup_target)
+        changes[jsonl.name] = migrate_jsonl_file(jsonl, mode_field="mode")
+
+    session_tokens = log_dir / "session-tokens.jsonl"
+    if session_tokens.exists():
+        backup_target = backup_dir / session_tokens.name
+        if not backup_target.exists():
+            shutil.copy2(session_tokens, backup_target)
+        changes[session_tokens.name] = migrate_jsonl_file(session_tokens, mode_field="scout_mode")
+
+    return changes
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--data-dir", type=Path, default=Path.home() / "Scout",
+        help="Path to the Scout data dir (default: ~/Scout)",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.data_dir.exists():
+        print(f"data dir not found: {args.data_dir}", file=sys.stderr)
+        return 1
+
+    changes = migrate_data_dir(args.data_dir)
+    total = sum(changes.values())
+    print(f"migrated {total} rows across {len(changes)} files")
+    for name, n in sorted(changes.items()):
+        print(f"  {name}: {n}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/regenerate-connector-health.py
+++ b/tools/regenerate-connector-health.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""tools/regenerate-connector-health.py — one-shot Plan 5 doc regen.
+
+After running migrate-mode-names.py on the JSONL logs, regenerate
+~/Scout/knowledge-base/connector-health.md so the matrix headers and
+alerting rollup match the new mode names.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--data-dir", type=Path, default=Path.home() / "Scout",
+        help="Path to the Scout data dir (default: ~/Scout)",
+    )
+    args = parser.parse_args(argv)
+
+    env = os.environ.copy()
+    env["SCOUT_DATA_DIR"] = str(args.data_dir)
+    scoutctl = Path.home() / "scout-plugin" / ".venv" / "bin" / "scoutctl"
+    result = subprocess.run(
+        [str(scoutctl), "connector-health-report"],
+        env=env,
+        check=False,
+    )
+    return result.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Plan 5 lands the v2 schedule subsystem in the engine — declarative `schedule.yaml` + a 5-minute dispatcher tick, replacing 8 per-slot launchd plists with a single `com.scout.schedule-tick.plist`. Scout-app refactor in companion PR (jordanrburger/Scout#new).

14 commits, 418 passed + 9 skipped, ruff/mypy/format clean.

### What's new

- **`scout.schedule` module** — Slot/Schedule dataclasses, SlotType/OnMissPolicy/SlotPriority enums, TZ-aware `target_today`, overlay support for `schedule.local.yaml` (19 unit tests).
- **`scoutctl schedule {list,show,validate,init,reload,tick,fire-now,install-plist,install-wake-schedule,snapshot,list-upcoming}`** — full sub-app. The dispatcher (`tick`) does compute-due / apply-miss-rules / network-probe / single-fire-per-tick / fcntl flock; `list-upcoming --json` is the contract scout-app's `ScheduleService` consumes; `snapshot` writes the canonical `engine/scout/schedule.snapshot.json` + dual-writes scout-app's bundled fixture.
- **Mode-name rename** — `connectors.yaml` migrates `required_in: [list-of-mode-names]` → `required_in_types: [briefing, consolidation, ...]`. `connector_health_report` chronic-skip rule keys on slot type.
- **One-shot migration tools** — `tools/migrate-mode-names.py` (rewrites `~/Scout/.scout-logs/connector-calls-*.jsonl` + `session-tokens.jsonl`; backs up to `.pre-plan-5-backup/`; idempotent) + `tools/regenerate-connector-health.py` (rewrites `connector-health.md` from migrated logs).
- **Wake-schedule installer** — opt-in `pmset` repeat rule wakes the Mac for the earliest weekday slot; AC-only caveat documented.
- **Manifest flag** — `schedule_v2: true`.

### Live deployment status (already executed locally)

1. ✅ `migrate-mode-names.py --data-dir ~/Scout` — 1348 rows across 16 files migrated, idempotent.
2. ✅ `regenerate-connector-health.py --data-dir ~/Scout` — 51 sessions in window, 0 alerts, new vocabulary.
3. ✅ Booted out 8 legacy plists + removed from `~/Library/LaunchAgents/` + `git rm` 6 vault master copies.
4. ✅ `scoutctl schedule install-plist --force --bootstrap` installed `com.scout.schedule-tick.plist`; first tick fired immediately, caught `morning-briefing`, spawned the runner.
5. ✅ Smoke verify — `launchctl list | grep com.scout` shows only `heartbeat` + `schedule-tick`; `scoutctl schedule list` shows 10 slots; `manifest show` reports `schedule_v2: true`.

## Test plan

- [ ] CI green on the matrix (Python 3.12+, ruff, ruff format, mypy, pytest, snapshot drift checks).
- [ ] Pull + run `scoutctl schedule list` on a fresh checkout — should list 10 slots from `engine/scout/defaults/schedule.yaml`.
- [ ] `scoutctl schedule snapshot --check` exits 0 (canonical drift check).
- [ ] `scoutctl schedule list-upcoming --window 24 --json | jq` returns sorted upcoming runs with the documented 4-field shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)