### PR TITLE
fix: phase assembly honors mode= declarations + repair research phases

### DIFF
--- a/engine/scout/scripts/bootstrap.py
+++ b/engine/scout/scripts/bootstrap.py
@@ -220,12 +220,21 @@ def _assemble(cfg: BootstrapConfig, kind: str) -> str:
     vars_ = _template_vars(cfg)
     phases_root = cfg.plugin_root / "phases"
     bodies: list[str] = [f"# {kind}\n\n**BASE_DIR:** `{cfg.vault}`\n"]
+    # Map assembly target → which modes this assembly is consumed by.
+    # SKILL.md is read by BOTH briefing- and consolidation-type runs (run-scout.sh
+    # auto-detects which); DREAMING.md by dreaming runs only; RESEARCH.md by
+    # research runs only. Phases declaring `mode: [...]` get filtered to only
+    # those whose mode list intersects the target. Phases with no `mode:`
+    # (legacy / cross-cutting) land in every target.
     if kind == "SKILL":
         sources = [phases_root / "core", phases_root / "connectors"]
+        target_modes = {"briefing", "consolidation"}
     elif kind == "DREAMING":
         sources = [phases_root / "core", phases_root / "modes"]
+        target_modes = {"dreaming"}
     else:  # RESEARCH
         sources = [phases_root / "core", phases_root / "research"]
+        target_modes = {"research"}
     for src_dir in sources:
         if not src_dir.exists():
             continue
@@ -238,7 +247,11 @@ def _assemble(cfg: BootstrapConfig, kind: str) -> str:
                 # '---' horizontal rules in markdown bodies (e.g., kb-management.md).
                 # Tracked as a Plan 8 followup to harden A5's parser.
                 continue
-            kept = select_sections(sections, enabled_connectors=cfg.enabled_connectors)
+            kept = select_sections(
+                sections,
+                enabled_connectors=cfg.enabled_connectors,
+                modes=target_modes,
+            )
             for s in kept:
                 bodies.append(render_template(s.body, vars_))
     return "\n\n".join(bodies)

--- a/engine/scout/scripts/phase_assembly.py
+++ b/engine/scout/scripts/phase_assembly.py
@@ -111,16 +111,28 @@ def select_sections(
     *,
     enabled_connectors: set[str],
     slot: str | None = None,
+    modes: set[str] | None = None,
 ) -> list[PhaseSection]:
-    """Filter sections: keep when requires is null OR connector enabled.
+    """Filter sections by connector, slot, and mode.
 
