### PR TITLE
Plan 6 engine — Slot.runtime field + dispatcher guard + scoutctl schedule validate --target

### DIFF
--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import typer
 
 from scout import __version__
-from scout.errors import ScoutError
+from scout.errors import ConfigError, ScoutError
 
 # Reserved for non-ScoutError exceptions escaping app(). Kept distinct
 # from ScoutError.exit_code == 1 so scout-app can decode "the CLI
@@ -299,10 +299,32 @@ def _register_schedule() -> None:
         typer.echo(_json.dumps(record, indent=2))
 
     @schedule_app.command("validate")
-    def cli_schedule_validate() -> None:
+    def cli_schedule_validate(
+        target: Path | None = typer.Option(
+            None,
+            "--target",
+            "-t",
+            help=(
+                "Validate the schedule.yaml at this path instead of the vault canonical. "
+                "Used by scout-app's editor to validate candidate writes before atomic-rename."
+            ),
+        ),
+    ) -> None:
         """Re-load the schedule (canonical + overlay if present); exit 0 on success."""
         from scout import paths as _paths
         from scout.schedule import load_default_schedule, load_schedule
+
+        if target is not None:
+            if not target.exists():
+                typer.echo(f"target does not exist: {target}", err=True)
+                raise typer.Exit(code=1)
+            try:
+                load_schedule(target)
+            except ConfigError as e:
+                typer.echo(str(e), err=True)
+                raise typer.Exit(code=1) from e
+            typer.echo(f"schedule OK: {target}")
+            return
 
         vault_path = _paths.data_dir() / ".scout-state" / "schedule.yaml"
         if vault_path.exists():

--- a/engine/scout/schedule.py
+++ b/engine/scout/schedule.py
@@ -42,6 +42,11 @@ class OnMissPolicy(enum.Enum):
     COLLAPSE = "collapse"
 
 
+class SlotRuntime(enum.Enum):
+    LOCAL = "local"
+    REMOTE = "remote"  # Reserved for Plan 7. Loader accepts; dispatcher rejects.
+
+
 class SlotPriority(enum.IntEnum):
     """Priority order for single-fire-per-tick selection.
 
@@ -73,6 +78,7 @@ class Slot:
     cooldown_minutes: int
     budget_usd: float | None = None  # optional; not load-bearing in v0.5
     tz: str | None = None  # optional IANA zone; absent → system local
+    runtime: SlotRuntime = SlotRuntime.LOCAL
 
     @property
     def priority(self) -> SlotPriority:
@@ -216,6 +222,13 @@ def _build_slot(key: str, raw: dict[str, Any]) -> Slot:
         cd = int(raw["cooldown_minutes"])
         if cd < 0:
             raise ConfigError(f"slot {key}: cooldown_minutes must be >= 0, got {cd}")
+        runtime_raw = raw.get("runtime", "local")
+        try:
+            runtime = SlotRuntime(runtime_raw)
+        except ValueError as e:
+            raise ConfigError(
+                f"slot {key!r}: runtime {runtime_raw!r} is not one of {[r.value for r in SlotRuntime]}"
+            ) from e
         return Slot(
             key=key,
             type=slot_type,
@@ -227,6 +240,7 @@ def _build_slot(key: str, raw: dict[str, Any]) -> Slot:
             cooldown_minutes=cd,
             budget_usd=raw.get("budget_usd"),
             tz=tz,
+            runtime=runtime,
         )
     except (KeyError, ValueError) as e:
         raise ConfigError(f"slot {key}: malformed entry: {e}") from e

--- a/engine/scout/scripts/schedule_tick.py
+++ b/engine/scout/scripts/schedule_tick.py
@@ -41,6 +41,7 @@ from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from scout import paths
+from scout.errors import ConfigError
 from scout.events import Event, now_iso
 from scout.ids import new_ulid
 from scout.schedule import (
@@ -48,6 +49,7 @@ from scout.schedule import (
     Schedule,
     Slot,
     SlotPriority,
+    SlotRuntime,
     SlotType,
     load_default_schedule,
     load_schedule,
@@ -381,7 +383,18 @@ def _spawn_runner(vault: Path, slot_key: str, slot: Slot) -> int:
     propagates from ``subprocess.Popen`` when the file does not exist on
     disk. We deliberately do NOT pre-check existence so that mocked
     Popen calls in tests still see the call.
+
+    Raises ``ConfigError`` if ``slot.runtime == SlotRuntime.REMOTE`` — remote
+    slots are reserved for Plan 7 (remote routine integration) and cannot be
+    dispatched until that work lands.
     """
