### PR TITLE
perf(budget-check): replace shell script's 5+ python3 -c calls with scoutctl subcommand

### DIFF
--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -125,6 +125,23 @@ def connector_health_report_cmd() -> None:
     raise typer.Exit(chr_main())
 
 
+# `scoutctl budget check` replaces ~/Scout/scripts/budget-check.sh (#74). The
+# bash version paid 5+ python3 cold starts per pre-session check; folded
+# in-process here it's one.
+budget_app = typer.Typer(help="Budget/cost gating for scheduled Scout runs.")
+app.add_typer(budget_app, name="budget")
+
+
+@budget_app.command("check")
+def budget_check_cmd(
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Print the decision and config."),
+) -> None:
+    """Decide whether the next session may proceed. Exit codes: 0=proceed, 1=skip, 2=backoff."""
+    from scout.scripts.budget_check import run as budget_run
+
+    raise typer.Exit(budget_run(verbose=verbose))
+
+
 def _register_connectors() -> None:
     """scoutctl connectors {list,show,reload} — read-only roster ops in v0.4."""
     connectors_app = typer.Typer(help="Connector roster operations (read-only in v0.4).")

--- a/engine/scout/scripts/bootstrap.py
+++ b/engine/scout/scripts/bootstrap.py
@@ -147,6 +147,7 @@ def _template_vars(cfg: BootstrapConfig) -> dict[str, str]:
         "GITHUB_USERNAME": cfg.connector_inputs.get("github_username", ""),
         "GITHUB_REPOS": cfg.connector_inputs.get("github_repos", ""),
         "SCOUT_DIR": str(cfg.vault),
+        "SCOUTCTL_BIN": str(cfg.plugin_root / ".venv" / "bin" / "scoutctl"),
         "TIMEZONE": cfg.timezone,
         "PLATFORM": cfg.platform,
         "MAX_BUDGET": cfg.connector_inputs.get("max_budget", "5.00"),

