### PR TITLE
Fix README install instructions; add .claude-plugin/marketplace.json (closes #3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,27 @@
+{
+  "name": "scout-plugin",
+  "owner": {
+    "name": "Jordan Burger"
+  },
+  "description": "Marketplace for the Scout autonomous knowledge management plugin",
+  "plugins": [
+    {
+      "name": "scout",
+      "source": "./",
+      "description": "Autonomous knowledge management and daily briefing system for Claude Code",
+      "version": "0.3.0",
+      "author": {
+        "name": "Jordan Burger"
+      },
+      "homepage": "https://github.com/jordanrburger/scout-plugin",
+      "repository": "https://github.com/jordanrburger/scout-plugin",
+      "keywords": [
+        "knowledge-management",
+        "briefing",
+        "automation",
+        "scheduling",
+        "obsidian"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,6 +2,18 @@
   "name": "scout",
   "version": "0.3.0",
   "description": "Autonomous knowledge management and daily briefing system. Monitors your work tools (Slack, Calendar, Linear, GitHub, etc.), synthesizes findings into a persistent knowledge base with a formal ontology, and delivers daily action items — all running unattended via scheduled Claude Code sessions. Six session types: Morning Briefing, Consolidation, Dreaming, Research, interactive Work sessions, and Meta Review. Pre-session hooks pre-compute KB staleness, recent git activity, PR state, and Claude Code session summaries before each run, trading a few seconds of shell work for large token savings inside the session.",
+  "author": {
+    "name": "Jordan Burger"
+  },
+  "homepage": "https://github.com/jordanrburger/scout-plugin",
+  "repository": "https://github.com/jordanrburger/scout-plugin",
+  "keywords": [
+    "knowledge-management",
+    "briefing",
+    "automation",
+    "scheduling",
+    "obsidian"
+  ],
   "commands": [
     "commands/scout-setup.md",
     "commands/scout-status.md",

--- a/README.md
+++ b/README.md
@@ -6,9 +6,21 @@ You shouldn't have to manually track what happened across seven different tools 
 
 ## Quick Start
 
+Scout is distributed as a Claude Code plugin via a built-in marketplace catalog (`.claude-plugin/marketplace.json`). Install it with:
+
 ```
-claude plugin add <repo-url>
+/plugin marketplace add jordanrburger/scout-plugin
+/plugin install scout@scout-plugin
 ```
+
+The first command registers this repo as a plugin marketplace; the second installs the `scout` plugin from it. After installing, the `/scout-*` commands and skills are available in every Claude Code session.
+
+> **Other ways to install**
+>
+> - **One-off (no install):** `claude --plugin-dir /path/to/scout-plugin` loads the plugin for a single session without persisting it.
+> - **From a local clone via marketplace:** `/plugin marketplace add /path/to/scout-plugin` (give it the directory containing `.claude-plugin/marketplace.json`).
+>
+> See [Discover and install plugins](https://code.claude.com/docs/en/discover-plugins) for the full Claude Code plugin documentation.
 
 Then run `/scout-setup` in any Claude Code session. The setup wizard detects your connected tools (MCP connectors, `gh` CLI, local directories), collects your details (name, Slack ID, email), scaffolds the Scout directory with a knowledge graph ontology, assembles personalized skill files from phase modules matching your connectors, sets up budget tracking scripts, and configures scheduling. Done in under 5 minutes.
 
@@ -188,7 +200,9 @@ Scout is built from **phase modules** — small, focused markdown files that eac
 
 ```
 scout-plugin/
-  plugin.json               -- Plugin manifest
+  .claude-plugin/
+    plugin.json             -- Plugin manifest
+    marketplace.json        -- Marketplace catalog (lets the repo install via /plugin marketplace add)
   commands/
     scout-setup.md          -- Interactive setup wizard
     scout-status.md         -- Dashboard command

--- a/engine/README.md
+++ b/engine/README.md
@@ -28,6 +28,6 @@ pytest tests/
 
 ## See also
 
-- `../plugin.json` — Claude Code plugin manifest
+- `../.claude-plugin/plugin.json` — Claude Code plugin manifest
 - Scout unification design spec lives in the scout-app repo under
   `docs/superpowers/specs/`.


### PR DESCRIPTION
## Summary

- Replaces the broken `claude plugin add <repo-url>` instruction in the README Quick Start with the correct `/plugin marketplace add` + `/plugin install` flow, and documents `--plugin-dir` for one-off (non-persistent) use.
- Adds `.claude-plugin/marketplace.json` so this repo doubles as a single-plugin git marketplace — users can install Scout directly from the repo with two slash commands.
- Moves `plugin.json` to its canonical `.claude-plugin/plugin.json` location (matches the Claude Code plugin spec and how all the other plugins on disk are laid out). Components (`commands/`, `skills/`, etc.) stay at the repo root.
- Refreshes the README plugin-structure diagram and the `engine/README.md` cross-reference to point at the new manifest path.

Closes #3.

## Test plan

- [ ] `/plugin marketplace add jordanrburger/scout-plugin` resolves the new `marketplace.json` and lists `scout` as installable.
- [ ] `/plugin install scout@scout-plugin` installs the plugin; `/scout-setup`, `/scout-status`, `/scout-work`, `/scout-meta-review` and the four scout-* skills appear.
- [ ] `claude --plugin-dir /path/to/scout-plugin` still loads the plugin for a single session (now via `.claude-plugin/plugin.json`).
- [ ] Existing engine tests still pass (`pytest engine/tests`) — none reference the manifest path, but worth a sanity run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)