### PR TITLE
perf(pre-session-data): one Python pass + KB-date mtime cache (closes #76, finishes #74)

### DIFF
--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -194,6 +194,27 @@ def heartbeat_run_cmd(
     raise typer.Exit(heartbeat_main(dry_run=dry_run))
 
 
+# `scoutctl pre-session data` replaces ~/Scout/scripts/pre-session-data.sh
+# (#74 + #76). The bash version ran a 4-subprocess pipeline per KB file plus
+# two python3 cold starts just to JSON-encode stdin. Folded into one Python
+# process here with an mtime cache for the KB date extraction.
+pre_session_app = typer.Typer(help="Pre-session data gathering for scheduled Scout runs.")
+app.add_typer(pre_session_app, name="pre-session")
+
+
+@pre_session_app.command("data")
+def pre_session_data_cmd(
+    session_type: str = typer.Argument(
+        "unknown",
+        help="Session type label (briefing | consolidation | dreaming | research).",
+    ),
+) -> None:
+    """Write .scout-cache/session-context.json from current vault + git + gh state."""
+    from scout.scripts.pre_session_data import main as psd_main
+
+    raise typer.Exit(psd_main(session_type))
+
+
 def _register_connectors() -> None:
     """scoutctl connectors {list,show,reload} — read-only roster ops in v0.4."""
     connectors_app = typer.Typer(help="Connector roster operations (read-only in v0.4).")

--- a/engine/scout/scripts/pre_session_data.py
+++ b/engine/scout/scripts/pre_session_data.py
@@ -1,0 +1,349 @@
+"""Gather routine pre-session data so the skill doesn't have to.
+
+Port of ``~/Scout/scripts/pre-session-data.sh`` (#74 + #76). The bash version:
+
+- ran ``head -5 | grep | head -1 | sed | sed`` per KB markdown file
+  (4–5 subprocess forks each)
+- shelled out to ``python3 -c`` twice just to JSON-encode stdin
+- spawned a third Python (``ontology/parser.py``) for the tasks query
+
+This module does the same work in one Python process. The KB date
+extraction is also cached by ``(path, mtime_ns)`` at
+``.scout-cache/kb-dates.cache.json`` so files unchanged since the last
+run are reused without reopening (closes #76).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from scout import paths
+
+OUTPUT_FILENAME = "session-context.json"
+KB_DATES_CACHE_FILENAME = "kb-dates.cache.json"
+DEFAULT_TZ = "America/New_York"
+DEFAULT_GIT_LOG_LOOKBACK = "12 hours ago"
+PR_LIST_LIMIT = 10
+KB_HEAD_SCAN_LINES = 5
+
+# Match the bash find filter: skip */ontology/* and *archive*.
+_SKIP_PATH_FRAGMENTS = ("/ontology/", "archive")
+
+# Mirrors the *intent* of the bash's ``grep -i 'last updated\|last verified'``
+# followed by ``sed 's/.*: *//'``. The bash sed is greedy on the LAST colon,
+# which silently truncates dates that contain a colon (e.g. "2:30 PM"). Here
+# we anchor on the "last updated/verified" label, eat any markdown bold
+# markers, then take everything after the first colon — preserving dates with
+# embedded times instead of corrupting them.
+_LAST_UPDATED_RE = re.compile(
+    r"(?:last\s+updated|last\s+verified)[\s*]*:[\s*]*(.*?)\s*$",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class SessionContext:
+    generated_at: str
+    session_type: str
+    git_recent: str = ""
+    kb_file_dates: dict[str, str] = field(default_factory=dict)
+    pr_authored: list[dict] = field(default_factory=list)
+    pr_review_requested: list[dict] = field(default_factory=list)
+    personal_tasks: str = ""
+
+
+# ----- KB date extraction with mtime cache --------------------------------
+
+
+@dataclass(frozen=True)
+class _KbEntry:
+    mtime_ns: int
+    last_updated: str  # empty string means "no line found" (still cached!)
+
+
+def _kb_path_excluded(rel_posix: str) -> bool:
+    return any(frag in rel_posix for frag in _SKIP_PATH_FRAGMENTS)
+
+
+def extract_last_updated(path: Path) -> str:
+    """Read the first ``KB_HEAD_SCAN_LINES`` lines and return the cleaned date string.
+
+    Replaces ``head -5 | grep | head -1 | sed | sed`` — one file open instead
+    of a 4-subprocess pipeline.
+    """
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as f:
+            for i, raw in enumerate(f):
+                if i >= KB_HEAD_SCAN_LINES:
+                    break
+                m = _LAST_UPDATED_RE.search(raw)
+                if m:
+                    return m.group(1).strip()
+    except OSError:
+        pass
+    return ""
+
+
+def _load_kb_dates_cache(cache_path: Path) -> dict[str, _KbEntry]:
+    if not cache_path.exists():
+        return {}
+    try:
+        with cache_path.open("r", encoding="utf-8") as f:
+            raw = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, _KbEntry] = {}
+    for rel, payload in raw.items():
+        if not isinstance(payload, dict):
+            continue
+        try:
+            out[rel] = _KbEntry(
+                mtime_ns=int(payload["mtime_ns"]),
+                last_updated=str(payload.get("last_updated", "")),
+            )
+        except (KeyError, TypeError, ValueError):
+            continue
+    return out
+
+
+def _write_kb_dates_cache(cache_path: Path, entries: dict[str, _KbEntry]) -> None:
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = cache_path.with_suffix(".json.tmp")
+    payload = {rel: asdict(entry) for rel, entry in entries.items()}
+    try:
+        with tmp.open("w", encoding="utf-8") as f:
+            json.dump(payload, f)
+        os.replace(tmp, cache_path)
+    except OSError:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+
+
+def gather_kb_file_dates(
+    kb_root: Path,
+    *,
+    scout_dir: Path,
+    cache_path: Path,
+) -> dict[str, str]:
+    """Return ``{relpath: last_updated_string}`` for KB files that have a date line.
+
+    Uses the cache for unchanged files (mtime match) and only opens the files
+    whose mtime moved. Output dict only includes files with a non-empty
+    ``last_updated`` value, matching the bash behavior.
+    """
+    if not kb_root.is_dir():
+        return {}
+
+    cached = _load_kb_dates_cache(cache_path)
+    next_cache: dict[str, _KbEntry] = {}
+    out: dict[str, str] = {}
+
+    for md_file in sorted(kb_root.rglob("*.md")):
+        try:
+            rel = md_file.relative_to(scout_dir).as_posix()
+        except ValueError:
+            continue
+        if _kb_path_excluded(rel):
+            continue
+        try:
+            mtime_ns = md_file.stat().st_mtime_ns
+        except OSError:
+            continue
+        prior = cached.get(rel)
+        if prior is not None and prior.mtime_ns == mtime_ns:
+            entry = prior
+        else:
+            entry = _KbEntry(mtime_ns=mtime_ns, last_updated=extract_last_updated(md_file))
+        next_cache[rel] = entry
+        if entry.last_updated:
+            out[rel] = entry.last_updated
+
+    _write_kb_dates_cache(cache_path, next_cache)
+    return out
+
+
+# ----- side-effect helpers ------------------------------------------------
+
+
+def _run(cmd: list[str], *, cwd: Path | None = None, timeout: int = 10) -> str:
+    """Run *cmd* and return stdout. Returns "" on any failure — never raises."""
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=str(cwd) if cwd is not None else None,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout.strip()
+
+
+def get_git_recent(scout_dir: Path, since: str = DEFAULT_GIT_LOG_LOOKBACK) -> str:
+    if not (scout_dir / ".git").is_dir():
+        return ""
+    return _run(["git", "log", "--oneline", f"--since={since}"], cwd=scout_dir, timeout=5)
+
+
+def _gh_json(args: list[str], timeout: int = 10) -> list[dict]:
+    """Invoke ``gh`` and parse the JSON array on stdout; on any failure return []."""
+    raw = _run(["gh", *args], timeout=timeout)
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    return parsed if isinstance(parsed, list) else []
+
+
+def get_pr_authored() -> list[dict]:
+    return _gh_json(
+        [
+            "pr",
+            "list",
+            "--author",
+            "@me",
+            "--state",
+            "open",
+            "--json",
+            "number,title,repository,reviewDecision,updatedAt",
+            "--limit",
+            str(PR_LIST_LIMIT),
+        ]
+    )
+
+
+def get_pr_review_requested() -> list[dict]:
+    return _gh_json(
+        [
+            "search",
+            "prs",
+            "--review-requested",
+            "@me",
+            "--state",
+            "open",
+            "--json",
+            "number,title,repository",
+            "--limit",
+            str(PR_LIST_LIMIT),
+        ]
+    )
+
+
+def get_personal_tasks(scout_dir: Path) -> str:
+    """Invoke the optional ontology parser. Empty string when not installed."""
+    parser = scout_dir / "knowledge-base" / "ontology" / "parser.py"
+    if not parser.is_file():
+        return ""
+    return _run(["python3", str(parser), "query", "--type", "task"], cwd=scout_dir, timeout=15)
+
+
+# ----- driver -------------------------------------------------------------
+
+
+def gather(
+    session_type: str,
+    *,
+    scout_dir: Path | None = None,
+    tz_name: str = DEFAULT_TZ,
+    now: datetime | None = None,
+) -> SessionContext:
+    """Collect all routine pre-session data into a :class:`SessionContext`.
+
+    Side-effect heavy: walks the KB, runs git, runs gh twice, invokes the
+    ontology parser. Each upstream call is wrapped to never raise.
+    """
+    target = scout_dir or paths.data_dir()
+    tz = ZoneInfo(tz_name)
+    now_dt = now or datetime.now(tz=tz)
+    generated_at = now_dt.astimezone(tz).strftime("%Y-%m-%dT%H:%M:%S")
+
+    kb_dates = gather_kb_file_dates(
+        target / "knowledge-base",
+        scout_dir=target,
+        cache_path=paths.cache_dir(target) / KB_DATES_CACHE_FILENAME,
+    )
+
+    return SessionContext(
+        generated_at=generated_at,
+        session_type=session_type,
+        git_recent=get_git_recent(target),
+        kb_file_dates=kb_dates,
+        pr_authored=get_pr_authored(),
+        pr_review_requested=get_pr_review_requested(),
+        personal_tasks=get_personal_tasks(target),
+    )
+
+
+def write_context(ctx: SessionContext, output_path: Path) -> None:
+    """Atomically write the gathered context as JSON."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = output_path.with_suffix(".json.tmp")
+    try:
+        with tmp.open("w", encoding="utf-8") as f:
+            json.dump(asdict(ctx), f, indent=2)
+        os.replace(tmp, output_path)
+    except OSError:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+
+
+def run(session_type: str = "unknown", *, data_dir: Path | None = None) -> Path:
+    """End-to-end: gather, write, return the output path."""
+    target = data_dir or paths.data_dir()
+    ctx = gather(session_type, scout_dir=target)
+    output_path = paths.cache_dir(target) / OUTPUT_FILENAME
+    write_context(ctx, output_path)
+    return output_path
+
+
+def main(session_type: str = "unknown") -> int:
+    try:
+        output_path = run(session_type)
+    except Exception:
+        return 0  # never block a session
+    print(f"Pre-session data written to {output_path} ({session_type})")
+    return 0
+
+
+__all__ = [
+    "DEFAULT_GIT_LOG_LOOKBACK",
+    "DEFAULT_TZ",
+    "KB_DATES_CACHE_FILENAME",
+    "KB_HEAD_SCAN_LINES",
+    "OUTPUT_FILENAME",
+    "PR_LIST_LIMIT",
+    "SessionContext",
+    "extract_last_updated",
+    "gather",
+    "gather_kb_file_dates",
+    "get_git_recent",
+    "get_personal_tasks",
+    "get_pr_authored",
+    "get_pr_review_requested",
+    "main",
+    "run",
+    "write_context",
+]
+
+
+_ = Iterable  # forward-compat re-export

--- a/engine/tests/unit/test_pre_session_data.py
+++ b/engine/tests/unit/test_pre_session_data.py
@@ -21,7 +21,6 @@ from scout.scripts.pre_session_data import (
     write_context,
 )
 
-
 # ----- last-updated extraction --------------------------------------------
 
 
@@ -45,9 +44,7 @@ def test_extract_last_updated_returns_empty_when_absent(tmp_path: Path) -> None:
 
 def test_extract_last_updated_only_scans_first_five_lines(tmp_path: Path) -> None:
     md = tmp_path / "doc.md"
-    md.write_text(
-        "line1\nline2\nline3\nline4\nline5\nLast updated: should be ignored\n"
-    )
+    md.write_text("line1\nline2\nline3\nline4\nline5\nLast updated: should be ignored\n")
     assert extract_last_updated(md) == ""
 
 
@@ -156,9 +153,7 @@ def test_gather_kb_file_dates_opens_each_file_once(tmp_path: Path, monkeypatch: 
 # ----- gh / git helpers --------------------------------------------------
 
 
-def test_gather_returns_empty_when_no_git_no_gh(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_gather_returns_empty_when_no_git_no_gh(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     from scout.scripts import pre_session_data as psd
 
     scout_dir = tmp_path / "vault"
@@ -182,9 +177,7 @@ def test_gather_calls_gh_helpers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     scout_dir = tmp_path / "vault"
     (scout_dir / "knowledge-base").mkdir(parents=True)
     monkeypatch.setattr(psd, "get_pr_authored", lambda: [{"number": 42, "title": "x"}])
-    monkeypatch.setattr(
-        psd, "get_pr_review_requested", lambda: [{"number": 43, "title": "y"}]
-    )
+    monkeypatch.setattr(psd, "get_pr_review_requested", lambda: [{"number": 43, "title": "y"}])
 
     ctx = gather("research", scout_dir=scout_dir)
     assert ctx.pr_authored == [{"number": 42, "title": "x"}]

--- a/engine/tests/unit/test_pre_session_data.py
+++ b/engine/tests/unit/test_pre_session_data.py
@@ -1,0 +1,212 @@
+"""Unit tests for scout.scripts.pre_session_data.
+
+Closes #74 (the pre-session-data slice) and #76 (kb_pre_filter double-open
+fix gets the mtime-cached extraction it needed).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scout.scripts.pre_session_data import (
+    KB_DATES_CACHE_FILENAME,
+    SessionContext,
+    extract_last_updated,
+    gather,
+    gather_kb_file_dates,
+    write_context,
+)
+
+
+# ----- last-updated extraction --------------------------------------------
+
+
+def test_extract_last_updated_with_colon(tmp_path: Path) -> None:
+    md = tmp_path / "doc.md"
+    md.write_text("# Title\n**Last updated:** May 27, 2026 2:30 PM ET\nbody\n")
+    assert extract_last_updated(md) == "May 27, 2026 2:30 PM ET"
+
+
+def test_extract_last_updated_case_insensitive(tmp_path: Path) -> None:
+    md = tmp_path / "doc.md"
+    md.write_text("# Title\nLast VERIFIED: 2026-05-25\n")
+    assert extract_last_updated(md) == "2026-05-25"
+
+
+def test_extract_last_updated_returns_empty_when_absent(tmp_path: Path) -> None:
+    md = tmp_path / "doc.md"
+    md.write_text("# Title\nno date line here\n")
+    assert extract_last_updated(md) == ""
+
+
+def test_extract_last_updated_only_scans_first_five_lines(tmp_path: Path) -> None:
+    md = tmp_path / "doc.md"
+    md.write_text(
+        "line1\nline2\nline3\nline4\nline5\nLast updated: should be ignored\n"
+    )
+    assert extract_last_updated(md) == ""
+
+
+# ----- KB walking + cache --------------------------------------------------
+
+
+def test_gather_kb_file_dates_walks_and_caches(tmp_path: Path) -> None:
+    scout_dir = tmp_path / "vault"
+    kb = scout_dir / "knowledge-base"
+    kb.mkdir(parents=True)
+    (kb / "foo.md").write_text("# foo\nLast updated: May 1, 2026\n")
+    (kb / "bar.md").write_text("# bar\nNo date here\n")
+
+    cache_path = tmp_path / ".scout-cache" / KB_DATES_CACHE_FILENAME
+    out = gather_kb_file_dates(kb, scout_dir=scout_dir, cache_path=cache_path)
+
+    assert "knowledge-base/foo.md" in out
+    assert out["knowledge-base/foo.md"] == "May 1, 2026"
+    # bar.md has no date — it's still cached (negative entry) but absent from
+    # the returned dict to match bash's "only emit non-empty" behavior.
+    assert "knowledge-base/bar.md" not in out
+    assert cache_path.exists()
+    cached = json.loads(cache_path.read_text())
+    assert "knowledge-base/bar.md" in cached  # negative cache entry stored
+
+
+def test_gather_kb_file_dates_reuses_cache_when_mtime_unchanged(tmp_path: Path) -> None:
+    scout_dir = tmp_path / "vault"
+    kb = scout_dir / "knowledge-base"
+    kb.mkdir(parents=True)
+    md = kb / "foo.md"
+    md.write_text("# foo\nLast updated: May 1, 2026\n")
+
+    cache_path = tmp_path / ".scout-cache" / KB_DATES_CACHE_FILENAME
+    gather_kb_file_dates(kb, scout_dir=scout_dir, cache_path=cache_path)
+
+    # Corrupt the file but preserve mtime — cache should still serve original.
+    original_mtime_ns = md.stat().st_mtime_ns
+    md.write_text("# foo\nLast updated: TOTALLY DIFFERENT\n")
+    os.utime(md, ns=(original_mtime_ns, original_mtime_ns))
+
+    out = gather_kb_file_dates(kb, scout_dir=scout_dir, cache_path=cache_path)
+    assert out["knowledge-base/foo.md"] == "May 1, 2026"
+
+
+def test_gather_kb_file_dates_re_extracts_on_mtime_bump(tmp_path: Path) -> None:
+    scout_dir = tmp_path / "vault"
+    kb = scout_dir / "knowledge-base"
+    kb.mkdir(parents=True)
+    md = kb / "foo.md"
+    md.write_text("# foo\nLast updated: May 1, 2026\n")
+    cache_path = tmp_path / ".scout-cache" / KB_DATES_CACHE_FILENAME
+    gather_kb_file_dates(kb, scout_dir=scout_dir, cache_path=cache_path)
+
+    md.write_text("# foo\nLast updated: May 28, 2026\n")
+    out = gather_kb_file_dates(kb, scout_dir=scout_dir, cache_path=cache_path)
+    assert out["knowledge-base/foo.md"] == "May 28, 2026"
+
+
+def test_gather_kb_file_dates_excludes_ontology_and_archive(tmp_path: Path) -> None:
+    scout_dir = tmp_path / "vault"
+    kb = scout_dir / "knowledge-base"
+    (kb / "ontology").mkdir(parents=True)
+    (kb / "archive").mkdir(parents=True)
+    (kb / "ontology" / "schema.md").write_text("Last updated: May 1, 2026\n")
+    (kb / "archive" / "old.md").write_text("Last updated: May 1, 2026\n")
+    (kb / "current.md").write_text("Last updated: May 1, 2026\n")
+    cache_path = tmp_path / ".scout-cache" / KB_DATES_CACHE_FILENAME
+    out = gather_kb_file_dates(kb, scout_dir=scout_dir, cache_path=cache_path)
+    assert set(out) == {"knowledge-base/current.md"}
+
+
+def test_gather_kb_file_dates_missing_root(tmp_path: Path) -> None:
+    out = gather_kb_file_dates(
+        tmp_path / "nope",
+        scout_dir=tmp_path,
+        cache_path=tmp_path / "cache.json",
+    )
+    assert out == {}
+
+
+def test_gather_kb_file_dates_opens_each_file_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression guard: bash version effectively opened each file 4-5 times
+    (head + grep + head + sed + sed). The cached-Python path opens at most once,
+    and zero times when cache hits."""
+    scout_dir = tmp_path / "vault"
+    kb = scout_dir / "knowledge-base"
+    kb.mkdir(parents=True)
+    md = kb / "foo.md"
+    md.write_text("# foo\nLast updated: May 1, 2026\n")
+    cache_path = tmp_path / ".scout-cache" / KB_DATES_CACHE_FILENAME
+
+    opens = {"count": 0}
+    original_open = Path.open
+
+    def counting_open(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if self == md:
+            opens["count"] += 1
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", counting_open)
+    gather_kb_file_dates(kb, scout_dir=scout_dir, cache_path=cache_path)
+    assert opens["count"] == 1
+
+
+# ----- gh / git helpers --------------------------------------------------
+
+
+def test_gather_returns_empty_when_no_git_no_gh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from scout.scripts import pre_session_data as psd
+
+    scout_dir = tmp_path / "vault"
+    (scout_dir / "knowledge-base").mkdir(parents=True)
+
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(scout_dir))
+    monkeypatch.setattr(psd, "get_pr_authored", lambda: [])
+    monkeypatch.setattr(psd, "get_pr_review_requested", lambda: [])
+
+    ctx = gather("briefing", scout_dir=scout_dir)
+    assert ctx.session_type == "briefing"
+    assert ctx.git_recent == ""
+    assert ctx.pr_authored == []
+    assert ctx.pr_review_requested == []
+    assert ctx.personal_tasks == ""
+
+
+def test_gather_calls_gh_helpers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from scout.scripts import pre_session_data as psd
+
+    scout_dir = tmp_path / "vault"
+    (scout_dir / "knowledge-base").mkdir(parents=True)
+    monkeypatch.setattr(psd, "get_pr_authored", lambda: [{"number": 42, "title": "x"}])
+    monkeypatch.setattr(
+        psd, "get_pr_review_requested", lambda: [{"number": 43, "title": "y"}]
+    )
+
+    ctx = gather("research", scout_dir=scout_dir)
+    assert ctx.pr_authored == [{"number": 42, "title": "x"}]
+    assert ctx.pr_review_requested == [{"number": 43, "title": "y"}]
+
+
+# ----- write_context ----------------------------------------------------
+
+
+def test_write_context_round_trip(tmp_path: Path) -> None:
+    ctx = SessionContext(
+        generated_at="2026-05-28T12:00:00",
+        session_type="briefing",
+        git_recent="abc 123\n",
+        kb_file_dates={"knowledge-base/foo.md": "May 1"},
+        pr_authored=[{"number": 1}],
+        pr_review_requested=[{"number": 2}],
+        personal_tasks="task list",
+    )
+    out = tmp_path / "session-context.json"
+    write_context(ctx, out)
+    parsed = json.loads(out.read_text())
+    assert parsed["session_type"] == "briefing"
+    assert parsed["pr_authored"] == [{"number": 1}]
+    assert parsed["kb_file_dates"]["knowledge-base/foo.md"] == "May 1"

--- a/templates/scripts/pre-session-data.sh.tmpl
+++ b/templates/scripts/pre-session-data.sh.tmpl
@@ -6,60 +6,26 @@
 # Usage: Called by {{INSTANCE_NAME}} runner scripts before invoking Claude.
 #   ./scripts/pre-session-data.sh [session-type]
 #   session-type: briefing | consolidation | dreaming | research
+#
+# This is a thin wrapper around `scoutctl pre-session data`. The bash version
+# ran a 4-subprocess pipeline (head | grep | head | sed | sed) per KB markdown
+# file plus two python3 -c calls just to JSON-encode stdin. Folded into one
+# Python process here with an mtime cache for the KB date extraction (#74 + #76).
 
 set -eu
 
 SESSION_TYPE="${1:-unknown}"
-SCOUT_DIR="${SCOUT_DIR:-{{SCOUT_DIR}}}"
-CACHE_DIR="$SCOUT_DIR/.scout-cache"
-OUTPUT="$CACHE_DIR/session-context.json"
-mkdir -p "$CACHE_DIR"
-
-NOW_LOCAL=$(TZ={{TIMEZONE}} date '+%Y-%m-%dT%H:%M:%S')
-
-# --- Git recent activity (last 12 hours) ---
-GIT_LOG=$(cd "$SCOUT_DIR" && git log --oneline --since="12 hours ago" 2>/dev/null || echo "")
-
-# --- KB file staleness (Last updated dates from first 5 lines) ---
-KB_STALENESS=""
-while IFS= read -r f; do
-  rel="${f#$SCOUT_DIR/}"
-  updated=$(head -5 "$f" 2>/dev/null | grep -i 'last updated\|last verified' | head -1 | sed 's/.*: *//' | sed 's/ *$//' || true)
-  if [ -n "$updated" ]; then
-    KB_STALENESS="${KB_STALENESS}    \"${rel}\": \"${updated}\",\n"
-  fi
-done < <(find "$SCOUT_DIR/knowledge-base" -name '*.md' -not -path '*/ontology/*' -not -path '*archive*' 2>/dev/null)
-
-# --- PR statuses (only if gh CLI is available and authenticated) ---
-PR_AUTHORED="[]"
-PR_REVIEW="[]"
-if command -v gh &>/dev/null; then
-  PR_AUTHORED=$(gh pr list --author @me --state open --json number,title,repository,reviewDecision,updatedAt --limit 10 2>/dev/null || echo "[]")
-  PR_REVIEW=$(gh search prs --review-requested @me --state open --json number,title,repository --limit 10 2>/dev/null || echo "[]")
+SCOUTCTL_BIN="{{SCOUTCTL_BIN}}"
+if [[ ! -x "$SCOUTCTL_BIN" ]]; then
+    if command -v scoutctl >/dev/null 2>&1; then
+        SCOUTCTL_BIN="$(command -v scoutctl)"
+    else
+        echo "pre-session-data.sh: scoutctl not found (looked at ${SCOUTCTL_BIN})" >&2
+        exit 1
+    fi
 fi
 
-# --- Active personal tasks (only if ontology parser is set up) ---
-TASKS=""
-if [ -f "$SCOUT_DIR/knowledge-base/ontology/parser.py" ]; then
-  TASKS=$(cd "$SCOUT_DIR" && python3 knowledge-base/ontology/parser.py query --type task 2>/dev/null || echo "")
-fi
+SCOUT_DATA_DIR="${SCOUT_DATA_DIR:-{{SCOUT_DIR}}}"
+export SCOUT_DATA_DIR
 
-# --- Write JSON ---
-GIT_JSON=$(echo "$GIT_LOG" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read().strip()))" 2>/dev/null || echo '""')
-TASKS_JSON=$(echo "$TASKS" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read().strip()))" 2>/dev/null || echo '""')
-
-cat > "$OUTPUT" <<ENDJSON
-{
-  "generated_at": "$NOW_LOCAL",
-  "session_type": "$SESSION_TYPE",
-  "git_recent": $GIT_JSON,
-  "kb_file_dates": {
-$(echo -e "$KB_STALENESS" | sed '$ s/,$//')
-  },
-  "pr_authored": $PR_AUTHORED,
-  "pr_review_requested": $PR_REVIEW,
-  "personal_tasks": $TASKS_JSON
-}
-ENDJSON
-
-echo "Pre-session data written to $OUTPUT ($SESSION_TYPE at $NOW_LOCAL)"
+exec "$SCOUTCTL_BIN" pre-session data "$SESSION_TYPE"


### PR DESCRIPTION
## Summary
- Closes #76. Final slice of #74 — \`scoutctl pre-session data\` joins \`scoutctl budget check\` (#87), \`session cc-cache\` (#88), and \`heartbeat run\` (#89) so all four pre-session shell scripts are now thin wrappers.
- Adds \`scout.scripts.pre_session_data\` and the CLI command.
- Walks each KB \`.md\` file at most once; persists per-file extractions to \`.scout-cache/kb-dates.cache.json\` keyed by mtime.
- Bonus correctness: the bash version's \`sed 's/.*: *//\` was greedy on the LAST colon and silently truncated dates like \`May 27, 2026 2:30 PM ET\`. The new regex anchors on the label and preserves embedded times.
- Rewrites \`templates/scripts/pre-session-data.sh.tmpl\` from 66 lines down to 28.

## Why
For every KB markdown file, the bash ran a 5-process pipeline (\`head -5 | grep | head -1 | sed | sed\`). With ~100 KB files that's 400–500 forks every session-start. Plus two \`python3 -c\` calls just to JSON-encode stdin, and another \`python3\` for the optional ontology parser query.

After this PR: one Python process opens each KB file at most once, and zero times if the file's mtime hasn't moved since the previous run.

## Test plan
- [x] \`pytest engine/tests/\` — 583 passed, 9 skipped (unrelated)
- [x] 13 new tests cover: regex correctness across multiple line shapes (including the bash-bug-fix case for embedded colons), 5-line head limit, mtime-keyed cache hit, cache invalidation on mtime bump, ontology/archive exclusion, missing root tolerance, single-open regression guard, gh-helper integration
- [x] Smoke-tested \`scoutctl pre-session data briefing\` against the live ~/Scout vault — wrote a 35 KB session-context.json with all sections populated
- [ ] Manual: re-bootstrap and time the next briefing's pre-session phase

## Closes the #74 slice list
- ✅ \`scoutctl budget check\` (#87)
- ✅ \`scoutctl session cc-cache\` (#88)
- ✅ \`scoutctl heartbeat run\` (#89)
- ✅ \`scoutctl pre-session data\` (this PR)

Once all four merge, every shell script in \`templates/scripts/\` that previously shelled out to \`python3 -c\` is now a thin wrapper.

## Stacking note
Same one-line \`SCOUTCTL_BIN\` addition to \`bootstrap.py\` as #87–#89. Trivial merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)