### PR TITLE
feat: make Scout scheduler work on non-canonical plugin layouts (marketplace, LOCAL_PLUGINS, dev trees)

### DIFF
--- a/commands/scout-setup.md
+++ b/commands/scout-setup.md
@@ -29,19 +29,36 @@ EOF
 - If output is `ORPHAN_JOBS`: tell the user "Found launchd jobs but no vault — half-reset state. Run this to clean up:" then show the [Manual Reset](#manual-reset) snippet. Stop here.
 - If output is `FRESH`: continue.
 
-Check the engine venv exists:
+Locate the venv that belongs to THIS plugin checkout. Use `$CLAUDE_PLUGIN_ROOT/.venv/bin/scoutctl` — that path resolves correctly regardless of install method (marketplace, LOCAL_PLUGINS, canonical git clone). Belt-and-suspenders: fall back to `~/scout-plugin` if `$CLAUDE_PLUGIN_ROOT` is somehow unset:
 
 ```bash
-test -x "$HOME/scout-plugin/.venv/bin/scoutctl" && echo "VENV_OK" || echo "VENV_MISSING"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$HOME/scout-plugin}"
+SCOUTCTL="$PLUGIN_ROOT/.venv/bin/scoutctl"
+test -x "$SCOUTCTL" && echo "VENV_OK" || echo "VENV_MISSING"
 ```
+
+Use `"$SCOUTCTL"` (and `$PLUGIN_ROOT`) in every subsequent invocation.
 
 - If `VENV_MISSING`: tell the user "Engine venv missing. Installing now (this typically takes 30–60 seconds)..." then run, with explicit 5-minute timeout:
 
   ```bash
-  bash ~/scout-plugin/scripts/install-venv.sh
+  bash "$PLUGIN_ROOT/scripts/install-venv.sh"
   ```
 
-  (Use the Bash tool with `timeout: 300000`.) If install fails: stop and instruct the user to run `bash ~/scout-plugin/scripts/install-venv.sh` manually, then retry `/scout-setup`.
+  (Use the Bash tool with `timeout: 300000`.) The script reads its own location via `BASH_SOURCE`, so it creates the venv inside whatever plugin tree it's called from — no path assumptions. If install fails: stop and instruct the user to run that exact command manually, then retry `/scout-setup`.
+
+If `VENV_OK`, additionally verify the venv is editable-installed FROM this plugin checkout (catches stale venvs from a prior install at a different plugin path):
+
+```bash
+PYTHON="$(dirname "$SCOUTCTL")/python"
+INSTALLED=$("$PYTHON" -c "import scout, os; print(os.path.realpath(os.path.dirname(os.path.dirname(scout.__file__))))" 2>/dev/null)
+EXPECTED=$(cd "$PLUGIN_ROOT/engine" && pwd -P)
+if [ "$INSTALLED" != "$EXPECTED" ]; then
+    echo "VENV_MISMATCH:$INSTALLED|$EXPECTED"
+fi
+```
+
+If `VENV_MISMATCH:<installed>|<expected>` is emitted, tell the user: "The venv at `$PLUGIN_ROOT/.venv/` is editable-installed from `<installed>`, but this plugin is loaded from `<expected>`. Re-installing now to pin it to this checkout..." then run `bash "$PLUGIN_ROOT/scripts/install-venv.sh"` and re-verify.
 
 ---
 
@@ -84,10 +101,10 @@ Confirm with the user: "Proceed with these connectors? Or pause to enable more f
 
 ## Step 3: Hand off to `scoutctl bootstrap install`
 
-Build the comma-separated connector list (only enabled), then run:
+Build the comma-separated connector list (only enabled), then run (use the `$SCOUTCTL` resolved in Step 0):
 
 ```bash
-~/scout-plugin/.venv/bin/scoutctl bootstrap install \
+"$SCOUTCTL" bootstrap install \
     --instance-name "<INSTANCE_NAME>" \
     --user-name "<USER_NAME>" \
     --user-email "<USER_EMAIL>" \
@@ -95,6 +112,8 @@ Build the comma-separated connector list (only enabled), then run:
     --platform "$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/macos/')" \
     --connectors "<comma-separated-enabled-list>"
 ```
+
+The plist + cron block installed by this step automatically reference `$SCOUTCTL` — `resolve_scoutctl_bin()` derives the path from the running engine's plugin root, so the scheduler is always pinned to the venv the wizard just used.
 
 Capture exit code and stdout. The command emits one line per concern: `installed: <path>`, `doctor: green`, plus warnings for sidecar files or missing snapshots.
 

--- a/commands/scout-status.md
+++ b/commands/scout-status.md
@@ -121,6 +121,47 @@ Note: derive `INSTANCE_LOWER` by lowercasing `INSTANCE_NAME` and replacing space
 
 Collect the output lines. Each loaded plist appears as a row with PID (or `-`), last exit code, and label. Exit code `0` means healthy; any other value is a warning.
 
+#### Scheduler bin-path validation (macOS)
+
+A loaded plist can still be broken if it points at a non-existent or non-executable scoutctl, or if scoutctl lives under a macOS TCC-protected directory (`~/Documents/`, `~/Desktop/`, `~/Downloads/`). Those failures are invisible to `launchctl list` — the job loads fine but every tick crashes during Python init.
+
+Read the installed schedule-tick plist and extract the scoutctl path it references:
+
+```bash
+PLIST="$HOME/Library/LaunchAgents/com.scout.schedule-tick.plist"
+if [ -f "$PLIST" ]; then
+    SCOUTCTL_BIN=$(/usr/libexec/PlistBuddy -c "Print :ProgramArguments:0" "$PLIST" 2>/dev/null)
+    echo "PLIST_SCOUTCTL_BIN=$SCOUTCTL_BIN"
+fi
+```
+
+Then verify three properties of `SCOUTCTL_BIN`:
+
+1. **Exists** — `[ -e "$SCOUTCTL_BIN" ]`. If not, flag as a broken plist.
+2. **Executable** — `[ -x "$SCOUTCTL_BIN" ]`. If not, flag.
+3. **Not under a TCC-protected dir** (after resolving symlinks). Resolve with `RESOLVED=$(readlink -f "$SCOUTCTL_BIN" 2>/dev/null || python3 -c "import os,sys;print(os.path.realpath(sys.argv[1]))" "$SCOUTCTL_BIN")`. Then check:
+   ```bash
+   case "$RESOLVED" in
+       "$HOME/Documents/"*|"$HOME/Desktop/"*|"$HOME/Downloads/"*) flag ;;
+   esac
+   ```
+
+Note: `realpath` on macOS BSD coreutils doesn't support `-f`; the Python one-liner is the portable fallback.
+
+#### Scheduler bin-path validation (Linux)
+
+If `PLATFORM` is `linux`, extract the scoutctl path from the user's crontab managed block:
+
+```bash
+SCOUTCTL_BIN=$(crontab -l 2>/dev/null | awk '
+    /^# >>> scout-managed >>>$/ { in_block = 1; next }
+    /^# <<< scout-managed <<<$/ { in_block = 0; next }
+    in_block && /scoutctl schedule tick/ { print $6; exit }
+')
+```
+
+Then check `[ -e "$SCOUTCTL_BIN" ]` and `[ -x "$SCOUTCTL_BIN" ]`. (TCC restrictions are macOS-specific; skip the protected-dir check on Linux.)
+
 ---
 
 ## Step 4: Compose and Display the Dashboard
@@ -267,6 +308,28 @@ If no entries are found for this instance:
   ⚠️  No launchd plists found for '<INSTANCE_NAME_LOWER>'. Scheduler may not be configured.
   Run `/scout-setup` and choose "Reconfigure" to set up scheduling.
 ```
+
+If the bin-path validation (step 3e sub-checks above) found issues, render one of these blocks immediately under the launchctl table:
+
+```
+  ❌ scoutctl path in plist not executable: /Users/foo/old/.venv/bin/scoutctl
+      Fix: scoutctl schedule install-plist --force
+      (the install command re-derives the canonical path from the loaded
+      plugin's venv — no manual override needed)
+```
+
+```
+  ❌ scoutctl is under ~/Documents (resolved: /Users/foo/Documents/.../scoutctl)
+      macOS TCC blocks launchd from reading this directory. Either:
+        - Move the plugin out of ~/Documents/, or
+        - Grant Full Disk Access to /opt/homebrew/bin/python3.x in
+          System Settings → Privacy & Security → Full Disk Access,
+      then re-install: scoutctl schedule install-plist --force
+```
+
+On Linux, swap "in plist" for "in crontab" and "install-plist" for "install-cron".
+
+If bin-path validation passes, no extra output — the launchctl table alone is enough.
 
 ---
 

--- a/commands/scout-update.md
+++ b/commands/scout-update.md
@@ -11,23 +11,58 @@ This command is for **existing vaults only**. If no vault exists, refuse and tel
 
 ---
 
-## Step 0: Pre-flight (refuse if no vault; refuse if pending sidecars)
+## Locating scoutctl
+
+Use the venv that lives inside the plugin Claude Code loaded — `$CLAUDE_PLUGIN_ROOT/.venv/bin/scoutctl`. That guarantees the upgrade reads templates and engine code from THIS plugin checkout, not from some other clone whose venv happens to be on `$PATH`. Belt-and-suspenders: fall back to `~/scout-plugin/.venv/bin/scoutctl` if `$CLAUDE_PLUGIN_ROOT` is somehow unset.
+
+```bash
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$HOME/scout-plugin}"
+SCOUTCTL="$PLUGIN_ROOT/.venv/bin/scoutctl"
+```
+
+Use `"$SCOUTCTL"` in every subsequent invocation.
+
+---
+
+## Step 0: Pre-flight (refuse if no vault, no venv, pending sidecars, or mismatched venv)
 
 Run:
 
 ```bash
 bash <<'EOF'
 set -e
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$HOME/scout-plugin}"
+SCOUTCTL="$PLUGIN_ROOT/.venv/bin/scoutctl"
+
 test -f "$HOME/Scout/scout-config.yaml" || { echo "NO_VAULT"; exit 0; }
 ls "$HOME/Scout/"{SKILL,DREAMING,RESEARCH}.md.proposed-merge 2>/dev/null && { echo "PENDING_SIDECARS"; exit 0; }
