### PR TITLE
fix(runners): retry transient API errors instead of failing the whole session

### DIFF
--- a/engine/scout/scripts/bootstrap.py
+++ b/engine/scout/scripts/bootstrap.py
@@ -105,6 +105,7 @@ _CAT1_TEMPLATES = (
     ("scripts/cc-session-cache.sh", "templates/scripts/cc-session-cache.sh.tmpl"),
     ("scripts/write-session-cost.sh", "templates/scripts/write-session-cost.sh.tmpl"),
     ("scripts/rate-limit-detect.sh", "templates/scripts/rate-limit-detect.sh.tmpl"),
+    ("scripts/claude-with-retry.sh", "templates/scripts/claude-with-retry.sh.tmpl"),
     ("hooks/kb-pre-filter.sh", "templates/hooks/kb-pre-filter.sh.tmpl"),
     (".gitignore", "templates/.gitignore.tmpl"),
 )

--- a/templates/run-dreaming.sh.tmpl
+++ b/templates/run-dreaming.sh.tmpl
@@ -78,15 +78,19 @@ MODE="${SCOUT_FORCE_MODE:-dreaming-manual}"
 
 START_TIME=$(date +%s)
 
-# Run Claude in print mode — capture exit code without triggering set -e
+# Run Claude in print mode through the retry wrapper — capture exit code without triggering set -e.
+# Wrapper handles log redirection and retries on transient API errors (socket close,
+# ECONNRESET, ConnectionRefused, Stream idle timeout, 529 Overloaded). See scripts/claude-with-retry.sh.
 EXIT_CODE=0
-cd "$SCOUT_DIR" && "$CLAUDE_BIN" \
+cd "$SCOUT_DIR" && "$SCOUT_DIR/scripts/claude-with-retry.sh" \
+    "$LOG_FILE" \
+    "$CLAUDE_BIN" \
     --permission-mode auto \
     --model opus \
     --max-budget-usd {{MAX_BUDGET}} \
     --name "{{INSTANCE_NAME_LOWER}}-${MODE}-$(date +%Y%m%d-%H%M)" \
     -p "$PROMPT" \
-    >> "$LOG_FILE" 2>&1 || EXIT_CODE=$?
+    || EXIT_CODE=$?
 END_TIME=$(date +%s)
 DURATION=$((END_TIME - START_TIME))
 

--- a/templates/run-research.sh.tmpl
+++ b/templates/run-research.sh.tmpl
@@ -63,15 +63,19 @@ MODE="${SCOUT_FORCE_MODE:-research-manual}"
 
 START_TIME=$(date +%s)
 
-# Run Claude in print mode — capture exit code without triggering set -e
+# Run Claude in print mode through the retry wrapper — capture exit code without triggering set -e.
+# Wrapper handles log redirection and retries on transient API errors (socket close,
+# ECONNRESET, ConnectionRefused, Stream idle timeout, 529 Overloaded). See scripts/claude-with-retry.sh.
 EXIT_CODE=0
-cd "$SCOUT_DIR" && "$CLAUDE_BIN" \
+cd "$SCOUT_DIR" && "$SCOUT_DIR/scripts/claude-with-retry.sh" \
+    "$LOG_FILE" \
+    "$CLAUDE_BIN" \
     --permission-mode auto \
     --model opus \
     --max-budget-usd {{MAX_BUDGET}} \
     --name "{{INSTANCE_NAME_LOWER}}-${MODE}-$(date +%Y%m%d-%H%M)" \
     -p "$PROMPT" \
-    >> "$LOG_FILE" 2>&1 || EXIT_CODE=$?
+    || EXIT_CODE=$?
 END_TIME=$(date +%s)
 DURATION=$((END_TIME - START_TIME))
 

--- a/templates/run-scout.sh.tmpl
+++ b/templates/run-scout.sh.tmpl
@@ -86,15 +86,19 @@ fi
 
 START_TIME=$(date +%s)
 