+    if slot.runtime == SlotRuntime.REMOTE:
+        raise ConfigError(
+            f"slot {slot_key!r} has runtime: remote, which is reserved for Plan 7 "
+            f"(remote routine integration). The dispatcher cannot fire remote slots "
+            f"until that work lands. Edit ~/Scout/.scout-state/schedule.yaml and set "
+            f"runtime: local, or delete the slot."
+        )
     runner_path = vault / slot.runner
     env = os.environ.copy()
     env["SCOUT_FORCE_MODE"] = slot_key

--- a/engine/tests/unit/test_cli_schedule_subapp.py
+++ b/engine/tests/unit/test_cli_schedule_subapp.py
@@ -170,3 +170,59 @@ def test_list_upcoming_no_json_emits_tab_separated_lines():
         assert slot_type in {"briefing", "consolidation", "dreaming", "research", "manual"}
         # scheduled_at_local should look like an ISO datetime
         assert "T" in scheduled_at_local or ":" in scheduled_at_local
+
+
+# ---------------------------------------------------------------------------
+# validate --target tests (Plan 6 Task 3)
+# ---------------------------------------------------------------------------
+
+
+def test_schedule_validate_target_flag_passes_for_valid_yaml(tmp_path):
+    """The --target flag points validate at an arbitrary path so the Schedules
+    tab editor can validate a candidate before committing via atomic-rename."""
+    target = tmp_path / "candidate.yaml"
+    target.write_text(
+        "schema_version: 1\n"
+        "slots:\n"
+        "  morning-briefing:\n"
+        "    type: briefing\n"
+        "    runner: run-scout.sh\n"
+        "    fires_at_local: '08:00'\n"
+        "    weekdays: [Mon, Tue, Wed, Thu, Fri]\n"
+        "    missed_window_hours: 4\n"
+        "    on_miss: fire\n"
+        "    cooldown_minutes: 60\n"
+    )
+    runner = CliRunner()
+    result = runner.invoke(app, ["schedule", "validate", "--target", str(target)])
+    assert result.exit_code == 0
+    assert "schedule OK" in result.output
+
+
+def test_schedule_validate_target_flag_fails_for_invalid_yaml(tmp_path):
+    target = tmp_path / "broken.yaml"
+    target.write_text("schema_version: 99\nslots: {}\n")
+    runner = CliRunner()
+    result = runner.invoke(app, ["schedule", "validate", "--target", str(target)])
+    assert result.exit_code == 1
+    # ConfigError message is surfaced — both stdout and stderr captures may have it.
+    combined = (result.stderr or "") + (result.output or "")
+    assert "schema_version" in combined
+
+
+def test_schedule_validate_target_flag_fails_for_missing_file(tmp_path):
+    missing = tmp_path / "does-not-exist.yaml"
+    runner = CliRunner()
+    result = runner.invoke(app, ["schedule", "validate", "--target", str(missing)])
+    assert result.exit_code == 1
+
+
+def test_schedule_validate_no_flag_keeps_default_behavior(tmp_path, monkeypatch):
+    """Without --target, validate reads from the vault path (or engine defaults).
+    Backward-compat with pre-Plan-6 callers."""
+    # Point the vault at an empty tmp_path so the defaults fallback kicks in.
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    runner = CliRunner()
+    result = runner.invoke(app, ["schedule", "validate"])
+    assert result.exit_code == 0
+    assert "schedule OK" in result.output