-    Optionally narrow to a specific slot (e.g., "outbound-scan").
+    Kept when ALL of the following hold:
+      - ``requires`` is null OR is an enabled connector
+      - ``slot`` is None OR matches the section's slot
+      - ``modes`` is None OR the section's mode is empty (applies to every
+        target) OR the section's mode list intersects ``modes``
+
+    The ``modes`` filter exists so a phase declared ``mode: [briefing]``
+    doesn't leak into a DREAMING.md assembly. Empty/absent mode means
+    "applies to every assembly target" (back-compat: phases authored
+    before mode filtering was enforced).
     """
     out: list[PhaseSection] = []
     for s in sections:
         if s.requires is not None and s.requires not in enabled_connectors:
             continue
         if slot is not None and s.slot != slot:
+            continue
+        if modes is not None and s.mode and not set(s.mode) & modes:
             continue
         out.append(s)
     return out

--- a/engine/tests/unit/test_phase_assembly.py
+++ b/engine/tests/unit/test_phase_assembly.py
@@ -87,6 +87,48 @@ def test_select_filters_mixed_connectors_within_file():
     assert len(both) == 2
 
 
+def test_select_filters_by_modes_excludes_non_intersecting(tmp_path):
+    """Sections declaring `mode: [briefing]` are dropped when target is `dreaming`."""
+    f = tmp_path / "p.md"
+    f.write_text("---\nphase: core\nname: briefing-only\nslot: x\nmode: [briefing]\nrequires: null\n---\nBODY-B\n")
+    sections = parse_phase_file(f)
+    kept = select_sections(sections, enabled_connectors=set(), modes={"dreaming"})
+    assert kept == []
+    kept_briefing = select_sections(sections, enabled_connectors=set(), modes={"briefing"})
+    assert len(kept_briefing) == 1
+
+
+def test_select_filters_by_modes_keeps_intersecting(tmp_path):
+    """A section declaring `mode: [briefing, consolidation]` is kept by either."""
+    f = tmp_path / "p.md"
+    f.write_text(
+        "---\nphase: core\nname: shared\nslot: x\nmode: [briefing, consolidation]\nrequires: null\n---\nBODY\n"
+    )
+    sections = parse_phase_file(f)
+    for target in ({"briefing"}, {"consolidation"}, {"briefing", "consolidation"}):
+        kept = select_sections(sections, enabled_connectors=set(), modes=target)
+        assert len(kept) == 1, target
+
+
+def test_select_modes_none_disables_mode_filter(tmp_path):
+    """Passing modes=None means every mode passes (back-compat)."""
+    f = tmp_path / "p.md"
+    f.write_text("---\nphase: core\nname: briefing-only\nslot: x\nmode: [briefing]\nrequires: null\n---\nBODY\n")
+    sections = parse_phase_file(f)
+    kept = select_sections(sections, enabled_connectors=set())  # modes default = None
+    assert len(kept) == 1
+
+
+def test_select_empty_mode_list_applies_to_every_target(tmp_path):
+    """A section with no `mode:` (or `mode: []`) lands in every assembly target."""
+    f = tmp_path / "p.md"
+    f.write_text("---\nphase: core\nname: cross-cutting\nslot: x\nrequires: null\n---\nBODY\n")
+    sections = parse_phase_file(f)
+    for target in ({"briefing"}, {"dreaming"}, {"research"}):
+        kept = select_sections(sections, enabled_connectors=set(), modes=target)
+        assert len(kept) == 1, target
+
+
 def test_parse_skips_trailing_fence_junk_section(tmp_path):
     """A file ending with '---' should not yield an empty junk section."""
     p = tmp_path / "trailing.md"

--- a/phases/research/commit-notify.md
+++ b/phases/research/commit-notify.md
@@ -2,7 +2,7 @@
 phase: research
 name: Commit and Notify
 slot: commit-notify
-mode: research
+mode: [research]
 requires: null
 ---
 
@@ -34,7 +34,7 @@ Add to `knowledge-base.md` Recent Sessions table:
 phase: research
 name: Slack Research Notification
 slot: notification
-mode: research
+mode: [research]
 requires: slack
 ---
 

--- a/phases/research/deep-research.md
+++ b/phases/research/deep-research.md
@@ -2,7 +2,7 @@
 phase: research
 name: Deep Research
 slot: deep-research
-mode: research
+mode: [research]
 requires: null
 ---
 

--- a/phases/research/knowledge-integration.md
+++ b/phases/research/knowledge-integration.md
@@ -2,7 +2,7 @@
 phase: research
 name: Knowledge Integration
 slot: integration
-mode: research
+mode: [research]
 requires: null
 ---
 

--- a/phases/research/research-targets.md
+++ b/phases/research/research-targets.md
@@ -2,7 +2,7 @@
 phase: research
 name: Research Target Selection
 slot: target-selection
-mode: research
+mode: [research]
 requires: null
 ---
 


### PR DESCRIPTION
## TL;DR

Two related bugs in v0.4 phase assembly that caused `mode:` frontmatter to be ignored:

1. `select_sections()` never filtered by `mode`. Every core phase landed in every assembly target (SKILL/DREAMING/RESEARCH), regardless of its declared mode.
2. `phases/research/*.md` use `mode: research` (bare string) instead of `mode: [research]` (list). The parser raises ValueError on strings, and `_assemble()` silently catches and skips. **Result: zero `phases/research/*` content has ever reached `RESEARCH.md` on v0.4.**

## Bug #1 — Mode filter ignored

`select_sections()` only checked `requires` (connector enabled) and `slot`. The `mode` field was parsed from frontmatter but discarded. So:

- `phases/core/action-items.md` declares `mode: [briefing, consolidation]` → leaks into `DREAMING.md` and `RESEARCH.md`.
- `phases/core/kb-management.md` declares `mode: [briefing, consolidation, dreaming]` → leaks into `RESEARCH.md`.
- After PR #20: `phases/core/meeting-prep.md` (`mode: [briefing]`) and `phases/core/inbox-processing.md` (`mode: [briefing, consolidation]`) leak into `DREAMING.md` and `RESEARCH.md`.

The leak doesn't corrupt anything — dreaming and research sessions just consume instructions they're not supposed to act on. Wasted tokens; occasional confusing behavior when the model mistakes a mode-mismatched phase for an active directive.

**Fix:** `select_sections()` gains a `modes: set[str] | None` parameter. A section is kept iff its mode list is empty (cross-cutting / legacy phases, e.g. `git-setup`) OR intersects the requested modes. `modes=None` preserves the previous behavior (back-compat for the slot-only callers).

`bootstrap._assemble()` passes target modes per kind:
- `SKILL` → `{"briefing", "consolidation"}` (run-scout.sh auto-detects which at runtime)
- `DREAMING` → `{"dreaming"}`
- `RESEARCH` → `{"research"}`

## Bug #2 — Research phases never parsed

All four `phases/research/*.md` files use `mode: research` (string). The parser at `phase_assembly.py:73` raises `ValueError` for non-list mode. `_assemble()` catches `(ValueError, yaml.YAMLError)` and silently skips the whole file. So `RESEARCH.md` has been silently missing its four mode-defining phases (`research-targets`, `deep-research`, `knowledge-integration`, `commit-notify`) since the v0.4 port landed.

**Fix:** Convert all four files from `mode: research` → `mode: [research]`. Trivial edit, no content changes.

## Tests

4 new tests in `test_phase_assembly.py` cover the new mode-filter contract:
- Excludes non-intersecting (e.g. briefing-only phase with dreaming target)
- Keeps intersecting (multi-mode phase across all matching targets)
- `modes=None` disables filtering (back-compat)
- Empty mode list applies to every target (cross-cutting)

Full suite: **533 passed**, 1 skipped. `ruff check` + `ruff format` clean.

## User-visible after merge + upgrade

| File | Change |
|---|---|
| `SKILL.md` | Unchanged (the leaks were INTO Dreaming/Research, not out of Skill) |
| `DREAMING.md` | No longer carries `action-items`, `inbox-processing`, `meeting-prep`, or `kb-management` content meant for briefing/consolidation. Only `git-setup` (mode-empty cross-cutting) + `kb-management` (which explicitly lists `dreaming`) + `phases/modes/*` remain. |
| `RESEARCH.md` | Gains the four research-specific phases (`research-targets`, `deep-research`, `knowledge-integration`, `commit-notify`) that have been silently missing since v0.4 shipped. |

## Test plan

- [x] Engine unit tests: 533 passed, 1 skipped
- [x] ruff check + format clean
- [ ] CI confirms matrix (macOS / Ubuntu × Python 3.11 / 3.12)
- [ ] Reviewer's vault, after `scoutctl bootstrap upgrade`: confirm `DREAMING.md` no longer contains "Action Item Categories"; confirm `RESEARCH.md` now contains "Target selection" / "knowledge-integration" content
