### PR TITLE
perf: three quick wins — launcher cache, schedule.yaml mtime cache, watch.sh opt-in polling (closes #81, #82, #83)

### DIFF
--- a/engine/bin/scoutctl
+++ b/engine/bin/scoutctl
@@ -12,11 +12,28 @@
 #                                     venv lives in marketplaces/
 #   4. system python3               — last resort; expects scout-engine on
 #                                     the global site-packages
+#
+# Per #81: once a candidate resolves, we cache the path at
+# ${PLUGIN_ROOT}/.scoutctl-py-cache so the next invocation can `[ -x ]`
+# exactly one path instead of probing the whole list again. The cache lives
+# inside the plugin so different plugin installs don't share state. The
+# cached path is verified executable on read; if it isn't, we fall through
+# to the full probe.
 set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ENGINE_DIR="${DIR%/bin}"
 PLUGIN_ROOT="${ENGINE_DIR%/engine}"
+
+CACHE_FILE="${PLUGIN_ROOT}/.scoutctl-py-cache"
+
+# Fast path: a previously-resolved interpreter is still executable.
+if [ -r "$CACHE_FILE" ]; then
+    CACHED_PY="$(cat "$CACHE_FILE" 2>/dev/null || true)"
+    if [ -n "$CACHED_PY" ] && [ -x "$CACHED_PY" ]; then
+        exec "$CACHED_PY" -m scout.cli "$@"
+    fi
+fi
 
 candidates=(
     "${PLUGIN_ROOT}/.venv/bin/python"
@@ -39,6 +56,10 @@ fi
 
 for VENV_PY in "${candidates[@]}"; do
     if [ -x "$VENV_PY" ]; then
+        # Best-effort write to the cache so the next call skips the probe.
+        # Failures (read-only plugin root in Claude Code's cache copy, no
+        # write perms, etc.) are silently ignored.
+        printf '%s\n' "$VENV_PY" >"$CACHE_FILE" 2>/dev/null || true
         exec "$VENV_PY" -m scout.cli "$@"
     fi
 done

--- a/engine/scout/scripts/schedule_tick.py
+++ b/engine/scout/scripts/schedule_tick.py
@@ -592,11 +592,28 @@ def _try_lock(lock_path: Path) -> Iterator[bool]:
 # ----- main entry points --------------------------------------------------
 
 
+# Process-level mtime cache for schedule.yaml. The dispatcher fires every
+# 5 min and the schedule rarely changes; re-parsing the YAML every tick is
+# pure overhead (#82). When the dispatcher runs as a long-lived process
+# (e.g. inside a daemon) this saves real work; when it runs as a one-shot
+# CLI invocation the cache is just dead weight, harmless.
+_SCHEDULE_CACHE: tuple[int, Schedule] | None = None
+
+
 def _load_or_default(vault: Path) -> Schedule:
+    global _SCHEDULE_CACHE
     sched_path = vault / ".scout-state" / "schedule.yaml"
-    if sched_path.exists():
+    if not sched_path.exists():
+        return load_default_schedule()
+    try:
+        mtime_ns = sched_path.stat().st_mtime_ns
+    except OSError:
         return load_schedule(sched_path)
-    return load_default_schedule()
+    if _SCHEDULE_CACHE is not None and _SCHEDULE_CACHE[0] == mtime_ns:
+        return _SCHEDULE_CACHE[1]
+    schedule = load_schedule(sched_path)
+    _SCHEDULE_CACHE = (mtime_ns, schedule)
+    return schedule
 
 
 @dataclass

--- a/engine/tests/unit/test_schedule_tick.py
+++ b/engine/tests/unit/test_schedule_tick.py
@@ -513,6 +513,7 @@ def test_load_or_default_invalidates_cache_on_mtime_change(tmp_path, monkeypatch
 
     # Rewrite with a bumped mtime → cache miss → re-parse.
     import os
+
     new_ts = sched_path.stat().st_mtime_ns + 1_000_000_000
     sched_path.write_text(sched_path.read_text())  # touch contents
     os.utime(sched_path, ns=(new_ts, new_ts))

--- a/engine/tests/unit/test_schedule_tick.py
+++ b/engine/tests/unit/test_schedule_tick.py
@@ -452,6 +452,75 @@ def test_write_last_fire_cache_round_trip(tmp_path):
     assert round_tripped["afternoon-consolidation"] == original["afternoon-consolidation"]
 
 
+# Schedule.yaml mtime cache (#82). Reuses the parsed Schedule across ticks
+# when the file hasn't changed — the dispatcher fires every 5 min and the
+# schedule rarely moves, so the YAML parse was pure overhead.
+
+
+def test_load_or_default_caches_parsed_schedule(tmp_path, monkeypatch):
+    from scout.scripts import schedule_tick as st
+
+    state = tmp_path / ".scout-state"
+    state.mkdir()
+    sched_path = state / "schedule.yaml"
+    sched_path.write_text(
+        "schema_version: 1\nslots:\n  smoke-slot:\n"
+        "    type: manual\n    runner: run-scout.sh\n    fires_at_local: '00:01'\n"
+        "    weekdays: [Mon, Tue, Wed, Thu, Fri, Sat, Sun]\n"
+        "    missed_window_hours: 24\n    on_miss: skip\n    cooldown_minutes: 5\n"
+    )
+    # Clear cache from any prior test runs in this process.
+    monkeypatch.setattr(st, "_SCHEDULE_CACHE", None)
+
+    calls = {"n": 0}
+    real_load = st.load_schedule
+
+    def counting_load_schedule(path):
+        calls["n"] += 1
+        return real_load(path)
+
+    monkeypatch.setattr(st, "load_schedule", counting_load_schedule)
+
+    s1 = st._load_or_default(tmp_path)
+    s2 = st._load_or_default(tmp_path)
+    assert s1 is s2  # same parsed object, returned from cache
+    assert calls["n"] == 1
+
+
+def test_load_or_default_invalidates_cache_on_mtime_change(tmp_path, monkeypatch):
+    from scout.scripts import schedule_tick as st
+
+    state = tmp_path / ".scout-state"
+    state.mkdir()
+    sched_path = state / "schedule.yaml"
+    sched_path.write_text(
+        "schema_version: 1\nslots:\n  smoke-slot:\n"
+        "    type: manual\n    runner: run-scout.sh\n    fires_at_local: '00:01'\n"
+        "    weekdays: [Mon, Tue, Wed, Thu, Fri, Sat, Sun]\n"
+        "    missed_window_hours: 24\n    on_miss: skip\n    cooldown_minutes: 5\n"
+    )
+    monkeypatch.setattr(st, "_SCHEDULE_CACHE", None)
+
+    calls = {"n": 0}
+    real_load = st.load_schedule
+
+    def counting_load_schedule(path):
+        calls["n"] += 1
+        return real_load(path)
+
+    monkeypatch.setattr(st, "load_schedule", counting_load_schedule)
+    st._load_or_default(tmp_path)
+
+    # Rewrite with a bumped mtime → cache miss → re-parse.
+    import os
+    new_ts = sched_path.stat().st_mtime_ns + 1_000_000_000
+    sched_path.write_text(sched_path.read_text())  # touch contents
+    os.utime(sched_path, ns=(new_ts, new_ts))
+
+    st._load_or_default(tmp_path)
+    assert calls["n"] == 2
+
+
 # 6. End-to-end: run() emits Event and writes JSONL row.
 
 

--- a/engine/tests/unit/test_scoutctl_launcher.py
+++ b/engine/tests/unit/test_scoutctl_launcher.py
@@ -102,6 +102,53 @@ def test_cache_path_prefers_local_venv_when_present(tmp_path):
     assert "VENV=cache-local" in result.stdout, result
 
 
+def test_caches_resolved_python_path(tmp_path):
+    """Per #81: the launcher writes the resolved Python to .scoutctl-py-cache
+    so the next invocation can skip the candidate probe."""
+    plugin_root = tmp_path / "scout-plugin"
+    launcher = _stage_launcher(plugin_root)
+    _make_fake_venv(plugin_root / ".venv", "plugin-root")
+    cache = plugin_root / ".scoutctl-py-cache"
+    assert not cache.exists()
+
+    result = _run(launcher)
+    assert "VENV=plugin-root" in result.stdout, result
+    assert cache.exists(), "first run should populate the cache"
+    cached_py = cache.read_text().strip()
+    assert cached_py.endswith(".venv/bin/python")
+
+    # Drop the venv stub; the cached path is now stale and should be ignored.
+    # If the cache were honoured blindly, the launcher would fail trying to
+    # exec a missing file.
+    cached_path = Path(cached_py)
+    cached_path.unlink()
+    cache.write_text(str(cached_path) + "\n")  # leave the stale path
+    result2 = _run(launcher)
+    # With no venv and no usable cache, we fall through to `python3 -m scout.cli`.
+    # The test environment doesn't have scout globally installed in tmp_path,
+    # so this typically returns non-zero — that's OK; we only assert the
+    # launcher itself didn't crash trying to exec a stale cached path.
+    assert result2.returncode != 127, "launcher crashed on stale cache: " + result2.stderr
+
+
+def test_cache_invalidates_when_target_disappears(tmp_path):
+    """A cached path that no longer exists must trigger a fresh probe."""
+    plugin_root = tmp_path / "scout-plugin"
+    launcher = _stage_launcher(plugin_root)
+    _make_fake_venv(plugin_root / ".venv", "plugin-root")
+
+    # Pre-seed the cache with a path that doesn't exist.
+    cache = plugin_root / ".scoutctl-py-cache"
+    cache.write_text("/nonexistent/python\n")
+
+    # Should fall through to the real probe and pick the plugin-root venv.
+    result = _run(launcher)
+    assert "VENV=plugin-root" in result.stdout, result
+    # And the cache should be updated to the correct path.
+    cached_py = cache.read_text().strip()
+    assert cached_py == str(plugin_root / ".venv" / "bin" / "python")
+
+
 @pytest.mark.skipif(shutil.which("python3") is None, reason="needs system python3 for last-resort exec")
 def test_falls_back_to_system_python3_when_no_venv(tmp_path):
     """No venv anywhere → exec python3 -m scout.cli, which fails cleanly

--- a/templates/action-items/watch.sh.tmpl
+++ b/templates/action-items/watch.sh.tmpl
@@ -7,13 +7,22 @@
 #   ./action-items/watch.sh                 # today's file (in configured timezone)
 #   ./action-items/watch.sh 2026-04-17      # specific date
 #   ./action-items/watch.sh path/to/file.md # explicit path
+#   ./action-items/watch.sh --poll [...]    # force a 2s polling fallback
 #
-# Uses fswatch if available (efficient), polling every 2s as a fallback.
+# Per #83: this script used to silently fall back to a 2s polling loop when
+# fswatch wasn't installed — a permanent low-grade CPU drain if the user left
+# it running. It now refuses to poll by default and requires --poll explicitly.
 
 set -euo pipefail
 
 SCOUT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$SCOUT_DIR"
+
+USE_POLLING="no"
+if [[ "${1:-}" == "--poll" ]]; then
+  USE_POLLING="yes"
+  shift
+fi
 
 ARG="${1:-}"
 if [[ -z "$ARG" ]]; then
@@ -52,8 +61,8 @@ render
 if command -v fswatch >/dev/null 2>&1; then
   echo "Watching $MD with fswatch… (Ctrl-C to stop)"
   fswatch -o "$MD" | while read -r _; do render; done
-else
-  echo "fswatch not installed; polling $MD every 2s. For efficiency: brew install fswatch"
+elif [[ "$USE_POLLING" == "yes" ]]; then
+  echo "fswatch not installed — polling $MD every 2s (forced via --poll). Ctrl-C to stop."
   LAST="$(stat -f %m "$MD" 2>/dev/null || stat -c %Y "$MD")"
   while :; do
     sleep 2
@@ -63,4 +72,17 @@ else
       render
     fi
   done
+else
+  cat >&2 <<MSG
+fswatch is not installed. The polling fallback used to run silently here and
+burn ~30 stat syscalls per minute forever (see issue #83).
+
+To watch the file efficiently:
+  brew install fswatch     # macOS
+  apt install fswatch      # Debian/Ubuntu
+
+Or, if you really want the polling fallback, re-run with --poll:
+  ./action-items/watch.sh --poll ${ARG:+$ARG}
+MSG
+  exit 1
 fi


### PR DESCRIPTION
## Summary
Three small, isolated perf fixes bundled into one PR. Each closes a low-severity issue from the audit:

### #81 — scoutctl launcher caches resolved Python
\`engine/bin/scoutctl\` now writes the chosen interpreter to \`${PLUGIN_ROOT}/.scoutctl-py-cache\` on first run. Subsequent invocations do one \`[ -x ]\` check instead of probing the full 2–4 candidate list. Self-heals if the cached path becomes invalid (venv rebuilt elsewhere). Plugin-scoped so multiple plugin installs don't share state.

### #82 — schedule.yaml parse cached by mtime
\`schedule_tick._load_or_default\` keeps a module-level \`(mtime_ns, Schedule)\` tuple and reuses the parsed object across calls. The dispatcher fires every 5 min and the schedule rarely moves — re-parsing was pure overhead.

### #83 — watch.sh refuses to poll without explicit opt-in
\`action-items/watch.sh\` used to silently fall into a 2-second polling \`stat\` loop if fswatch wasn't installed — a permanent ~30 stat/min CPU drain if a user left the watcher running. It now prints a clear "brew install fswatch" message and exits 1, unless invoked with \`--poll\` to force the old behavior.

## Test plan
- [x] \`pytest engine/tests/\` — 574 passed, 9 skipped (unrelated)
- [x] New launcher tests: cache populated on first run, cache invalidated when target disappears
- [x] New schedule_tick tests: cache hit when mtime unchanged, cache miss when mtime bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)