### PR TITLE
fix(test): smoke test default SCOUTCTL path → ~/scout-plugin/.venv

### DIFF
--- a/engine/tests/integration/test_bootstrap_smoke.sh
+++ b/engine/tests/integration/test_bootstrap_smoke.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 TEST_VAULT=$(mktemp -d -t scout-smoke-XXXXXX)
 trap 'rm -rf "$TEST_VAULT"' EXIT
 
-SCOUTCTL="${SCOUTCTL:-$HOME/scout-plugin-plan-8/.venv/bin/scoutctl}"
+SCOUTCTL="${SCOUTCTL:-$HOME/scout-plugin/.venv/bin/scoutctl}"
 
 if [ ! -x "$SCOUTCTL" ]; then
     echo "FAIL: scoutctl not found at $SCOUTCTL" >&2


### PR DESCRIPTION
Plan 8's bootstrap smoke test had a hardcoded default `SCOUTCTL=${SCOUTCTL:-$HOME/scout-plugin-plan-8/.venv/bin/scoutctl}` from when the work was happening in a development worktree. After v0.4.0 merged and the worktree was removed, that path no longer exists.

Repoint to the canonical `$HOME/scout-plugin/.venv/bin/scoutctl` install location. `SCOUTCTL=...` env-var override still works for development reruns from worktrees.

## Test plan
- [x] `bash engine/tests/integration/test_bootstrap_smoke.sh` against canonical install → `PASS: bootstrap smoke test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)