### PR TITLE
fix(engine): scoutctl schedule list --json (Plan 6 hot-fix)

### DIFF
--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -257,13 +257,48 @@ def _register_schedule() -> None:
     app.add_typer(schedule_app, name="schedule")
 
     @schedule_app.command("list")
-    def cli_schedule_list() -> None:
+    def cli_schedule_list(
+        as_json: bool = typer.Option(
+            False,
+            "--json/--no-json",
+            help=(
+                "Emit a JSON array of full slot records (key/type/runner/"
+                "fires_at_local/weekdays/missed_window_hours/on_miss/"
+                "cooldown_minutes/budget_usd/tz/runtime) instead of "
+                "tab-separated lines. Plan 6's ScheduleEditService consumes "
+                "this for the in-app editor."
+            ),
+        ),
+    ) -> None:
         """List the registered schedule slots."""
+        import json as _json
+
         from scout import paths as _paths
         from scout.schedule import load_default_schedule, load_schedule
 
         vault_path = _paths.data_dir() / ".scout-state" / "schedule.yaml"
         sched = load_schedule(vault_path) if vault_path.exists() else load_default_schedule()
+
+        if as_json:
+            records = [
+                {
+                    "key": sched[key].key,
+                    "type": sched[key].type.value,
+                    "runner": sched[key].runner,
+                    "fires_at_local": sched[key].fires_at_local,
+                    "weekdays": list(sched[key].weekdays),
+                    "missed_window_hours": sched[key].missed_window_hours,
+                    "on_miss": sched[key].on_miss.value,
+                    "cooldown_minutes": sched[key].cooldown_minutes,
+                    "budget_usd": sched[key].budget_usd,
+                    "tz": sched[key].tz,
+                    "runtime": sched[key].runtime.value,
+                }
+                for key in sorted(sched.keys())
+            ]
+            typer.echo(_json.dumps(records))
+            return
+
         for key in sorted(sched.keys()):
             slot = sched[key]
             typer.echo(

--- a/engine/tests/unit/test_cli_schedule_subapp.py
+++ b/engine/tests/unit/test_cli_schedule_subapp.py
@@ -20,6 +20,47 @@ def test_schedule_list_shows_all_default_slots():
     assert "research" in result.stdout
 
 
+def test_schedule_list_json_emits_full_slot_records():
+    """Plan 6's ScheduleEditService consumes this exact JSON shape to populate
+    the in-app editor. Each record must have all 11 Slot fields, sorted by
+    slot_key alphabetically.
+    """
+    result = runner.invoke(app, ["schedule", "list", "--json"])
+    assert result.exit_code == 0, result.stdout + result.stderr
+
+    data = json.loads(result.stdout)
+    assert isinstance(data, list)
+    assert len(data) == 10  # default schedule.yaml ships 10 slots
+
+    # Sorted alphabetically by slot_key.
+    keys = [s["key"] for s in data]
+    assert keys == sorted(keys)
+
+    # morning-briefing field-shape spot-check (all 11 fields present).
+    morning = next(s for s in data if s["key"] == "morning-briefing")
+    assert morning["type"] == "briefing"
+    assert morning["runner"] == "run-scout.sh"
+    assert morning["fires_at_local"] == "08:00"
+    assert morning["weekdays"] == ["Mon", "Tue", "Wed", "Thu", "Fri"]
+    assert morning["missed_window_hours"] == 4
+    assert morning["on_miss"] == "fire"
+    assert morning["cooldown_minutes"] == 60
+    assert morning["budget_usd"] is None
+    assert morning["tz"] is None
+    assert morning["runtime"] == "local"
+
+
+def test_schedule_list_default_emits_tab_separated():
+    """Backward compat: --no-json (default) preserves the original
+    tab-separated output for existing terminal users."""
+    result = runner.invoke(app, ["schedule", "list"])
+    assert result.exit_code == 0
+    # Tab-separated, not JSON — first non-empty line should NOT start with `[`.
+    first_line = next((line for line in result.stdout.splitlines() if line.strip()), "")
+    assert not first_line.startswith("[")
+    assert "\t" in first_line
+
+
 def test_schedule_show_single_slot_returns_full_record():
     result = runner.invoke(app, ["schedule", "show", "morning-briefing"])
     assert result.exit_code == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary

Hot-fix for Plan 6 — adds the `--json` flag to `scoutctl schedule list` that the Plan 6 spec assumed existed but didn't.

## What was broken

scout-app's `ScheduleEditService.loadAll()` calls `scoutctl schedule list --json`. Without this fix, that command errors with `Error: No such option: --json`. Swift's `JSONDecoder` then fails on the tab-separated stderr-redirected-as-stdout output, surfacing as a red banner in the Schedules tab: *"The data couldn't be read because it isn't in the correct format"* + an empty-state view. (Confirmed live by Jordan after Plan 6 merged.)

## What this PR does

- `engine/scout/cli.py::cli_schedule_list` gains a `--json/--no-json` flag.
- Default (`--no-json`) preserves the existing tab-separated output for terminal users — backward-compat.
- `--json` emits a sorted-by-`slot_key` JSON array of full 11-field Slot records (matching the Swift `Slot` decoder's `CodingKeys`).

## Why it wasn't caught earlier

- Plan 6 spec referenced "existing `scoutctl schedule list --json`" — wrong premise.
- Plan 6 unit tests used a `QueueProcessRunner` stub that returned canned JSON without invoking real scoutctl, so the integration gap stayed invisible.
- The opt-in E2E test (`ScheduleEditE2ETest`, gated on `SCOUT_DATA_DIR`) WOULD have caught it — never run before merge.
- The Task 14 manual smoke confirmed the app didn't crash on Schedules tab click; it just rendered the error path silently.

## Test plan

- [x] `tests/unit/test_cli_schedule_subapp.py::test_schedule_list_json_emits_full_slot_records` — new
- [x] `tests/unit/test_cli_schedule_subapp.py::test_schedule_list_default_emits_tab_separated` — new (backward-compat guard)
- [x] Full engine suite: 429 passed + 9 skipped (was 427 + 9 baseline)
- [x] Live: `scoutctl schedule list --json | jq length` → 10
- [ ] Post-merge: relaunch local Scout.app, click Schedules → see 10 slots populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)