-test -x "$HOME/scout-plugin/.venv/bin/scoutctl" || { echo "VENV_MISSING"; exit 0; }
+test -x "$SCOUTCTL" || { echo "VENV_MISSING:$PLUGIN_ROOT"; exit 0; }
+
+# Verify the venv is editable-installed FROM this plugin checkout.
+# Otherwise we'd run the upgrade against the OTHER tree's templates.
+PYTHON="$(dirname "$SCOUTCTL")/python"
+INSTALLED=$("$PYTHON" -c "import scout, os; print(os.path.realpath(os.path.dirname(os.path.dirname(scout.__file__))))" 2>/dev/null)
+EXPECTED=$(cd "$PLUGIN_ROOT/engine" 2>/dev/null && pwd -P)
+if [ -n "$INSTALLED" ] && [ -n "$EXPECTED" ] && [ "$INSTALLED" != "$EXPECTED" ]; then
+    echo "VENV_MISMATCH:$INSTALLED|$EXPECTED"
+    exit 0
+fi
 echo "READY"
 EOF
 ```
 
 - `NO_VAULT`: "No Scout vault found at `~/Scout/`. Run `/scout-setup` for a fresh install."
 - `PENDING_SIDECARS`: "Unresolved merge conflicts from a prior `/scout-update`:" — list the sidecar files. Then: "Edit each file to remove conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`), then run `mv X.md.proposed-merge X.md` for each. Then re-run `/scout-update`."
-- `VENV_MISSING`: "Engine venv missing. Run `bash ~/scout-plugin/scripts/install-venv.sh` then re-run `/scout-update`."
+- `VENV_MISSING:<plugin-root>`: "Engine venv missing at `<plugin-root>/.venv/`. Install it with:" then show:
+  ```
+  bash "$CLAUDE_PLUGIN_ROOT/scripts/install-venv.sh"
+  ```
+  (or substitute the actual plugin root if `$CLAUDE_PLUGIN_ROOT` isn't set in the user's shell). Then re-run `/scout-update`.
+- `VENV_MISMATCH:<installed>|<expected>`: "The venv at `$PLUGIN_ROOT/.venv/` is editable-installed from `<installed>`, but this plugin is loaded from `<expected>`. Running the upgrade now would apply the OTHER tree's templates, not the ones in this checkout. Re-install the venv pinned to this plugin source:" then show:
+  ```
+  bash "$CLAUDE_PLUGIN_ROOT/scripts/install-venv.sh"
+  ```
+  Then re-run `/scout-update`.
 - `READY`: continue.
 
 ---
@@ -37,7 +72,7 @@ EOF
 Read the current and target plugin versions:
 
 ```bash
-~/scout-plugin/.venv/bin/scoutctl version
+"$SCOUTCTL" version
 python3 -c "import json; print(json.load(open('${CLAUDE_PLUGIN_ROOT}/plugin.json'))['version'])"
 grep version_at_last_update ~/Scout/scout-config.yaml || true
 ```
@@ -51,7 +86,7 @@ If user declines, stop.
 ## Step 2: Run `scoutctl bootstrap upgrade`
 
 ```bash
-~/scout-plugin/.venv/bin/scoutctl bootstrap upgrade
+"$SCOUTCTL" bootstrap upgrade
 ```
 
 Capture exit code (0 = green, 1 = yellow, 2 = red) and stdout/stderr.

