### PR TITLE
fix(action-items): auto-register prefix found in file but missing from id-map

### DIFF
--- a/engine/scout/action_items/_common.py
+++ b/engine/scout/action_items/_common.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from scout import paths
 from scout.action_items.parser import ActionItem
 from scout.errors import ActionItemError
-from scout.id_map import IdMap
+from scout.id_map import IdMap, IdMapEntry
+from scout.ids import new_ulid
 
 # Matches the comment shape that `add-comment` writes:
 #   `  - <author>: <text>`
@@ -117,11 +119,30 @@ def resolve_target(
 
     if by_id is not None:
         entry = id_map.lookup_by_prefix(by_id)
-        if entry is None:
-            raise ActionItemError(
-                f"prefix [#{by_id}] not found in id-map; if this is a legacy line, retry with --by-subject"
-            )
         match = next((i for i in items if i.short_prefix == by_id), None)
+        if entry is None:
+            # The briefing / consolidation skill can write a fresh `[#XXXX]`
+            # line straight into the markdown without calling
+            # `add_prefix_to_line` — which means the prefix lives in the
+            # file but never gets registered. If we can see the prefix on a
+            # real task line in this same file, auto-register it now and
+            # carry on. This keeps `mark-done --by-id` working even when
+            # the skill writer skips registration. (Legacy unprefixed lines
+            # still need `--by-subject`; the error message points the way.)
+            if match is None:
+                raise ActionItemError(
+                    f"prefix [#{by_id}] not found in id-map; if this is a legacy line, retry with --by-subject"
+                )
+            entry = IdMapEntry(
+                ulid=new_ulid(),
+                short_prefix=by_id,
+                last_title=match.title,
+                last_file=str(paths.action_items_daily_path(data=data_dir).name),
+                last_line=match.line_number,
+            )
+            id_map.register(entry)
+            id_map.save()
+            return match, entry.ulid, "id"
         if match is None:
             raise ActionItemError(f"prefix [#{by_id}] is in id-map but not present in this file")
         return match, entry.ulid, "id"

--- a/engine/tests/unit/test_action_items_common.py
+++ b/engine/tests/unit/test_action_items_common.py
@@ -103,9 +103,7 @@ def test_resolve_target_auto_registers_prefix_in_file_but_not_idmap(
             short_prefix="KPTK",
         ),
     ]
-    target, ulid, via = resolve_target(
-        items=items, data_dir=fake_data_dir, by_id="KPTK", by_subject=None
-    )
+    target, ulid, via = resolve_target(items=items, data_dir=fake_data_dir, by_id="KPTK", by_subject=None)
     assert target.short_prefix == "KPTK"
     assert via == "id"
     assert ulid  # a new ULID was minted

--- a/engine/tests/unit/test_action_items_common.py
+++ b/engine/tests/unit/test_action_items_common.py
@@ -81,6 +81,44 @@ def test_resolve_target_unknown_id_raises(fake_data_dir: Path) -> None:
         resolve_target(items=[], data_dir=fake_data_dir, by_id="ZZZZ", by_subject=None)
 
 
+def test_resolve_target_auto_registers_prefix_in_file_but_not_idmap(
+    fake_data_dir: Path,
+) -> None:
+    """The briefing/consolidation skill writes fresh `[#XXXX]` lines directly
+    into the markdown without registering them in the id-map. When a mutator
+    sees the prefix on a parsed item but the id-map is empty, it should
+    register on-the-fly so `mark-done --by-id` keeps working without a manual
+    `backfill-prefixes` pass."""
+    items = [
+        ActionItem(
+            priority="🔥",
+            title="Rotate Kai Pricing GitHub token",
+            status="open",
+            section="Urgent",
+            context_links=[],
+            notes=[],
+            details=[],
+            raw_line="- [ ] [#KPTK] 🔥 Rotate Kai Pricing GitHub token",
+            line_number=12,
+            short_prefix="KPTK",
+        ),
+    ]
+    target, ulid, via = resolve_target(
+        items=items, data_dir=fake_data_dir, by_id="KPTK", by_subject=None
+    )
+    assert target.short_prefix == "KPTK"
+    assert via == "id"
+    assert ulid  # a new ULID was minted
+
+    # Persisted: a follow-up call sees the registered entry rather than
+    # auto-registering again.
+    m2 = IdMap.load(fake_data_dir)
+    e2 = m2.lookup_by_prefix("KPTK")
+    assert e2 is not None
+    assert e2.ulid == ulid
+    assert e2.last_title == "Rotate Kai Pricing GitHub token"
+
+
 def test_resolve_target_ambiguous_subject_raises(fake_data_dir: Path) -> None:
     items = [
         ActionItem(


### PR DESCRIPTION
## Symptom

Hitting Done on a brand-new urgent task (#KPTK in today's file) from Scout.app fails with:

```
prefix [#KPTK] not found in id-map; if this is a legacy line, retry with --by-subject
```

The task line carries the prefix, the parser sees it, but the id-map has no entry — so mutators bail before they ever touch the file.

## Root cause

The briefing/consolidation skills write fresh `[#XXXX]` lines straight into the daily markdown. They never call `add_prefix_to_line` (the writer path that registers the prefix in `id-map.json`), so the id-map is silently out of sync with the markdown for every net-new task the LLM emits.

## Fix

`resolve_target` now checks the parsed items list before deciding the prefix is unknown:

- Prefix in `id-map` → use the stored ULID (unchanged).
- Prefix on a parsed item in this file but missing from `id-map` → mint a new ULID, register it, save the id-map, return.
- Prefix on neither → keep the existing "legacy line, retry with `--by-subject`" error.

The bug never resurfaces for the same prefix after the first call — the registration is persisted.

## Test plan

- [x] New unit test `test_resolve_target_auto_registers_prefix_in_file_but_not_idmap` covers the happy path: empty id-map, ActionItem with `short_prefix="KPTK"`, mutator round-trip + persisted entry.
- [x] All 39 existing tests across mark-done / snooze / add-comment / delete-comment / edit-comment / common still pass — the new logic only triggers on a path that previously raised.
- [x] Verified against the real vault:
  ```
  scoutctl action-items mark-done ~/Scout/action-items/action-items-2026-05-25.md --by-id KPTK
  ```
  flips `[#KPTK]` to `[x]` and writes KPTK into `id-map.json` on the first invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)