### PR TITLE
fix(lint): Plan 8 ruff check + format cleanups

### DIFF
--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -621,8 +621,11 @@ def _register_schedule() -> None:
         """Install or remove com.scout.heartbeat.plist."""
         from scout.scripts.install_heartbeat_plist import (
             install_plist as _i,
+        )
+        from scout.scripts.install_heartbeat_plist import (
             uninstall_plist as _u,
         )
+
         if uninstall:
             _u(bootout=bootstrap)
             typer.echo("uninstalled com.scout.heartbeat.plist")
@@ -641,9 +644,14 @@ def _register_schedule() -> None:
         """Install or remove the Linux scout-managed crontab block."""
         from scout.scripts.install_cron import (
             CrontabApplyError,
+        )
+        from scout.scripts.install_cron import (
             install_cron as _i,
+        )
+        from scout.scripts.install_cron import (
             uninstall_cron as _u,
         )
+
         try:
             if uninstall:
                 _u(home=Path.home())
@@ -662,14 +670,22 @@ def _register_schedule() -> None:
     ) -> None:
         """Platform-aware installer (launchd on macOS, cron on Linux)."""
         import platform as _platform
+
         system = _platform.system()
         if system == "Darwin":
-            from scout.scripts.install_schedule_plist import (
-                install_plist as install_st, uninstall_plist as uninstall_st,
+            from scout.scripts.install_heartbeat_plist import (
+                install_plist as install_hb,
             )
             from scout.scripts.install_heartbeat_plist import (
-                install_plist as install_hb, uninstall_plist as uninstall_hb,
+                uninstall_plist as uninstall_hb,
             )
+            from scout.scripts.install_schedule_plist import (
+                install_plist as install_st,
+            )
+            from scout.scripts.install_schedule_plist import (
+                uninstall_plist as uninstall_st,
+            )
+
             if uninstall:
                 uninstall_st(bootout=True)
                 uninstall_hb(bootout=True)
@@ -680,6 +696,7 @@ def _register_schedule() -> None:
             typer.echo("installed launchd plists")
         elif system == "Linux":
             from scout.scripts.install_cron import install_cron, uninstall_cron
+
             if uninstall:
                 uninstall_cron(home=Path.home())
                 typer.echo("uninstalled scout-managed crontab block")
@@ -795,8 +812,8 @@ def _register_bootstrap() -> None:
         connectors: str = typer.Option("", "--connectors", help="Comma-separated enabled connector names"),
     ) -> None:
         """Install Scout into the user's vault directory."""
-        from scout import paths as _paths
         from scout import __version__
+        from scout import paths as _paths
         from scout.scripts.bootstrap import BootstrapConfig, install
 
         vault = _paths.data_dir()
@@ -830,8 +847,8 @@ def _register_bootstrap() -> None:
         skip_claude: bool = typer.Option(False, "--skip-claude"),
     ) -> None:
         """Upgrade an existing vault against the current plugin templates."""
-        from scout import paths as _paths
         from scout import __version__
+        from scout import paths as _paths
         from scout.scripts.bootstrap import BootstrapConfig, upgrade
 
         vault = _paths.data_dir()
@@ -840,6 +857,7 @@ def _register_bootstrap() -> None:
             typer.echo(f"no vault at {vault} — run /scout-setup", err=True)
             raise typer.Exit(code=2)
         import yaml as _yaml
+
         existing = _yaml.safe_load(cfg_path.read_text()) or {}
         connectors = set(existing.get("connectors", {}).get("enabled") or [])
         instance = existing.get("instance", {})
@@ -896,9 +914,7 @@ def _register_bootstrap() -> None:
         timezone: str = typer.Option("America/New_York", "--timezone"),
         max_budget: str = typer.Option("5.00", "--max-budget"),
         platform: str = typer.Option("macos", "--platform"),