--- a/engine/README.md
+++ b/engine/README.md
@@ -26,6 +26,40 @@ scoutctl manifest show
 pytest tests/
 ```
 
+## Non-canonical install locations
+
+The engine works at any path on disk, not just `~/scout-plugin/`. Three
+install methods are all supported:
+
+- **Claude Code marketplace** — plugin lands under
+  `~/.claude/plugins/marketplaces/<marketplace>/scout-plugin/`.
+- **Local-plugins / dev tree** — plugin lives in your own directory tree
+  (e.g. `~/LOCAL_PLUGINS/scout-plugin/`).
+- **Canonical git clone** — plugin at `~/scout-plugin/` directly.
+
+How each layer adapts:
+
+- **Slash commands (`/scout-setup`, `/scout-update`)**: use
+  `$CLAUDE_PLUGIN_ROOT` (set by Claude Code at slash-command invocation)
+  to locate the plugin, install the venv inside it via
+  `scripts/install-venv.sh`, and verify the venv is editable-installed
+  from the same checkout — flagged as `VENV_MISMATCH` otherwise.
+- **`scoutctl schedule install-plist` / `install-cron`**: write
+  `<plugin_root>/.venv/bin/scoutctl` into the plist or cron block, where
+  `plugin_root` is derived from the running engine's package location
+  (`Path(scout.__file__).parent.parent.parent`). No override knob —
+  enforcing this single source of truth eliminates the failure mode
+  where the scheduler runs a different scoutctl than the engine the
+  user thinks is loaded.
+- **`scoutctl bootstrap doctor` / `/scout-status`**: read the installed
+  plist's `ProgramArguments[0]` and verify it points at an existing,
+  executable scoutctl outside any macOS TCC-protected directory
+  (`~/Documents/`, `~/Desktop/`, `~/Downloads/`). Flagged RED with a
+  fix-command hint if any check fails.
+
+The legacy `~/scout-plugin/` path is preserved everywhere as a fallback
+default — canonical-layout installs see no behavior change.
+
 ## See also
 
 - `../.claude-plugin/plugin.json` — Claude Code plugin manifest

--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -430,7 +430,14 @@ def _register_schedule() -> None:
             help="Remove the plist (and bootout the job) instead of installing.",
         ),
     ) -> None:
-        """Install or remove com.scout.schedule-tick.plist in ~/Library/LaunchAgents/."""
+        """Install or remove com.scout.schedule-tick.plist in ~/Library/LaunchAgents/.
+
+        The scoutctl path written into the plist is always
+        ``<plugin_root>/.venv/bin/scoutctl`` for the plugin checkout that
+        is running this command (see ``resolve_scoutctl_bin``). No override
+        knob is exposed by design — the scheduler should always point at
+        the venv that matches the currently-loaded engine.
+        """
         from pathlib import Path as _Path
 
         from scout.scripts.install_schedule_plist import install_plist as _i
@@ -641,7 +648,11 @@ def _register_schedule() -> None:
     def cli_schedule_install_cron(
         uninstall: bool = typer.Option(False, "--uninstall"),
     ) -> None:
-        """Install or remove the Linux scout-managed crontab block."""
+        """Install or remove the Linux scout-managed crontab block.
+
+        The scoutctl path written into the cron block is derived from the
+        running engine's plugin root (same contract as ``install-plist``).
+        """
         from scout.scripts.install_cron import (
             CrontabApplyError,
         )

--- a/engine/scout/defaults/com.scout.schedule-tick.plist
+++ b/engine/scout/defaults/com.scout.schedule-tick.plist
@@ -4,7 +4,10 @@
   com.scout.schedule-tick.plist — runs `scoutctl schedule tick` every 5 min.
 
   Installed by `scoutctl schedule install-plist`, which fills __USER_HOME__
-  at install time. Replaces the 7 per-slot legacy plists deleted in Task 11.
+  and __SCOUTCTL_BIN__ at install time. __SCOUTCTL_BIN__ defaults to
+  ~/scout-plugin/.venv/bin/scoutctl (canonical layout) but falls back to
+  the venv that ran the install command so non-canonical layouts work too.
+  Replaces the 7 per-slot legacy plists deleted in Task 11.
 -->
 <plist version="1.0">
 <dict>
@@ -12,7 +15,7 @@
     <string>com.scout.schedule-tick</string>
     <key>ProgramArguments</key>
     <array>
-        <string>__USER_HOME__/scout-plugin/.venv/bin/scoutctl</string>
+        <string>__SCOUTCTL_BIN__</string>
         <string>schedule</string>
         <string>tick</string>
     </array>

--- a/engine/scout/defaults/cron-managed-block.tmpl
+++ b/engine/scout/defaults/cron-managed-block.tmpl
@@ -3,6 +3,6 @@
 # Do not edit by hand — your changes will be lost on the next /scout-update.
 SHELL=/bin/bash
 PATH=__USER_HOME__/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin
-*/5 * * * * __USER_HOME__/scout-plugin/.venv/bin/scoutctl schedule tick >> __USER_HOME__/Scout/.scout-logs/cron.log 2>&1
+*/5 * * * * __SCOUTCTL_BIN__ schedule tick >> __USER_HOME__/Scout/.scout-logs/cron.log 2>&1
 */30 * * * * __USER_HOME__/Scout/scripts/heartbeat.sh >> __USER_HOME__/Scout/.scout-logs/cron.log 2>&1
 # <<< scout-managed <<<

--- a/engine/scout/scripts/bootstrap_doctor.py
+++ b/engine/scout/scripts/bootstrap_doctor.py
@@ -72,8 +72,7 @@ def _check_macos_plist_scoutctl_bin(*, home: Path) -> tuple[list[str], list[str]
         return errors, warnings
     scoutctl_bin = Path(args[0])
     fix_hint = (
-        "Fix with: scoutctl schedule install-plist --force "
-        "(re-derives the canonical path from the loaded plugin's venv)"
+        "Fix: scoutctl schedule install-plist --force (re-derives the canonical path from the loaded plugin's venv)"
     )
     if not scoutctl_bin.exists():
         errors.append(f"plist references non-existent scoutctl: {scoutctl_bin}. {fix_hint}")
@@ -127,14 +126,18 @@ def _check_linux_cron_scoutctl_bin() -> tuple[list[str], list[str]]:
             continue
         # Standard cron line: 5 time fields + command. Token at index 5 is the
         # executable path (assumes no whitespace in the path — same assumption
-        # baked into install_cron's template).
+        # baked into install_cron's template). Defensive sanity check: the
+        # token must look like a scoutctl path. If the user hand-edited the
+        # managed block to use `@daily` shorthand (1 cron token instead of 5)
+        # or otherwise broke the layout, parts[5] would point at the wrong
+        # token — better to bail than to falsely accuse a different binary.
         parts = line.split()
-        if len(parts) >= 6:
+        if len(parts) >= 6 and parts[5].endswith("/scoutctl"):
             scoutctl_bin = Path(parts[5])
         break
     if scoutctl_bin is None:
         return errors, warnings
-    fix_hint = "Fix with: scoutctl schedule install-cron (re-derives the canonical path from the loaded plugin's venv)"
+    fix_hint = "Fix: scoutctl schedule install-cron (re-derives the canonical path from the loaded plugin's venv)"
     if not scoutctl_bin.exists():
         errors.append(f"crontab references non-existent scoutctl: {scoutctl_bin}. {fix_hint}")
     elif not os.access(scoutctl_bin, os.X_OK):

--- a/engine/scout/scripts/bootstrap_doctor.py
+++ b/engine/scout/scripts/bootstrap_doctor.py
@@ -7,6 +7,8 @@ diagnostic via `scoutctl bootstrap doctor`. Never mutates the vault.
 from __future__ import annotations
 
 import os
+import platform
+import plistlib
 import subprocess
 from dataclasses import dataclass, field
 from enum import Enum
@@ -39,11 +41,122 @@ _REQUIRED_CAT1_FILES = (
     "hooks/kb-pre-filter.sh",
 )
 
+# macOS TCC-protected directories — launchd-spawned processes cannot read files
+# inside these without Full Disk Access granted to the executable.
+_MACOS_TCC_PROTECTED_DIRS = ("Documents", "Desktop", "Downloads")
 
-def run_doctor(*, vault: Path, check_jobs: bool = True) -> DoctorReport:
+
+def _check_macos_plist_scoutctl_bin(*, home: Path) -> tuple[list[str], list[str]]:
+    """Inspect the installed schedule-tick plist's scoutctl path.
+
+    Reports as error if the file doesn't exist or isn't executable. Reports
+    as error if the resolved path falls under a macOS TCC-protected directory
+    (launchd cannot read those without Full Disk Access). Returns empty if
+    the plist isn't installed — that case is already covered by the
+    launchctl-list check upstream.
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+    plist_path = home / "Library" / "LaunchAgents" / "com.scout.schedule-tick.plist"
+    if not plist_path.exists():
+        return errors, warnings
+    try:
+        with plist_path.open("rb") as f:
+            data = plistlib.load(f)
+    except (plistlib.InvalidFileException, OSError) as e:
+        warnings.append(f"could not parse {plist_path.name}: {e}")
+        return errors, warnings
+    args = data.get("ProgramArguments") or []
+    if not args:
+        warnings.append(f"{plist_path.name}: ProgramArguments empty")
+        return errors, warnings
+    scoutctl_bin = Path(args[0])
+    fix_hint = (
+        "Fix with: scoutctl schedule install-plist --force "
+        "(re-derives the canonical path from the loaded plugin's venv)"
+    )
+    if not scoutctl_bin.exists():
+        errors.append(f"plist references non-existent scoutctl: {scoutctl_bin}. {fix_hint}")
+        return errors, warnings
+    if not os.access(scoutctl_bin, os.X_OK):
+        errors.append(f"plist references non-executable scoutctl: {scoutctl_bin}. {fix_hint}")
+        return errors, warnings
+    # TCC dir check: macOS sandbox blocks launchd-spawned processes from reading
+    # files in protected dirs. We compare RESOLVED paths so a symlinked plugin
+    # that lands in ~/Documents is still caught.
+    resolved = scoutctl_bin.resolve()
+    home_resolved = home.resolve()
+    for protected in _MACOS_TCC_PROTECTED_DIRS:
+        protected_path = home_resolved / protected
+        try:
+            resolved.relative_to(protected_path)
+        except ValueError:
+            continue
+        errors.append(
+            f"scoutctl resolves into ~/{protected} ({resolved}). macOS TCC blocks "
+            f"launchd from reading this directory without Full Disk Access. Move the "
+            f"plugin out of ~/{protected}, then re-install: "
+            f"scoutctl schedule install-plist --force"
+        )
+        break
+    return errors, warnings
+
+
+def _check_linux_cron_scoutctl_bin() -> tuple[list[str], list[str]]:
+    """Inspect the Linux scout-managed cron block for the scoutctl path."""
+    errors: list[str] = []
+    warnings: list[str] = []
+    try:
+        proc = subprocess.run(["crontab", "-l"], capture_output=True, text=True, check=False, timeout=5)
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return errors, warnings
+    if proc.returncode != 0:
+        return errors, warnings
+    in_block = False
+    scoutctl_bin: Path | None = None
+    for line in proc.stdout.splitlines():
+        stripped = line.strip()
+        if stripped == "# >>> scout-managed >>>":
+            in_block = True
+            continue
+        if stripped == "# <<< scout-managed <<<":
+            break
+        if not in_block:
+            continue
+        if "scoutctl schedule tick" not in line:
+            continue
+        # Standard cron line: 5 time fields + command. Token at index 5 is the
+        # executable path (assumes no whitespace in the path — same assumption
+        # baked into install_cron's template).
+        parts = line.split()
+        if len(parts) >= 6:
+            scoutctl_bin = Path(parts[5])
+        break
+    if scoutctl_bin is None:
+        return errors, warnings
+    fix_hint = "Fix with: scoutctl schedule install-cron (re-derives the canonical path from the loaded plugin's venv)"
+    if not scoutctl_bin.exists():
+        errors.append(f"crontab references non-existent scoutctl: {scoutctl_bin}. {fix_hint}")
+    elif not os.access(scoutctl_bin, os.X_OK):
+        errors.append(f"crontab references non-executable scoutctl: {scoutctl_bin}. {fix_hint}")
+    return errors, warnings
+
+
+def _check_scheduler_bin_path(*, home: Path) -> tuple[list[str], list[str]]:
+    """Dispatch to the platform-specific scoutctl-bin-path check."""
+    system = platform.system()
+    if system == "Darwin":
+        return _check_macos_plist_scoutctl_bin(home=home)
+    if system == "Linux":
+        return _check_linux_cron_scoutctl_bin()
+    return [], []
+
+
+def run_doctor(*, vault: Path, check_jobs: bool = True, home: Path | None = None) -> DoctorReport:
     """Run all doctor checks against ``vault``. Pure read."""
     errors: list[str] = []
     warnings: list[str] = []
+    home = home or Path.home()
 
     if not vault.is_dir():
         if vault.exists():
@@ -121,6 +234,14 @@ def run_doctor(*, vault: Path, check_jobs: bool = True) -> DoctorReport:
                 errors.append("launchd: com.scout.heartbeat not registered")
         except (subprocess.SubprocessError, FileNotFoundError):
             warnings.append("launchctl unavailable — skipped job registration check")
+
+    # Scheduler scoutctl path — verify the path baked into the installed plist
+    # (macOS) or cron block (Linux) actually points to an executable scoutctl
+    # and isn't trapped in a TCC-protected directory.
+    if check_jobs:
+        bin_errors, bin_warnings = _check_scheduler_bin_path(home=home)
+        errors.extend(bin_errors)
+        warnings.extend(bin_warnings)
 
     if errors:
         return DoctorReport(severity=Severity.RED, errors=errors, warnings=warnings)

--- a/engine/scout/scripts/install_cron.py
+++ b/engine/scout/scripts/install_cron.py
@@ -72,8 +72,19 @@ def _strip_managed_block(text: str) -> str:
 
 
 def _render_block(home: Path) -> str:
-    """Render the cron-managed-block template with HOME substituted."""
-    return TEMPLATE.read_text(encoding="utf-8").replace("__USER_HOME__", str(home))
+    """Render the cron-managed-block template with HOME + scoutctl path substituted.
+
+    The scoutctl path is derived from the running engine's plugin root via
+    ``install_schedule_plist.resolve_scoutctl_bin`` — same single source of
+    truth as the macOS plist.
+    """
+    from scout.scripts.install_schedule_plist import resolve_scoutctl_bin
+
+    return (
+        TEMPLATE.read_text(encoding="utf-8")
+        .replace("__USER_HOME__", str(home))
+        .replace("__SCOUTCTL_BIN__", str(resolve_scoutctl_bin()))
+    )
 
 
 def _backup(previous: str, backup_dir: Path) -> None:

--- a/engine/scout/scripts/install_schedule_plist.py
+++ b/engine/scout/scripts/install_schedule_plist.py
@@ -1,7 +1,8 @@
 """Helper for `scoutctl schedule install-plist [--uninstall] [--force]`.
 
-Filling __USER_HOME__ in the template at install time; not at runtime, because
-launchd's plist parser doesn't expand env vars in <string> values.
+Filling __USER_HOME__ and __SCOUTCTL_BIN__ in the template at install time;
+not at runtime, because launchd's plist parser doesn't expand env vars in
+<string> values.
 """
 
 from __future__ import annotations
@@ -12,6 +13,29 @@ from pathlib import Path
 
 PLIST_NAME = "com.scout.schedule-tick.plist"
 TEMPLATE = Path(__file__).parent.parent / "defaults" / PLIST_NAME
+
+
+def resolve_scoutctl_bin() -> Path:
+    """Return the scoutctl bound to THIS plugin checkout.
+
+    Convention: the venv lives at ``<plugin_root>/.venv/`` and scoutctl is
+    its standard console-script entry point. We derive ``plugin_root`` from
+    the running engine's package location, so the answer is correct
+    whichever install method seeded the venv:
+      - canonical ``~/scout-plugin/`` git clone,
+      - ``LOCAL_PLUGINS/`` dev tree,
+      - marketplace install under ``~/.claude/plugins/marketplaces/...``.
+
+    The slash commands enforce this same convention on the way in
+    (``$CLAUDE_PLUGIN_ROOT/.venv/bin/scoutctl`` with a VENV_MISMATCH check
+    against the editable-installed source), so there is intentionally no
+    knob to point the plist at an unrelated scoutctl — that would create
+    drift between the scheduler and the engine the user thinks is loaded.
+    """
+    import scout
+
+    plugin_root = Path(scout.__file__).parent.parent.parent
+    return plugin_root / ".venv" / "bin" / "scoutctl"
 
 
 def install_plist(
@@ -27,7 +51,11 @@ def install_plist(
     target = agents_dir / PLIST_NAME
     if target.exists() and not force:
         raise FileExistsError(target)
-    rendered = TEMPLATE.read_text(encoding="utf-8").replace("__USER_HOME__", str(home))
+    rendered = (
+        TEMPLATE.read_text(encoding="utf-8")
+        .replace("__USER_HOME__", str(home))
+        .replace("__SCOUTCTL_BIN__", str(resolve_scoutctl_bin()))
+    )
     target.write_text(rendered, encoding="utf-8")
     if bootstrap:
         # `launchctl bootstrap gui/$UID <plist>` loads the job. Best-effort.

--- a/engine/tests/unit/test_bootstrap_doctor.py
+++ b/engine/tests/unit/test_bootstrap_doctor.py
@@ -349,3 +349,65 @@ def test_cron_scoutctl_bin_missing_is_red_on_linux(tmp_path, monkeypatch):
     monkeypatch.setattr("scout.scripts.bootstrap_doctor.subprocess.run", fake_run)
     report = run_doctor(vault=tmp_path, check_jobs=True, home=tmp_path)
     assert any("non-existent scoutctl" in e and "install-cron" in e for e in report.errors)
+
+
+# Defensive branches: corrupt plist, empty ProgramArguments, no-cron-block
+
+
+def test_plist_corrupt_xml_yields_warning(tmp_path, monkeypatch):
+    """plistlib raises InvalidFileException on a malformed plist → warning, not error."""
+    _populate_minimal_vault(tmp_path)
+    _stub_jobs_present(monkeypatch)
+    monkeypatch.setattr("scout.scripts.bootstrap_doctor.platform.system", lambda: "Darwin")
+    plist_dir = tmp_path / "Library" / "LaunchAgents"
+    plist_dir.mkdir(parents=True)
+    (plist_dir / "com.scout.schedule-tick.plist").write_text("not a valid plist <<<")
+
+    report = run_doctor(vault=tmp_path, check_jobs=True, home=tmp_path)
+    # The corrupt-plist branch is informational; a separate launchctl-list
+    # error would already mark this RED, but the plist parse failure itself
+    # is a warning (yellow) — we don't want to escalate on a parse glitch
+    # when launchctl might still load it.
+    assert any("could not parse" in w and "com.scout.schedule-tick.plist" in w for w in report.warnings)
+
+
+def test_plist_empty_program_arguments_yields_warning(tmp_path, monkeypatch):
+    """ProgramArguments=[] in the plist is structurally valid but unusable → warning."""
+    import plistlib
+
+    _populate_minimal_vault(tmp_path)
+    _stub_jobs_present(monkeypatch)
+    monkeypatch.setattr("scout.scripts.bootstrap_doctor.platform.system", lambda: "Darwin")
+    plist_dir = tmp_path / "Library" / "LaunchAgents"
+    plist_dir.mkdir(parents=True)
+    with (plist_dir / "com.scout.schedule-tick.plist").open("wb") as f:
+        plistlib.dump({"Label": "com.scout.schedule-tick", "ProgramArguments": []}, f)
+
+    report = run_doctor(vault=tmp_path, check_jobs=True, home=tmp_path)
+    assert any("ProgramArguments empty" in w for w in report.warnings)
+
+
+def test_cron_no_scout_managed_block_yields_no_errors_on_linux(tmp_path, monkeypatch):
+    """Linux: crontab has user content but no scout-managed block → check returns silently.
+
+    Useful: a user mid-uninstall, or a fresh Linux machine with cron entries
+    that aren't Scout. Doctor shouldn't complain about Scout's cron when
+    Scout's cron isn't there.
+    """
+    _populate_minimal_vault(tmp_path)
+    monkeypatch.setattr("scout.scripts.bootstrap_doctor.platform.system", lambda: "Linux")
+    monkeypatch.setattr("scout.scripts.bootstrap_doctor.os.name", "posix")
+
+    from subprocess import CompletedProcess
+
+    def fake_run(args, **_kwargs):
+        if args[:2] == ["crontab", "-l"]:
+            return CompletedProcess(args, 0, stdout="0 * * * * /usr/bin/something-else\n", stderr="")
+        if args[:2] == ["launchctl", "list"]:
+            raise FileNotFoundError("launchctl")
+        return CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("scout.scripts.bootstrap_doctor.subprocess.run", fake_run)
+    report = run_doctor(vault=tmp_path, check_jobs=True, home=tmp_path)
+    assert not any("scoutctl" in e for e in report.errors)
+    assert not any("scoutctl" in w for w in report.warnings)

--- a/engine/tests/unit/test_bootstrap_doctor.py
+++ b/engine/tests/unit/test_bootstrap_doctor.py
@@ -188,5 +188,164 @@ def test_check_jobs_with_both_jobs_present_is_green(tmp_path, monkeypatch):
 
     monkeypatch.setattr("scout.scripts.bootstrap_doctor.subprocess.run", fake_run)
     monkeypatch.setattr("scout.scripts.bootstrap_doctor.os.name", "posix")
-    report = run_doctor(vault=tmp_path, check_jobs=True)
+    monkeypatch.setattr("scout.scripts.bootstrap_doctor.platform.system", lambda: "Darwin")
+    report = run_doctor(vault=tmp_path, check_jobs=True, home=tmp_path)
     assert report.severity is Severity.GREEN
+
+
+# MINOR 7 — scoutctl-bin-path checks (macOS plist + Linux cron)
+
+
+def _write_plist(home: Path, scoutctl_bin: Path) -> Path:
+    """Write a minimal schedule-tick plist that points at scoutctl_bin."""
+    import plistlib
+
+    plist_dir = home / "Library" / "LaunchAgents"
+    plist_dir.mkdir(parents=True, exist_ok=True)
+    plist_path = plist_dir / "com.scout.schedule-tick.plist"
+    with plist_path.open("wb") as f:
+        plistlib.dump(
+            {
+                "Label": "com.scout.schedule-tick",
+                "ProgramArguments": [str(scoutctl_bin), "schedule", "tick"],
+                "StartInterval": 300,
+            },
+            f,
+        )
+    return plist_path
+
+
+def _stub_jobs_present(monkeypatch) -> None:
+    """Make the launchctl-list check pass so the bin-path check is what drives severity."""
+    from subprocess import CompletedProcess
+
+    def fake_run(args, **_kwargs):
+        return CompletedProcess(
+            args,
+            0,
+            stdout="-\t0\tcom.scout.schedule-tick\n-\t0\tcom.scout.heartbeat\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr("scout.scripts.bootstrap_doctor.subprocess.run", fake_run)
+    monkeypatch.setattr("scout.scripts.bootstrap_doctor.os.name", "posix")
+
+
+def test_plist_scoutctl_bin_missing_is_red(tmp_path, monkeypatch):
+    """plist references a path that doesn't exist → RED with fix hint."""
+    _populate_minimal_vault(tmp_path)
+    _stub_jobs_present(monkeypatch)
+    monkeypatch.setattr("scout.scripts.bootstrap_doctor.platform.system", lambda: "Darwin")
+    _write_plist(tmp_path, tmp_path / "nonexistent" / "scoutctl")
+
+    report = run_doctor(vault=tmp_path, check_jobs=True, home=tmp_path)
+    assert report.severity is Severity.RED
+    assert any("non-existent scoutctl" in e for e in report.errors)
+    assert any("install-plist --force" in e for e in report.errors)
+
+
+def test_plist_scoutctl_bin_not_executable_is_red(tmp_path, monkeypatch):
+    """plist references a file that exists but isn't executable → RED with fix hint."""
+    _populate_minimal_vault(tmp_path)
+    _stub_jobs_present(monkeypatch)
+    monkeypatch.setattr("scout.scripts.bootstrap_doctor.platform.system", lambda: "Darwin")
+    scoutctl = tmp_path / "venv" / "bin" / "scoutctl"
+    scoutctl.parent.mkdir(parents=True)
+    scoutctl.write_text("#!/bin/sh\nexit 0\n")
+    scoutctl.chmod(0o644)  # not executable
+    _write_plist(tmp_path, scoutctl)
+
+    report = run_doctor(vault=tmp_path, check_jobs=True, home=tmp_path)
+    assert report.severity is Severity.RED
+    assert any("non-executable scoutctl" in e for e in report.errors)
+
+
+def test_plist_scoutctl_bin_in_documents_is_red_with_tcc_hint(tmp_path, monkeypatch):
+    """scoutctl resolves under ~/Documents/ → RED with TCC-aware explanation."""
+    _populate_minimal_vault(tmp_path)
+    _stub_jobs_present(monkeypatch)
+    monkeypatch.setattr("scout.scripts.bootstrap_doctor.platform.system", lambda: "Darwin")
+    # The actual binary lives under tmp_path/Documents/... and is executable.
+    scoutctl = tmp_path / "Documents" / "scout-plugin" / ".venv" / "bin" / "scoutctl"
+    scoutctl.parent.mkdir(parents=True)
+    scoutctl.write_text("#!/bin/sh\nexit 0\n")
+    scoutctl.chmod(0o755)
+    _write_plist(tmp_path, scoutctl)
+
+    report = run_doctor(vault=tmp_path, check_jobs=True, home=tmp_path)
+    assert report.severity is Severity.RED
+    assert any("~/Documents" in e and "TCC" in e for e in report.errors)
+
+
+def test_plist_scoutctl_bin_in_documents_via_symlink_is_red(tmp_path, monkeypatch):
+    """scoutctl reachable via a symlink that resolves into ~/Documents → still RED.
+
+    This catches the LOCAL_PLUGINS-symlinked-into-home pattern that originally
+    motivated the bin-path-configurable refactor.
+    """
+    _populate_minimal_vault(tmp_path)
+    _stub_jobs_present(monkeypatch)
+    monkeypatch.setattr("scout.scripts.bootstrap_doctor.platform.system", lambda: "Darwin")
+    real = tmp_path / "Documents" / "LOCAL_PLUGINS" / "scout-plugin" / ".venv" / "bin" / "scoutctl"
+    real.parent.mkdir(parents=True)
+    real.write_text("#!/bin/sh\nexit 0\n")
+    real.chmod(0o755)
+    link = tmp_path / "scout-plugin"
+    link.symlink_to(real.parent.parent.parent)  # ~/scout-plugin -> Documents/LOCAL_PLUGINS/scout-plugin
+    via_symlink = link / ".venv" / "bin" / "scoutctl"
+    _write_plist(tmp_path, via_symlink)
+
+    report = run_doctor(vault=tmp_path, check_jobs=True, home=tmp_path)
+    assert report.severity is Severity.RED
+    assert any("~/Documents" in e for e in report.errors)
+
+
+def test_plist_scoutctl_bin_outside_protected_dirs_is_green(tmp_path, monkeypatch):
+    """Happy path: plist references a real executable scoutctl outside protected dirs."""
+    _populate_minimal_vault(tmp_path)
+    _stub_jobs_present(monkeypatch)
+    monkeypatch.setattr("scout.scripts.bootstrap_doctor.platform.system", lambda: "Darwin")
+    scoutctl = tmp_path / "scout-plugin" / ".venv" / "bin" / "scoutctl"
+    scoutctl.parent.mkdir(parents=True)
+    scoutctl.write_text("#!/bin/sh\nexit 0\n")
+    scoutctl.chmod(0o755)
+    _write_plist(tmp_path, scoutctl)
+
+    report = run_doctor(vault=tmp_path, check_jobs=True, home=tmp_path)
+    assert report.severity is Severity.GREEN
+
+
+def test_bin_path_check_skipped_when_check_jobs_false(tmp_path, monkeypatch):
+    """check_jobs=False suppresses both launchctl AND the new bin-path check."""
+    _populate_minimal_vault(tmp_path)
+    monkeypatch.setattr("scout.scripts.bootstrap_doctor.platform.system", lambda: "Darwin")
+    _write_plist(tmp_path, tmp_path / "definitely-missing" / "scoutctl")
+
+    report = run_doctor(vault=tmp_path, check_jobs=False, home=tmp_path)
+    assert report.severity is Severity.GREEN
+
+
+def test_cron_scoutctl_bin_missing_is_red_on_linux(tmp_path, monkeypatch):
+    """Linux: crontab references a non-existent scoutctl → RED with fix hint."""
+    _populate_minimal_vault(tmp_path)
+    monkeypatch.setattr("scout.scripts.bootstrap_doctor.platform.system", lambda: "Linux")
+    monkeypatch.setattr("scout.scripts.bootstrap_doctor.os.name", "posix")
+
+    from subprocess import CompletedProcess
+
+    missing = tmp_path / "missing" / "scoutctl"
+    crontab_output = (
+        f"# >>> scout-managed >>>\n*/5 * * * * {missing} schedule tick >> /tmp/cron.log 2>&1\n# <<< scout-managed <<<\n"
+    )
+
+    def fake_run(args, **_kwargs):
+        if args[:2] == ["crontab", "-l"]:
+            return CompletedProcess(args, 0, stdout=crontab_output, stderr="")
+        # launchctl on Linux returns FileNotFoundError → demoted to warning
+        if args[:2] == ["launchctl", "list"]:
+            raise FileNotFoundError("launchctl")
+        return CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("scout.scripts.bootstrap_doctor.subprocess.run", fake_run)
+    report = run_doctor(vault=tmp_path, check_jobs=True, home=tmp_path)
+    assert any("non-existent scoutctl" in e and "install-cron" in e for e in report.errors)

--- a/engine/tests/unit/test_install_cron.py
+++ b/engine/tests/unit/test_install_cron.py
@@ -61,6 +61,15 @@ def test_install_into_empty_crontab(fake, tmp_path):
     assert "scoutctl schedule tick" in fake.content
     assert "heartbeat.sh" in fake.content
     assert str(tmp_path) in fake.content  # __USER_HOME__ replaced
+    assert "__SCOUTCTL_BIN__" not in fake.content  # placeholder substituted
+
+
+def test_install_uses_resolver_for_scoutctl_path(fake, tmp_path):
+    """Rendered crontab references the scoutctl returned by resolve_scoutctl_bin()."""
+    from scout.scripts.install_schedule_plist import resolve_scoutctl_bin
+
+    cron_mod.install_cron(home=tmp_path, backup_dir=tmp_path)
+    assert f"{resolve_scoutctl_bin()} schedule tick" in fake.content
 
 
 def test_install_replaces_existing_managed_block(fake, tmp_path):

--- a/engine/tests/unit/test_install_schedule_plist.py
+++ b/engine/tests/unit/test_install_schedule_plist.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
-from scout.scripts.install_schedule_plist import install_plist, uninstall_plist
+from scout.scripts.install_schedule_plist import (
+    install_plist,
+    resolve_scoutctl_bin,
+    uninstall_plist,
+)
 
 
 def test_install_plist_writes_filled_template(tmp_path):
@@ -15,8 +21,28 @@ def test_install_plist_writes_filled_template(tmp_path):
     assert written.exists()
     content = written.read_text()
     assert "__USER_HOME__" not in content  # placeholders filled
+    assert "__SCOUTCTL_BIN__" not in content
     assert str(tmp_path) in content
     assert "<integer>300</integer>" in content
+
+
+def test_install_plist_substitutes_resolver_output(tmp_path):
+    """The plist's ProgramArguments[0] is exactly what resolve_scoutctl_bin returns."""
+    target_dir = tmp_path / "LaunchAgents"
+    target_dir.mkdir()
+    install_plist(home=tmp_path, agents_dir=target_dir)
+    content = (target_dir / "com.scout.schedule-tick.plist").read_text()
+    assert f"<string>{resolve_scoutctl_bin()}</string>" in content
+
+
+def test_resolve_scoutctl_bin_points_at_running_engine_venv():
+    """Resolver always derives plugin_root from the running engine's package
+    location and appends `.venv/bin/scoutctl` — single source of truth for
+    'the scoutctl that matches the currently-loaded engine'."""
+    import scout
+
+    expected_plugin_root = Path(scout.__file__).parent.parent.parent
+    assert resolve_scoutctl_bin() == expected_plugin_root / ".venv" / "bin" / "scoutctl"
 
 
 def test_install_plist_refuses_to_overwrite_without_force(tmp_path):


### PR DESCRIPTION
## TL;DR

v0.4's launchd plist, cron block, and slash commands all hardcoded `$HOME/scout-plugin/.venv/bin/scoutctl`. That assumes every user has their plugin at the canonical `~/scout-plugin/` path. **Marketplace installs and any non-canonical layout silently break.** This PR makes the entire scheduler stack location-agnostic, adds diagnostic checks at install time + on-demand, and pins the scheduler to a single source of truth: the venv inside the loaded plugin checkout.

## The bug that motivated this

While migrating a vault from v0.3 → v0.4 with the plugin checked out at `~/Documents/Prace/KBC/AI-TESTING/LOCAL_PLUGINS/scout-plugin/`, every scheduled tick crashed silently:

```
PermissionError: [Errno 1] Operation not permitted:
  '/Users/.../Documents/.../LOCAL_PLUGINS/scout-plugin/.venv/pyvenv.cfg'