--- a/engine/tests/unit/test_schedule_loader.py
+++ b/engine/tests/unit/test_schedule_loader.py
@@ -14,6 +14,7 @@ from scout.schedule import (
     Schedule,
     Slot,
     SlotPriority,
+    SlotRuntime,
     SlotType,
     load_default_schedule,
     load_schedule,
@@ -478,3 +479,92 @@ def test_next_fires_default_schedule_returns_slots_within_24h():
     # Results should be in chronological order
     fire_times = [fire_dt for _, fire_dt in results]
     assert fire_times == sorted(fire_times)
+
+
+# ---------------------------------------------------------------------------
+# SlotRuntime — Plan 6 Task 1: runtime enum field on Slot
+# ---------------------------------------------------------------------------
+
+
+def test_slot_runtime_defaults_to_local_when_absent(tmp_path):
+    """YAML without a runtime key should produce Slot.runtime == LOCAL."""
+    yaml_file = tmp_path / "schedule.yaml"
+    yaml_file.write_text(
+        "schema_version: 1\n"
+        "slots:\n"
+        "  morning-briefing:\n"
+        "    type: briefing\n"
+        "    runner: run-scout.sh\n"
+        "    fires_at_local: '08:00'\n"
+        "    weekdays: [Mon, Tue, Wed, Thu, Fri]\n"
+        "    missed_window_hours: 4\n"
+        "    on_miss: fire\n"
+        "    cooldown_minutes: 60\n"
+        # runtime key intentionally absent
+    )
+    sched = load_schedule(yaml_file)
+    assert sched["morning-briefing"].runtime == SlotRuntime.LOCAL
+
+
+def test_slot_runtime_parses_local_explicitly(tmp_path):
+    """YAML with runtime: local should parse to SlotRuntime.LOCAL."""
+    yaml_file = tmp_path / "schedule.yaml"
+    yaml_file.write_text(
+        "schema_version: 1\n"
+        "slots:\n"
+        "  morning-briefing:\n"
+        "    type: briefing\n"
+        "    runner: run-scout.sh\n"
+        "    fires_at_local: '08:00'\n"
+        "    weekdays: [Mon, Tue, Wed, Thu, Fri]\n"
+        "    missed_window_hours: 4\n"
+        "    on_miss: fire\n"
+        "    cooldown_minutes: 60\n"
+        "    runtime: local\n"
+    )
+    sched = load_schedule(yaml_file)
+    assert sched["morning-briefing"].runtime == SlotRuntime.LOCAL
+
+
+def test_slot_runtime_parses_remote(tmp_path):
+    """YAML with runtime: remote should parse to SlotRuntime.REMOTE.
+
+    Note: the dispatcher guard (Task 2) is what rejects REMOTE at fire-time.
+    The loader accepts it without error.
+    """
+    yaml_file = tmp_path / "schedule.yaml"
+    yaml_file.write_text(
+        "schema_version: 1\n"
+        "slots:\n"
+        "  morning-briefing:\n"
+        "    type: briefing\n"
+        "    runner: run-scout.sh\n"
+        "    fires_at_local: '08:00'\n"
+        "    weekdays: [Mon, Tue, Wed, Thu, Fri]\n"
+        "    missed_window_hours: 4\n"
+        "    on_miss: fire\n"
+        "    cooldown_minutes: 60\n"
+        "    runtime: remote\n"
+    )
+    sched = load_schedule(yaml_file)
+    assert sched["morning-briefing"].runtime == SlotRuntime.REMOTE
+
+
+def test_slot_runtime_invalid_value_raises_config_error(tmp_path):
+    """YAML with an unrecognized runtime value should raise ConfigError mentioning 'runtime'."""
+    yaml_file = tmp_path / "schedule.yaml"
+    yaml_file.write_text(
+        "schema_version: 1\n"
+        "slots:\n"
+        "  morning-briefing:\n"
+        "    type: briefing\n"
+        "    runner: run-scout.sh\n"
+        "    fires_at_local: '08:00'\n"
+        "    weekdays: [Mon, Tue, Wed, Thu, Fri]\n"
+        "    missed_window_hours: 4\n"
+        "    on_miss: fire\n"
+        "    cooldown_minutes: 60\n"
+        "    runtime: cloud\n"  # not a valid SlotRuntime value
+    )
+    with pytest.raises(ConfigError, match="runtime"):
+        load_schedule(yaml_file)

--- a/engine/tests/unit/test_schedule_tick.py
+++ b/engine/tests/unit/test_schedule_tick.py
@@ -7,10 +7,14 @@ from datetime import datetime, timedelta
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
+import pytest
+
+from scout.errors import ConfigError
 from scout.events import Event
 from scout.schedule import (
     OnMissPolicy,
     Slot,
+    SlotRuntime,
     SlotType,
     load_default_schedule,
 )
@@ -22,6 +26,7 @@ from scout.scripts.schedule_tick import (
     _filter_winner_by_priority,
     _network_ready,
     _read_last_fire_index,
+    _spawn_runner,
     candidates_by_key,
 )
 from scout.scripts.schedule_tick import (
@@ -499,3 +504,26 @@ def test_fire_now_runner_missing_emits_fire_failed(tmp_path, monkeypatch):
     with patch("scout.scripts.schedule_tick.subprocess.Popen", side_effect=FileNotFoundError("nope")):
         ev = fire_now("any-slot")
     assert ev.kind == "slot.fire_failed"
+
+
+# 9. runtime guard: dispatcher rejects remote slots until Plan 7.
+
+
+def test_spawn_runner_rejects_remote_runtime(tmp_path):
+    """Plan 7 forward-compat: dispatcher refuses to spawn `runtime: remote` slots
+    until the routines API integration ships. Until then, save attempts in the
+    Schedules tab UI render Remote as disabled, so this guard catches manual
+    YAML edits that set runtime: remote."""
+    slot = Slot(
+        key="research",
+        type=SlotType.RESEARCH,
+        runner="run-research.sh",
+        fires_at_local="14:00",
+        weekdays=("Mon",),
+        missed_window_hours=4,
+        on_miss=OnMissPolicy.SKIP,
+        cooldown_minutes=240,
+        runtime=SlotRuntime.REMOTE,
+    )
+    with pytest.raises(ConfigError, match="runtime: remote.*Plan 7"):
+        _spawn_runner(vault=tmp_path, slot_key="research", slot=slot)


### PR DESCRIPTION
## Summary

Three small additive engine changes that scout-app's Plan 6 Schedules-tab editor needs to consume. UI PR will follow once this lands.

3 commits, 427 passed + 9 skipped (was 418 + 9 baseline; +9 new tests across Tasks 1–3), ruff/format/mypy clean (modulo the pre-existing `types-requests` stub gap on `cli_notify_telegram`, unchanged by this PR).

### What's new

- **`SlotRuntime` enum** (`engine/scout/schedule.py`) — `LOCAL = "local"` (default), `REMOTE = "remote"` (reserved). The loader parses the field with backward-compat defaulting (existing vault YAMLs without `runtime` still load as LOCAL).
- **Dispatcher guard** (`engine/scout/scripts/schedule_tick.py::_spawn_runner`) — raises `ConfigError` with a clear Plan-7 message when a slot has `runtime: remote`. Covers both the scheduled tick path and the manual `fire_now()` path.
- **`scoutctl schedule validate --target <path>` flag** (`engine/scout/cli.py::cli_schedule_validate`) — validates a schedule.yaml at an arbitrary path. The Plan 6 editor calls this on a tmpfile before atomic-renaming onto canonical. No-flag behavior (canonical-or-defaults) is fully preserved for backward compat.

### Why these together

The three changes form a self-contained forward-compat slice for Plan 6's Schedules tab UI:
- Schema reservation (Slot.runtime) lets the UI render the Remote picker as disabled today, then unlocks it cleanly when Plan 7 wires up Anthropic routines.
- Dispatcher guard ensures any manually-edited YAML with `runtime: remote` fails loudly at fire-time instead of silently spawning a local subprocess.
- `validate --target` is the engine-side hook that scout-app's `ScheduleEditService.save()` uses to validate a candidate before atomic-renaming.

## Test plan

- [x] CI green on the matrix (`lint` + `test (macos|ubuntu, 3.11|3.12)` × 4)
- [x] `scoutctl schedule list` shows 10 slots (no behavior change for default LOCAL)
- [x] `scoutctl schedule validate` (no flag) exits 0 against the live vault — backward compat
- [x] `scoutctl schedule validate --target /tmp/test-schedule.yaml` exits 0 on a valid candidate, 1 on missing/invalid
- [x] Existing 418 tests still pass; +9 new tests across Tasks 1–3

🤖 Generated with [Claude Code](https://claude.com/claude-code)