-        connectors: str = typer.Option(
-            "", "--connectors", help="Comma-separated enabled connector names"
-        ),
+        connectors: str = typer.Option("", "--connectors", help="Comma-separated enabled connector names"),
         skip_jobs: bool = typer.Option(
             True,
             "--no-jobs/--rebootstrap-jobs",
@@ -928,9 +944,7 @@ def _register_bootstrap() -> None:
             timezone=timezone,
             platform=platform,
             plugin_version=__version__,
-            enabled_connectors=set(
-                c.strip() for c in connectors.split(",") if c.strip()
-            ),
+            enabled_connectors=set(c.strip() for c in connectors.split(",") if c.strip()),
             connector_inputs={
                 "user_slack_id": user_slack_id,
                 "github_username": github_username,

--- a/engine/scout/schedule.py
+++ b/engine/scout/schedule.py
@@ -44,7 +44,9 @@ class OnMissPolicy(enum.Enum):
 
 class SlotRuntime(enum.Enum):
     LOCAL = "local"
-    REMOTE = "remote"  # Reserved for a future plan (remote routine integration via Anthropic routines API); not yet wired. Loader accepts; dispatcher rejects.
+    # Reserved for a future plan (remote routine integration via Anthropic
+    # routines API); not yet wired. Loader accepts; dispatcher rejects.
+    REMOTE = "remote"
 
 
 class SlotPriority(enum.IntEnum):

--- a/engine/scout/scripts/bootstrap.py
+++ b/engine/scout/scripts/bootstrap.py
@@ -149,6 +149,7 @@ def _atomic_write(path: Path, content: str) -> None:
 
 # ---------- stages ----------
 
+
 def _stage_create_dirs(cfg: BootstrapConfig) -> None:
     for rel in _CAT1_DIR_LAYOUT:
         (cfg.vault / rel).mkdir(parents=True, exist_ok=True)
@@ -407,7 +408,7 @@ def install(cfg: BootstrapConfig) -> InstallResult:
     try:
         _stage_create_dirs(cfg)
         _stage_cat1_writes(cfg)
-        _stage_install_only_seeds(cfg)   # <-- NEW
+        _stage_install_only_seeds(cfg)  # <-- NEW
         _stage_seed_schedule(cfg)
         _stage_cat1b_runners(cfg, is_upgrade=False)
         _stage_cat4_install(cfg)
@@ -431,9 +432,7 @@ def _is_legacy_vault(vault: Path) -> bool:
 def upgrade(cfg: BootstrapConfig) -> UpgradeResult:
     """Run the upgrade pipeline. Refuses if no vault or if vault is legacy (pre-Plan-8)."""
     if not _vault_exists(cfg.vault):
-        raise FileNotFoundError(
-            f"no vault at {cfg.vault} — run /scout-setup instead."
-        )
+        raise FileNotFoundError(f"no vault at {cfg.vault} — run /scout-setup instead.")
     if _is_legacy_vault(cfg.vault):
         raise RuntimeError(
             f"legacy vault detected at {cfg.vault} (no scout-config.yaml). "
@@ -485,8 +484,7 @@ def migrate_legacy(cfg: BootstrapConfig) -> MigrateLegacyResult:
     """
     if not (cfg.vault / ".scout-state").exists():
         raise FileNotFoundError(
-            f"no vault at {cfg.vault} (no .scout-state/ directory) — "
-            f"run /scout-setup for a fresh install."
+            f"no vault at {cfg.vault} (no .scout-state/ directory) — run /scout-setup for a fresh install."
         )
     if (cfg.vault / "scout-config.yaml").exists():
         raise FileExistsError(

--- a/engine/scout/scripts/bootstrap_lock.py
+++ b/engine/scout/scripts/bootstrap_lock.py
@@ -90,9 +90,7 @@ def remove_stale_lock(lock_path: Path) -> None:
         lock_path.unlink()
 
 
-def acquire_lock_with_wait(
-    lock_path: Path, *, timeout_s: int = 300, poll_s: int = 10
-) -> None:
+def acquire_lock_with_wait(lock_path: Path, *, timeout_s: int = 300, poll_s: int = 10) -> None:
     """Acquire with up to ``timeout_s`` of polling. Raise LockBusyError on timeout."""
     deadline = time.monotonic() + timeout_s
     while True:

--- a/engine/scout/scripts/connector_probes.py
+++ b/engine/scout/scripts/connector_probes.py
@@ -15,8 +15,8 @@ import yaml
 
 
 class ProbeKind(Enum):
-    MCP_TOOL = "mcp_tool"   # primary is an MCP tool name to call
-    BASH = "bash"           # primary is "bash"; command is the shell command
+    MCP_TOOL = "mcp_tool"  # primary is an MCP tool name to call
+    BASH = "bash"  # primary is "bash"; command is the shell command
 
 
 @dataclass(frozen=True)
@@ -24,7 +24,7 @@ class Probe:
     name: str
     kind: ProbeKind
     tool_chain: list[str] = field(default_factory=list)  # MCP_TOOL only
-    bash_command: str = ""                                # BASH only
+    bash_command: str = ""  # BASH only
     needs_user_input: list[str] = field(default_factory=list)
 
 
@@ -32,10 +32,7 @@ def load_registry(path: Path) -> dict[str, Probe]:
     """Parse connector-probes.yaml into typed Probe objects."""
     raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     if not isinstance(raw, dict):
-        raise ValueError(
-            f"connector-probes.yaml must be a YAML mapping at the top level, "
-            f"got {type(raw).__name__}"
-        )
+        raise ValueError(f"connector-probes.yaml must be a YAML mapping at the top level, got {type(raw).__name__}")
     out: dict[str, Probe] = {}
     for name, body in raw.items():
         if not isinstance(body, dict):

--- a/engine/scout/scripts/install_cron.py
+++ b/engine/scout/scripts/install_cron.py
@@ -33,19 +33,14 @@ def _list_crontab() -> str:
 
 def _apply_crontab(content: str) -> None:
     """Apply the new crontab via temp-file. Atomic from user's perspective."""
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".cron", delete=False, encoding="utf-8"
-    ) as tf:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".cron", delete=False, encoding="utf-8") as tf:
         tf.write(content)
         path = tf.name
     try:
-        proc = subprocess.run(
-            ["crontab", path], capture_output=True, text=True, check=False
-        )
+        proc = subprocess.run(["crontab", path], capture_output=True, text=True, check=False)
         if proc.returncode != 0:
             raise CrontabApplyError(
-                f"crontab apply failed (rc={proc.returncode}): "
-                f"{proc.stderr or proc.stdout or '(no output)'}"
+                f"crontab apply failed (rc={proc.returncode}): {proc.stderr or proc.stdout or '(no output)'}"
             )
     finally:
         if os.path.exists(path):
@@ -95,6 +90,7 @@ def _backup(previous: str, backup_dir: Path) -> None:
     except OSError as e:
         # Best-effort — don't mask the successful crontab apply.
         import sys
+
         print(f"warning: failed to write crontab backup: {e}", file=sys.stderr)
 
 

--- a/engine/scout/scripts/phase_assembly.py
+++ b/engine/scout/scripts/phase_assembly.py
@@ -75,9 +75,7 @@ def parse_phase_file(path: Path) -> list[PhaseSection]:
                 "Wrap in brackets: [briefing]"
             )
         else:
-            raise ValueError(
-                f"{path} [{section_id}]: 'mode' must be a YAML list, got {type(raw_mode).__name__}"
-            )
+            raise ValueError(f"{path} [{section_id}]: 'mode' must be a YAML list, got {type(raw_mode).__name__}")
 
         # Validate ``requires``: must be a string or null, not a list.
         raw_requires = fm.get("requires")
@@ -87,16 +85,13 @@ def parse_phase_file(path: Path) -> list[PhaseSection]:
             requires = raw_requires
         else:
             raise ValueError(
-                f"{path} [{section_id}]: 'requires' must be a string or null, "
-                f"got {type(raw_requires).__name__}"
+                f"{path} [{section_id}]: 'requires' must be a string or null, got {type(raw_requires).__name__}"
             )
 
         # Validate ``phase``: must be present and non-empty.
         phase_val = str(fm.get("phase", "")).strip()
         if not phase_val:
-            raise ValueError(
-                f"{path} [{section_id}]: 'phase' field is required and must be non-empty"
-            )
+            raise ValueError(f"{path} [{section_id}]: 'phase' field is required and must be non-empty")
 
         sections.append(
             PhaseSection(

--- a/engine/scout/scripts/three_way_merge.py
+++ b/engine/scout/scripts/three_way_merge.py
@@ -58,7 +58,5 @@ def three_way_merge(*, base: str, ours: str, theirs: str) -> MergeResult:
         # git merge-file: returncode 0 = clean, 1..127 = conflict count,
         # 128/255 = fatal git error. Treat fatal as "raise".
         if proc.returncode < 0 or proc.returncode > 127:
-            raise RuntimeError(
-                f"git merge-file exited {proc.returncode}: {proc.stderr.strip()}"
-            )
+            raise RuntimeError(f"git merge-file exited {proc.returncode}: {proc.stderr.strip()}")
         return MergeResult(content=proc.stdout, conflicts=proc.returncode > 0)

--- a/engine/tests/unit/test_bootstrap_install.py
+++ b/engine/tests/unit/test_bootstrap_install.py
@@ -26,8 +26,8 @@ def _config(vault: Path, *, plugin_root: Path) -> BootstrapConfig:
         plugin_version="0.4.0",
         enabled_connectors=set(),
         connector_inputs={},
-        skip_jobs=True,        # don't touch ~/Library/LaunchAgents in tests
-        skip_claude=True,      # don't run a real Claude session
+        skip_jobs=True,  # don't touch ~/Library/LaunchAgents in tests
+        skip_claude=True,  # don't run a real Claude session
     )
 
 
@@ -87,6 +87,7 @@ def test_install_records_plugin_version(tmp_path):
     install(_config(vault, plugin_root=plugin))
     config_text = (vault / "scout-config.yaml").read_text()
     import yaml
+
     cfg = yaml.safe_load(config_text)
     assert cfg["plugin"]["version_at_last_setup"] == "0.4.0"
     assert cfg["plugin"]["version_at_last_update"] == "0.4.0"

--- a/engine/tests/unit/test_bootstrap_migrate_legacy.py
+++ b/engine/tests/unit/test_bootstrap_migrate_legacy.py
@@ -48,7 +48,7 @@ def _populate_legacy_vault(vault: Path) -> None:
     (vault / "DREAMING.md").write_text("# DREAMING\n\nVault-customized content. " * 100)
     (vault / "RESEARCH.md").write_text("# RESEARCH\n\nVault-customized content. " * 50)
     # Legacy runners with hand-edited content.
-    (vault / "run-scout.sh").write_text("#!/bin/bash\n# legacy hand-edited runner\nSCOUT_DIR=\"...\"\n")
+    (vault / "run-scout.sh").write_text('#!/bin/bash\n# legacy hand-edited runner\nSCOUT_DIR="..."\n')
     (vault / "run-dreaming.sh").write_text("#!/bin/bash\n# legacy\n")
     (vault / "run-research.sh").write_text("#!/bin/bash\n# legacy\n")
 
@@ -160,6 +160,7 @@ def test_migrate_then_upgrade_works(tmp_path):
     cfg = _config(tmp_path, plugin_root=plugin)
     cfg.plugin_version = "0.4.1"
     from scout.scripts.bootstrap import upgrade as _upgrade
+
     _upgrade(cfg)  # no exception expected
     new_cfg = yaml.safe_load((tmp_path / "scout-config.yaml").read_text())
     assert new_cfg["plugin"]["version_at_last_update"] == "0.4.1"
@@ -190,6 +191,7 @@ def test_migrate_then_upgrade_preserves_live_cat4(tmp_path):
     cfg = _config(tmp_path, plugin_root=plugin)
     cfg.plugin_version = "0.4.1"
     from scout.scripts.bootstrap import upgrade as _upgrade
+
     _upgrade(cfg)
     # Live cat-4 must STILL match pre-migrate content.
     assert (tmp_path / "SKILL.md").read_text() == pre_migrate_skill
@@ -253,6 +255,7 @@ def test_upgrade_sidecar_when_base_equals_theirs_but_ours_diverges(tmp_path):
     cfg = _config(tmp_path, plugin_root=plugin)
     cfg.plugin_version = "0.4.1"
     from scout.scripts.bootstrap import upgrade as _upgrade
+
     result = _upgrade(cfg)
     # Live must be untouched.
     assert live.read_text() == synthetic

--- a/engine/tests/unit/test_install_cron.py
+++ b/engine/tests/unit/test_install_cron.py
@@ -101,12 +101,7 @@ def test_install_writes_backup_of_previous_crontab(fake, tmp_path):
 
 
 def test_uninstall_removes_managed_block(fake, tmp_path):
-    fake.content = (
-        "# user line\n"
-        "# >>> scout-managed >>>\n"
-        "*/5 * * * * scoutctl schedule tick\n"
-        "# <<< scout-managed <<<\n"
-    )
+    fake.content = "# user line\n# >>> scout-managed >>>\n*/5 * * * * scoutctl schedule tick\n# <<< scout-managed <<<\n"
     cron_mod.uninstall_cron(home=tmp_path, backup_dir=tmp_path)
     assert "# >>> scout-managed >>>" not in fake.content
     assert "# user line" in fake.content
@@ -120,11 +115,7 @@ def test_uninstall_silent_when_no_block(fake, tmp_path):
 
 def test_install_when_crontab_is_only_managed_block(fake, tmp_path):
     """If the user's crontab is only the managed block, install replaces cleanly with no leading blank."""
-    fake.content = (
-        "# >>> scout-managed >>>\n"
-        "*/99 * * * * old-content\n"
-        "# <<< scout-managed <<<\n"
-    )
+    fake.content = "# >>> scout-managed >>>\n*/99 * * * * old-content\n# <<< scout-managed <<<\n"
     cron_mod.install_cron(home=tmp_path, backup_dir=tmp_path)
     # No leading blank line
     assert not fake.content.startswith("\n")
@@ -135,12 +126,7 @@ def test_install_when_crontab_is_only_managed_block(fake, tmp_path):
 
 def test_install_with_corrupt_unclosed_block(fake, tmp_path):
     """Open marker without close — strip leaves it alone (no truncation)."""
-    fake.content = (
-        "# user line A\n"
-        "# >>> scout-managed >>>\n"
-        "*/5 * * * * orphaned-line\n"
-        "# user line B\n"
-    )
+    fake.content = "# user line A\n# >>> scout-managed >>>\n*/5 * * * * orphaned-line\n# user line B\n"
     # Should still apply: install adds a fresh block at the end while leaving
     # the corrupt block in place. User has to clean up manually.
     cron_mod.install_cron(home=tmp_path, backup_dir=tmp_path)
@@ -153,12 +139,7 @@ def test_install_with_corrupt_unclosed_block(fake, tmp_path):
 
 def test_uninstall_writes_backup(fake, tmp_path):
     """uninstall_cron also writes a backup of the prior crontab."""
-    fake.content = (
-        "# user line\n"
-        "# >>> scout-managed >>>\n"
-        "*/5 * * * * scoutctl schedule tick\n"
-        "# <<< scout-managed <<<\n"
-    )
+    fake.content = "# user line\n# >>> scout-managed >>>\n*/5 * * * * scoutctl schedule tick\n# <<< scout-managed <<<\n"
     cron_mod.uninstall_cron(home=tmp_path, backup_dir=tmp_path)
     backups = list(tmp_path.glob(".crontab.scout-bak.*"))
     assert len(backups) == 1

--- a/engine/tests/unit/test_three_way_merge.py
+++ b/engine/tests/unit/test_three_way_merge.py
@@ -7,8 +7,8 @@ from scout.scripts.three_way_merge import MergeResult, three_way_merge
 
 def test_clean_merge_no_conflict():
     base = "alpha\nbeta\ngamma\n"
-    ours = "alpha\nbeta\ngamma\ndelta\n"      # plugin added a line at end
-    theirs = "alpha\nBETA\ngamma\n"            # vault edited middle line
+    ours = "alpha\nbeta\ngamma\ndelta\n"  # plugin added a line at end
+    theirs = "alpha\nBETA\ngamma\n"  # vault edited middle line
     result = three_way_merge(base=base, ours=ours, theirs=theirs)
     assert isinstance(result, MergeResult)
     assert result.conflicts is False
@@ -19,8 +19,8 @@ def test_clean_merge_no_conflict():
 
 def test_conflicting_change_returns_markers():
     base = "alpha\nbeta\ngamma\n"
-    ours = "alpha\nBETA-OURS\ngamma\n"          # plugin changed line 2
-    theirs = "alpha\nBETA-THEIRS\ngamma\n"      # vault changed line 2 differently
+    ours = "alpha\nBETA-OURS\ngamma\n"  # plugin changed line 2
+    theirs = "alpha\nBETA-THEIRS\ngamma\n"  # vault changed line 2 differently
     result = three_way_merge(base=base, ours=ours, theirs=theirs)
     assert result.conflicts is True
     assert "<<<<<<<" in result.content
@@ -28,7 +28,7 @@ def test_conflicting_change_returns_markers():
     assert ">>>>>>>" in result.content
     assert "BETA-OURS" in result.content
     assert "BETA-THEIRS" in result.content
-    assert "|||||||" in result.content   # diff3-style base block
+    assert "|||||||" in result.content  # diff3-style base block
 
 
 def test_identical_inputs_no_change():
@@ -47,7 +47,7 @@ def test_empty_inputs():
 def test_one_side_deletes_content():
     """Vault keeps content; plugin (ours) removes it. No conflict expected."""
     base = "alpha\nbeta\ngamma\n"
-    ours = "alpha\ngamma\n"        # plugin removed beta
+    ours = "alpha\ngamma\n"  # plugin removed beta
     theirs = "alpha\nbeta\ngamma\n"  # vault unchanged
     result = three_way_merge(base=base, ours=ours, theirs=theirs)
     assert result.conflicts is False


### PR DESCRIPTION
## Summary

CI on PR #16 (Plan 8) failed on `lint` while `test` passed across all 4 matrix combos (macOS + Ubuntu × Python 3.11 + 3.12). Three classes of issue:

1. **`ruff check` (I001 import-block ordering)**: 5 sites in `scout/cli.py` where the new bootstrap + schedule install subcommand bodies had unordered lazy imports. Auto-fixed via `ruff --fix`.
2. **`ruff format`**: 11 files needed reformatting. Plan 8 code was written without running `ruff format` locally. Auto-fixed via `ruff format`.
3. **`ruff check` (E501 long line)**: the new `SlotRuntime.REMOTE` comment in `scout/schedule.py:47` grew to 159 chars after the M3 amendment. Broken into a 2-line block comment above the enum member.

## Test plan
- [x] `cd engine && .venv/bin/ruff check scout tests` → All checks passed!
- [x] `cd engine && .venv/bin/ruff format --check scout tests` → 119 files already formatted
- [x] `cd engine && .venv/bin/mypy scout` → Success: no issues found in 55 source files
- [x] `shellcheck bin/scoutctl` → clean
- [x] `cd engine && .venv/bin/pytest -q` → 529 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)