Fatal Python error: init_import_site: Failed to import the site module
```

Root cause: macOS TCC blocks launchd-spawned processes from reading `~/Documents/`, `~/Desktop/`, `~/Downloads/` without per-binary Full Disk Access. The plist's hardcoded `__USER_HOME__/scout-plugin/.venv/bin/scoutctl` only worked because a manual symlink was in place, and Python resolved the symlink to a path under `~/Documents/` during interpreter init.

The doctor reported **yellow** (only stale runner-backup warnings) while every 5-minute tick wrote a fresh PermissionError to `launchd-schedule-tick-stderr.log` for hours.

## Three install layouts that didn't work before

| Layout | Behavior on `main` today |
|---|---|
| Canonical `~/scout-plugin/` git clone | ✅ Works |
| **Marketplace install** (`~/.claude/plugins/marketplaces/.../scout-plugin/`) | ❌ Silently broken — `$HOME/scout-plugin/` doesn't exist, slash commands can't find scoutctl, plist hardcoded path doesn't resolve |
| **LOCAL_PLUGINS / dev tree** | ❌ Requires manual `~/scout-plugin` symlink workaround |
| Plugin under `~/Documents/*` etc. | ❌ macOS TCC silently fails every tick; doctor stays green |

After this PR, all four work without manual setup beyond Claude Code's standard plugin install flow. The TCC-protected-dir case is caught by the doctor + `/scout-status` with explicit fix instructions.

## What this PR does

### `c12f524` — Pin plist + cron scoutctl path to the loaded plugin's venv

Replaces the hardcoded path with a `__SCOUTCTL_BIN__` template placeholder in:
- `engine/scout/defaults/com.scout.schedule-tick.plist`
- `engine/scout/defaults/cron-managed-block.tmpl`

Substituted at install time by a new `resolve_scoutctl_bin()` helper:

```python
def resolve_scoutctl_bin() -> Path:
    import scout
    plugin_root = Path(scout.__file__).parent.parent.parent
    return plugin_root / ".venv" / "bin" / "scoutctl"
```

**Convention:** the venv always lives at `<plugin_root>/.venv/`. `install-venv.sh` already enforces this on the install side via `BASH_SOURCE`; this commit makes the scheduler-install side respect the same convention.

The path is derived from the running engine's package location — single source of truth. The slash command verification (commit 3) catches any pre-existing mismatch before it can reach the plist.

### `5a0884e` — Doctor + `/scout-status` check the scheduler bin path

The previous commit pins the path at install time. This commit verifies it stays valid after install — catching post-install drift (user moves plugin, OS update changes paths, plist hand-edited, etc.) that launchctl-list alone can't see.

**`scoutctl bootstrap doctor`** (runs auto as install-pipeline stage 8):
- Reads `~/Library/LaunchAgents/com.scout.schedule-tick.plist` via `plistlib`
- Extracts `ProgramArguments[0]` and verifies:
  - file exists
  - is executable
  - resolved path (follows symlinks) is **not** under `~/Documents/`, `~/Desktop/`, `~/Downloads/` — macOS TCC dirs that launchd cannot read without Full Disk Access
- Same check on Linux against the scout-managed crontab block (TCC dirs skipped — Linux has no analogue). Defensive sanity check: the cron parser only trusts `parts[5]` if it ends with `/scoutctl`.
- All errors include the fix command: `scoutctl schedule install-plist --force` (re-derives the canonical path automatically)

**`/scout-status` slash command:**
- New "Scheduler bin-path validation" subsection in Step 3e
- Reads the plist via `/usr/libexec/PlistBuddy` (macOS) or the crontab block (Linux)
- Renders a clear error block under "Scheduler Health" with the fix command when validation fails
- Silent when validation passes

**Why both layers?** Doctor is programmatic and runs at install time (catches the bug in the build pipeline). `/scout-status` is user-facing and runs on demand (catches drift that develops after install). Doctor depends on the user being able to invoke scoutctl, which isn't always the case if the scheduler is broken. `/scout-status` works regardless because Claude Code runs the slash-command's bash without depending on scoutctl being on PATH.

### `d52d62e` — Anchor `/scout-setup` and `/scout-update` to `$CLAUDE_PLUGIN_ROOT`

Previously, both slash commands hardcoded `$HOME/scout-plugin/.venv/bin/scoutctl` in shell snippets, plus used `command -v scoutctl` as a fallback. Two problems:

1. **Marketplace install breaks** — `$HOME/scout-plugin/` doesn't exist; the venv-existence check fails immediately.
2. **PATH-based lookup is unsafe** — could resolve to a scoutctl from a different plugin clone, in which case `bootstrap upgrade` reads templates from the wrong tree and applies them silently.

This commit:
- Anchors both commands to `${CLAUDE_PLUGIN_ROOT:-$HOME/scout-plugin}` (Claude Code injects `$CLAUDE_PLUGIN_ROOT` at slash-command invocation time)
- Adds a Python introspection check that verifies the venv's editable-installed source matches `$CLAUDE_PLUGIN_ROOT/engine`:
  ```bash
  PYTHON="$(dirname "$SCOUTCTL")/python"
  INSTALLED=$("$PYTHON" -c "import scout, os;
      print(os.path.realpath(os.path.dirname(os.path.dirname(scout.__file__))))")
  EXPECTED=$(cd "$PLUGIN_ROOT/engine" && pwd -P)
  ```
- Surfaces `VENV_MISMATCH:<installed>|<expected>` if they differ, with a fix command pointing at `$CLAUDE_PLUGIN_ROOT/scripts/install-venv.sh`
- Updates `engine/README.md` with a new "Non-canonical install locations" section documenting the three-layer story

### `d7c011f` — Test + lint follow-ups from review

- Defensive sanity check on Linux cron parser (`parts[5]` must end with `/scoutctl`).
- Three new tests covering defensive branches: corrupt plist (warning, not error), empty `ProgramArguments` (warning), Linux crontab with no scout-managed block (returns silently).
- Standardized on `Fix:` prefix across all error messages.

## Net result

| Install layout | Before this PR | After this PR |
|---|---|---|
| `~/scout-plugin/` (canonical) | ✅ Works | ✅ Works (unchanged behavior — `$CLAUDE_PLUGIN_ROOT` resolves here) |
| `~/LOCAL_PLUGINS/scout-plugin/` (dev tree) | ⚠️ Requires `~/scout-plugin` symlink + venv reinstall | ✅ Works without manual steps |
| `~/.claude/plugins/marketplaces/.../scout-plugin/` (marketplace) | ❌ Silently broken | ✅ Works |
| TCC-trapped install under `~/Documents/` | ❌ Schedule-tick crashes silently, doctor stays green | ❌ Same runtime failure, **but doctor + `/scout-status` flag RED with TCC-aware fix instructions** |

## Behavior change to expect on first `install-plist --force` after merge

The new resolver returns `Path(scout.__file__).parent.parent.parent / ".venv/bin/scoutctl"`. For canonical clones at `~/scout-plugin/`, this matches the existing path verbatim — no change. For symlinked-into-place installs (e.g. `~/scout-plugin -> ~/LOCAL_PLUGINS/scout-plugin`), pip-editable's `.pth` writes the resolved target into Python's import path, so `scout.__file__` is the resolved path. The next `install-plist --force` will replace the symlinked path stored in the existing plist with the resolved one. Both work; the resolved version is more robust (doesn't depend on the symlink remaining in place).

## Test plan

- [x] Full engine test suite: 542 passed, 1 skipped (parity test, requires real vault).
- [x] ruff check + ruff format: clean.
- [x] Sanity-checked the slash-command heredocs in a real shell — happy path (`READY`), missing venv at bogus plugin root (`VENV_MISSING:<root>`), and mismatched editable source (`VENV_MISMATCH:<installed>|<expected>`) all produce the expected outputs.
- [x] Exercised all five doctor scenarios against the editable-installed engine: happy path GREEN; missing path / non-executable / in-Documents / via-symlink-into-Documents all RED with correct fix hints.
- [x] Confirmed the live plist on the author's machine matches `resolve_scoutctl_bin()` output post-install.
- [ ] CI confirms (test + lint matrix across macOS / Ubuntu × Python 3.11 / 3.12).
- [ ] Reviewer runs `scoutctl bootstrap upgrade` on a non-canonical layout (LOCAL_PLUGINS or marketplace) and confirms no manual symlink is needed.
