### PR TITLE
perf(scheduler): cache last-fire index to stop 5-min ticks rescanning JSONLs

### DIFF
--- a/engine/scout/scripts/schedule_tick.py
+++ b/engine/scout/scripts/schedule_tick.py
@@ -284,9 +284,7 @@ def _write_last_fire_cache(
         "schema_version": _LAST_FIRE_CACHE_SCHEMA_VERSION,
         "tracker_mtime_ns": _file_mtime_ns(tracker_path),
         "session_tokens_mtime_ns": _file_mtime_ns(session_tokens_path),
-        "last_fire": {
-            key: ts.astimezone(_dt.UTC).isoformat().replace("+00:00", "Z") for key, ts in index.items()
-        },
+        "last_fire": {key: ts.astimezone(_dt.UTC).isoformat().replace("+00:00", "Z") for key, ts in index.items()},
     }
     try:
         with tmp_path.open("w", encoding="utf-8") as f:

--- a/engine/scout/scripts/schedule_tick.py
+++ b/engine/scout/scripts/schedule_tick.py
@@ -70,6 +70,13 @@ TRACKER_FILENAME = "usage-tracker.jsonl"
 SESSION_TOKENS_FILENAME = "session-tokens.jsonl"
 EVENT_LOG_PREFIX = "schedule-events-"
 
+# Cache of the {slot_key: latest_ts} index, keyed by source-file mtimes.
+# Avoids re-reading both JSONL trackers end-to-end on every 5-min tick once
+# they've grown to thousands of rows. Invalidated by any mtime change on either
+# source file; full JSONL scan rebuilds and rewrites the cache on miss.
+LAST_FIRE_CACHE_FILENAME = "last-fire.json"
+_LAST_FIRE_CACHE_SCHEMA_VERSION = 1
+
 # Mode-name rename map applied when reading legacy session-tokens.jsonl rows.
 # Ships in Plan 5 to bridge pre-rename JSONL data through to post-rename slot
 # keys. Once Task 7's tools/migrate-mode-names.py runs against the live vault,
@@ -204,6 +211,108 @@ def _read_last_fire_index(tracker_path: Path) -> dict[str, _dt.datetime]:
         except OSError:
             continue
     return out