-# Run Claude in print mode — capture exit code without triggering set -e
+# Run Claude in print mode through the retry wrapper — capture exit code without triggering set -e.
+# Wrapper handles log redirection and retries on transient API errors (socket close,
+# ECONNRESET, ConnectionRefused, Stream idle timeout, 529 Overloaded). See scripts/claude-with-retry.sh.
 EXIT_CODE=0
-cd "$SCOUT_DIR" && "$CLAUDE_BIN" \
+cd "$SCOUT_DIR" && "$SCOUT_DIR/scripts/claude-with-retry.sh" \
+    "$LOG_FILE" \
+    "$CLAUDE_BIN" \
     --permission-mode auto \
     --model opus \
     --max-budget-usd {{MAX_BUDGET}} \
     --name "{{INSTANCE_NAME_LOWER}}-${MODE}-$(date +%Y%m%d-%H%M)" \
     -p "$PROMPT" \
-    >> "$LOG_FILE" 2>&1 || EXIT_CODE=$?
+    || EXIT_CODE=$?
 END_TIME=$(date +%s)
 DURATION=$((END_TIME - START_TIME))
 

--- a/templates/scripts/claude-with-retry.sh.tmpl
+++ b/templates/scripts/claude-with-retry.sh.tmpl
@@ -1,0 +1,79 @@
+#!/bin/bash
+# claude-with-retry.sh — invoke `claude -p` with bounded retry for transient API errors.
+#
+# Retries on the network/API failure class that's killing long {{INSTANCE_NAME}} sessions:
+#   - "socket connection was closed unexpectedly"  (undici UND_ERR_SOCKET)
+#   - "Unable to connect to API (ECONNRESET)"
+#   - "Unable to connect to API (ConnectionRefused)"
+#   - "Stream idle timeout - partial response received"
+#   - "529 Overloaded"                              (Anthropic upstream temp)
+#
+# Does NOT retry on:
+#   - 401 / 403 auth failures   (need user intervention)
+#   - "Exceeded USD budget"     (intentional budget gate)
+#   - Any non-zero exit whose log tail doesn't match the transient list
+#
+# IMPORTANT: each retry re-runs `claude -p` from scratch with the full prompt.
+# That is safe only if the SKILL.md flow is idempotent — i.e. mid-run commits
+# leave a recoverable state and a fresh invocation will not double-commit.
+# The {{INSTANCE_NAME}} dreaming/consolidation/research modes are *documented*
+# as restartable, but verify in a dry run before relying on this in production.
+#
+# Usage:
+#   claude-with-retry.sh <log-file> <claude-bin> <claude-args...>
+#
+# Env knobs:
+#   SCOUT_RETRY_MAX=2          total attempts (default: 2 → 1 retry)
+#   SCOUT_RETRY_BACKOFF_S=60   base backoff seconds (default 60; scales linearly: 60s, 120s, ...)
+#   SCOUT_RETRY_DISABLE=1      single-attempt mode (legacy behavior)
+#
+# Exit code: the exit code of the final attempt.
+
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+    echo "usage: $0 <log-file> <claude-bin> <claude-args...>" >&2
+    exit 2
+fi
+
+LOG_FILE="$1"; shift
+CLAUDE_BIN="$1"; shift
+
+MAX_ATTEMPTS="${SCOUT_RETRY_MAX:-2}"
+BACKOFF_S="${SCOUT_RETRY_BACKOFF_S:-60}"
+if [ "${SCOUT_RETRY_DISABLE:-0}" = "1" ]; then
+    MAX_ATTEMPTS=1
+fi
+
+# Pipe-separated grep -E regex. Keep narrow — anything matched here triggers a retry.
+TRANSIENT_PATTERNS='socket connection was closed unexpectedly|Unable to connect to API \(ECONNRESET\)|Unable to connect to API \(ConnectionRefused\)|Stream idle timeout|529 Overloaded'
+
+attempt=1
+exit_code=0
+while :; do
+    if [ "$attempt" -gt 1 ]; then
+        echo "=== Claude retry attempt $attempt/$MAX_ATTEMPTS at $(date) ===" >> "$LOG_FILE"
+    fi
+
+    exit_code=0
+    "$CLAUDE_BIN" "$@" >> "$LOG_FILE" 2>&1 || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        exit 0
+    fi
+
+    if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+        echo "=== Retry exhausted: $MAX_ATTEMPTS attempts, last exit $exit_code ===" >> "$LOG_FILE"
+        exit "$exit_code"
+    fi
+
+    if ! tail -50 "$LOG_FILE" | grep -qE "$TRANSIENT_PATTERNS"; then
+        echo "=== Failure not classified as transient — no retry (exit $exit_code) ===" >> "$LOG_FILE"
+        exit "$exit_code"
+    fi
+
+    sleep_s=$(( BACKOFF_S * attempt ))
+    echo "=== Transient API error detected — sleeping ${sleep_s}s before retry ===" >> "$LOG_FILE"
+    sleep "$sleep_s"
+    attempt=$(( attempt + 1 ))
+done


