### PR TITLE
fix: smooth out plugin setup/upgrade rough edges

### DIFF
--- a/commands/scout-setup.md
+++ b/commands/scout-setup.md
@@ -101,7 +101,7 @@ Confirm with the user: "Proceed with these connectors? Or pause to enable more f
 
 ## Step 3: Hand off to `scoutctl bootstrap install`
 
-Build the comma-separated connector list (only enabled), then run (use the `$SCOUTCTL` resolved in Step 0):
+Build the comma-separated connector list (only enabled), then run (use the `$SCOUTCTL` resolved in Step 0). Pass every connector input you collected in Step 2 — these get persisted into `scout-config.yaml` and are what cat-1b runner templates (run-scout.sh / run-dreaming.sh / run-research.sh) substitute for `CLAUDE_BIN`, `USER_SLACK_ID`, etc. Omit any flag whose connector you didn't enable; the install command supplies safe defaults.
 
 ```bash
 "$SCOUTCTL" bootstrap install \
@@ -110,7 +110,12 @@ Build the comma-separated connector list (only enabled), then run (use the `$SCO
     --user-email "<USER_EMAIL>" \
     --timezone "<TIMEZONE>" \
     --platform "$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/macos/')" \
-    --connectors "<comma-separated-enabled-list>"
+    --connectors "<comma-separated-enabled-list>" \
+    --user-slack-id "<USER_SLACK_ID>" \
+    --github-username "<GITHUB_USERNAME>" \
+    --github-repos "<comma-separated-repos>" \
+    --claude-bin "<absolute-path-to-claude>" \
+    --max-budget "<dollars>"
 ```
 
 The plist + cron block installed by this step automatically reference `$SCOUTCTL` — `resolve_scoutctl_bin()` derives the path from the running engine's plugin root, so the scheduler is always pinned to the venv the wizard just used.

--- a/engine/bin/scoutctl
+++ b/engine/bin/scoutctl
@@ -2,14 +2,45 @@
 # scoutctl launcher — resolves the venv Python deterministically so
 # hooks invoked from LaunchAgents (which don't inherit user PATH)
 # still find the right interpreter.
+#
+# Probe order:
+#   1. ${PLUGIN_ROOT}/.venv         — canonical location written by
+#                                     scripts/install-venv.sh
+#   2. ${PLUGIN_ROOT}/engine/.venv  — legacy / hand-built layout
+#   3. Sibling marketplaces/ tree   — recover when we're loaded from
+#                                     Claude Code's cache/ copy but the
+#                                     venv lives in marketplaces/
+#   4. system python3               — last resort; expects scout-engine on
+#                                     the global site-packages
 set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ENGINE_DIR="${DIR%/bin}"
-VENV_PY="${ENGINE_DIR}/.venv/bin/python"
+PLUGIN_ROOT="${ENGINE_DIR%/engine}"
 
-if [ -x "$VENV_PY" ]; then
-    exec "$VENV_PY" -m scout.cli "$@"
-else
-    exec python3 -m scout.cli "$@"
+candidates=(
+    "${PLUGIN_ROOT}/.venv/bin/python"
+    "${ENGINE_DIR}/.venv/bin/python"
+)
+
+# Claude Code installs a marketplace plugin twice: a frozen copy under
+# plugins/cache/<marketplace>/<plugin>/<version>/ (used at runtime) and a
+# clone under plugins/marketplaces/<marketplace>/ (where install-venv.sh
+# typically lands). Cross-jump when the launcher fires from cache/.
+if [[ "$PLUGIN_ROOT" == */plugins/cache/* ]]; then
+    PLUGINS_DIR="${PLUGIN_ROOT%%/cache/*}"
+    REST="${PLUGIN_ROOT#*/cache/}"
+    MARKETPLACE_NAME="${REST%%/*}"
+    candidates+=(
+        "${PLUGINS_DIR}/marketplaces/${MARKETPLACE_NAME}/.venv/bin/python"
+        "${PLUGINS_DIR}/marketplaces/${MARKETPLACE_NAME}/engine/.venv/bin/python"
+    )
 fi
+
+for VENV_PY in "${candidates[@]}"; do
+    if [ -x "$VENV_PY" ]; then
+        exec "$VENV_PY" -m scout.cli "$@"
+    fi
+done
+
+exec python3 -m scout.cli "$@"

--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -821,6 +821,17 @@ def _register_bootstrap() -> None:
         skip_jobs: bool = typer.Option(False, "--no-jobs"),
         skip_claude: bool = typer.Option(False, "--skip-claude"),
         connectors: str = typer.Option("", "--connectors", help="Comma-separated enabled connector names"),
+        # Per-connector inputs collected by /scout-setup. Mirroring the
+        # migrate-legacy flags keeps the two entrypoints symmetric and
+        # ensures cat-1b runners get rendered with the user's real
+        # claude_bin / Slack ID / etc. instead of falling back to the
+        # template defaults (which is what triggered the "regen ships
+        # placeholders" bug).
+        user_slack_id: str = typer.Option("", "--user-slack-id"),
+        github_username: str = typer.Option("", "--github-username"),
+        github_repos: str = typer.Option("", "--github-repos"),
+        claude_bin: str = typer.Option("/usr/local/bin/claude", "--claude-bin"),
+        max_budget: str = typer.Option("5.00", "--max-budget"),
     ) -> None:
         """Install Scout into the user's vault directory."""
         from scout import __version__
@@ -839,7 +850,13 @@ def _register_bootstrap() -> None:
             platform=platform,
             plugin_version=__version__,
             enabled_connectors=set(c.strip() for c in connectors.split(",") if c.strip()),
-            connector_inputs={},
+            connector_inputs={
+                "user_slack_id": user_slack_id,
+                "github_username": github_username,
+                "github_repos": github_repos,
+                "claude_bin": claude_bin,
+                "max_budget": max_budget,
+            },
             skip_jobs=skip_jobs,
             skip_claude=skip_claude,
         )

--- a/engine/scout/scripts/bootstrap.py
+++ b/engine/scout/scripts/bootstrap.py
@@ -380,6 +380,14 @@ def _stage_version_stamp(cfg: BootstrapConfig, *, is_upgrade: bool) -> None:
     plugin = existing.setdefault("plugin", {})
     if not is_upgrade:
         plugin["version_at_last_setup"] = cfg.plugin_version
+    else:
+        # Backfill version_at_last_setup if it's missing — happens for vaults
+        # whose first /scout-update predates this field being persisted, and
+        # for vaults whose scout-config.yaml had duplicate `plugin:` blocks
+        # (PyYAML silently drops the earlier one on read). Doctor requires
+        # both fields, so leaving the gap was making upgraded vaults
+        # permanently red.
+        plugin.setdefault("version_at_last_setup", cfg.plugin_version)
     plugin["version_at_last_update"] = cfg.plugin_version
     plugin.setdefault("applied_migrations", [])
     _atomic_write(config_path, yaml.safe_dump(existing, sort_keys=False))
@@ -461,6 +469,12 @@ def upgrade(cfg: BootstrapConfig) -> UpgradeResult:
     acquire_lock_with_wait(lock)
     try:
         _stage_cat1_writes(cfg)
+        # _stage_seed_schedule is idempotent (returns early if the file
+        # exists) so it's safe to call on upgrade. Without it, vaults set
+        # up before .scout-state/schedule.yaml was a first-class file
+        # never get one written, and the dispatcher silently falls back
+        # to the packaged default.
+        _stage_seed_schedule(cfg)
         backups = _stage_cat1b_runners(cfg, is_upgrade=True)
         conflicts = _stage_cat4_upgrade(cfg)
         _stage_jobs_install(cfg)

--- a/engine/tests/unit/test_bootstrap_install.py
+++ b/engine/tests/unit/test_bootstrap_install.py
@@ -91,3 +91,39 @@ def test_install_records_plugin_version(tmp_path):
     cfg = yaml.safe_load(config_text)
     assert cfg["plugin"]["version_at_last_setup"] == "0.4.0"
     assert cfg["plugin"]["version_at_last_update"] == "0.4.0"
+
+
+def test_install_persists_connector_inputs(tmp_path):
+    """Install must persist connector inputs so the next upgrade's
+    template renders use the user's real values instead of defaults.
+
+    Regression: cli_bootstrap_install previously hardcoded
+    connector_inputs={}, which meant fresh installs left scout-config.yaml
+    without `connectors.inputs`. The next /scout-update would then regen
+    cat-1b runners with placeholder CLAUDE_BIN / empty USER_SLACK_ID."""
+    plugin = Path(__file__).parent.parent.parent.parent
+    vault = tmp_path / "Scout"
+    cfg = _config(vault, plugin_root=plugin)
+    cfg.enabled_connectors = {"slack", "github"}
+    cfg.connector_inputs = {
+        "user_slack_id": "U123ABC",
+        "github_username": "alice",
+        "github_repos": "org/repo-a,org/repo-b",
+        "claude_bin": "/opt/homebrew/bin/claude",
+        "max_budget": "12.50",
+    }
+    install(cfg)
+
+    import yaml
+
+    persisted = yaml.safe_load((vault / "scout-config.yaml").read_text())
+    assert persisted["connectors"]["enabled"] == ["github", "slack"]  # sorted
+    inputs = persisted["connectors"]["inputs"]
+    assert inputs["user_slack_id"] == "U123ABC"
+    assert inputs["claude_bin"] == "/opt/homebrew/bin/claude"
+    assert inputs["max_budget"] == "12.50"
+
+    # And the rendered runner picked them up rather than falling back to
+    # the template defaults — this is the failure mode the friend's vault hit.
+    runner_text = (vault / "run-scout.sh").read_text()
+    assert "/opt/homebrew/bin/claude" in runner_text

--- a/engine/tests/unit/test_bootstrap_upgrade.py
+++ b/engine/tests/unit/test_bootstrap_upgrade.py
@@ -99,3 +99,64 @@ def test_upgrade_runner_hand_edit_creates_backup(tmp_path):
     backups = list(vault.glob("run-scout.sh.bak.*"))
     assert len(backups) == 1
     assert "# hand edit" in backups[0].read_text()
+
+
+def test_upgrade_seeds_missing_schedule_yaml(tmp_path):
+    """Upgrade must write .scout-state/schedule.yaml if it's missing.
+
+    Regression: pre-fix upgrade() never called _stage_seed_schedule, so
+    vaults whose initial install predated explicit schedule seeding
+    stayed on the silent packaged-defaults fallback and the doctor's
+    schedule check stayed red."""
+    plugin = Path(__file__).parent.parent.parent.parent
+    vault = tmp_path / "Scout"
+    install(_config(vault, plugin_root=plugin))
+
+    # Simulate the legacy state: a vault without an explicit schedule file.
+    schedule = vault / ".scout-state" / "schedule.yaml"
+    schedule.unlink()
+    assert not schedule.exists()
+
+    upgrade(_config(vault, plugin_root=plugin))
+    assert schedule.exists()
+    assert "schema_version" in schedule.read_text()
+
+
+def test_upgrade_backfills_missing_version_at_last_setup(tmp_path):
+    """Upgrade must fill in version_at_last_setup if the existing config
+    lost it — happens for vaults whose scout-config.yaml had a duplicate
+    `plugin:` block (PyYAML keeps only the last on safe_load)."""
+    plugin = Path(__file__).parent.parent.parent.parent
+    vault = tmp_path / "Scout"
+    install(_config(vault, plugin_root=plugin))
+
+    config_path = vault / "scout-config.yaml"
+    config = yaml.safe_load(config_path.read_text())
+    del config["plugin"]["version_at_last_setup"]
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False))
+
+    cfg = _config(vault, plugin_root=plugin)
+    cfg.plugin_version = "0.4.2"
+    upgrade(cfg)
+
+    after = yaml.safe_load(config_path.read_text())
+    # Backfilled to the upgrading version (best-available stamp; we don't
+    # know what the original setup version was).
+    assert after["plugin"]["version_at_last_setup"] == "0.4.2"
+    assert after["plugin"]["version_at_last_update"] == "0.4.2"
+
+
+def test_upgrade_leaves_existing_version_at_last_setup_alone(tmp_path):
+    """When version_at_last_setup is already present, upgrade must not
+    clobber it — only version_at_last_update advances."""
+    plugin = Path(__file__).parent.parent.parent.parent
+    vault = tmp_path / "Scout"
+    install(_config(vault, plugin_root=plugin))  # writes both fields = 0.4.0
+
+    cfg = _config(vault, plugin_root=plugin)
+    cfg.plugin_version = "0.4.5"
+    upgrade(cfg)
+
+    after = yaml.safe_load((vault / "scout-config.yaml").read_text())
+    assert after["plugin"]["version_at_last_setup"] == "0.4.0"
+    assert after["plugin"]["version_at_last_update"] == "0.4.5"

--- a/engine/tests/unit/test_scoutctl_launcher.py
+++ b/engine/tests/unit/test_scoutctl_launcher.py
@@ -1,0 +1,117 @@
+"""Smoke tests for engine/bin/scoutctl venv resolution.
+
+The launcher is a bash script that has to find a venv across several
+layouts (canonical install, legacy in-engine, Claude Code's cache→
+marketplace split). We exercise it by laying out fake plugin trees in
+tmp_path with a stub `python` that echoes which candidate fired.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+LAUNCHER = Path(__file__).parent.parent.parent / "bin" / "scoutctl"
+
+
+def _make_fake_venv(venv_dir: Path, label: str) -> None:
+    """Write a stub `python` that echoes its label and exits 0."""
+    bin_dir = venv_dir / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    python = bin_dir / "python"
+    python.write_text(f"#!/bin/bash\necho VENV={label}\nexit 0\n")
+    python.chmod(python.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _stage_launcher(plugin_root: Path) -> Path:
+    """Copy the real launcher into a synthetic plugin tree."""
+    bin_dir = plugin_root / "engine" / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    target = bin_dir / "scoutctl"
+    shutil.copy2(LAUNCHER, target)
+    target.chmod(target.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return target
+
+
+def _run(launcher: Path, extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [str(launcher), "version"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_picks_plugin_root_venv(tmp_path):
+    plugin_root = tmp_path / "scout-plugin"
+    launcher = _stage_launcher(plugin_root)
+    _make_fake_venv(plugin_root / ".venv", "plugin-root")
+    result = _run(launcher)
+    assert "VENV=plugin-root" in result.stdout, result
+
+
+def test_picks_engine_venv_when_plugin_root_missing(tmp_path):
+    """Legacy in-engine layout still works."""
+    plugin_root = tmp_path / "scout-plugin"
+    launcher = _stage_launcher(plugin_root)
+    _make_fake_venv(plugin_root / "engine" / ".venv", "engine-legacy")
+    result = _run(launcher)
+    assert "VENV=engine-legacy" in result.stdout, result
+
+
+def test_prefers_plugin_root_over_engine(tmp_path):
+    """When both venvs exist, the canonical install-venv.sh location wins."""
+    plugin_root = tmp_path / "scout-plugin"
+    launcher = _stage_launcher(plugin_root)
+    _make_fake_venv(plugin_root / ".venv", "canonical")
+    _make_fake_venv(plugin_root / "engine" / ".venv", "legacy")
+    result = _run(launcher)
+    assert "VENV=canonical" in result.stdout, result
+
+
+def test_cache_path_falls_back_to_marketplace(tmp_path):
+    """Launcher invoked from cache/ resolves to marketplaces/ venv."""
+    plugins_dir = tmp_path / ".claude" / "plugins"
+    cache_root = plugins_dir / "cache" / "scout-plugin" / "scout" / "0.4.0"
+    marketplace_root = plugins_dir / "marketplaces" / "scout-plugin"
+    launcher = _stage_launcher(cache_root)
+    # Venv only present in marketplaces/, not in cache/.
+    _make_fake_venv(marketplace_root / ".venv", "marketplace")
+    result = _run(launcher)
+    assert "VENV=marketplace" in result.stdout, result
+
+
+def test_cache_path_prefers_local_venv_when_present(tmp_path):
+    """If cache/ has its own venv, don't cross-jump."""
+    plugins_dir = tmp_path / ".claude" / "plugins"
+    cache_root = plugins_dir / "cache" / "scout-plugin" / "scout" / "0.4.0"
+    marketplace_root = plugins_dir / "marketplaces" / "scout-plugin"
+    launcher = _stage_launcher(cache_root)
+    _make_fake_venv(cache_root / ".venv", "cache-local")
+    _make_fake_venv(marketplace_root / ".venv", "marketplace")
+    result = _run(launcher)
+    assert "VENV=cache-local" in result.stdout, result
+
+
+@pytest.mark.skipif(shutil.which("python3") is None, reason="needs system python3 for last-resort exec")
+def test_falls_back_to_system_python3_when_no_venv(tmp_path):
+    """No venv anywhere → exec python3 -m scout.cli, which fails cleanly
+    if scout isn't installed globally. We only assert the launcher ran the
+    fallback path (non-zero exit + 'No module' message, OR scout output if
+    the dev's global python happens to have it)."""
+    plugin_root = tmp_path / "scout-plugin"
+    launcher = _stage_launcher(plugin_root)
+    result = _run(launcher)
+    # Either system python complained that scout isn't installed, or it
+    # succeeded (developer has scout globally). Both are acceptable — we
+    # just want to be sure we didn't exit before reaching the fallback.
+    assert result.returncode != 127, "launcher itself crashed: " + result.stderr

--- a/scripts/install-venv.sh
+++ b/scripts/install-venv.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
-# Fallback installer for ~/scout-plugin/.venv — invoked manually if
-# /scout-setup's automatic venv install times out.
+# Build the scout-engine venv at $PLUGIN_ROOT/.venv.
 #
-# Usage: bash ~/scout-plugin/scripts/install-venv.sh
+# Invoked by /scout-setup (with a 5-minute timeout) and as a manual fallback
+# from /scout-update when the venv is missing or pinned to the wrong tree.
 #
-# After this completes, retry /scout-setup or run /scout-setup --skip-venv-install.
+# Usage: bash <plugin-root>/scripts/install-venv.sh
+#
+# The plugin root is derived from this script's own location, so it works
+# whether the script lives under ~/.claude/plugins/cache/...,
+# ~/.claude/plugins/marketplaces/..., or a hand-cloned ~/scout-plugin.
 
 set -euo pipefail
 
@@ -16,13 +20,43 @@ if [ ! -d "$PLUGIN_ROOT/engine" ]; then
     exit 1
 fi
 
+# Pick a Python interpreter that satisfies engine[requires-python] = ">=3.11".
+# Apple's bundled /usr/bin/python3 is 3.9.x on every macOS we support, so
+# `python3` alone is unreliable — try the explicit minors first.
+PYTHON=""
+for candidate in python3.13 python3.12 python3.11; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+        PYTHON="$candidate"
+        break
+    fi
+done
+if [ -z "$PYTHON" ] && command -v python3 >/dev/null 2>&1; then
+    if python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)' >/dev/null 2>&1; then
+        PYTHON="python3"
+    fi
+fi
+if [ -z "$PYTHON" ]; then
+    cat >&2 <<EOF
+error: no Python >= 3.11 found on PATH.
+scout-engine requires Python 3.11 or newer. Install one of:
+  macOS:   brew install python@3.13
+  Debian:  sudo apt install python3.13 python3.13-venv
+  pyenv:   pyenv install 3.13 && pyenv shell 3.13
+then re-run: bash $PLUGIN_ROOT/scripts/install-venv.sh
+EOF
+    exit 1
+fi
+
+PYTHON_VERSION="$("$PYTHON" -c 'import sys; print("%d.%d.%d" % sys.version_info[:3])')"
+echo "using $PYTHON ($PYTHON_VERSION)"
+
 if [ -d "$VENV" ]; then
     echo "venv already exists at $VENV — recreating..."
     rm -rf "$VENV"
 fi
 
 echo "creating venv at $VENV..."
-python3 -m venv "$VENV"
+"$PYTHON" -m venv "$VENV"
 
 echo "installing scout-engine in editable mode (this may take 30-60s)..."
 "$VENV/bin/pip" install --quiet --upgrade pip


### PR DESCRIPTION
## Summary

Four independent papercuts that a friend hit when upgrading the plugin through the Claude Code marketplace flow. Each had a manual workaround; together they made bootstrap effectively unusable until you knew the lore.

- **`scripts/install-venv.sh`**: probes `python3.13` → `3.12` → `3.11`, falling through to `python3` only when it self-reports ≥ 3.11. Apple's `/usr/bin/python3` is 3.9.x on every macOS we support, so the bare `python3` invocation was unreliable.
- **`engine/bin/scoutctl`**: probes `${PLUGIN_ROOT}/.venv` first (where `install-venv.sh` actually writes) before legacy `${PLUGIN_ROOT}/engine/.venv`. Adds a cache-to-marketplace cross-jump for Claude Code marketplace installs — `$CLAUDE_PLUGIN_ROOT` resolves to `plugins/cache/` at hook-fire time but the venv typically lives under `plugins/marketplaces/`.
- **`scoutctl bootstrap install`**: accepts `--user-slack-id` / `--github-username` / `--github-repos` / `--claude-bin` / `--max-budget` and persists them into `scout-config.yaml`. Without this, `/scout-update` re-rendered cat-1b runners with template defaults (literal `/usr/local/bin/claude`, empty Slack ID) every time. `/scout-setup` was already collecting these values — it just had no flags to pass them through. The slash command is updated to match.
- **`scoutctl bootstrap upgrade`**: calls `_stage_seed_schedule` (idempotent) so vaults predating explicit schedule seeding get `.scout-state/schedule.yaml` on next upgrade; `setdefault`s `version_at_last_setup` so vaults whose `scout-config.yaml` had duplicate `plugin:` blocks (which `safe_load` silently dedupes by dropping the earlier occurrence) don't stay permanently doctor-red.

## Test plan

- [x] `pytest engine/tests/unit engine/tests/integration` — 541 passed, 9 skipped (pre-existing skips: textual TUI, parity test needing a real vault)
- [x] `bash engine/tests/integration/test_bootstrap_smoke.sh` — install + upgrade + doctor all green end-to-end
- [x] `ruff check engine/` + `ruff format --check engine/` — clean
- [x] 6 new launcher smoke tests for cache/marketplace/legacy/plugin-root combinations
- [x] 1 new install test verifying connector inputs round-trip into `scout-config.yaml` *and* the rendered `run-scout.sh`
- [x] 3 new upgrade tests for: schedule seeding, missing-`version_at_last_setup` backfill, non-clobber of existing `version_at_last_setup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)