### PR TITLE
fix: top-5 critical audit findings (#31, #32, #33, #35, #36)

### DIFF
--- a/engine/scout/action_items/_common.py
+++ b/engine/scout/action_items/_common.py
@@ -7,20 +7,99 @@ Event construction.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from scout.action_items.parser import ActionItem
 from scout.errors import ActionItemError
 from scout.id_map import IdMap
 
+# Matches the comment shape that `add-comment` writes:
+#   `  - <author>: <text>`
+# Author allows letters/digits/`._-` to mirror the parser's tolerance.
+# The snooze marker `  - snoozed-until: YYYY-MM-DD` also fits this shape; we
+# strip those when listing comments since they are not user-authored notes.
+_COMMENT_SUB_BULLET_RE = re.compile(
+    r"^(?P<indent>\s+)-\s+(?P<author>[A-Za-z][A-Za-z0-9._-]*)\s*:\s*(?P<text>.+?)\s*$"
+)
+_SNOOZE_MARKER_AUTHORS = {"snoozed-until"}
 
-def find_line_number(path: Path, raw_line: str) -> int:
-    """1-indexed line number where `raw_line` first appears as a complete line."""
+
+def list_comment_lines(path: Path, *, task_line_number: int) -> list[tuple[int, str, str]]:
+    """Walk the indented sub-bullets directly under `task_line_number`.
+
+    Returns a list of `(line_number, author, text)` tuples for each comment
+    `  - <author>: <text>` sub-bullet attached to the task, in file order.
+    The `snoozed-until` marker is filtered out — it's machine metadata, not
+    a user-authored comment.
+
+    Stops at the first non-indented line, empty line, or a new task line.
+    """
     lines = path.read_text(encoding="utf-8").splitlines()
-    for n, line in enumerate(lines, start=1):
-        if line == raw_line:
-            return n
-    raise ActionItemError(f"could not locate line in {path.name}: {raw_line!r}")
+    idx = task_line_number - 1
+    if not 0 <= idx < len(lines):
+        raise ActionItemError(
+            f"list_comment_lines: task line {task_line_number} out of range (1..{len(lines)})"
+        )
+    comments: list[tuple[int, str, str]] = []
+    j = idx + 1
+    while j < len(lines):
+        line = lines[j]
+        if not line.strip():
+            break
+        # Stop when we drop back to a top-level (unindented) bullet.
+        if not (line.startswith(" ") or line.startswith("\t")):
+            break
+        m = _COMMENT_SUB_BULLET_RE.match(line)
+        if m is None:
+            # Non-comment indented line (e.g. a sub-task or detail bullet).
+            # Skip it but keep scanning; comments may appear after.
+            j += 1
+            continue
+        author = m.group("author")
+        if author.lower() in _SNOOZE_MARKER_AUTHORS:
+            j += 1
+            continue
+        comments.append((j + 1, author, m.group("text")))
+        j += 1
+    return comments
+
+
+def select_comment(
+    *,
+    candidates: list[tuple[int, str, str]],
+    index: int | None,
+    text: str | None,
+) -> tuple[int, str, str]:
+    """Pick a single comment from `candidates` by 1-based `index` or substring `text`.
+
+    Exactly one of `index` / `text` must be provided. Substring matching is
+    case-insensitive against the comment body and must resolve to exactly
+    one row — ambiguous matches raise.
+    """
+    if (index is None) == (text is None):
+        raise ActionItemError(
+            "comment selector requires exactly one of --index or --text"
+        )
+    if not candidates:
+        raise ActionItemError("no comments found on this task")
+    if index is not None:
+        if index < 1 or index > len(candidates):
+            raise ActionItemError(
+                f"--index {index} out of range; task has {len(candidates)} comment(s)"
+            )
+        return candidates[index - 1]
+    assert text is not None
+    needle = text.lower()
+    matches = [c for c in candidates if needle in c[2].lower()]
+    if not matches:
+        raise ActionItemError(f"no comment matched text: {text!r}")
+    if len(matches) > 1:
+        raise ActionItemError(
+            f"ambiguous comment text {text!r}; matched {len(matches)}:\n"
+            + "\n".join(f"  {i + 1}. {c[2]}" for i, c in enumerate(matches))
+        )
+    return matches[0]
 
 
 def resolve_target(
@@ -57,7 +136,12 @@ def resolve_target(
 
     # by_subject path
     assert by_subject is not None  # enforced by the exactly-one-of check above
-    matches = [i for i in items if i.status == "open" and by_subject.lower() in i.raw_line.lower()]
+    # Match against the cleaned title, NOT the raw_line. raw_line includes
+    # the `[#XXXX]` prefix marker and priority emoji, which would cause a
+    # user search for e.g. "A3F7" to silently match the prefix token of an
+    # unrelated task. Users wanting to find by prefix should use --by-id.
+    needle = by_subject.lower()
+    matches = [i for i in items if i.status == "open" and needle in i.title.lower()]
     if len(matches) == 0:
         raise ActionItemError(f"no open task matched subject: {by_subject!r}")
     if len(matches) > 1:

--- a/engine/scout/action_items/_common.py
+++ b/engine/scout/action_items/_common.py
@@ -19,9 +19,7 @@ from scout.id_map import IdMap
 # Author allows letters/digits/`._-` to mirror the parser's tolerance.
 # The snooze marker `  - snoozed-until: YYYY-MM-DD` also fits this shape; we
 # strip those when listing comments since they are not user-authored notes.
-_COMMENT_SUB_BULLET_RE = re.compile(
-    r"^(?P<indent>\s+)-\s+(?P<author>[A-Za-z][A-Za-z0-9._-]*)\s*:\s*(?P<text>.+?)\s*$"
-)
+_COMMENT_SUB_BULLET_RE = re.compile(r"^(?P<indent>\s+)-\s+(?P<author>[A-Za-z][A-Za-z0-9._-]*)\s*:\s*(?P<text>.+?)\s*$")
 _SNOOZE_MARKER_AUTHORS = {"snoozed-until"}
 
 
@@ -38,9 +36,7 @@ def list_comment_lines(path: Path, *, task_line_number: int) -> list[tuple[int, 
     lines = path.read_text(encoding="utf-8").splitlines()
     idx = task_line_number - 1
     if not 0 <= idx < len(lines):
-        raise ActionItemError(
-            f"list_comment_lines: task line {task_line_number} out of range (1..{len(lines)})"
-        )
+        raise ActionItemError(f"list_comment_lines: task line {task_line_number} out of range (1..{len(lines)})")
     comments: list[tuple[int, str, str]] = []
     j = idx + 1
     while j < len(lines):
@@ -78,16 +74,12 @@ def select_comment(
     one row — ambiguous matches raise.
     """
     if (index is None) == (text is None):
-        raise ActionItemError(
-            "comment selector requires exactly one of --index or --text"
-        )
+        raise ActionItemError("comment selector requires exactly one of --index or --text")
     if not candidates:
         raise ActionItemError("no comments found on this task")
     if index is not None:
         if index < 1 or index > len(candidates):
-            raise ActionItemError(
-                f"--index {index} out of range; task has {len(candidates)} comment(s)"
-            )
+            raise ActionItemError(f"--index {index} out of range; task has {len(candidates)} comment(s)")
         return candidates[index - 1]
     assert text is not None
     needle = text.lower()

--- a/engine/scout/action_items/add_comment.py
+++ b/engine/scout/action_items/add_comment.py
@@ -14,7 +14,7 @@ import datetime as dt
 from pathlib import Path
 
 from scout import paths
-from scout.action_items._common import find_line_number, resolve_target
+from scout.action_items._common import resolve_target
 from scout.action_items.parser import parse_file
 from scout.action_items.writer import insert_below
 from scout.events import Event, now_iso
@@ -55,8 +55,7 @@ def add_comment(
         by_subject=by_subject,
     )
 
-    line_number = find_line_number(target_path, match.raw_line)
-    insert_below(target_path, line_number=line_number, text=f"  - {comment}")
+    insert_below(target_path, line_number=match.line_number, text=f"  - {comment}")
 
     return Event(
         id=new_ulid(),

--- a/engine/scout/action_items/cli.py
+++ b/engine/scout/action_items/cli.py
@@ -59,7 +59,10 @@ def cli_snooze(
     from_kind: str | None = typer.Option(
         None,
         "--from-kind",
-        help="Source section kind (e.g. 'urgent', 'todo'). Recorded in the snoozed-until marker so a carry-forward can recover the original priority on the target day.",
+        help=(
+            "Source section kind (e.g. 'urgent', 'todo'). Recorded in the snoozed-until marker so a "
+            "carry-forward can recover the original priority on the target day."
+        ),
     ),
     path: Path | None = typer.Argument(
         None,

--- a/engine/scout/action_items/cli.py
+++ b/engine/scout/action_items/cli.py
@@ -56,6 +56,11 @@ def cli_snooze(
     until: str = typer.Option(..., "--until", help="YYYY-MM-DD"),
     subject: str | None = typer.Option(None, "--subject", help="Substring of task title (legacy fallback)."),
     by_id: str | None = typer.Option(None, "--by-id", help="4-char Crockford prefix from `[#XXXX]`."),
+    from_kind: str | None = typer.Option(
+        None,
+        "--from-kind",
+        help="Source section kind (e.g. 'urgent', 'todo'). Recorded in the snoozed-until marker so a carry-forward can recover the original priority on the target day.",
+    ),
     path: Path | None = typer.Argument(
         None,
         help="Daily markdown file (default: today). When given, its grandparent is the data dir.",
@@ -84,7 +89,14 @@ def cli_snooze(
         except ValueError as e:
             raise ActionItemError(f"unrecognized daily filename: {path.name}") from e
 
-    snooze(by_id=by_id, by_subject=subject, until=target_date, date=date, data_dir=data_dir)
+    snooze(
+        by_id=by_id,
+        by_subject=subject,
+        from_kind=from_kind,
+        until=target_date,
+        date=date,
+        data_dir=data_dir,
+    )
 
 
 @app.command("add-comment")
@@ -116,6 +128,84 @@ def cli_add_comment(
             raise ActionItemError(f"unrecognized daily filename: {path.name}") from e
 
     add_comment(by_id=by_id, by_subject=subject, comment=comment, date=date, data_dir=data_dir)
+
+
+@app.command("delete-comment")
+def cli_delete_comment(
+    subject: str | None = typer.Option(None, "--subject", help="Substring of task title (legacy fallback)."),
+    by_id: str | None = typer.Option(None, "--by-id", help="4-char Crockford prefix from `[#XXXX]`."),
+    index: int | None = typer.Option(None, "--index", help="1-based index of the comment to delete."),
+    text: str | None = typer.Option(None, "--text", help="Case-insensitive substring of the comment body."),
+    path: Path | None = typer.Argument(
+        None,
+        help="Daily markdown file (default: today). When given, its grandparent is the data dir.",
+    ),
+) -> None:
+    from scout.action_items.delete_comment import delete_comment
+
+    if (subject is None) == (by_id is None):
+        raise ActionItemError("delete-comment requires exactly one of --subject or --by-id")
+    if (index is None) == (text is None):
+        raise ActionItemError("delete-comment requires exactly one of --index or --text")
+
+    data_dir: Path | None = None
+    date: _dt.date | None = None
+    if path is not None:
+        data_dir = path.parent.parent
+        stem = path.stem
+        try:
+            date = _dt.date.fromisoformat(stem.removeprefix("action-items-"))
+        except ValueError as e:
+            raise ActionItemError(f"unrecognized daily filename: {path.name}") from e
+
+    delete_comment(
+        by_id=by_id,
+        by_subject=subject,
+        index=index,
+        text=text,
+        date=date,
+        data_dir=data_dir,
+    )
+
+
+@app.command("edit-comment")
+def cli_edit_comment(
+    new_text: str = typer.Option(..., "--new-text", help="Replacement body for the comment."),
+    subject: str | None = typer.Option(None, "--subject", help="Substring of task title (legacy fallback)."),
+    by_id: str | None = typer.Option(None, "--by-id", help="4-char Crockford prefix from `[#XXXX]`."),
+    index: int | None = typer.Option(None, "--index", help="1-based index of the comment to edit."),
+    text: str | None = typer.Option(None, "--text", help="Case-insensitive substring of the comment body."),
+    path: Path | None = typer.Argument(
+        None,
+        help="Daily markdown file (default: today). When given, its grandparent is the data dir.",
+    ),
+) -> None:
+    from scout.action_items.edit_comment import edit_comment
+
+    if (subject is None) == (by_id is None):
+        raise ActionItemError("edit-comment requires exactly one of --subject or --by-id")
+    if (index is None) == (text is None):
+        raise ActionItemError("edit-comment requires exactly one of --index or --text")
+
+    data_dir: Path | None = None
+    date: _dt.date | None = None
+    if path is not None:
+        data_dir = path.parent.parent
+        stem = path.stem
+        try:
+            date = _dt.date.fromisoformat(stem.removeprefix("action-items-"))
+        except ValueError as e:
+            raise ActionItemError(f"unrecognized daily filename: {path.name}") from e
+
+    edit_comment(
+        new_text=new_text,
+        by_id=by_id,
+        by_subject=subject,
+        index=index,
+        text=text,
+        date=date,
+        data_dir=data_dir,
+    )
 
 
 @app.command("render")

--- a/engine/scout/action_items/delete_comment.py
+++ b/engine/scout/action_items/delete_comment.py
@@ -1,0 +1,73 @@
+"""Delete a comment sub-bullet beneath an action item.
+
+The inverse of `add_comment` — removes a single `  - <author>: <text>`
+line attached to the matched task. Git history is the archive.
+
+Selection rules:
+- The task is resolved by `by_id` (preferred) or `by_subject` (legacy
+  fallback), same contract as the other mutators.
+- The comment within that task is selected by 1-based `index` (counts
+  user-authored sub-bullets, skipping the `snoozed-until` marker) or by
+  case-insensitive substring `text`. Exactly one must be provided.
+
+Returns an `Event` describing the mutation.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+from scout import paths
+from scout.action_items._common import (
+    list_comment_lines,
+    resolve_target,
+    select_comment,
+)
+from scout.action_items.parser import parse_file
+from scout.action_items.writer import delete_line
+from scout.events import Event, now_iso
+from scout.ids import new_ulid
+
+
+def _today() -> dt.date:
+    return dt.date.today()
+
+
+def delete_comment(
+    *,
+    by_id: str | None = None,
+    by_subject: str | None = None,
+    index: int | None = None,
+    text: str | None = None,
+    date: dt.date | None = None,
+    data_dir: Path | None = None,
+) -> Event:
+    target_path = paths.action_items_daily_path(data=data_dir, date=date or _today())
+
+    items = parse_file(target_path) if target_path.exists() else []
+    match, item_ulid, via = resolve_target(
+        items=items,
+        data_dir=data_dir if data_dir is not None else paths.data_dir(),
+        by_id=by_id,
+        by_subject=by_subject,
+    )
+
+    task_line = match.line_number
+    candidates = list_comment_lines(target_path, task_line_number=task_line)
+    line_no, author, body = select_comment(candidates=candidates, index=index, text=text)
+    delete_line(target_path, line_number=line_no)
+
+    return Event(
+        id=new_ulid(),
+        ts=now_iso(),
+        kind="action_item.comment_deleted",
+        source="cli:delete_comment",
+        payload={
+            "item_id": item_ulid,
+            "via": via,
+            "title": match.title,
+            "comment_author": author,
+            "comment_text": body,
+        },
+    )

--- a/engine/scout/action_items/edit_comment.py
+++ b/engine/scout/action_items/edit_comment.py
@@ -1,0 +1,87 @@
+"""Replace the body of an existing comment beneath an action item.
+
+Same task/comment resolution as `delete_comment`. Preserves the
+`  - <author>: ` prefix and the original indent — only the body text
+changes.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import re
+from pathlib import Path
+
+from scout import paths
+from scout.action_items._common import (
+    list_comment_lines,
+    resolve_target,
+    select_comment,
+)
+from scout.action_items.parser import parse_file
+from scout.action_items.writer import replace_line
+from scout.errors import ActionItemError
+from scout.events import Event, now_iso
+from scout.ids import new_ulid
+
+_AUTHOR_PREFIX_RE = re.compile(
+    r"^(?P<head>\s+-\s+[A-Za-z][A-Za-z0-9._-]*\s*:\s+).*$"
+)
+
+
+def _today() -> dt.date:
+    return dt.date.today()
+
+
+def edit_comment(
+    *,
+    new_text: str,
+    by_id: str | None = None,
+    by_subject: str | None = None,
+    index: int | None = None,
+    text: str | None = None,
+    date: dt.date | None = None,
+    data_dir: Path | None = None,
+) -> Event:
+    if not new_text.strip():
+        raise ActionItemError("edit-comment: --new-text must not be empty")
+
+    target_path = paths.action_items_daily_path(data=data_dir, date=date or _today())
+
+    items = parse_file(target_path) if target_path.exists() else []
+    match, item_ulid, via = resolve_target(
+        items=items,
+        data_dir=data_dir if data_dir is not None else paths.data_dir(),
+        by_id=by_id,
+        by_subject=by_subject,
+    )
+
+    task_line = match.line_number
+    candidates = list_comment_lines(target_path, task_line_number=task_line)
+    line_no, author, old_text = select_comment(candidates=candidates, index=index, text=text)
+
+    # Pull the existing line so we keep its original indent + author prefix
+    # byte-for-byte. Only the body changes.
+    lines = target_path.read_text(encoding="utf-8").splitlines()
+    original = lines[line_no - 1]
+    m = _AUTHOR_PREFIX_RE.match(original)
+    if m is None:
+        raise ActionItemError(
+            f"edit-comment: could not parse author prefix on line {line_no}: {original!r}"
+        )
+    replacement = m.group("head") + new_text
+    replace_line(target_path, line_number=line_no, text=replacement)
+
+    return Event(
+        id=new_ulid(),
+        ts=now_iso(),
+        kind="action_item.comment_edited",
+        source="cli:edit_comment",
+        payload={
+            "item_id": item_ulid,
+            "via": via,
+            "title": match.title,
+            "comment_author": author,
+            "old_text": old_text,
+            "new_text": new_text,
+        },
+    )

--- a/engine/scout/action_items/edit_comment.py
+++ b/engine/scout/action_items/edit_comment.py
@@ -23,9 +23,7 @@ from scout.errors import ActionItemError
 from scout.events import Event, now_iso
 from scout.ids import new_ulid
 
-_AUTHOR_PREFIX_RE = re.compile(
-    r"^(?P<head>\s+-\s+[A-Za-z][A-Za-z0-9._-]*\s*:\s+).*$"
-)
+_AUTHOR_PREFIX_RE = re.compile(r"^(?P<head>\s+-\s+[A-Za-z][A-Za-z0-9._-]*\s*:\s+).*$")
 
 
 def _today() -> dt.date:
@@ -65,9 +63,7 @@ def edit_comment(
     original = lines[line_no - 1]
     m = _AUTHOR_PREFIX_RE.match(original)
     if m is None:
-        raise ActionItemError(
-            f"edit-comment: could not parse author prefix on line {line_no}: {original!r}"
-        )
+        raise ActionItemError(f"edit-comment: could not parse author prefix on line {line_no}: {original!r}")
     replacement = m.group("head") + new_text
     replace_line(target_path, line_number=line_no, text=replacement)
 

--- a/engine/scout/action_items/mark_done.py
+++ b/engine/scout/action_items/mark_done.py
@@ -11,7 +11,7 @@ import datetime as dt
 from pathlib import Path
 
 from scout import paths
-from scout.action_items._common import find_line_number, resolve_target
+from scout.action_items._common import resolve_target
 from scout.action_items.parser import parse_file
 from scout.action_items.writer import flip_checkbox
 from scout.events import Event, now_iso
@@ -51,8 +51,7 @@ def mark_done(
         by_subject=by_subject,
     )
 
-    line_number = find_line_number(target_path, match.raw_line)
-    flip_checkbox(target_path, line_number=line_number, to_done=True)
+    flip_checkbox(target_path, line_number=match.line_number, to_done=True)
 
     return Event(
         id=new_ulid(),

--- a/engine/scout/action_items/parser.py
+++ b/engine/scout/action_items/parser.py
@@ -84,7 +84,7 @@ def parse_action_items(filepath: Path) -> list[ActionItem]:
         return []
 
     items: list[ActionItem] = []
-    lines = filepath.read_text().splitlines()
+    lines = filepath.read_text(encoding="utf-8").splitlines()
 
     current_section = ""
     current_subsection = ""

--- a/engine/scout/action_items/render.py
+++ b/engine/scout/action_items/render.py
@@ -104,7 +104,7 @@ COMMENT_RE = re.compile(
 def parse(md_path: Path) -> tuple[str, list[str], list[Section]]:
     """Return (title, preamble_paragraphs, sections)."""
 
-    text = md_path.read_text()
+    text = md_path.read_text(encoding="utf-8")
     lines = text.splitlines()
 
     title = ""

--- a/engine/scout/action_items/snooze.py
+++ b/engine/scout/action_items/snooze.py
@@ -16,7 +16,7 @@ import datetime as dt
 from pathlib import Path
 
 from scout import paths
-from scout.action_items._common import find_line_number, resolve_target
+from scout.action_items._common import resolve_target
 from scout.action_items.parser import parse_file
 from scout.action_items.writer import insert_below
 from scout.errors import ActionItemError
@@ -34,6 +34,7 @@ def snooze(
     until: dt.date,
     by_id: str | None = None,
     by_subject: str | None = None,
+    from_kind: str | None = None,
     date: dt.date | None = None,
     data_dir: Path | None = None,
 ) -> Event:
@@ -64,22 +65,28 @@ def snooze(
         by_subject=by_subject,
     )
 
-    line_number = find_line_number(target_path, match.raw_line)
-    insert_below(
-        target_path,
-        line_number=line_number,
-        text=f"  - snoozed-until: {until.isoformat()}",
-    )
+    # The optional `(from-kind: <kind>)` tail lets downstream renderers
+    # (and the next day's consolidation pass) recover the source section's
+    # priority kind when the task carries forward. Without it, an urgent
+    # task that lands under `## 🛌 Snoozed` on the target day loses its
+    # visual urgency.
+    marker = f"  - snoozed-until: {until.isoformat()}"
+    if from_kind:
+        marker += f" (from-kind: {from_kind})"
+    insert_below(target_path, line_number=match.line_number, text=marker)
 
+    payload: dict[str, object] = {
+        "item_id": item_ulid,
+        "via": via,
+        "title": match.title,
+        "until": until.isoformat(),
+    }
+    if from_kind:
+        payload["from_kind"] = from_kind
     return Event(
         id=new_ulid(),
         ts=now_iso(),
         kind="action_item.snoozed",
         source="cli:snooze",
-        payload={
-            "item_id": item_ulid,
-            "via": via,
-            "title": match.title,
-            "until": until.isoformat(),
-        },
+        payload=payload,
     )

--- a/engine/scout/action_items/writer.py
+++ b/engine/scout/action_items/writer.py
@@ -8,11 +8,18 @@ sibling temp file in the same directory, fsync it, then rename.
 from __future__ import annotations
 
 import os
+import re
 import tempfile
 from pathlib import Path
 
 from scout.errors import ActionItemError
 from scout.ids import short_prefix_pattern
+
+# Top-level checkbox line, with any leading whitespace. Captures the indent
+# and the marker so the prefix can be inserted while preserving the indent.
+# Case-insensitive `[x]` matches `[X]` too, mirroring the parser/backfill
+# candidate regex.
+_CHECKBOX_LINE_RE = re.compile(r"^(?P<indent>\s*)(?P<marker>- \[[ xX]\] )")
 
 
 def atomic_write_lines(target: Path, lines: list[str]) -> None:
@@ -87,6 +94,10 @@ def delete_line(target: Path, *, line_number: int) -> None:
 def add_prefix_to_line(target: Path, *, line_number: int, prefix: str) -> None:
     """Insert `[#PREFIX] ` after the checkbox marker on the 1-indexed line.
 
+    Preserves leading whitespace (the parser and backfill candidate regex
+    both accept indented top-level items, so the writer must too).
+    Accepts both `[x]` and `[X]` checkbox completion markers.
+
     Refuses if the line already carries a `[#XXXX]` prefix — the caller
     should not be asking to add one if scout.id_map already has a record.
     """
@@ -97,11 +108,9 @@ def add_prefix_to_line(target: Path, *, line_number: int, prefix: str) -> None:
     line = lines[idx]
     if short_prefix_pattern().search(line):
         raise ActionItemError(f"add_prefix_to_line: line {line_number} already has prefix")
-    # Find the checkbox marker (`- [ ]` or `- [x]`) and insert after it.
-    for marker in ("- [ ] ", "- [x] "):
-        if line.startswith(marker):
-            lines[idx] = marker + f"[#{prefix}] " + line[len(marker) :]
-            break
-    else:
+    m = _CHECKBOX_LINE_RE.match(line)
+    if m is None:
         raise ActionItemError(f"add_prefix_to_line: line {line_number} doesn't start with a checkbox marker")
+    head_end = m.end()
+    lines[idx] = line[:head_end] + f"[#{prefix}] " + line[head_end:]
     atomic_write_lines(target, lines)

--- a/engine/scout/action_items/writer.py
+++ b/engine/scout/action_items/writer.py
@@ -64,6 +64,26 @@ def insert_below(target: Path, *, line_number: int, text: str) -> None:
     atomic_write_lines(target, lines)
 
 
+def replace_line(target: Path, *, line_number: int, text: str) -> None:
+    """Replace the 1-indexed line wholesale with `text`."""
+    lines = _read_lines(target)
+    idx = line_number - 1
+    if not 0 <= idx < len(lines):
+        raise ActionItemError(f"replace_line: line {line_number} out of range (1..{len(lines)})")
+    lines[idx] = text
+    atomic_write_lines(target, lines)
+
+
+def delete_line(target: Path, *, line_number: int) -> None:
+    """Remove the 1-indexed line entirely."""
+    lines = _read_lines(target)
+    idx = line_number - 1
+    if not 0 <= idx < len(lines):
+        raise ActionItemError(f"delete_line: line {line_number} out of range (1..{len(lines)})")
+    del lines[idx]
+    atomic_write_lines(target, lines)
+
+
 def add_prefix_to_line(target: Path, *, line_number: int, prefix: str) -> None:
     """Insert `[#PREFIX] ` after the checkbox marker on the 1-indexed line.
 

--- a/engine/scout/scripts/bootstrap_lock.py
+++ b/engine/scout/scripts/bootstrap_lock.py
@@ -8,6 +8,7 @@ between bootstrap stages and dispatcher ticks.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import time
 from pathlib import Path
@@ -51,19 +52,42 @@ def is_lock_held_by_live_pid(lock_path: Path) -> bool:
 
 
 def acquire_lock(lock_path: Path) -> None:
-    """Take the lock by writing our PID. Raise if already held by a live PID."""
-    if is_lock_held_by_live_pid(lock_path):
+    """Take the lock by atomically creating the file with our PID.
+
+    Uses ``O_CREAT | O_EXCL`` so two racing callers cannot both believe
+    they hold the lock — one wins the create, the other gets
+    ``FileExistsError`` and we surface it as :class:`LockBusyError`.
+
+    Stale locks (file exists, but its PID is dead) are unlinked before
+    the atomic claim, so a normal warm path is unchanged.
+    """
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # If a stale lock exists, remove it before claiming. The unlink is
+    # racy on its own, but combined with the O_EXCL claim below, at most
+    # one racing process succeeds.
+    if lock_path.exists() and not is_lock_held_by_live_pid(lock_path):
+        with contextlib.suppress(FileNotFoundError):
+            lock_path.unlink()
+
+    try:
+        fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+    except FileExistsError as e:
+        # Either held by a live PID, or another caller raced us to claim.
         try:
-            pid_str = lock_path.read_text(encoding="utf-8").strip()
-            pid = int(pid_str)
+            pid = int(lock_path.read_text(encoding="utf-8").strip())
         except (ValueError, OSError):
             pid = -1
-        raise LockBusyError(lock_path, pid)
-    if lock_path.exists():
-        # Stale (dead PID). Remove and continue.
-        lock_path.unlink()
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    lock_path.write_text(str(os.getpid()), encoding="utf-8")
+        raise LockBusyError(lock_path, pid) from e
+
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(str(os.getpid()))
+    except Exception:
+        # Roll back the partial claim so the next caller can retry cleanly.
+        with contextlib.suppress(FileNotFoundError):
+            lock_path.unlink()
+        raise
 
 
 def release_lock(lock_path: Path) -> None:

--- a/engine/scout/scripts/schedule_tick.py
+++ b/engine/scout/scripts/schedule_tick.py
@@ -33,7 +33,9 @@ import json
 import os
 import socket
 import subprocess
+import sys
 import time as _time
+import traceback
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -746,10 +748,16 @@ def fire_now(slot_key: str) -> Event:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """CLI entry point. Returns 0 on success, 1 on unhandled error."""
+    """CLI entry point. Returns 0 on success, 1 on unhandled error.
+
+    On unhandled exceptions, the traceback is printed to stderr so that
+    cron/launchd logs capture the failure — silent exit-1 leaves no signal
+    for diagnosing why the tick stopped firing.
+    """
     try:
         run()
     except Exception:
+        traceback.print_exc(file=sys.stderr)
         return 1
     return 0
 

--- a/engine/tests/unit/test_action_items_common.py
+++ b/engine/tests/unit/test_action_items_common.py
@@ -168,8 +168,6 @@ def test_resolve_target_by_subject_matches_title_substring(fake_data_dir: Path) 
             short_prefix="A3F7",
         ),
     ]
-    target, _, via = resolve_target(
-        items=items, data_dir=fake_data_dir, by_id=None, by_subject="task x"
-    )
+    target, _, via = resolve_target(items=items, data_dir=fake_data_dir, by_id=None, by_subject="task x")
     assert target.title == "task X"
     assert via == "subject"

--- a/engine/tests/unit/test_action_items_common.py
+++ b/engine/tests/unit/test_action_items_common.py
@@ -6,24 +6,10 @@ from pathlib import Path
 
 import pytest
 
-from scout.action_items._common import find_line_number, resolve_target
+from scout.action_items._common import resolve_target
 from scout.action_items.parser import ActionItem
 from scout.errors import ActionItemError
 from scout.id_map import IdMap, IdMapEntry
-
-
-def test_find_line_number_returns_1_indexed(tmp_path: Path) -> None:
-    f = tmp_path / "x.md"
-    f.write_text("alpha\nbeta\ngamma\n")
-    assert find_line_number(f, "beta") == 2
-    assert find_line_number(f, "alpha") == 1
-
-
-def test_find_line_number_raises_when_missing(tmp_path: Path) -> None:
-    f = tmp_path / "x.md"
-    f.write_text("only line\n")
-    with pytest.raises(ActionItemError, match="could not locate"):
-        find_line_number(f, "missing line")
 
 
 def test_resolve_target_by_id_returns_entry_and_match(fake_data_dir: Path) -> None:
@@ -136,3 +122,54 @@ def test_resolve_target_prefix_in_idmap_but_missing_from_items_raises(
     # Items list is empty — simulates the wrong-file case.
     with pytest.raises(ActionItemError, match="is in id-map but not present"):
         resolve_target(items=[], data_dir=fake_data_dir, by_id="A3F7", by_subject=None)
+
+
+# Regression: by_subject must match against item.title (cleaned), not
+# raw_line (which includes the [#XXXX] prefix marker and the priority
+# emoji). Otherwise a search for "A3F7" silently matches the prefix
+# token of an unrelated task. Issue #32.
+
+
+def test_resolve_target_by_subject_does_not_match_prefix_token(fake_data_dir: Path) -> None:
+    """A subject substring that only appears inside the [#XXXX] prefix
+    marker (and not in the cleaned title) must NOT match — users searching
+    for a prefix should use --by-id, not --by-subject."""
+    items = [
+        ActionItem(
+            priority="🔴",
+            title="task X",
+            status="open",
+            section="In Progress",
+            context_links=[],
+            notes=[],
+            details=[],
+            raw_line="- [ ] [#A3F7] 🔴 task X",
+            line_number=5,
+            short_prefix="A3F7",
+        ),
+    ]
+    with pytest.raises(ActionItemError, match="no open task matched"):
+        resolve_target(items=items, data_dir=fake_data_dir, by_id=None, by_subject="A3F7")
+
+
+def test_resolve_target_by_subject_matches_title_substring(fake_data_dir: Path) -> None:
+    """Sanity: a substring that appears in the cleaned title still matches."""
+    items = [
+        ActionItem(
+            priority="🔴",
+            title="task X",
+            status="open",
+            section="In Progress",
+            context_links=[],
+            notes=[],
+            details=[],
+            raw_line="- [ ] [#A3F7] 🔴 task X",
+            line_number=5,
+            short_prefix="A3F7",
+        ),
+    ]
+    target, _, via = resolve_target(
+        items=items, data_dir=fake_data_dir, by_id=None, by_subject="task x"
+    )
+    assert target.title == "task X"
+    assert via == "subject"

--- a/engine/tests/unit/test_action_items_delete_comment.py
+++ b/engine/tests/unit/test_action_items_delete_comment.py
@@ -1,0 +1,154 @@
+"""Unit tests for scout.action_items.delete_comment."""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import pytest
+
+from scout.action_items.delete_comment import delete_comment
+from scout.errors import ActionItemError
+from scout.events import Event
+from scout.id_map import IdMap, IdMapEntry
+
+
+def _make_daily(fake_data_dir: Path, body: str) -> Path:
+    daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
+    daily.parent.mkdir(parents=True, exist_ok=True)
+    daily.write_text(body)
+    return daily
+
+
+def _register_prefix(fake_data_dir: Path, prefix: str = "A3F7") -> None:
+    m = IdMap.load(fake_data_dir)
+    m.register(IdMapEntry("01HXAAA", prefix, "task", "action-items-2026-04-26.md", 5))
+    m.save()
+
+
+def test_delete_comment_by_index(
+    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_prefix(fake_data_dir)
+    daily = _make_daily(
+        fake_data_dir,
+        "## In Progress\n\n"
+        "- [ ] [#A3F7] task\n"
+        "  - jordan: first\n"
+        "  - jordan: second\n"
+        "  - jordan: third\n"
+        "- [ ] another task\n",
+    )
+    monkeypatch.setattr(
+        "scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26)
+    )
+
+    event = delete_comment(by_id="A3F7", index=2, data_dir=fake_data_dir)
+
+    text = daily.read_text()
+    assert "first" in text
+    assert "second" not in text
+    assert "third" in text
+    assert "another task" in text
+    assert isinstance(event, Event)
+    assert event.kind == "action_item.comment_deleted"
+    assert event.source == "cli:delete_comment"
+    assert event.payload["comment_text"] == "second"
+
+
+def test_delete_comment_by_text_substring(
+    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_prefix(fake_data_dir)
+    _make_daily(
+        fake_data_dir,
+        "## In Progress\n\n"
+        "- [ ] [#A3F7] task\n"
+        "  - jordan: vendor confirmed\n"
+        "  - jordan: legal review needed\n",
+    )
+    monkeypatch.setattr(
+        "scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26)
+    )
+
+    delete_comment(by_id="A3F7", text="legal", data_dir=fake_data_dir)
+
+    text = (fake_data_dir / "action-items" / "action-items-2026-04-26.md").read_text()
+    assert "vendor confirmed" in text
+    assert "legal review" not in text
+
+
+def test_delete_comment_ignores_snoozed_until_marker(
+    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The snoozed-until sub-bullet shares the comment shape but is machine
+    metadata. `--index 1` must point at the first real comment, not the marker."""
+    _register_prefix(fake_data_dir)
+    daily = _make_daily(
+        fake_data_dir,
+        "## In Progress\n\n"
+        "- [ ] [#A3F7] task\n"
+        "  - snoozed-until: 2026-05-01\n"
+        "  - jordan: real comment\n",
+    )
+    monkeypatch.setattr(
+        "scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26)
+    )
+
+    delete_comment(by_id="A3F7", index=1, data_dir=fake_data_dir)
+
+    text = daily.read_text()
+    assert "snoozed-until: 2026-05-01" in text
+    assert "real comment" not in text
+
+
+def test_delete_comment_index_out_of_range(
+    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_prefix(fake_data_dir)
+    _make_daily(
+        fake_data_dir,
+        "- [ ] [#A3F7] task\n  - jordan: only one\n",
+    )
+    monkeypatch.setattr(
+        "scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26)
+    )
+
+    with pytest.raises(ActionItemError, match="--index 5 out of range"):
+        delete_comment(by_id="A3F7", index=5, data_dir=fake_data_dir)
+
+
+def test_delete_comment_ambiguous_text(
+    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_prefix(fake_data_dir)
+    _make_daily(
+        fake_data_dir,
+        "- [ ] [#A3F7] task\n"
+        "  - jordan: vendor ping\n"
+        "  - jordan: vendor confirmed\n",
+    )
+    monkeypatch.setattr(
+        "scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26)
+    )
+
+    with pytest.raises(ActionItemError, match="ambiguous"):
+        delete_comment(by_id="A3F7", text="vendor", data_dir=fake_data_dir)
+
+
+def test_delete_comment_requires_exactly_one_selector(
+    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_prefix(fake_data_dir)
+    _make_daily(fake_data_dir, "- [ ] [#A3F7] task\n  - jordan: hi\n")
+    monkeypatch.setattr(
+        "scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26)
+    )
+
+    with pytest.raises(ActionItemError, match="exactly one of --index or --text"):
+        delete_comment(by_id="A3F7", data_dir=fake_data_dir)
+
+    with pytest.raises(ActionItemError, match="exactly one of --index or --text"):
+        delete_comment(
+            by_id="A3F7", index=1, text="hi", data_dir=fake_data_dir
+        )

--- a/engine/tests/unit/test_action_items_delete_comment.py
+++ b/engine/tests/unit/test_action_items_delete_comment.py
@@ -26,9 +26,7 @@ def _register_prefix(fake_data_dir: Path, prefix: str = "A3F7") -> None:
     m.save()
 
 
-def test_delete_comment_by_index(
-    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_delete_comment_by_index(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _register_prefix(fake_data_dir)
     daily = _make_daily(
         fake_data_dir,
@@ -39,9 +37,7 @@ def test_delete_comment_by_index(
         "  - jordan: third\n"
         "- [ ] another task\n",
     )
-    monkeypatch.setattr(
-        "scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26)
-    )
+    monkeypatch.setattr("scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26))
 
     event = delete_comment(by_id="A3F7", index=2, data_dir=fake_data_dir)
 
@@ -56,20 +52,13 @@ def test_delete_comment_by_index(
     assert event.payload["comment_text"] == "second"
 
 
-def test_delete_comment_by_text_substring(
-    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_delete_comment_by_text_substring(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _register_prefix(fake_data_dir)
     _make_daily(
         fake_data_dir,
-        "## In Progress\n\n"
-        "- [ ] [#A3F7] task\n"
-        "  - jordan: vendor confirmed\n"
-        "  - jordan: legal review needed\n",
+        "## In Progress\n\n- [ ] [#A3F7] task\n  - jordan: vendor confirmed\n  - jordan: legal review needed\n",
     )
-    monkeypatch.setattr(
-        "scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26)
-    )
+    monkeypatch.setattr("scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26))
 
     delete_comment(by_id="A3F7", text="legal", data_dir=fake_data_dir)
 
@@ -78,22 +67,15 @@ def test_delete_comment_by_text_substring(
     assert "legal review" not in text
 
 
-def test_delete_comment_ignores_snoozed_until_marker(
-    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_delete_comment_ignores_snoozed_until_marker(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The snoozed-until sub-bullet shares the comment shape but is machine
     metadata. `--index 1` must point at the first real comment, not the marker."""
     _register_prefix(fake_data_dir)
     daily = _make_daily(
         fake_data_dir,
-        "## In Progress\n\n"
-        "- [ ] [#A3F7] task\n"
-        "  - snoozed-until: 2026-05-01\n"
-        "  - jordan: real comment\n",
+        "## In Progress\n\n- [ ] [#A3F7] task\n  - snoozed-until: 2026-05-01\n  - jordan: real comment\n",
     )
-    monkeypatch.setattr(
-        "scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26)
-    )
+    monkeypatch.setattr("scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26))
 
     delete_comment(by_id="A3F7", index=1, data_dir=fake_data_dir)
 
@@ -102,53 +84,37 @@ def test_delete_comment_ignores_snoozed_until_marker(
     assert "real comment" not in text
 
 
-def test_delete_comment_index_out_of_range(
-    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_delete_comment_index_out_of_range(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _register_prefix(fake_data_dir)
     _make_daily(
         fake_data_dir,
         "- [ ] [#A3F7] task\n  - jordan: only one\n",
     )
-    monkeypatch.setattr(
-        "scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26)
-    )
+    monkeypatch.setattr("scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26))
 
     with pytest.raises(ActionItemError, match="--index 5 out of range"):
         delete_comment(by_id="A3F7", index=5, data_dir=fake_data_dir)
 
 
-def test_delete_comment_ambiguous_text(
-    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_delete_comment_ambiguous_text(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _register_prefix(fake_data_dir)
     _make_daily(
         fake_data_dir,
-        "- [ ] [#A3F7] task\n"
-        "  - jordan: vendor ping\n"
-        "  - jordan: vendor confirmed\n",
+        "- [ ] [#A3F7] task\n  - jordan: vendor ping\n  - jordan: vendor confirmed\n",
     )
-    monkeypatch.setattr(
-        "scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26)
-    )
+    monkeypatch.setattr("scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26))
 
     with pytest.raises(ActionItemError, match="ambiguous"):
         delete_comment(by_id="A3F7", text="vendor", data_dir=fake_data_dir)
 
 
-def test_delete_comment_requires_exactly_one_selector(
-    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_delete_comment_requires_exactly_one_selector(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _register_prefix(fake_data_dir)
     _make_daily(fake_data_dir, "- [ ] [#A3F7] task\n  - jordan: hi\n")
-    monkeypatch.setattr(
-        "scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26)
-    )
+    monkeypatch.setattr("scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26))
 
     with pytest.raises(ActionItemError, match="exactly one of --index or --text"):
         delete_comment(by_id="A3F7", data_dir=fake_data_dir)
 
     with pytest.raises(ActionItemError, match="exactly one of --index or --text"):
-        delete_comment(
-            by_id="A3F7", index=1, text="hi", data_dir=fake_data_dir
-        )
+        delete_comment(by_id="A3F7", index=1, text="hi", data_dir=fake_data_dir)

--- a/engine/tests/unit/test_action_items_edit_comment.py
+++ b/engine/tests/unit/test_action_items_edit_comment.py
@@ -26,19 +26,13 @@ def _register_prefix(fake_data_dir: Path, prefix: str = "A3F7") -> None:
     m.save()
 
 
-def test_edit_comment_by_index_replaces_body_only(
-    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_edit_comment_by_index_replaces_body_only(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _register_prefix(fake_data_dir)
     daily = _make_daily(
         fake_data_dir,
-        "- [ ] [#A3F7] task\n"
-        "  - jordan: first draft\n"
-        "  - jordan: second draft\n",
+        "- [ ] [#A3F7] task\n  - jordan: first draft\n  - jordan: second draft\n",
     )
-    monkeypatch.setattr(
-        "scout.action_items.edit_comment._today", lambda: dt.date(2026, 4, 26)
-    )
+    monkeypatch.setattr("scout.action_items.edit_comment._today", lambda: dt.date(2026, 4, 26))
 
     event = edit_comment(
         by_id="A3F7",
@@ -57,20 +51,15 @@ def test_edit_comment_by_index_replaces_body_only(
     assert event.payload["new_text"] == "first final"
 
 
-def test_edit_comment_preserves_original_indent(
-    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_edit_comment_preserves_original_indent(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A comment indented with four spaces (e.g. under a nested sub-task) keeps
     its indent after the edit. Author prefix also preserved."""
     _register_prefix(fake_data_dir)
     daily = _make_daily(
         fake_data_dir,
-        "- [ ] [#A3F7] task\n"
-        "    - alice: nested note\n",
+        "- [ ] [#A3F7] task\n    - alice: nested note\n",
     )
-    monkeypatch.setattr(
-        "scout.action_items.edit_comment._today", lambda: dt.date(2026, 4, 26)
-    )
+    monkeypatch.setattr("scout.action_items.edit_comment._today", lambda: dt.date(2026, 4, 26))
 
     edit_comment(
         by_id="A3F7",
@@ -82,34 +71,22 @@ def test_edit_comment_preserves_original_indent(
     assert "    - alice: nested edit\n" in daily.read_text()
 
 
-def test_edit_comment_rejects_empty_text(
-    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_edit_comment_rejects_empty_text(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _register_prefix(fake_data_dir)
     _make_daily(fake_data_dir, "- [ ] [#A3F7] task\n  - jordan: original\n")
-    monkeypatch.setattr(
-        "scout.action_items.edit_comment._today", lambda: dt.date(2026, 4, 26)
-    )
+    monkeypatch.setattr("scout.action_items.edit_comment._today", lambda: dt.date(2026, 4, 26))
 
     with pytest.raises(ActionItemError, match="new-text must not be empty"):
-        edit_comment(
-            by_id="A3F7", index=1, new_text="   ", data_dir=fake_data_dir
-        )
+        edit_comment(by_id="A3F7", index=1, new_text="   ", data_dir=fake_data_dir)
 
 
-def test_edit_comment_by_text_substring(
-    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_edit_comment_by_text_substring(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _register_prefix(fake_data_dir)
     daily = _make_daily(
         fake_data_dir,
-        "- [ ] [#A3F7] task\n"
-        "  - jordan: ping vendor\n"
-        "  - jordan: legal sign-off\n",
+        "- [ ] [#A3F7] task\n  - jordan: ping vendor\n  - jordan: legal sign-off\n",
     )
-    monkeypatch.setattr(
-        "scout.action_items.edit_comment._today", lambda: dt.date(2026, 4, 26)
-    )
+    monkeypatch.setattr("scout.action_items.edit_comment._today", lambda: dt.date(2026, 4, 26))
 
     edit_comment(
         by_id="A3F7",

--- a/engine/tests/unit/test_action_items_edit_comment.py
+++ b/engine/tests/unit/test_action_items_edit_comment.py
@@ -1,0 +1,123 @@
+"""Unit tests for scout.action_items.edit_comment."""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import pytest
+
+from scout.action_items.edit_comment import edit_comment
+from scout.errors import ActionItemError
+from scout.events import Event
+from scout.id_map import IdMap, IdMapEntry
+
+
+def _make_daily(fake_data_dir: Path, body: str) -> Path:
+    daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
+    daily.parent.mkdir(parents=True, exist_ok=True)
+    daily.write_text(body)
+    return daily
+
+
+def _register_prefix(fake_data_dir: Path, prefix: str = "A3F7") -> None:
+    m = IdMap.load(fake_data_dir)
+    m.register(IdMapEntry("01HXAAA", prefix, "task", "action-items-2026-04-26.md", 5))
+    m.save()
+
+
+def test_edit_comment_by_index_replaces_body_only(
+    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_prefix(fake_data_dir)
+    daily = _make_daily(
+        fake_data_dir,
+        "- [ ] [#A3F7] task\n"
+        "  - jordan: first draft\n"
+        "  - jordan: second draft\n",
+    )
+    monkeypatch.setattr(
+        "scout.action_items.edit_comment._today", lambda: dt.date(2026, 4, 26)
+    )
+
+    event = edit_comment(
+        by_id="A3F7",
+        index=1,
+        new_text="first final",
+        data_dir=fake_data_dir,
+    )
+
+    text = daily.read_text()
+    assert "  - jordan: first final\n" in text
+    assert "first draft" not in text
+    assert "second draft" in text  # untouched
+    assert isinstance(event, Event)
+    assert event.kind == "action_item.comment_edited"
+    assert event.payload["old_text"] == "first draft"
+    assert event.payload["new_text"] == "first final"
+
+
+def test_edit_comment_preserves_original_indent(
+    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A comment indented with four spaces (e.g. under a nested sub-task) keeps
+    its indent after the edit. Author prefix also preserved."""
+    _register_prefix(fake_data_dir)
+    daily = _make_daily(
+        fake_data_dir,
+        "- [ ] [#A3F7] task\n"
+        "    - alice: nested note\n",
+    )
+    monkeypatch.setattr(
+        "scout.action_items.edit_comment._today", lambda: dt.date(2026, 4, 26)
+    )
+
+    edit_comment(
+        by_id="A3F7",
+        index=1,
+        new_text="nested edit",
+        data_dir=fake_data_dir,
+    )
+
+    assert "    - alice: nested edit\n" in daily.read_text()
+
+
+def test_edit_comment_rejects_empty_text(
+    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_prefix(fake_data_dir)
+    _make_daily(fake_data_dir, "- [ ] [#A3F7] task\n  - jordan: original\n")
+    monkeypatch.setattr(
+        "scout.action_items.edit_comment._today", lambda: dt.date(2026, 4, 26)
+    )
+
+    with pytest.raises(ActionItemError, match="new-text must not be empty"):
+        edit_comment(
+            by_id="A3F7", index=1, new_text="   ", data_dir=fake_data_dir
+        )
+
+
+def test_edit_comment_by_text_substring(
+    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register_prefix(fake_data_dir)
+    daily = _make_daily(
+        fake_data_dir,
+        "- [ ] [#A3F7] task\n"
+        "  - jordan: ping vendor\n"
+        "  - jordan: legal sign-off\n",
+    )
+    monkeypatch.setattr(
+        "scout.action_items.edit_comment._today", lambda: dt.date(2026, 4, 26)
+    )
+
+    edit_comment(
+        by_id="A3F7",
+        text="legal",
+        new_text="legal cleared 2026-04-26",
+        data_dir=fake_data_dir,
+    )
+
+    text = daily.read_text()
+    assert "  - jordan: legal cleared 2026-04-26\n" in text
+    assert "ping vendor" in text

--- a/engine/tests/unit/test_action_items_mark_done.py
+++ b/engine/tests/unit/test_action_items_mark_done.py
@@ -155,3 +155,63 @@ def test_mark_done_event_id_and_ts_well_formed(fake_data_dir, monkeypatch):
     event = mark_done(by_id="A3F7", data_dir=fake_data_dir)
     assert len(event.id) == 26
     assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", event.ts)
+
+
+# Regression: mark_done must mutate the line indicated by the parser's
+# item.line_number, not re-scan the file for the first matching raw_line.
+# The old behavior performed a second read and matched first-occurrence,
+# which under any TOCTOU race could target an unrelated line. Issue #32.
+
+
+def test_mark_done_uses_parser_line_number_even_under_external_edit(fake_data_dir, monkeypatch):
+    """The writer must use the parser's item.line_number — not a rescan
+    for the first matching raw_line. If the file is externally edited
+    between parse and write, the writer should fail loudly (line_number
+    no longer valid) rather than silently flipping a different line
+    that happens to match by content (the old find_line_number behavior)."""
+    today = dt.date(2026, 4, 26)
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: today)
+
+    # Initial file: target task is at line 3.
+    daily = fake_data_dir / "action-items" / f"action-items-{today.isoformat()}.md"
+    daily.parent.mkdir(parents=True, exist_ok=True)
+    daily.write_text(
+        "## Section\n"
+        "\n"
+        "- [ ] target task\n"  # line 3
+        "- [ ] other task\n"
+    )
+
+    # Hook parse_file: after it returns the items (target at line 3), simulate
+    # an external edit that prepends a duplicate raw_line at line 1 and pushes
+    # the original content down. The old find_line_number-based code would
+    # rescan and return line 1 → silently flip the wrong line.
+    import scout.action_items.parser as parser_mod
+
+    real_parse = parser_mod.parse_file
+
+    def parse_then_external_edit(path):
+        items = real_parse(path)
+        path.write_text(
+            "- [ ] target task\n"  # NEW duplicate at line 1
+            "## Section\n"  # line 2
+            "\n"  # line 3 — now empty (was the target)
+            "- [ ] target task\n"  # line 4 — original target shifted down
+            "- [ ] other task\n"  # line 5
+        )
+        return items
+
+    monkeypatch.setattr("scout.action_items.mark_done.parse_file", parse_then_external_edit)
+
+    # New contract: the writer uses line_number=3 (from the parser). After the
+    # external edit, line 3 is empty — flip_checkbox raises. This is BETTER
+    # than the old behavior, which would have silently flipped the duplicate
+    # at line 1.
+    with pytest.raises(ActionItemError):
+        mark_done(by_subject="target", data_dir=fake_data_dir)
+
+    # And critically: the injected duplicate at line 1 was NOT silently flipped.
+    result = daily.read_text().splitlines()
+    assert result[0] == "- [ ] target task", (
+        f"injected duplicate at line 1 must NOT have been flipped; got: {result[0]!r}"
+    )

--- a/engine/tests/unit/test_action_items_parser.py
+++ b/engine/tests/unit/test_action_items_parser.py
@@ -123,3 +123,31 @@ def test_parser_handles_prefix_without_priority_emoji() -> None:
     assert item.short_prefix == "E1Q2"
     assert item.priority == ""
     assert item.title == "Plain prefixed task without priority"
+
+
+# Regression: parse_file must specify encoding="utf-8" so non-UTF-8 locales
+# (e.g. LANG=C in CI) don't silently corrupt emoji/wikilink/Unicode content.
+# Issue #33.
+
+
+def test_parse_file_reads_with_explicit_utf8_encoding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """parse_file must pass encoding='utf-8' to read_text — otherwise the
+    platform default applies and non-UTF-8 locales silently re-encode the
+    file on the round-trip parse→write."""
+    md = tmp_path / "scout.md"
+    md.write_text("# X\n\n## Section\n\n- [ ] 🔴 Important task\n", encoding="utf-8")
+
+    captured: list[str | None] = []
+    real_read_text = Path.read_text
+
+    def spy(self: Path, *args: object, **kwargs: object) -> str:
+        captured.append(kwargs.get("encoding"))  # type: ignore[arg-type]
+        return real_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", spy)
+    items = parse_file(md)
+
+    assert "utf-8" in captured, f"read_text was called without encoding=utf-8: {captured}"
+    assert any(i.priority == "🔴" for i in items)

--- a/engine/tests/unit/test_action_items_parser.py
+++ b/engine/tests/unit/test_action_items_parser.py
@@ -130,9 +130,7 @@ def test_parser_handles_prefix_without_priority_emoji() -> None:
 # Issue #33.
 
 
-def test_parse_file_reads_with_explicit_utf8_encoding(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_parse_file_reads_with_explicit_utf8_encoding(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """parse_file must pass encoding='utf-8' to read_text — otherwise the
     platform default applies and non-UTF-8 locales silently re-encode the
     file on the round-trip parse→write."""

--- a/engine/tests/unit/test_action_items_render.py
+++ b/engine/tests/unit/test_action_items_render.py
@@ -34,3 +34,30 @@ def test_render_missing_file_raises(tmp_path: Path) -> None:
     missing = tmp_path / "no-such-file.md"
     with pytest.raises(ActionItemError, match="not found"):
         render(missing)
+
+
+# Regression: parse() inside render must specify encoding="utf-8" so non-UTF-8
+# locales don't silently mis-decode emoji headers (silently dropping sections).
+# Issue #33.
+
+
+def test_render_reads_with_explicit_utf8_encoding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """render() must read source markdown with explicit utf-8 encoding so
+    that emoji section headers and unicode titles survive the parse step on
+    a non-UTF-8 default locale."""
+    md = tmp_path / "scout.md"
+    md.write_text("# Title\n\n## 📌 Section\n\n- [ ] 🔴 Task with emoji\n", encoding="utf-8")
+
+    captured: list[str | None] = []
+    real_read_text = Path.read_text
+
+    def spy(self: Path, *args: object, **kwargs: object) -> str:
+        captured.append(kwargs.get("encoding"))  # type: ignore[arg-type]
+        return real_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", spy)
+    render(md)
+
+    assert "utf-8" in captured, f"read_text was called without encoding=utf-8: {captured}"

--- a/engine/tests/unit/test_action_items_render.py
+++ b/engine/tests/unit/test_action_items_render.py
@@ -41,9 +41,7 @@ def test_render_missing_file_raises(tmp_path: Path) -> None:
 # Issue #33.
 
 
-def test_render_reads_with_explicit_utf8_encoding(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_render_reads_with_explicit_utf8_encoding(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """render() must read source markdown with explicit utf-8 encoding so
     that emoji section headers and unicode titles survive the parse step on
     a non-UTF-8 default locale."""

--- a/engine/tests/unit/test_action_items_snooze.py
+++ b/engine/tests/unit/test_action_items_snooze.py
@@ -115,9 +115,7 @@ def test_snooze_records_from_kind_in_marker(fake_data_dir: Path, monkeypatch: py
     assert event.payload["from_kind"] == "urgent"
 
 
-def test_snooze_omits_from_kind_when_not_provided(
-    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_snooze_omits_from_kind_when_not_provided(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Existing callers that don't pass from_kind keep the original marker shape."""
     m = IdMap.load(fake_data_dir)
     m.register(IdMapEntry("01HXAAA", "A3F7", "task", "action-items-2026-04-26.md", 1))

--- a/engine/tests/unit/test_action_items_snooze.py
+++ b/engine/tests/unit/test_action_items_snooze.py
@@ -92,6 +92,49 @@ def test_snooze_event_id_and_ts_well_formed(fake_data_dir: Path, monkeypatch: py
     assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", event.ts)
 
 
+def test_snooze_records_from_kind_in_marker(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Optional `from_kind` is embedded in the snooze marker as a `(from-kind: …)`
+    suffix so a later carry-forward can restore the source section's priority on
+    the target day."""
+    m = IdMap.load(fake_data_dir)
+    m.register(IdMapEntry("01HXAAA", "A3F7", "task", "action-items-2026-04-26.md", 1))
+    m.save()
+    daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
+    daily.parent.mkdir(parents=True, exist_ok=True)
+    daily.write_text("## 🔴 Urgent\n\n- [ ] [#A3F7] 🔴 task\n")
+    monkeypatch.setattr("scout.action_items.snooze._today", lambda: dt.date(2026, 4, 26))
+
+    event = snooze(
+        by_id="A3F7",
+        until=dt.date(2026, 5, 1),
+        from_kind="urgent",
+        data_dir=fake_data_dir,
+    )
+
+    assert "- snoozed-until: 2026-05-01 (from-kind: urgent)" in daily.read_text()
+    assert event.payload["from_kind"] == "urgent"
+
+
+def test_snooze_omits_from_kind_when_not_provided(
+    fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Existing callers that don't pass from_kind keep the original marker shape."""
+    m = IdMap.load(fake_data_dir)
+    m.register(IdMapEntry("01HXAAA", "A3F7", "task", "action-items-2026-04-26.md", 1))
+    m.save()
+    daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
+    daily.parent.mkdir(parents=True, exist_ok=True)
+    daily.write_text("- [ ] [#A3F7] task\n")
+    monkeypatch.setattr("scout.action_items.snooze._today", lambda: dt.date(2026, 4, 26))
+
+    event = snooze(by_id="A3F7", until=dt.date(2026, 5, 1), data_dir=fake_data_dir)
+
+    text = daily.read_text()
+    assert "- snoozed-until: 2026-05-01\n" in text
+    assert "from-kind" not in text
+    assert "from_kind" not in event.payload
+
+
 def test_snooze_rejects_non_date_until(fake_data_dir: Path) -> None:
     """A string accidentally passed for `until` must fail loudly at the boundary,
     not silently AttributeError mid-mutation."""

--- a/engine/tests/unit/test_action_items_writer.py
+++ b/engine/tests/unit/test_action_items_writer.py
@@ -136,3 +136,71 @@ def test_add_prefix_to_specific_line_in_multi_line_file(tmp_path: Path) -> None:
     assert target.read_text() == (
         "# Header\n\n- [ ] 🔴 first task\n- [ ] [#B5K2] 🟡 second task\n- [ ] 🟢 third task\n"
     )
+
+
+# Regression: add_prefix_to_line must accept indented checkbox lines.
+# The parser and backfill candidate regex both accept `^\s*- \[[ xX]\] `,
+# but the writer used to require zero-indent. An indented item would crash
+# the writer mid-backfill, leaving the file partially modified and the
+# id-map out of sync with the file. Issue #31.
+
+
+def test_add_prefix_to_indented_checkbox_preserves_indent(tmp_path: Path) -> None:
+    """A single-space-indented checkbox is a valid top-level item per the
+    parser. The writer must insert the prefix without losing the indent."""
+    target = tmp_path / "f.md"
+    target.write_text(" - [ ] indented one space\n")
+    from scout.action_items.writer import add_prefix_to_line
+
+    add_prefix_to_line(target, line_number=1, prefix="A3F7")
+
+    assert target.read_text() == " - [ ] [#A3F7] indented one space\n"
+
+
+def test_add_prefix_to_done_indented_checkbox_preserves_indent(tmp_path: Path) -> None:
+    target = tmp_path / "f.md"
+    target.write_text(" - [x] indented and done\n")
+    from scout.action_items.writer import add_prefix_to_line
+
+    add_prefix_to_line(target, line_number=1, prefix="B5K2")
+
+    assert target.read_text() == " - [x] [#B5K2] indented and done\n"
+
+
+def test_add_prefix_handles_uppercase_X(tmp_path: Path) -> None:
+    """The backfill candidate regex accepts `[X]` (uppercase). The writer
+    must too — otherwise a file with any externally-completed item using
+    `[X]` crashes mid-backfill (id-map state torn). See Issue #31."""
+    target = tmp_path / "f.md"
+    target.write_text("- [X] done with uppercase X\n")
+    from scout.action_items.writer import add_prefix_to_line
+
+    add_prefix_to_line(target, line_number=1, prefix="C7M9")
+
+    assert target.read_text() == "- [X] [#C7M9] done with uppercase X\n"
+
+
+def test_backfill_prefixes_handles_indented_checkbox_end_to_end(
+    fake_data_dir: Path,
+) -> None:
+    """End-to-end regression for Issue #31: a file that mixes an
+    indented checkbox with a regular one must be backfilled without the
+    writer crashing mid-loop and leaving the file partially modified."""
+    target = fake_data_dir / "action-items" / "sample.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        "# Day\n"
+        "\n"
+        " - [ ] indented task\n"  # indent=1 — top-level item per parser
+        "- [ ] regular task\n"
+    )
+
+    from scout.action_items.backfill import backfill_prefixes
+
+    plan = backfill_prefixes(target=target, data_dir=fake_data_dir, dry_run=False)
+
+    assert len(plan) == 2, f"expected to backfill both items, got: {plan}"
+    out = target.read_text()
+    # Both lines must now carry a prefix, and the indent on line 3 must be preserved.
+    assert " - [ ] [#" in out, f"indent of indented line not preserved: {out!r}"
+    assert "\n- [ ] [#" in out, f"non-indented line not prefixed: {out!r}"

--- a/engine/tests/unit/test_bootstrap_lock.py
+++ b/engine/tests/unit/test_bootstrap_lock.py
@@ -128,3 +128,41 @@ def test_acquire_lock_clears_stale_dead_pid(tmp_path):
     lock.write_text("999999")  # dead PID
     acquire_lock(lock)
     assert lock.read_text().strip() == str(os.getpid())
+
+
+# Regression: acquire_lock must be atomic. The previous implementation
+# did an `exists()` check, then `unlink()`, then `write_text()` — three
+# non-atomic syscalls. Two racing processes could both pass the check,
+# both write their PID, and both believe they held the lock. Issue #36.
+
+
+def test_acquire_lock_is_atomic_under_concurrent_callers(tmp_path):
+    """When two concurrent callers race to acquire the same lock,
+    exactly one must succeed and the other must see LockBusyError —
+    NOT both succeed with the second silently clobbering the first."""
+    import threading
+
+    lock = tmp_path / ".scout-session.lock"
+    results: list[str] = []
+    barrier = threading.Barrier(2)
+
+    def attempt() -> None:
+        barrier.wait()  # synchronize start
+        try:
+            acquire_lock(lock)
+        except LockBusyError:
+            results.append("busy")
+            return
+        results.append("success")
+
+    threads = [threading.Thread(target=attempt) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert sorted(results) == ["busy", "success"], (
+        f"expected exactly one success and one busy, got: {results}"
+    )
+    assert lock.exists()
+    assert lock.read_text().strip() == str(os.getpid())

--- a/engine/tests/unit/test_bootstrap_lock.py
+++ b/engine/tests/unit/test_bootstrap_lock.py
@@ -161,8 +161,6 @@ def test_acquire_lock_is_atomic_under_concurrent_callers(tmp_path):
     for t in threads:
         t.join()
 
-    assert sorted(results) == ["busy", "success"], (
-        f"expected exactly one success and one busy, got: {results}"
-    )
+    assert sorted(results) == ["busy", "success"], f"expected exactly one success and one busy, got: {results}"
     assert lock.exists()
     assert lock.read_text().strip() == str(os.getpid())

--- a/engine/tests/unit/test_schedule_tick.py
+++ b/engine/tests/unit/test_schedule_tick.py
@@ -30,6 +30,9 @@ from scout.scripts.schedule_tick import (
     candidates_by_key,
 )
 from scout.scripts.schedule_tick import (
+    main as tick_main,
+)
+from scout.scripts.schedule_tick import (
     run as tick_run,
 )
 
@@ -527,3 +530,19 @@ def test_spawn_runner_rejects_remote_runtime(tmp_path):
     )
     with pytest.raises(ConfigError, match="runtime: remote.*not yet implemented"):
         _spawn_runner(vault=tmp_path, slot_key="research", slot=slot)
+
+
+# main(): unhandled exceptions must surface, not be silently swallowed.
+# Regression test for issue #35 — cron/launchd had no way to diagnose failures.
+
+
+def test_main_prints_traceback_to_stderr_when_run_raises(capsys):
+    """Unhandled exceptions from run() must produce a traceback on stderr so
+    cron/launchd logs capture the failure. Exit code stays 1."""
+    boom = RuntimeError("synthetic failure for visibility test")
+    with patch("scout.scripts.schedule_tick.run", side_effect=boom):
+        rc = tick_main([])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "synthetic failure for visibility test" in captured.err
+    assert "Traceback" in captured.err


### PR DESCRIPTION
## Summary

Addresses the top five critical findings from the engine audit. All fixes were written test-first (failing test → minimal fix → green), and each is in its own commit.

| # | Issue | Fix |
|---|-------|-----|
| #35 | `schedule_tick.main()` swallowed all exceptions silently | Print `traceback.format_exc()` to stderr so cron/launchd logs the failure |
| #33 | `read_text()` without encoding corrupted non-UTF-8 vaults | Pass `encoding="utf-8"` in `parser.parse_file` and `render.parse` |
| #32 | `find_line_number` first-match bug + `by_subject` matched `raw_line` | Removed `find_line_number`; mutators now use `match.line_number` directly; `by_subject` matches `item.title` (no spurious prefix-token matches) |
| #36 | `bootstrap_lock.acquire_lock` not atomic | Use `os.open(O_CREAT|O_EXCL|O_WRONLY)` — POSIX-atomic claim; one racing caller wins, others see `LockBusyError` |
| #31 | `add_prefix_to_line` rejected indented or `[X]` checkboxes | Regex-based capture that preserves leading whitespace and accepts `[X]`/`[x]` — no more mid-backfill crashes that leave the file partially modified |

## Tests

- **569 passed, 9 skipped, 0 failed** across the full engine test suite.
- New regression tests for each fix:
  - `test_main_prints_traceback_to_stderr_when_run_raises`
  - `test_parse_file_reads_with_explicit_utf8_encoding`, `test_render_reads_with_explicit_utf8_encoding`
  - `test_resolve_target_by_subject_does_not_match_prefix_token`, `test_resolve_target_by_subject_matches_title_substring`, `test_mark_done_uses_parser_line_number_even_under_external_edit`
  - `test_acquire_lock_is_atomic_under_concurrent_callers` (passes 10/10 runs)
  - `test_add_prefix_to_indented_checkbox_preserves_indent`, `test_add_prefix_to_done_indented_checkbox_preserves_indent`, `test_add_prefix_handles_uppercase_X`, `test_backfill_prefixes_handles_indented_checkbox_end_to_end`

Each test was verified to fail RED on the unfixed code before the fix was applied.

## Note: carried in-flight comment-editing work

Commit `3a9eca4` (fix #32) also includes uncommitted comment-editing WIP that was already in the working tree (`edit_comment`, `delete_comment`, `list_comment_lines`/`select_comment` helpers, `replace_line`/`delete_line` writers, snooze `--from-kind` flag, and their tests). The #32 fix touched `_common.py` imports that overlap with this WIP, so it was rolled in to keep the working tree consistent. Tests for the new commands are included.

## Closes

Closes #31
Closes #32
Closes #33
Closes #35
Closes #36

## Test plan

- [x] `pytest tests/` passes (569/569 non-skipped)
- [x] Each new regression test verified RED before fix, GREEN after
- [ ] Manual smoke: `scoutctl action-items backfill <file>` on a file with indented checkboxes
- [ ] Manual smoke: `scoutctl action-items mark-done --by-subject "task"` on a file with prefixed items
- [ ] Manual smoke: simulate a broken vault and run `scoutctl schedule tick` — confirm traceback in stderr