### PR DESCRIPTION
## Summary

Long-running scheduled Scout sessions fail outright on a single transient API/network blip. Across one vault's last 5 weeks of `.scout-logs/`, **22 of 276 runs failed (~8%), and 14 of those 22 (~64% of failures) are transient network errors** with no retry path:

| Error fingerprint | Count |
|---|---|
| `Unable to connect to API (ConnectionRefused)` | 7 |
| `Stream idle timeout – partial response received` | 5 |
| `socket connection was closed unexpectedly` (undici `UND_ERR_SOCKET`) | 1 |
| `Unable to connect to API (ECONNRESET)` | 1 |
| `529 Overloaded` | 1 |

One concrete example: a `dreaming` session at 2026-05-21 20:36 ran for 8m47s, did ~171K tokens of useful work cached, was mid-stream on a tool turn when api.anthropic.com's edge closed the TCP socket — entire session lost, no resume. `pmset -g log` confirmed no local sleep/wifi drop in the window, so this was peer-side.

## The fix

Add `scripts/claude-with-retry.sh` — a thin bash wrapper that:

- Invokes `claude -p` and watches its exit code
- On non-zero exit, tails the log for a narrow set of transient patterns (socket close, ECONNRESET, ConnectionRefused, Stream idle timeout, 529 Overloaded)
- If match → sleep linear backoff (60s base, scales by attempt), retry up to `SCOUT_RETRY_MAX` (default 2 total attempts)
- If no match (auth failure, budget exhaustion, anything else) → exit immediately with the original code

All three runner templates now invoke `claude` via the wrapper. The wrapper owns log redirection; existing lock / budget-check / rate-limit-detect / cost-tracker scaffolding is unchanged. The wrapper is registered in `bootstrap.py:_CAT1_TEMPLATES` so `scoutctl bootstrap install/upgrade` deploys it + sets executable bit.

## Knobs

- `SCOUT_RETRY_MAX=2` (default) — total attempts
- `SCOUT_RETRY_BACKOFF_S=60` (default) — base backoff seconds; scales linearly per attempt
- `SCOUT_RETRY_DISABLE=1` — single-attempt fallback (legacy behavior)

## Caveats

1. **Cost ceiling per session doubles** with `MAX=2`: up to `2 × --max-budget-usd`. The 3-hour window check in `budget-check.sh` still absorbs cross-session damage.
2. **Each retry re-runs `claude -p` from scratch with the full prompt.** Safe only if the SKILL.md flow is idempotent (commit-as-you-go, state-aware restart). Dreaming/consolidation/research are documented as restartable; a manual `kill -9` dry run is recommended before relying on this in anger.
3. **Lock survives retries** — the runner's `LOCK_FILE` trap spans all attempts; no race.

## Test plan

- [x] `bash -n` on all 4 new/modified shell files — clean
- [x] `engine/tests/unit/test_bootstrap_*` (65 tests) — all pass
- [ ] Soak test: enable on a vault, observe at least one retry path triggered by a real transient (or simulate with `iptables`/`pfctl` block of `api.anthropic.com` mid-session)
- [ ] Confirm `scoutctl bootstrap upgrade` on an existing vault writes the new wrapper at `scripts/claude-with-retry.sh` and updates `run-*.sh` runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)