### PR TITLE
fix(action-items): backfill skips items whose source line has no checkbox

### DIFF
--- a/engine/scout/action_items/backfill.py
+++ b/engine/scout/action_items/backfill.py
@@ -11,10 +11,18 @@ no-op (returns an empty list).
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from scout.id_map import IdMap, IdMapEntry
 from scout.ids import new_short_prefix, new_ulid
+
+# `add_prefix_to_line` only operates on lines that actually carry a checkbox
+# marker. The parser is more permissive — under sections like "Files Touched"
+# it can surface plain `- **name** — body` bullets as `status == "open"`
+# items, which then crash the writer mid-backfill. Pre-filter against the raw
+# source line to skip anything that isn't a real task.
+_CHECKBOX_RE = re.compile(r"^\s*- \[[ xX]\] ")
 
 
 def backfill_prefixes(
@@ -34,7 +42,15 @@ def backfill_prefixes(
     from scout.action_items.writer import add_prefix_to_line
 
     items = parse_file(target)
-    candidates = [i for i in items if i.status == "open" and i.short_prefix is None]
+    raw_lines = target.read_text(encoding="utf-8").splitlines()
+
+    def _has_checkbox(line_number: int) -> bool:
+        idx = line_number - 1
+        if not 0 <= idx < len(raw_lines):
+            return False
+        return _CHECKBOX_RE.match(raw_lines[idx]) is not None
+
+    candidates = [i for i in items if i.status == "open" and i.short_prefix is None and _has_checkbox(i.line_number)]
     if not candidates:
         return []
 


### PR DESCRIPTION
## Symptom

\`scoutctl action-items backfill-prefixes\` crashed mid-run on a real vault with:
\`\`\`
add_prefix_to_line: line 248 doesn't start with a checkbox marker
\`\`\`
One bad bullet prevented every legitimate task on later lines from being prefixed, leaving the daily file half-migrated.

## Root cause

\`action_items.parser.parse_action_items\` surfaces \`- **name** — body\` bullets under sections like "Files Touched" with \`status == "open"\` even though they don't carry a \`- [ ]\` checkbox. Backfill picked them up as candidates, then \`add_prefix_to_line\` correctly refused.

## Fix

In \`backfill_prefixes\`, re-read the raw source line for each candidate and require a \`^\\s*- \\[[ xX]\\] \` match before queueing. The parser stays untouched — its broader interpretation of "items in a section" is fine for read-only paths like \`list\` and \`render\`. Backfill (which writes) just needs the stricter checkbox guarantee.

## Verification

- All 86 action-items unit tests still pass.
- Real-vault repro: 74 candidates → 62 actual writes (12 non-checkbox bullets skipped), zero crashes.
- Idempotent: re-running on the post-backfill file is a no-op.