### PR TITLE
Mandate [#XXXX] task prefixes + add new-prefix/backfill-prefixes CLIs

### DIFF
--- a/engine/scout/action_items/backfill.py
+++ b/engine/scout/action_items/backfill.py
@@ -1,0 +1,73 @@
+"""Add `[#XXXX]` short prefixes to action-items lines that lack them.
+
+Lets vaults that predate the prefix convention migrate without hand-editing.
+Reads the file via `parse_file`, picks every open-status item with
+`short_prefix is None`, mints a fresh non-colliding prefix per line, writes
+all of them in one pass, and registers the new prefixes into id-map.json.
+
+Idempotent: re-running the command on a file that already has prefixes is a
+no-op (returns an empty list).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scout.id_map import IdMap, IdMapEntry
+from scout.ids import new_short_prefix, new_ulid
+
+
+def backfill_prefixes(
+    *,
+    target: Path,
+    data_dir: Path,
+    dry_run: bool = False,
+) -> list[tuple[int, str, str]]:
+    """Mint and (optionally) write prefixes for unprefixed open items in
+    `target`.
+
+    Returns a list of `(line_number, new_prefix, title)` tuples for every
+    line we'd touch. When `dry_run` is True, no file or id-map writes happen
+    — the return value is the same so callers can show a preview.
+    """
+    from scout.action_items.parser import parse_file
+    from scout.action_items.writer import add_prefix_to_line
+
+    items = parse_file(target)
+    candidates = [i for i in items if i.status == "open" and i.short_prefix is None]
+    if not candidates:
+        return []
+
+    id_map = IdMap.load(data_dir)
+    in_use = id_map.in_use_prefixes()
+
+    plan: list[tuple[int, str, str]] = []
+    for item in candidates:
+        prefix = new_short_prefix(exclude=in_use)
+        in_use.add(prefix)
+        plan.append((item.line_number, prefix, item.title))
+
+    if dry_run:
+        return plan
+
+    # Apply line edits from the bottom up so earlier line numbers don't
+    # shift under us. `add_prefix_to_line` reads the file each call — that
+    # accepts the cost for the rare-event path; the file is small (a few
+    # hundred lines max in practice).
+    for line_no, prefix, _ in sorted(plan, key=lambda p: p[0], reverse=True):
+        add_prefix_to_line(target, line_number=line_no, prefix=prefix)
+
+    # Register every new prefix in id-map so the next `--by-id` lookup
+    # works. Uses fresh ULIDs; title + position metadata come from the
+    # pre-edit parse since the post-edit text is identical except for the
+    # bracketed prefix marker.
+    for line_no, prefix, title in plan:
+        id_map.register(IdMapEntry(
+            ulid=new_ulid(),
+            short_prefix=prefix,
+            last_title=title,
+            last_file=target.name,
+            last_line=line_no,
+        ))
+    id_map.save()
+    return plan

--- a/engine/scout/action_items/backfill.py
+++ b/engine/scout/action_items/backfill.py
@@ -62,12 +62,14 @@ def backfill_prefixes(
     # pre-edit parse since the post-edit text is identical except for the
     # bracketed prefix marker.
     for line_no, prefix, title in plan:
-        id_map.register(IdMapEntry(
-            ulid=new_ulid(),
-            short_prefix=prefix,
-            last_title=title,
-            last_file=target.name,
-            last_line=line_no,
-        ))
+        id_map.register(
+            IdMapEntry(
+                ulid=new_ulid(),
+                short_prefix=prefix,
+                last_title=title,
+                last_file=target.name,
+                last_line=line_no,
+            )
+        )
     id_map.save()
     return plan

--- a/engine/scout/action_items/cli.py
+++ b/engine/scout/action_items/cli.py
@@ -158,6 +158,68 @@ def cli_list(
         sys.stdout.write(format_items(items))
 
 
+@app.command("new-prefix")
+def cli_new_prefix(
+    path: Path | None = typer.Argument(
+        None,
+        help="Daily markdown file (default: today). Used to derive data_dir for the id-map.",
+    ),
+) -> None:
+    """Print a fresh `[#XXXX]` Crockford prefix not currently in the id-map.
+
+    Briefing/consolidation/dreaming prompts call this once per new task line
+    so every task carries a stable identifier from creation. Output is bare
+    (no `[#]` brackets, no newline-prefix) so callers can interpolate it
+    directly into a task line:
+
+        prefix=$(scoutctl action-items new-prefix)
+        echo "- [ ] [#${prefix}] **subject** body" >> "$DAILY"
+
+    Reads existing id-map.json to avoid collision; does NOT register the new
+    prefix — registration happens when the action-items writer next sees the
+    line with the prefix attached.
+    """
+    from scout import paths
+    from scout.id_map import IdMap
+    from scout.ids import new_short_prefix
+
+    data_dir = path.parent.parent if path is not None else paths.data_dir()
+    id_map = IdMap.load(data_dir)
+    prefix = new_short_prefix(exclude=id_map.in_use_prefixes())
+    sys.stdout.write(prefix + "\n")
+
+
+@app.command("backfill-prefixes")
+def cli_backfill_prefixes(
+    path: Path | None = typer.Argument(
+        None,
+        help="Daily markdown file (default: today). When given, its grandparent is the data dir.",
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Print the would-be changes; don't write."),
+) -> None:
+    """Add `[#XXXX]` prefixes to every open task line that doesn't have one.
+
+    Idempotent: lines that already carry a prefix are left untouched. New
+    prefixes are minted via `scout.ids.new_short_prefix` (collision-checked
+    against `id-map.json`) and registered into the id-map as part of the
+    write. Lets existing vaults adopt the prefix convention without a
+    hand-edit pass.
+    """
+    from scout import paths
+    from scout.action_items.backfill import backfill_prefixes
+
+    target = path or paths.action_items_daily_path()
+    data_dir = path.parent.parent if path is not None else paths.data_dir()
+    added = backfill_prefixes(target=target, data_dir=data_dir, dry_run=dry_run)
+    if not added:
+        sys.stdout.write("no unprefixed open tasks found\n")
+        return
+    verb = "would add" if dry_run else "added"
+    sys.stdout.write(f"{verb} {len(added)} prefix(es):\n")
+    for line_no, prefix, title in added:
+        sys.stdout.write(f"  line {line_no}: [#{prefix}] {title}\n")
+
+
 @app.command("watch")
 def cli_watch(
     target: str | None = typer.Argument(

--- a/phases/core/action-items.md
+++ b/phases/core/action-items.md
@@ -35,25 +35,25 @@ Create `action-items/action-items-YYYY-MM-DD.md` using today's date. Include:
 
 ## 🔴 Urgent
 
-- **[Item title]** — [Description with specific details, not vague summaries]
+- [ ] [#XXXX] **[Item title]** — [Description with specific details, not vague summaries]
   - Source: [Which connector(s) confirmed this]
   - Context: [[wikilink-to-relevant-kb-file]]
 
 ## 🟡 To Do
 
-- **[Item title]** — [Description]
+- [ ] [#XXXX] **[Item title]** — [Description]
   - Source: [connector evidence]
   - Context: [[wikilink]]
 
 ## 🟢 Watching
 
-- **[Item title]** — [What you're tracking and why]
+- [ ] [#XXXX] **[Item title]** — [What you're tracking and why]
   - Source: [connector evidence]
   - Context: [[wikilink]]
 
 ## ✅ Done
 
-- **[Item title]** — [What was completed and how]
+- [x] [#XXXX] **[Item title]** — [What was completed and how]
   - Evidence: [Link to message, PR, calendar change, or other proof]
   - Completed: [date/time]
 
@@ -61,12 +61,50 @@ Create `action-items/action-items-YYYY-MM-DD.md` using today's date. Include:
 
 Items carried forward from previous days that are still open.
 
-- **[Item title]** — [Status update since last check]
+- [ ] [#XXXX] **[Item title]** — [Status update since last check]
   - Originally from: action-items-YYYY-MM-DD
   - Current status: [what's changed]
 ```
 
 All action items files must include `[[wikilinks]]` to any KB files referenced by action items.
+
+### Hard Rule — Every Task Line Has a Stable `[#XXXX]` Prefix
+
+**Every new task line you write MUST start with a fresh `[#XXXX]` 4-char Crockford prefix.** The prefix is the structural identifier scout-app uses to mark tasks done, snooze them, and attach comments — without it, the app falls back to brittle markdown-substring matching that fails on emoji, italics, em-dashes, embedded links, or any non-ASCII drift. Issue #10 of scout-app catalogs the failure modes.
+
+**Canonical task line shape:**
+```
+- [ ] [#XXXX] **<bold subject>** <optional body, links, italic context>
+```
+
+The prefix goes **after** the checkbox marker and **before** the bold subject. Exactly that order — the parser keys off it.
+
+**Mint a fresh prefix per task** by shelling out to scoutctl. The CLI collision-checks against `id-map.json` so two consecutive calls always return different prefixes:
+
+```bash
+# Inside your task-writing loop:
+PFX=$(scoutctl action-items new-prefix)
+echo "- [ ] [#${PFX}] **${SUBJECT}** ${BODY}" >> "$DAILY_FILE"
+```
+
+**Carry-forward keeps the original prefix.** When propagating an item from yesterday's file into today's, copy the `[#XXXX]` verbatim — do NOT mint a new one. The prefix is the task's identity across days; minting a new one breaks the link in scout-app's session↔task store and severs the commit-history trail.
+
+**Existing unprefixed lines (legacy carryover):** when you find a task carried forward from a pre-prefix era that lacks `[#XXXX]`, mint a fresh prefix for it on first touch. Or run the one-shot backfill at the top of the briefing:
+
+```bash
+scoutctl action-items backfill-prefixes "$DAILY_FILE"
+```
+
+The backfill is idempotent — already-prefixed lines are left alone — so it's safe to run defensively at the start of every briefing/consolidation step that writes new lines.
+
+**Self-check before commit:** every `- [ ]` and `- [x]` line in the file MUST match the regex `^\s*- \[[ x]\] \[#[0-9A-HJKMNP-TV-Z]{4}\] `. A `grep` sanity check at compose time catches drift:
+
+```bash
+grep -nE '^\s*- \[[ x]\] ' "$DAILY_FILE" | grep -vE ' \[#[0-9A-HJKMNP-TV-Z]{4}\] ' && \
+    echo "ERROR: lines missing [#XXXX] prefix above — fix before commit" >&2
+```
+
+If that grep finds anything, the file is non-compliant and scout-app's writes will silently fall back to fragile subject-matching for those lines.
 
 ## Knowledge Graph Personal Tasks
 


### PR DESCRIPTION
## Why

scout-app keeps shipping tactical fixes for "no open task matched subject" failures (v0.5.3, v0.5.4) because the substring-matching contract with markdown is too brittle to enforce from the app side alone. Em-dashes, emoji, Unicode normalisation, and `[label](url)` links embedded in bold subjects all diverge between the app's captured `plainSubject` and the plugin's raw `i.raw_line.lower()` substring check. scout-app issue [#10](https://github.com/jordanrburger/Scout/issues/10) catalogs the failure modes and proposes structural fixes; this PR ships the lightest of them (Option A — stable IDs in markdown).

The plumbing has always existed in this repo: `scout.ids.new_short_prefix`, `scout.id_map.IdMap`, `parser.short_prefix` extraction, and `resolve_target`'s `--by-id` path. Three pieces were missing to make it usable from the skill prompt.

## What

### 1. `scoutctl action-items new-prefix [PATH]`
Prints a fresh collision-checked 4-char Crockford prefix to stdout. Briefing/consolidation prompts shell out to it per task:

\`\`\`bash
pfx=\$(scoutctl action-items new-prefix)
echo "- [ ] [#\${pfx}] **\${subject}** \${body}" >> \$DAILY
\`\`\`

### 2. \`scoutctl action-items backfill-prefixes [PATH] [--dry-run]\`
Adds \`[#XXXX]\` to every open task line in the file that doesn't already have one, registers them in \`id-map.json\`, and reports each added line. Idempotent; safe to run at the top of every briefing step. New \`scout.action_items.backfill\` module.

### 3. \`phases/core/action-items.md\` updated
Hard Rule section mandating the prefix shape \`- [ ] [#XXXX] **subject** body\`, the mint snippet, the carry-forward-keeps-prefix rule, the backfill command, and a pre-commit grep self-check. Briefing, consolidation, and dreaming all pull this phase so the convention propagates without per-mode duplication.

## Verification

- All 556 plugin tests pass on this branch.
- End-to-end test of the backfill CLI:
  - Skips already-prefixed and already-done lines.
  - Mints unique prefixes for open unprefixed lines.
  - Writes back atomically with \`add_prefix_to_line\`.
  - Registers each new prefix in \`id-map.json\`.
- \`new-prefix\` returns distinct values across consecutive calls (collision check against \`id_map.in_use_prefixes()\` works).

## Companion change

scout-app v0.5.5 lands the app-side parser update (extract \`[#XXXX]\` → \`ActionTask.shortPrefix\` → pass \`--by-id\` instead of \`--subject\` when present). That ships separately.

## Migration

Existing vaults adopt the convention by running \`scoutctl action-items backfill-prefixes\` once per daily file (or via the next briefing/consolidation, which can do it inline per the phase doc). No data loss; backfill is idempotent.