+
+
+def _file_mtime_ns(path: Path) -> int | None:
+    """Return ``stat().st_mtime_ns`` for ``path``, or ``None`` if missing.
+
+    Used as the cache key for the last-fire index: any change to either tracker
+    file invalidates the cache.
+    """
+    try:
+        return path.stat().st_mtime_ns
+    except OSError:
+        return None
+
+
+def _load_last_fire_cache(
+    state_dir: Path,
+    tracker_path: Path,
+    session_tokens_path: Path,
+) -> dict[str, _dt.datetime] | None:
+    """Return the cached ``{slot_key: latest_ts}`` index, or ``None`` on miss/stale.
+
+    The cache file lives at ``<state_dir>/last-fire.json`` and records the
+    source-file mtimes seen when the cache was built. Returns ``None`` (forcing
+    a JSONL rebuild) when:
+      - the cache file is missing or unreadable
+      - the cache schema_version doesn't match (forward-compat upgrades)
+      - either tracker file's mtime has changed since the cache was written
+        (a new fire was recorded, or session_tokens enriched the JSONL)
+    """
+    cache_path = state_dir / LAST_FIRE_CACHE_FILENAME
+    if not cache_path.exists():
+        return None
+    try:
+        with cache_path.open("r", encoding="utf-8") as f:
+            cache = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(cache, dict):
+        return None
+    if cache.get("schema_version") != _LAST_FIRE_CACHE_SCHEMA_VERSION:
+        return None
+    if cache.get("tracker_mtime_ns") != _file_mtime_ns(tracker_path):
+        return None
+    if cache.get("session_tokens_mtime_ns") != _file_mtime_ns(session_tokens_path):
+        return None
+    raw_index = cache.get("last_fire")
+    if not isinstance(raw_index, dict):
+        return None
+    out: dict[str, _dt.datetime] = {}
+    for key, ts_str in raw_index.items():
+        if not isinstance(key, str) or not isinstance(ts_str, str):
+            continue
+        try:
+            out[key] = _parse_iso_z(ts_str)
+        except ValueError:
+            continue
+    return out
+
+
+def _write_last_fire_cache(
+    state_dir: Path,
+    index: dict[str, _dt.datetime],
+    tracker_path: Path,
+    session_tokens_path: Path,
+) -> None:
+    """Atomically write the last-fire index cache. Best-effort — never raises."""
+    state_dir.mkdir(parents=True, exist_ok=True)
+    cache_path = state_dir / LAST_FIRE_CACHE_FILENAME
+    tmp_path = cache_path.with_suffix(".json.tmp")
+    payload = {
+        "schema_version": _LAST_FIRE_CACHE_SCHEMA_VERSION,
+        "tracker_mtime_ns": _file_mtime_ns(tracker_path),
+        "session_tokens_mtime_ns": _file_mtime_ns(session_tokens_path),
+        "last_fire": {
+            key: ts.astimezone(_dt.UTC).isoformat().replace("+00:00", "Z") for key, ts in index.items()
+        },
+    }
+    try:
+        with tmp_path.open("w", encoding="utf-8") as f:
+            json.dump(payload, f)
+        os.replace(tmp_path, cache_path)
+    except OSError:
+        with contextlib.suppress(OSError):
+            tmp_path.unlink()
+
+
+def _get_last_fire_index(state_dir: Path, tracker_path: Path) -> dict[str, _dt.datetime]:
+    """Return the ``{slot_key: latest_ts}`` index, using the cache when valid.
+
+    Cache layout: ``<state_dir>/last-fire.json``, mtime-keyed to both
+    ``usage-tracker.jsonl`` and ``session-tokens.jsonl``. On miss or staleness,
+    falls back to the full JSONL scan in :func:`_read_last_fire_index` and
+    rewrites the cache. This avoids re-parsing thousands of rows on every
+    5-min tick (see issue #73).
+    """
+    session_tokens_path = tracker_path.parent / SESSION_TOKENS_FILENAME
+    cached = _load_last_fire_cache(state_dir, tracker_path, session_tokens_path)
+    if cached is not None:
+        return cached
+    index = _read_last_fire_index(tracker_path)
+    _write_last_fire_cache(state_dir, index, tracker_path, session_tokens_path)
+    return index
 
 
 def _record_fire(tracker_path: Path, slot_key: str, slot: Slot, now: _dt.datetime) -> None:
@@ -525,6 +634,7 @@ def run() -> Event:
             )
         return _do_tick(
             vault=vault,
+            state_dir=state,
             log_dir=log_dir,
             tracker_path=tracker_path,
             started_at=started_at,
@@ -534,12 +644,13 @@ def run() -> Event:
 def _do_tick(
     *,
     vault: Path,
+    state_dir: Path,
     log_dir: Path,
     tracker_path: Path,
     started_at: float,
 ) -> Event:
     schedule = _load_or_default(vault)
-    last_fire = _read_last_fire_index(tracker_path)
+    last_fire = _get_last_fire_index(state_dir, tracker_path)
     now = _now()
 
     candidates = _compute_due_slots(schedule, last_fire, now)
@@ -592,6 +703,16 @@ def _do_tick(
             result.skipped.append({"slot_key": winner_key, "reason": "fire_failed"})
         else:
             _record_fire(tracker_path, winner_key, winner_slot, now)
+            # Keep the last-fire cache consistent with the row we just
+            # appended; otherwise the next tick would see a tracker-mtime
+            # mismatch and pay for a full JSONL rescan.
+            last_fire[winner_key] = now
+            _write_last_fire_cache(
+                state_dir,
+                last_fire,
+                tracker_path,
+                tracker_path.parent / SESSION_TOKENS_FILENAME,
+            )
             _emit_event(
                 log_dir,
                 kind="slot.fired",
@@ -730,7 +851,18 @@ def fire_now(slot_key: str) -> Event:
                     "error": f"{type(exc).__name__}: {exc}",
                 },
             )
+        # Snapshot the index BEFORE _record_fire so we don't lose entries:
+        # _record_fire bumps the tracker mtime, which would otherwise force
+        # _load_last_fire_cache to return None on the next call.
+        existing = _get_last_fire_index(state, tracker_path)
         _record_fire(tracker_path, slot_key, slot, now)
+        existing[slot_key] = now
+        _write_last_fire_cache(
+            state,
+            existing,
+            tracker_path,
+            tracker_path.parent / SESSION_TOKENS_FILENAME,
+        )
         return _emit_event(
             log_dir,
             kind="slot.fired",
@@ -769,8 +901,11 @@ __all__ = [
     "_apply_miss_rules",
     "_compute_due_slots",
     "_filter_winner_by_priority",
+    "_get_last_fire_index",
+    "_load_last_fire_cache",
     "_network_ready",
     "_read_last_fire_index",
+    "_write_last_fire_cache",
     "candidates_by_key",
     "fire_now",
     "main",

--- a/engine/tests/unit/test_schedule_tick.py
+++ b/engine/tests/unit/test_schedule_tick.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timedelta
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
@@ -24,9 +25,12 @@ from scout.scripts.schedule_tick import (
     _apply_miss_rules,
     _compute_due_slots,
     _filter_winner_by_priority,
+    _get_last_fire_index,
+    _load_last_fire_cache,
     _network_ready,
     _read_last_fire_index,
     _spawn_runner,
+    _write_last_fire_cache,
     candidates_by_key,
 )
 from scout.scripts.schedule_tick import (
@@ -307,6 +311,151 @@ def test_read_last_fire_index_falls_through_legacy_usage_tracker_rows(tmp_path):
     )
     index = _read_last_fire_index(tracker)
     assert index == {}  # silently skipped; no error
+
+
+# 5b. Cached last-fire index (perf fix for #73).
+#
+# The cache lives at .scout-state/last-fire.json and is keyed by the mtimes
+# of both usage-tracker.jsonl and session-tokens.jsonl. The fast path returns
+# the cached dict in O(slots); a miss/staleness falls through to the full
+# JSONL scan via _read_last_fire_index and rewrites the cache.
+
+
+def _make_tracker(tmp_path):
+    log_dir = tmp_path / ".scout-logs"
+    log_dir.mkdir(exist_ok=True)
+    state_dir = tmp_path / ".scout-state"
+    state_dir.mkdir(exist_ok=True)
+    tracker = log_dir / "usage-tracker.jsonl"
+    tracker.write_text(
+        '{"ts":"2026-05-11T12:00:00Z","type":"briefing","scout_mode":"morning-briefing"}\n'
+        '{"ts":"2026-05-11T17:00:00Z","type":"consolidation","scout_mode":"afternoon-consolidation"}\n'
+    )
+    return tracker, state_dir
+
+
+def test_get_last_fire_index_writes_cache_on_first_call(tmp_path):
+    tracker, state_dir = _make_tracker(tmp_path)
+    assert not (state_dir / "last-fire.json").exists()
+
+    index = _get_last_fire_index(state_dir, tracker)
+
+    assert "morning-briefing" in index
+    assert "afternoon-consolidation" in index
+    # Cache was written so the next call doesn't scan again.
+    assert (state_dir / "last-fire.json").exists()
+
+
+def test_get_last_fire_index_uses_cache_when_mtimes_match(tmp_path):
+    """Cache hit: source files unchanged since warm-up → cache is honoured."""
+    tracker, state_dir = _make_tracker(tmp_path)
+
+    # Warm the cache.
+    _get_last_fire_index(state_dir, tracker)
+
+    # If we corrupt the underlying JSONL but leave its mtime untouched,
+    # the cache should still serve the previously-extracted index without
+    # re-scanning — that's the whole point of the cache.
+    original_mtime_ns = tracker.stat().st_mtime_ns
+    tracker.write_bytes(b"not-json garbage that would raise on rescan\n")
+    os.utime(tracker, ns=(original_mtime_ns, original_mtime_ns))
+
+    session_tokens = tracker.parent / "session-tokens.jsonl"
+    cached = _load_last_fire_cache(state_dir, tracker, session_tokens)
+    assert cached is not None
+    assert "morning-briefing" in cached
+    assert "afternoon-consolidation" in cached
+
+
+def test_get_last_fire_index_invalidates_cache_on_tracker_change(tmp_path):
+    tracker, state_dir = _make_tracker(tmp_path)
+    _get_last_fire_index(state_dir, tracker)  # warm
+
+    # Append a new row → tracker mtime bumps → cache should be invalidated.
+    with tracker.open("a", encoding="utf-8") as f:
+        f.write(
+            '{"ts":"2026-05-12T08:00:00Z","type":"briefing","scout_mode":"morning-briefing"}\n'
+        )
+
+    session_tokens = tracker.parent / "session-tokens.jsonl"
+    assert _load_last_fire_cache(state_dir, tracker, session_tokens) is None
+
+    # _get_last_fire_index detects the staleness and rebuilds.
+    fresh = _get_last_fire_index(state_dir, tracker)
+    # The newer 2026-05-12 row wins over the cached 2026-05-11 row.
+    assert fresh["morning-briefing"].day == 12
+
+
+def test_get_last_fire_index_invalidates_cache_on_session_tokens_change(tmp_path):
+    tracker, state_dir = _make_tracker(tmp_path)
+    _get_last_fire_index(state_dir, tracker)  # warm
+
+    # Touching session-tokens.jsonl must also invalidate the cache, since
+    # _read_last_fire_index reads both files.
+    session_tokens = tracker.parent / "session-tokens.jsonl"
+    session_tokens.write_text(
+        '{"ts":"2026-05-13T09:00:00Z","scout_mode":"morning-briefing"}\n'
+    )
+
+    assert _load_last_fire_cache(state_dir, tracker, session_tokens) is None
+    fresh = _get_last_fire_index(state_dir, tracker)
+    assert fresh["morning-briefing"].day == 13
+
+
+def test_load_last_fire_cache_rejects_wrong_schema_version(tmp_path):
+    state_dir = tmp_path / ".scout-state"
+    state_dir.mkdir()
+    tracker = tmp_path / "usage-tracker.jsonl"
+    tracker.write_text("")
+    session_tokens = tracker.parent / "session-tokens.jsonl"
+
+    # Hand-write a cache file with a bad schema version.
+    (state_dir / "last-fire.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 999,
+                "tracker_mtime_ns": tracker.stat().st_mtime_ns,
+                "session_tokens_mtime_ns": None,
+                "last_fire": {"morning-briefing": "2026-05-11T12:00:00Z"},
+            }
+        )
+    )
+    assert _load_last_fire_cache(state_dir, tracker, session_tokens) is None
+
+
+def test_load_last_fire_cache_handles_corrupt_json(tmp_path):
+    state_dir = tmp_path / ".scout-state"
+    state_dir.mkdir()
+    tracker = tmp_path / "usage-tracker.jsonl"
+    tracker.write_text("")
+    session_tokens = tracker.parent / "session-tokens.jsonl"
+
+    (state_dir / "last-fire.json").write_text("{not valid json")
+    # Corrupt cache must not raise — it returns None and the caller rebuilds.
+    assert _load_last_fire_cache(state_dir, tracker, session_tokens) is None
+
+
+def test_write_last_fire_cache_round_trip(tmp_path):
+    state_dir = tmp_path / ".scout-state"
+    state_dir.mkdir()
+    tracker = tmp_path / "usage-tracker.jsonl"
+    tracker.write_text("")
+    session_tokens = tracker.parent / "session-tokens.jsonl"
+
+    et = ZoneInfo("America/New_York")
+    original = {
+        "morning-briefing": datetime(2026, 5, 11, 8, 0, tzinfo=et),
+        "afternoon-consolidation": datetime(2026, 5, 11, 17, 0, tzinfo=et),
+    }
+    _write_last_fire_cache(state_dir, original, tracker, session_tokens)
+
+    round_tripped = _load_last_fire_cache(state_dir, tracker, session_tokens)
+    assert round_tripped is not None
+    # Timestamps are normalised to UTC on write — compare as moments.
+    assert round_tripped["morning-briefing"] == original["morning-briefing"]
+    assert (
+        round_tripped["afternoon-consolidation"] == original["afternoon-consolidation"]
+    )
 
 
 # 6. End-to-end: run() emits Event and writes JSONL row.

--- a/engine/tests/unit/test_schedule_tick.py
+++ b/engine/tests/unit/test_schedule_tick.py
@@ -373,9 +373,7 @@ def test_get_last_fire_index_invalidates_cache_on_tracker_change(tmp_path):
 
     # Append a new row → tracker mtime bumps → cache should be invalidated.
     with tracker.open("a", encoding="utf-8") as f:
-        f.write(
-            '{"ts":"2026-05-12T08:00:00Z","type":"briefing","scout_mode":"morning-briefing"}\n'
-        )
+        f.write('{"ts":"2026-05-12T08:00:00Z","type":"briefing","scout_mode":"morning-briefing"}\n')
 
     session_tokens = tracker.parent / "session-tokens.jsonl"
     assert _load_last_fire_cache(state_dir, tracker, session_tokens) is None
@@ -393,9 +391,7 @@ def test_get_last_fire_index_invalidates_cache_on_session_tokens_change(tmp_path
     # Touching session-tokens.jsonl must also invalidate the cache, since
     # _read_last_fire_index reads both files.
     session_tokens = tracker.parent / "session-tokens.jsonl"
-    session_tokens.write_text(
-        '{"ts":"2026-05-13T09:00:00Z","scout_mode":"morning-briefing"}\n'
-    )
+    session_tokens.write_text('{"ts":"2026-05-13T09:00:00Z","scout_mode":"morning-briefing"}\n')
 
     assert _load_last_fire_cache(state_dir, tracker, session_tokens) is None
     fresh = _get_last_fire_index(state_dir, tracker)
@@ -453,9 +449,7 @@ def test_write_last_fire_cache_round_trip(tmp_path):
     assert round_tripped is not None
     # Timestamps are normalised to UTC on write — compare as moments.
     assert round_tripped["morning-briefing"] == original["morning-briefing"]
-    assert (
-        round_tripped["afternoon-consolidation"] == original["afternoon-consolidation"]
-    )
+    assert round_tripped["afternoon-consolidation"] == original["afternoon-consolidation"]
 
 
 # 6. End-to-end: run() emits Event and writes JSONL row.


### PR DESCRIPTION
## Summary
- Closes #73.
- Adds a small JSON cache at \`.scout-state/last-fire.json\` keyed by the mtimes of both \`usage-tracker.jsonl\` and \`session-tokens.jsonl\`.
- Fast path: O(slots) read. Miss/staleness falls through to the existing full JSONL scan and rewrites the cache.
- \`_record_fire\` keeps the cache fresh after appending so the next tick stays on the fast path.

## Why
\`schedule_tick\` runs every 5 min via launchd. \`_read_last_fire_index\` was re-reading both tracker files end-to-end on every tick. Combined with #66 (no log rotation), each tick got slower forever — a steady CPU drip in the background. Now most ticks pay constant time.

## Test plan
- [x] \`pytest engine/tests/\` — 577 passed, 9 skipped (unrelated)
- [x] New unit tests cover: cache write on first call, cache hit on unchanged mtimes, invalidation on tracker append, invalidation on session-tokens write, bad schema rejection, corrupt JSON safety, full round-trip
- [ ] Manual: tail \`schedule-events-*.jsonl\` after this lands to confirm \`schedule.tick.completed.duration_ms\` drops on real ticks

🤖 Generated with [Claude Code](https://claude.com/claude-code)