--- a/engine/scout/scripts/budget_check.py
+++ b/engine/scout/scripts/budget_check.py
@@ -1,0 +1,245 @@
+"""Pre-run budget check — decides whether a Scout session should proceed.
+
+Port of ``~/Scout/scripts/budget-check.sh``. Same exit-code semantics:
+  - 0 = proceed (budget available)
+  - 1 = skip (budget exhausted or near limit)
+  - 2 = backoff (recent rate-limit event or recent failure)
+
+Per #74, the bash version shells out to ``python3 -c`` five+ times for trivial
+JSON / datetime arithmetic, paying ~150-300 ms of interpreter startup each.
+Folding the logic into a single ``scoutctl budget check`` invocation means
+one cold start per session-launch instead of five.
+
+The check is intentionally tolerant of malformed config / tracker rows:
+unparseable rows are silently skipped (same as the bash original).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from scout import paths
+
+# Defaults — mirror budget-check.sh defaults so behavior is preserved when no
+# .scout-config.yaml is present.
+DEFAULT_WINDOW_HOURS = 5
+DEFAULT_DAILY_BUDGET_USD = 50.0
+DEFAULT_SKIP_THRESHOLD_PCT = 80.0
+DEFAULT_FAILURE_BACKOFF_MIN = 60
+
+EXIT_PROCEED = 0
+EXIT_SKIP_OVER_BUDGET = 1
+EXIT_BACKOFF = 2
+
+
+@dataclass(frozen=True)
+class BudgetConfig:
+    daily_budget_usd: float = DEFAULT_DAILY_BUDGET_USD
+    window_hours: int = DEFAULT_WINDOW_HOURS
+    skip_threshold_pct: float = DEFAULT_SKIP_THRESHOLD_PCT
+    failure_backoff_min: int = DEFAULT_FAILURE_BACKOFF_MIN
+
+    @property
+    def window_budget_usd(self) -> float:
+        return round(self.daily_budget_usd * self.window_hours / 24, 2)
+
+    @property
+    def skip_threshold_usd(self) -> float:
+        return round(self.window_budget_usd * self.skip_threshold_pct / 100, 2)
+
+
+@dataclass(frozen=True)
+class BudgetDecision:
+    exit_code: int
+    reason: str  # human-readable explanation for --verbose / event logs
+
+    @property
+    def should_proceed(self) -> bool:
+        return self.exit_code == EXIT_PROCEED
+
+
+# Lightweight YAML reader for the four flat scalar keys this script needs.
+# Avoids importing pyyaml on the hot path — and the bash version uses grep+awk
+# for parity reasons. Anything more structured falls through to the default.
+_CONFIG_KEYS = {
+    "daily_budget_estimate_usd": ("daily_budget_usd", float),
+    "rate_limit_window_hours": ("window_hours", int),
+    "skip_threshold_pct": ("skip_threshold_pct", float),
+    "failure_backoff_minutes": ("failure_backoff_min", int),
+}
+
+_CONFIG_LINE_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*([^#\s][^#]*?)\s*(?:#.*)?$")
+
+
+def load_config(config_path: Path) -> BudgetConfig:
+    """Parse the four scalar keys this check cares about from .scout-config.yaml.
+
+    Missing file or unparseable rows fall back to defaults — matches the bash
+    `grep ... | awk` pattern which silently no-ops on missing keys.
+    """
+    overrides: dict[str, Any] = {}
+    if not config_path.exists():
+        return BudgetConfig()
+    try:
+        text = config_path.read_text(encoding="utf-8")
+    except OSError:
+        return BudgetConfig()
+    for line in text.splitlines():
+        m = _CONFIG_LINE_RE.match(line)
+        if not m:
+            continue
+        yaml_key, raw_value = m.group(1), m.group(2).strip().strip("\"'")
+        mapping = _CONFIG_KEYS.get(yaml_key)
+        if mapping is None:
+            continue
+        field_name, caster = mapping
+        try:
+            overrides[field_name] = caster(raw_value)
+        except (TypeError, ValueError):
+            continue
+    return BudgetConfig(**overrides)
+
+
+def _iter_tracker_rows(tracker_path: Path) -> Iterable[dict]:
+    """Yield decoded JSON rows from the tracker; skip malformed lines silently."""
+    try:
+        with tracker_path.open("r", encoding="utf-8") as f:
+            for raw in f:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict):
+                    yield row
+    except OSError:
+        return
+
+
+def _parse_ts(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def decide(
+    tracker_path: Path,
+    config: BudgetConfig,
+    *,
+    now: datetime | None = None,
+) -> BudgetDecision:
+    """Return the budget decision for *now* given the tracker history.
+
+    Walks the tracker exactly once and computes everything the bash script
+    used three separate ``python3 -c`` invocations to extract: window-cost
+    sum, last exit_code + ts, and whether any rate_limit event landed within
+    the failure-backoff window (×2).
+    """
+    if not tracker_path.exists():
+        return BudgetDecision(EXIT_PROCEED, "no tracker — first run")
+
+    now = now or datetime.now(UTC)
+    window_start = now - timedelta(hours=config.window_hours)
+    rate_limit_cutoff = now - timedelta(minutes=config.failure_backoff_min * 2)
+
+    total_cost = 0.0
+    last_exit: int | None = None
+    last_ts: datetime | None = None
+    saw_recent_rate_limit = False
+
+    for row in _iter_tracker_rows(tracker_path):
+        ts = _parse_ts(row.get("ts"))
+        if ts is None:
+            continue
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=UTC)
+
+        # Rate-limit gate uses the wider 2× backoff window from bash:86-103.
+        if row.get("type") == "rate_limit" and ts >= rate_limit_cutoff:
+            saw_recent_rate_limit = True
+
+        if ts < window_start:
+            continue
+
+        try:
+            total_cost += float(row.get("budget_spent", 0) or 0)
+        except (TypeError, ValueError):
+            pass
+        try:
+            last_exit = int(row.get("exit_code", 0))
+        except (TypeError, ValueError):
+            pass
+        last_ts = ts
+
+    if saw_recent_rate_limit:
+        return BudgetDecision(
+            EXIT_BACKOFF,
+            f"rate_limit event in last {config.failure_backoff_min * 2}m — backing off",
+        )
+
+    if last_exit not in (0, None) and last_ts is not None:
+        minutes_since = int((now - last_ts).total_seconds() / 60)
+        if minutes_since < config.failure_backoff_min:
+            return BudgetDecision(
+                EXIT_BACKOFF,
+                f"recent failure {minutes_since}m ago (backoff: {config.failure_backoff_min}m)",
+            )
+
+    if total_cost >= config.skip_threshold_usd:
+        return BudgetDecision(
+            EXIT_SKIP_OVER_BUDGET,
+            f"window cost ${total_cost:.2f} >= skip threshold ${config.skip_threshold_usd:.2f}",
+        )
+
+    return BudgetDecision(
+        EXIT_PROCEED,
+        f"budget OK — ${total_cost:.2f} spent (threshold: ${config.skip_threshold_usd:.2f})",
+    )
+
+
+def run(*, verbose: bool = False, data_dir: Path | None = None) -> int:
+    """Execute the check and return the appropriate exit code.
+
+    ``data_dir`` is exposed so tests can target a tmp vault without setting
+    the environment variable. Production callers leave it None.
+    """
+    target = data_dir or paths.data_dir()
+    tracker_path = paths.logs_dir(target) / "usage-tracker.jsonl"
+    config = load_config(paths.config_path(target))
+    decision = decide(tracker_path, config)
+    if verbose:
+        print(f"[budget-check] {decision.reason}")
+        print(
+            f"[budget-check] window: {config.window_hours}h, "
+            f"daily: ${config.daily_budget_usd:.2f}, "
+            f"window budget: ${config.window_budget_usd:.2f}, "
+            f"skip at: ${config.skip_threshold_usd:.2f}"
+        )
+    return decision.exit_code
+
+
+__all__ = [
+    "BudgetConfig",
+    "BudgetDecision",
+    "DEFAULT_DAILY_BUDGET_USD",
+    "DEFAULT_FAILURE_BACKOFF_MIN",
+    "DEFAULT_SKIP_THRESHOLD_PCT",
+    "DEFAULT_WINDOW_HOURS",
+    "EXIT_BACKOFF",
+    "EXIT_PROCEED",
+    "EXIT_SKIP_OVER_BUDGET",
+    "decide",
+    "load_config",
+    "run",
+]

--- a/engine/tests/unit/test_budget_check.py
+++ b/engine/tests/unit/test_budget_check.py
@@ -25,7 +25,6 @@ from scout.scripts.budget_check import (
     run,
 )
 
-
 # ----- config parsing ------------------------------------------------------
 
 
@@ -56,9 +55,7 @@ def test_load_config_overrides_each_known_key(tmp_path: Path) -> None:
 def test_load_config_silently_skips_bad_values(tmp_path: Path) -> None:
     """Bash uses `grep | awk` and silently falls back on parse failures."""
     path = tmp_path / "config.yaml"
-    path.write_text(
-        "daily_budget_estimate_usd: not-a-number\nrate_limit_window_hours: 8\n"
-    )
+    path.write_text("daily_budget_estimate_usd: not-a-number\nrate_limit_window_hours: 8\n")
     cfg = load_config(path)
     assert cfg.daily_budget_usd == DEFAULT_DAILY_BUDGET_USD
     assert cfg.window_hours == 8
@@ -102,8 +99,7 @@ def test_decide_skips_when_window_cost_meets_threshold(tmp_path: Path) -> None:
     cfg = BudgetConfig(daily_budget_usd=50, window_hours=5, skip_threshold_pct=80)
     # threshold ~$8.33 — push two rows summing to $9.
     tracker.write_text(
-        _row(_now() - timedelta(hours=2), budget_spent=4.5)
-        + _row(_now() - timedelta(hours=1), budget_spent=4.5)
+        _row(_now() - timedelta(hours=2), budget_spent=4.5) + _row(_now() - timedelta(hours=1), budget_spent=4.5)
     )
 
     decision = decide(tracker, cfg, now=_now())
@@ -143,9 +139,7 @@ def test_decide_does_not_backoff_on_old_rate_limit(tmp_path: Path) -> None:
 def test_decide_backoffs_on_recent_failure(tmp_path: Path) -> None:
     tracker = tmp_path / "tracker.jsonl"
     cfg = BudgetConfig(failure_backoff_min=60)
-    tracker.write_text(
-        _row(_now() - timedelta(minutes=30), exit_code=1, budget_spent=0.0)
-    )
+    tracker.write_text(_row(_now() - timedelta(minutes=30), exit_code=1, budget_spent=0.0))
 
     decision = decide(tracker, cfg, now=_now())
     assert decision.exit_code == EXIT_BACKOFF
@@ -155,9 +149,7 @@ def test_decide_backoffs_on_recent_failure(tmp_path: Path) -> None:
 def test_decide_does_not_backoff_on_old_failure(tmp_path: Path) -> None:
     tracker = tmp_path / "tracker.jsonl"
     cfg = BudgetConfig(failure_backoff_min=60)
-    tracker.write_text(
-        _row(_now() - timedelta(minutes=120), exit_code=1, budget_spent=0.0)
-    )
+    tracker.write_text(_row(_now() - timedelta(minutes=120), exit_code=1, budget_spent=0.0))
 
     assert decide(tracker, cfg, now=_now()).exit_code == EXIT_PROCEED
 
@@ -185,7 +177,9 @@ def test_run_returns_proceed_for_empty_vault(tmp_path: Path, monkeypatch: pytest
     assert run() == EXIT_PROCEED
 
 
-def test_run_verbose_does_not_raise(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+def test_run_verbose_does_not_raise(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
     monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
     (tmp_path / ".scout-logs").mkdir()
     rc = run(verbose=True)

--- a/engine/tests/unit/test_budget_check.py
+++ b/engine/tests/unit/test_budget_check.py
@@ -1,0 +1,194 @@
+"""Unit tests for scout.scripts.budget_check — ports bash budget-check.sh behavior.
+
+The bash script's exit-code contract is the canonical interface; these tests
+exercise it: 0 == proceed, 1 == skip (over budget), 2 == backoff.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from scout.scripts.budget_check import (
+    DEFAULT_DAILY_BUDGET_USD,
+    DEFAULT_FAILURE_BACKOFF_MIN,
+    DEFAULT_SKIP_THRESHOLD_PCT,
+    DEFAULT_WINDOW_HOURS,
+    EXIT_BACKOFF,
+    EXIT_PROCEED,
+    EXIT_SKIP_OVER_BUDGET,
+    BudgetConfig,
+    decide,
+    load_config,
+    run,
+)
+
+
+# ----- config parsing ------------------------------------------------------
+
+
+def test_load_config_returns_defaults_when_file_missing(tmp_path: Path) -> None:
+    cfg = load_config(tmp_path / "nope.yaml")
+    assert cfg.daily_budget_usd == DEFAULT_DAILY_BUDGET_USD
+    assert cfg.window_hours == DEFAULT_WINDOW_HOURS
+    assert cfg.skip_threshold_pct == DEFAULT_SKIP_THRESHOLD_PCT
+    assert cfg.failure_backoff_min == DEFAULT_FAILURE_BACKOFF_MIN
+
+
+def test_load_config_overrides_each_known_key(tmp_path: Path) -> None:
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        "daily_budget_estimate_usd: 100\n"
+        "rate_limit_window_hours: 8\n"
+        "skip_threshold_pct: 90\n"
+        "failure_backoff_minutes: 30\n"
+        "unrelated_key: should_be_ignored\n"
+    )
+    cfg = load_config(path)
+    assert cfg.daily_budget_usd == 100
+    assert cfg.window_hours == 8
+    assert cfg.skip_threshold_pct == 90
+    assert cfg.failure_backoff_min == 30
+
+
+def test_load_config_silently_skips_bad_values(tmp_path: Path) -> None:
+    """Bash uses `grep | awk` and silently falls back on parse failures."""
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        "daily_budget_estimate_usd: not-a-number\nrate_limit_window_hours: 8\n"
+    )
+    cfg = load_config(path)
+    assert cfg.daily_budget_usd == DEFAULT_DAILY_BUDGET_USD
+    assert cfg.window_hours == 8
+
+
+def test_budget_config_derives_window_and_threshold() -> None:
+    cfg = BudgetConfig(daily_budget_usd=48, window_hours=6, skip_threshold_pct=50)
+    assert cfg.window_budget_usd == pytest.approx(12.0)
+    assert cfg.skip_threshold_usd == pytest.approx(6.0)
+
+
+# ----- decide() ------------------------------------------------------------
+
+
+def _now() -> datetime:
+    return datetime(2026, 5, 28, 12, 0, tzinfo=UTC)
+
+
+def _row(ts: datetime, **fields: object) -> str:
+    import json
+
+    return json.dumps({"ts": ts.isoformat().replace("+00:00", "Z"), **fields}) + "\n"
+
+
+def test_decide_proceeds_when_tracker_missing(tmp_path: Path) -> None:
+    decision = decide(tmp_path / "missing.jsonl", BudgetConfig(), now=_now())
+    assert decision.exit_code == EXIT_PROCEED
+
+
+def test_decide_proceeds_when_window_cost_under_threshold(tmp_path: Path) -> None:
+    tracker = tmp_path / "tracker.jsonl"
+    cfg = BudgetConfig(daily_budget_usd=50, window_hours=5, skip_threshold_pct=80)
+    # window_budget = 50*5/24 ≈ 10.42 ; skip_threshold = 8.33
+    tracker.write_text(_row(_now() - timedelta(hours=1), budget_spent=2.0))
+
+    assert decide(tracker, cfg, now=_now()).exit_code == EXIT_PROCEED
+
+
+def test_decide_skips_when_window_cost_meets_threshold(tmp_path: Path) -> None:
+    tracker = tmp_path / "tracker.jsonl"
+    cfg = BudgetConfig(daily_budget_usd=50, window_hours=5, skip_threshold_pct=80)
+    # threshold ~$8.33 — push two rows summing to $9.
+    tracker.write_text(
+        _row(_now() - timedelta(hours=2), budget_spent=4.5)
+        + _row(_now() - timedelta(hours=1), budget_spent=4.5)
+    )
+
+    decision = decide(tracker, cfg, now=_now())
+    assert decision.exit_code == EXIT_SKIP_OVER_BUDGET
+    assert "skip threshold" in decision.reason
+
+
+def test_decide_ignores_rows_outside_window(tmp_path: Path) -> None:
+    tracker = tmp_path / "tracker.jsonl"
+    cfg = BudgetConfig(daily_budget_usd=50, window_hours=5, skip_threshold_pct=80)
+    # Old row that would put us over budget if counted.
+    tracker.write_text(_row(_now() - timedelta(hours=24), budget_spent=999.0))
+
+    assert decide(tracker, cfg, now=_now()).exit_code == EXIT_PROCEED
+
+
+def test_decide_backoffs_on_recent_rate_limit(tmp_path: Path) -> None:
+    tracker = tmp_path / "tracker.jsonl"
+    cfg = BudgetConfig(failure_backoff_min=60)
+    # 90 min ago is inside the 2× backoff window (120 min).
+    tracker.write_text(_row(_now() - timedelta(minutes=90), type="rate_limit"))
+
+    decision = decide(tracker, cfg, now=_now())
+    assert decision.exit_code == EXIT_BACKOFF
+    assert "rate_limit" in decision.reason
+
+
+def test_decide_does_not_backoff_on_old_rate_limit(tmp_path: Path) -> None:
+    tracker = tmp_path / "tracker.jsonl"
+    cfg = BudgetConfig(failure_backoff_min=60)
+    # 200 min ago is OUTSIDE the 2× backoff window (120 min).
+    tracker.write_text(_row(_now() - timedelta(minutes=200), type="rate_limit"))
+
+    assert decide(tracker, cfg, now=_now()).exit_code == EXIT_PROCEED
+
+
+def test_decide_backoffs_on_recent_failure(tmp_path: Path) -> None:
+    tracker = tmp_path / "tracker.jsonl"
+    cfg = BudgetConfig(failure_backoff_min=60)
+    tracker.write_text(
+        _row(_now() - timedelta(minutes=30), exit_code=1, budget_spent=0.0)
+    )
+
+    decision = decide(tracker, cfg, now=_now())
+    assert decision.exit_code == EXIT_BACKOFF
+    assert "recent failure" in decision.reason
+
+
+def test_decide_does_not_backoff_on_old_failure(tmp_path: Path) -> None:
+    tracker = tmp_path / "tracker.jsonl"
+    cfg = BudgetConfig(failure_backoff_min=60)
+    tracker.write_text(
+        _row(_now() - timedelta(minutes=120), exit_code=1, budget_spent=0.0)
+    )
+
+    assert decide(tracker, cfg, now=_now()).exit_code == EXIT_PROCEED
+
+
+def test_decide_skips_malformed_rows(tmp_path: Path) -> None:
+    tracker = tmp_path / "tracker.jsonl"
+    cfg = BudgetConfig()
+    tracker.write_text(
+        "this is not json\n"
+        + _row(_now() - timedelta(hours=1), budget_spent=0.5)
+        + "{not even an object: true}\n"
+        + '{"ts": "not-a-date", "budget_spent": 99}\n'
+    )
+
+    # Single valid row ($0.50) is well under threshold.
+    assert decide(tracker, cfg, now=_now()).exit_code == EXIT_PROCEED
+
+
+# ----- run() — end-to-end through paths ----------------------------------
+
+
+def test_run_returns_proceed_for_empty_vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    (tmp_path / ".scout-logs").mkdir()
+    assert run() == EXIT_PROCEED
+
+
+def test_run_verbose_does_not_raise(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    (tmp_path / ".scout-logs").mkdir()
+    rc = run(verbose=True)
+    captured = capsys.readouterr()
+    assert rc == EXIT_PROCEED
+    assert "[budget-check]" in captured.out

--- a/templates/scripts/budget-check.sh.tmpl
+++ b/templates/scripts/budget-check.sh.tmpl
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Pre-run budget check — decides whether a session should proceed
+# Pre-run budget check — decides whether a session should proceed.
 #
 # Exit codes:
 #   0 = proceed (budget available)
@@ -7,128 +7,26 @@
 #   2 = backoff (recent failure, possible rate limit)
 #
 # Usage: budget-check.sh [--verbose]
-# Called by runner scripts before launching claude
+# Called by runner scripts before launching claude.
+#
+# This is a thin wrapper around `scoutctl budget check` — the logic lives in
+# scout.scripts.budget_check so the runner pays one Python cold start instead
+# of the 5+ that the previous bash version paid via `python3 -c '...'` calls
+# (see issue #74).
 
 set -euo pipefail
 
-TRACKER_FILE="{{SCOUT_DIR}}/.scout-logs/usage-tracker.jsonl"
-CONFIG_FILE="{{SCOUT_DIR}}/.scout-config.yaml"
-VERBOSE="${1:-}"
-
-# Defaults (overridden by config if present)
-WINDOW_HOURS=5
-DAILY_BUDGET_USD=50
-SKIP_THRESHOLD_PCT=80
-FAILURE_BACKOFF_MIN=60
-SESSION_COST_ESTIMATE=8  # conservative estimate per session
-
-log() {
-    if [ "$VERBOSE" = "--verbose" ]; then
-        echo "[budget-check] $1"
-    fi
-}
-
-# If no tracker exists yet, always proceed (first run)
-if [ ! -f "$TRACKER_FILE" ]; then
-    log "No tracker file — first run, proceeding"
-    exit 0
-fi
-
-# Parse config if it exists
-if [ -f "$CONFIG_FILE" ]; then
-    DAILY_BUDGET_USD=$(grep 'daily_budget_estimate_usd:' "$CONFIG_FILE" 2>/dev/null | awk '{print $2}' || echo "$DAILY_BUDGET_USD")
-    WINDOW_HOURS=$(grep 'rate_limit_window_hours:' "$CONFIG_FILE" 2>/dev/null | awk '{print $2}' || echo "$WINDOW_HOURS")
-    SKIP_THRESHOLD_PCT=$(grep 'skip_threshold_pct:' "$CONFIG_FILE" 2>/dev/null | awk '{print $2}' || echo "$SKIP_THRESHOLD_PCT")
-    FAILURE_BACKOFF_MIN=$(grep 'failure_backoff_minutes:' "$CONFIG_FILE" 2>/dev/null | awk '{print $2}' || echo "$FAILURE_BACKOFF_MIN")
-fi
-
-# Calculate window budget (portion of daily budget for the rolling window)
-WINDOW_BUDGET=$(python3 -c "print(round($DAILY_BUDGET_USD * $WINDOW_HOURS / 24, 2))")
-SKIP_THRESHOLD=$(python3 -c "print(round($WINDOW_BUDGET * $SKIP_THRESHOLD_PCT / 100, 2))")
-
-log "Window: ${WINDOW_HOURS}h, Daily budget: \$${DAILY_BUDGET_USD}, Window budget: \$${WINDOW_BUDGET}, Skip at: \$${SKIP_THRESHOLD}"
-
-# Sum costs in the current window
-WINDOW_START=$(date -v-${WINDOW_HOURS}H -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -d "${WINDOW_HOURS} hours ago" -u '+%Y-%m-%dT%H:%M:%SZ')
-
-WINDOW_COST=$(python3 -c "
-import json, sys
-from datetime import datetime
-
-window_start = datetime.fromisoformat('$WINDOW_START'.replace('Z', '+00:00'))
-total = 0.0
-last_exit_code = 0
-last_ts = None
-
-for line in open('$TRACKER_FILE'):
-    line = line.strip()
-    if not line:
-        continue
-    try:
-        entry = json.loads(line)
-        ts = datetime.fromisoformat(entry['ts'].replace('Z', '+00:00'))
-        if ts >= window_start:
-            total += float(entry.get('budget_spent', 0))
-            last_exit_code = int(entry.get('exit_code', 0))
-            last_ts = ts
-    except (json.JSONDecodeError, KeyError, ValueError):
-        continue
-
-print(f'{total:.2f}|{last_exit_code}|{last_ts.isoformat() if last_ts else \"none\"}')
-")
-
-COST=$(echo "$WINDOW_COST" | cut -d'|' -f1)
-LAST_EXIT=$(echo "$WINDOW_COST" | cut -d'|' -f2)
-LAST_TS=$(echo "$WINDOW_COST" | cut -d'|' -f3)
-
-log "Window cost: \$${COST}, Last exit: ${LAST_EXIT}, Last run: ${LAST_TS}"
-
-# Check for recent rate_limit events in tracker
-LAST_RATE_LIMIT=$(python3 -c "
-import json
-from datetime import datetime, timezone, timedelta
-cutoff = datetime.now(timezone.utc) - timedelta(minutes=int('$FAILURE_BACKOFF_MIN') * 2)
-found = False
-for line in open('$TRACKER_FILE'):
-    line = line.strip()
-    if not line: continue
-    try:
-        e = json.loads(line)
-        if e.get('type') == 'rate_limit':
-            ts = datetime.fromisoformat(e['ts'].replace('Z', '+00:00'))
-            if ts >= cutoff:
-                found = True
-    except: continue
-print('yes' if found else 'no')
-" 2>/dev/null || echo "no")
-
-if [ "$LAST_RATE_LIMIT" = "yes" ]; then
-    log "Rate limit event detected within ${FAILURE_BACKOFF_MIN}m * 2 — extended backoff"
-    exit 2
-fi
-
-# Check for recent failure (possible rate limit)
-if [ "$LAST_EXIT" != "0" ] && [ "$LAST_TS" != "none" ]; then
-    MINUTES_SINCE=$(python3 -c "
-from datetime import datetime, timezone
-last = datetime.fromisoformat('$LAST_TS')
-if last.tzinfo is None:
-    last = last.replace(tzinfo=timezone.utc)
-now = datetime.now(timezone.utc)
-print(int((now - last).total_seconds() / 60))
-")
-    if [ "$MINUTES_SINCE" -lt "$FAILURE_BACKOFF_MIN" ]; then
-        log "Recent failure ${MINUTES_SINCE}m ago (backoff: ${FAILURE_BACKOFF_MIN}m) — backing off"
-        exit 2
+SCOUTCTL_BIN="{{SCOUTCTL_BIN}}"
+if [[ ! -x "$SCOUTCTL_BIN" ]]; then
+    if command -v scoutctl >/dev/null 2>&1; then
+        SCOUTCTL_BIN="$(command -v scoutctl)"
+    else
+        echo "budget-check.sh: scoutctl not found (looked at ${SCOUTCTL_BIN})" >&2
+        exit 1
     fi
 fi
 
-# Check if window cost exceeds threshold
-SHOULD_SKIP=$(python3 -c "print('yes' if float('$COST') >= float('$SKIP_THRESHOLD') else 'no')")
-if [ "$SHOULD_SKIP" = "yes" ]; then
-    log "Window cost \$${COST} >= skip threshold \$${SKIP_THRESHOLD} — skipping"
-    exit 1
-fi
+SCOUT_DATA_DIR="${SCOUT_DATA_DIR:-{{SCOUT_DIR}}}"
+export SCOUT_DATA_DIR
 
-log "Budget OK — \$${COST} spent in window (threshold: \$${SKIP_THRESHOLD})"
-exit 0
+exec "$SCOUTCTL_BIN" budget check ${1:+"$1"}


### PR DESCRIPTION
## Summary
- Partial fix for #74 — the budget-check slice.
- Adds \`scoutctl budget check\` (and \`scout.scripts.budget_check\` module).
- Rewrites \`templates/scripts/budget-check.sh.tmpl\` from 134 lines of bash + 5 \`python3 -c\` calls down to a 25-line wrapper that just execs scoutctl.
- Adds \`SCOUTCTL_BIN\` to the bootstrap template-vars so the wrapper can find scoutctl on disk.

## Why
\`budget-check.sh\` runs at the start of every scheduled Scout session and shelled out to \`python3 -c\` five+ separate times — once for window-budget math, once for skip-threshold math, once to JSON-scan the tracker for window cost, once to detect recent rate-limit events, once to compute minutes-since-failure, plus a final yes/no compare. Each \`python3\` cold start is ~150-300 ms on macOS, so the pre-session phase paid about 1 s of pure interpreter startup before Claude even launched.

Folding it into one \`scoutctl budget check\` invocation makes that ~1 s into ~200 ms (one cold start) and walks the tracker exactly once.

## Behavior preserved
Exit codes match the bash original: \`0\` proceed, \`1\` over-budget, \`2\` backoff (recent rate-limit OR recent failure within the configured window). Same defaults, same config keys (\`daily_budget_estimate_usd\`, \`rate_limit_window_hours\`, \`skip_threshold_pct\`, \`failure_backoff_minutes\`).

## Test plan
- [x] \`pytest engine/tests/\` — 585 passed, 9 skipped (unrelated)
- [x] 15 new tests cover: defaults, each config override, malformed config, malformed tracker rows, all three exit-code paths, the 2× rate-limit window, the \`run()\` end-to-end
- [x] Smoke-tested \`scoutctl budget check --verbose\` against the live ~/Scout vault (returns 0, prints sensible config)
- [ ] Manual: re-bootstrap to deploy the new wrapper, watch session start time on the next briefing

## Next slices for #74
- \`scoutctl heartbeat decide\` (replaces 3 python3 -c calls in heartbeat.sh)
- \`scoutctl pre-session data\` (replaces 2 python3 -c + per-KB-file pipeline in pre-session-data.sh)
- \`scoutctl session cc-cache\` (replaces 1 python3 -c per ~/.claude/projects/*.jsonl in cc-session-cache.sh — also closes #75)

🤖 Generated with [Claude Code](https://claude.com/claude-code)