### PR TITLE
perf(hooks): drop per-tool-call Python spawn; reconstruct from session JSONL on Stop (closes #72)

### DIFF
--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -86,6 +86,17 @@ def hook_session_tokens() -> None:
     raise typer.Exit(session_tokens_main())
 
 
+@hook_app.command("session-tool-log")
+def hook_session_tool_log() -> None:
+    """Stop hook: replay tool calls from the session transcript into connector-calls JSONL.
+
+    Replaces the per-PostToolUse Python spawn in `connector-log` (#72).
+    """
+    from scout.hooks.session_tool_log import main as session_tool_log_main
+
+    raise typer.Exit(session_tool_log_main())
+
+
 @hook_app.command("kb-pre-filter")
 def hook_kb_pre_filter(
     session_type: str = typer.Option(

--- a/engine/scout/hooks/session_tool_log.py
+++ b/engine/scout/hooks/session_tool_log.py
@@ -1,0 +1,325 @@
+"""Stop hook: reconstruct per-tool-call records from the Claude Code session JSONL.
+
+Replaces the per-PostToolUse Python spawn in ``connector_log`` (#72). The
+old hook fired on every tool call, paying ~200-500 ms of Python cold-start
+each time. For a 100-tool-call Scout session that was 20-50 seconds of
+pure interpreter startup — the dominant CPU sink during a run.
+
+This module fires once at session end (Stop hook), walks the session's
+transcript JSONL, pairs ``tool_use`` events with their ``tool_result``
+counterparts, and writes the same ``connector-calls-YYYY-MM-DD.jsonl``
+rows the PostToolUse hook produced. Output is wire-compatible — the
+``connector_health_report`` consumer doesn't notice the change.
+
+Hook contract (Claude Code Stop hook stdin JSON):
+  - ``transcript_path``: absolute path to the session JSONL (preferred)
+  - ``session_id``: fallback used to derive the path under
+    ``~/.claude/projects/<encoded-cwd>/<session_id>.jsonl``
+
+Short-circuits when ``SCOUT_MODE`` is unset (interactive sessions don't
+need tool-call accounting). Never raises — hooks must never block a
+session.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import IO, Any
+from zoneinfo import ZoneInfo
+
+from scout import paths
+from scout.events import Event, now_iso
+from scout.hooks.connector_log import classify
+from scout.ids import new_ulid
+
+
+@dataclass(frozen=True)
+class ToolCallRecord:
+    """One tool call reconstructed from a JSONL pair (tool_use + tool_result)."""
+
+    tool_name: str
+    tool_input: dict[str, Any]
+    tool_response: dict[str, Any]
+
+
+# ----- transcript discovery ------------------------------------------------
+
+
+def _resolve_transcript_path(payload: dict[str, Any]) -> Path | None:
+    """Pick the transcript path from the Stop-hook payload.
+
+    Order:
+      1. ``transcript_path`` if present and exists
+      2. ``session_id`` resolved against ``~/.claude/projects/<encoded-cwd>/``
+         using ``cwd`` from the payload (Claude Code encodes the cwd's path
+         segments with leading-dash + each ``/`` becoming ``-``)
+    """
+    raw_path = payload.get("transcript_path")
+    if isinstance(raw_path, str) and raw_path:
+        candidate = Path(raw_path).expanduser()
+        if candidate.is_file():
+            return candidate
+
+    session_id = payload.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        return None
+
+    cwd = payload.get("cwd")
+    if isinstance(cwd, str) and cwd:
+        encoded = cwd.replace("/", "-")
+        candidate = Path.home() / ".claude" / "projects" / encoded / f"{session_id}.jsonl"
+        if candidate.is_file():
+            return candidate
+
+    # Last resort — scan every project dir for the session ID. Slow but only
+    # used as a fallback when cwd is missing.
+    projects = Path.home() / ".claude" / "projects"
+    if projects.is_dir():
+        for projdir in projects.iterdir():
+            candidate = projdir / f"{session_id}.jsonl"
+            if candidate.is_file():
+                return candidate
+    return None
+
+
+# ----- JSONL parsing -------------------------------------------------------
+
+
+def _iter_rows(jsonl_path: Path) -> Iterator[dict[str, Any]]:
+    """Yield decoded JSON rows from the transcript. Malformed lines are skipped."""
+    try:
+        with jsonl_path.open("r", encoding="utf-8", errors="replace") as f:
+            for raw in f:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict):
+                    yield row
+    except OSError:
+        return
+
+
+def _tool_response_from_result(result: dict[str, Any]) -> dict[str, Any]:
+    """Convert a JSONL ``tool_result`` block to the PostToolUse-shaped dict.
+
+    The PostToolUse hook saw ``tool_response`` with fields like ``isError``,
+    ``returncode``, ``error``, ``content`` (sometimes a list of blocks). The
+    transcript ``tool_result`` block uses ``is_error`` (snake) and stores
+    ``content`` as either a string or a list of typed blocks. We normalise
+    so ``connector_log.classify``'s error detection still works.
+    """
+    out: dict[str, Any] = {}
+    if result.get("is_error") is True:
+        out["isError"] = True
+    raw_content = result.get("content")
+    if isinstance(raw_content, list):
+        out["content"] = raw_content
+    elif isinstance(raw_content, str):
+        # Stuff the string into a single text block so callers expecting the
+        # list shape don't crash. classify() doesn't read this path, but
+        # we keep it compatible for downstream consumers.
+        out["content"] = [{"type": "text", "text": raw_content}]
+    return out
+
+
+def extract_tool_calls(rows: Iterable[dict[str, Any]]) -> list[ToolCallRecord]:
+    """Walk the transcript and emit one ``ToolCallRecord`` per completed call.
+
+    Pairs ``tool_use`` blocks (in assistant messages) with their matching
+    ``tool_result`` blocks (in subsequent user messages) by ``tool_use_id``.
+    Tool calls without a matching result are still emitted with an empty
+    response — they happened, even if the session ended before the result
+    landed.
+    """
+    pending: dict[str, ToolCallRecord] = {}
+    completed: list[tuple[int, ToolCallRecord]] = []
+    order: dict[str, int] = {}
+
+    for row in rows:
+        msg = row.get("message")
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+
+        if role == "assistant":
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                if block.get("type") != "tool_use":
+                    continue
+                tool_id = block.get("id")
+                if not isinstance(tool_id, str):
+                    continue
+                rec = ToolCallRecord(
+                    tool_name=str(block.get("name") or "unknown"),
+                    tool_input=dict(block.get("input") or {}),
+                    tool_response={},
+                )
+                pending[tool_id] = rec
+                order[tool_id] = len(order)
+
+        elif role == "user":
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                if block.get("type") != "tool_result":
+                    continue
+                tool_id = block.get("tool_use_id")
+                if not isinstance(tool_id, str):
+                    continue
+                prior = pending.pop(tool_id, None)
+                if prior is None:
+                    continue
+                paired = ToolCallRecord(
+                    tool_name=prior.tool_name,
+                    tool_input=prior.tool_input,
+                    tool_response=_tool_response_from_result(block),
+                )
+                completed.append((order[tool_id], paired))
+
+    # Tool calls without a matching result — still record them.
+    for tool_id, rec in pending.items():
+        completed.append((order[tool_id], rec))
+
+    completed.sort(key=lambda t: t[0])
+    return [rec for _, rec in completed]
+
+
+# ----- emit JSONL ----------------------------------------------------------
+
+
+def _et_date() -> str:
+    return datetime.now(ZoneInfo("America/New_York")).date().isoformat()
+
+
+def _is_error(tool_response: dict[str, Any]) -> tuple[bool, str]:
+    """Mirror the error-detection logic from connector_log.run."""
+    is_error = False
+    err_snippet = ""
+    if tool_response.get("isError") is True:
+        is_error = True
+    rc = tool_response.get("returncode")
+    if isinstance(rc, int) and rc != 0:
+        is_error = True
+    if tool_response.get("error"):
+        is_error = True
+        err_snippet = str(tool_response["error"])[:160]
+    content = tool_response.get("content")
+    if isinstance(content, list):
+        for item in content:
+            if isinstance(item, dict) and item.get("isError"):
+                is_error = True
+                if not err_snippet:
+                    err_snippet = (item.get("text") or "")[:160]
+    return is_error, err_snippet
+
+
+def write_records(
+    records: Iterable[ToolCallRecord],
+    *,
+    mode: str,
+    session_id: str,
+    log_dir: Path,
+) -> int:
+    """Append one JSONL row per record. Returns the number written."""
+    if not records:
+        return 0
+    log_dir.mkdir(parents=True, exist_ok=True)
+    out_path = log_dir / f"connector-calls-{_et_date()}.jsonl"
+    written = 0
+    try:
+        with out_path.open("a", encoding="utf-8") as f:
+            ts_utc = datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+            for rec in records:
+                is_err, err_snippet = _is_error(rec.tool_response)
+                connector = classify(rec.tool_name, rec.tool_input)
+                row: dict[str, Any] = {
+                    "ts": ts_utc,
+                    "session_id": session_id,
+                    "mode": mode,
+                    "tool": rec.tool_name,
+                    "connector": connector,
+                    "error": is_err,
+                }
+                if err_snippet:
+                    row["err"] = err_snippet
+                f.write(json.dumps(row) + "\n")
+                written += 1
+    except OSError:
+        pass
+    return written
+
+
+# ----- driver --------------------------------------------------------------
+
+
+def run(*, stdin: IO[str] | None = None) -> Event | None:
+    """Read one Stop-hook payload from stdin and replay its tool calls.
+
+    Returns ``None`` if SCOUT_MODE is unset (interactive session) or if the
+    transcript can't be found. Errors are swallowed — hooks must never raise.
+    """
+    mode = os.environ.get("SCOUT_MODE")
+    if not mode:
+        return None
+
+    src = stdin if stdin is not None else sys.stdin
+    try:
+        payload = json.load(src)
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    transcript_path = _resolve_transcript_path(payload)
+    if transcript_path is None:
+        return None
+
+    session_id = str(payload.get("session_id") or transcript_path.stem)
+    log_dir = paths.data_dir() / ".scout-logs"
+
+    records = extract_tool_calls(_iter_rows(transcript_path))
+    count = write_records(records, mode=mode, session_id=session_id, log_dir=log_dir)
+
+    return Event(
+        id=new_ulid(),
+        ts=now_iso(),
+        kind="session.tool_log.written",
+        source="hook:session-tool-log",
+        payload={
+            "session_id": session_id,
+            "mode": mode,
+            "transcript_path": str(transcript_path),
+            "calls_written": count,
+        },
+    )
+
+
+def main() -> int:
+    try:
+        run()
+    except Exception:
+        pass
+    return 0
+
+
+__all__ = [
+    "ToolCallRecord",
+    "extract_tool_calls",
+    "main",
+    "run",
+    "write_records",
+]

--- a/engine/tests/unit/test_session_tool_log.py
+++ b/engine/tests/unit/test_session_tool_log.py
@@ -1,0 +1,223 @@
+"""Unit tests for scout.hooks.session_tool_log.
+
+Closes #72: per-tool-call PostToolUse hook was replaced with a single
+Stop-hook walk of the session transcript. The output JSONL must remain
+wire-compatible with the old hook so `connector_health_report` keeps
+working unchanged.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from scout.hooks.session_tool_log import (
+    ToolCallRecord,
+    extract_tool_calls,
+    run,
+    write_records,
+)
+
+
+# ----- helpers ------------------------------------------------------------
+
+
+def _user_msg(content) -> dict:
+    return {"message": {"role": "user", "content": content}}
+
+
+def _assistant_tool_use(tool_id: str, name: str, **input_kwargs) -> dict:
+    return {
+        "message": {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "id": tool_id, "name": name, "input": input_kwargs},
+            ],
+        },
+    }
+
+
+def _user_tool_result(tool_id: str, content, *, is_error: bool = False) -> dict:
+    block = {"type": "tool_result", "tool_use_id": tool_id, "content": content}
+    if is_error:
+        block["is_error"] = True
+    return _user_msg([block])
+
+
+# ----- extract_tool_calls ------------------------------------------------
+
+
+def test_extract_pairs_tool_use_with_tool_result() -> None:
+    rows = [
+        _user_msg("kick it off"),
+        _assistant_tool_use("toolu_1", "Bash", command="ls"),
+        _user_tool_result("toolu_1", "file1\nfile2"),
+    ]
+    calls = extract_tool_calls(rows)
+    assert len(calls) == 1
+    assert calls[0].tool_name == "Bash"
+    assert calls[0].tool_input == {"command": "ls"}
+    assert calls[0].tool_response  # non-empty
+
+
+def test_extract_emits_in_chronological_order() -> None:
+    rows = [
+        _assistant_tool_use("toolu_1", "Bash", command="first"),
+        _assistant_tool_use("toolu_2", "Bash", command="second"),
+        _user_tool_result("toolu_2", "second result"),  # arrives first
+        _user_tool_result("toolu_1", "first result"),  # arrives second
+    ]
+    calls = extract_tool_calls(rows)
+    # Output order matches tool_use issuance, not tool_result arrival.
+    assert [c.tool_input["command"] for c in calls] == ["first", "second"]
+
+
+def test_extract_emits_unmatched_tool_use_with_empty_response() -> None:
+    """A tool_use without a tool_result (session crashed mid-call) is still
+    recorded — we still know the tool fired."""
+    rows = [
+        _assistant_tool_use("toolu_1", "Bash", command="never finished"),
+    ]
+    calls = extract_tool_calls(rows)
+    assert len(calls) == 1
+    assert calls[0].tool_response == {}
+
+
+def test_extract_skips_non_tool_messages() -> None:
+    rows = [
+        _user_msg("just chatting"),
+        {"message": {"role": "assistant", "content": [{"type": "text", "text": "hi"}]}},
+        {"type": "permission-mode", "permissionMode": "auto"},  # non-message row
+    ]
+    assert extract_tool_calls(rows) == []
+
+
+def test_extract_propagates_is_error_flag() -> None:
+    rows = [
+        _assistant_tool_use("toolu_1", "Bash", command="false"),
+        _user_tool_result("toolu_1", "exit 1", is_error=True),
+    ]
+    calls = extract_tool_calls(rows)
+    assert calls[0].tool_response.get("isError") is True
+
+
+def test_extract_handles_content_as_string_or_list() -> None:
+    rows_string = [
+        _assistant_tool_use("toolu_1", "Read", file_path="/p"),
+        _user_tool_result("toolu_1", "single string content"),
+    ]
+    rows_list = [
+        _assistant_tool_use("toolu_2", "Read", file_path="/p"),
+        _user_tool_result(
+            "toolu_2", [{"type": "text", "text": "block content"}]
+        ),
+    ]
+    assert len(extract_tool_calls(rows_string)) == 1
+    assert len(extract_tool_calls(rows_list)) == 1
+
+
+# ----- write_records ----------------------------------------------------
+
+
+def test_write_records_emits_jsonl_with_classify_field(tmp_path: Path) -> None:
+    log_dir = tmp_path / ".scout-logs"
+    records = [
+        ToolCallRecord(tool_name="Bash", tool_input={"command": "gh pr list"}, tool_response={}),
+        ToolCallRecord(tool_name="Read", tool_input={"file_path": "/x"}, tool_response={}),
+    ]
+    count = write_records(records, mode="briefing", session_id="abc", log_dir=log_dir)
+    assert count == 2
+    files = list(log_dir.glob("connector-calls-*.jsonl"))
+    assert len(files) == 1
+    lines = files[0].read_text().splitlines()
+    rows = [json.loads(line) for line in lines]
+    assert rows[0]["tool"] == "Bash"
+    assert rows[0]["connector"] == "github"  # classify("Bash", {"command": "gh ..."}) → "github"
+    assert rows[1]["tool"] == "Read"
+    assert rows[1]["connector"] == "read"
+    assert all(r["mode"] == "briefing" and r["session_id"] == "abc" for r in rows)
+
+
+def test_write_records_no_op_on_empty(tmp_path: Path) -> None:
+    log_dir = tmp_path / ".scout-logs"
+    count = write_records([], mode="briefing", session_id="abc", log_dir=log_dir)
+    assert count == 0
+    assert not log_dir.exists() or not list(log_dir.glob("*.jsonl"))
+
+
+def test_write_records_records_error_snippet(tmp_path: Path) -> None:
+    log_dir = tmp_path / ".scout-logs"
+    records = [
+        ToolCallRecord(
+            tool_name="Bash",
+            tool_input={"command": "false"},
+            tool_response={"error": "command failed", "isError": True},
+        ),
+    ]
+    write_records(records, mode="dreaming", session_id="x", log_dir=log_dir)
+    line = next(log_dir.glob("connector-calls-*.jsonl")).read_text().splitlines()[0]
+    row = json.loads(line)
+    assert row["error"] is True
+    assert row["err"] == "command failed"
+
+
+# ----- end-to-end via run() ---------------------------------------------
+
+
+def test_run_short_circuits_when_scout_mode_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("SCOUT_MODE", raising=False)
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text("")
+    stdin = io.StringIO(json.dumps({"transcript_path": str(transcript)}))
+    assert run(stdin=stdin) is None
+
+
+def test_run_processes_transcript_and_writes_event(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SCOUT_MODE", "briefing")
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path / "vault"))
+
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text(
+        "\n".join(
+            json.dumps(row)
+            for row in [
+                _assistant_tool_use("toolu_x", "Bash", command="ls"),
+                _user_tool_result("toolu_x", "file1\nfile2"),
+            ]
+        )
+        + "\n"
+    )
+
+    stdin = io.StringIO(
+        json.dumps({"transcript_path": str(transcript), "session_id": "abc"})
+    )
+    ev = run(stdin=stdin)
+    assert ev is not None
+    assert ev.kind == "session.tool_log.written"
+    assert ev.payload["calls_written"] == 1
+
+    log_dir = tmp_path / "vault" / ".scout-logs"
+    files = list(log_dir.glob("connector-calls-*.jsonl"))
+    assert len(files) == 1
+    assert "Bash" in files[0].read_text()
+
+
+def test_run_no_op_when_transcript_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SCOUT_MODE", "briefing")
+    stdin = io.StringIO(json.dumps({"transcript_path": str(tmp_path / "absent.jsonl")}))
+    assert run(stdin=stdin) is None
+
+
+def test_run_no_op_on_malformed_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SCOUT_MODE", "briefing")
+    stdin = io.StringIO("not json at all")
+    assert run(stdin=stdin) is None

--- a/engine/tests/unit/test_session_tool_log.py
+++ b/engine/tests/unit/test_session_tool_log.py
@@ -21,7 +21,6 @@ from scout.hooks.session_tool_log import (
     write_records,
 )
 
-
 # ----- helpers ------------------------------------------------------------
 
 
@@ -111,9 +110,7 @@ def test_extract_handles_content_as_string_or_list() -> None:
     ]
     rows_list = [
         _assistant_tool_use("toolu_2", "Read", file_path="/p"),
-        _user_tool_result(
-            "toolu_2", [{"type": "text", "text": "block content"}]
-        ),
+        _user_tool_result("toolu_2", [{"type": "text", "text": "block content"}]),
     ]
     assert len(extract_tool_calls(rows_string)) == 1
     assert len(extract_tool_calls(rows_list)) == 1
@@ -167,9 +164,7 @@ def test_write_records_records_error_snippet(tmp_path: Path) -> None:
 # ----- end-to-end via run() ---------------------------------------------
 
 
-def test_run_short_circuits_when_scout_mode_unset(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_short_circuits_when_scout_mode_unset(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("SCOUT_MODE", raising=False)
     transcript = tmp_path / "session.jsonl"
     transcript.write_text("")
@@ -177,9 +172,7 @@ def test_run_short_circuits_when_scout_mode_unset(
     assert run(stdin=stdin) is None
 
 
-def test_run_processes_transcript_and_writes_event(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_processes_transcript_and_writes_event(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("SCOUT_MODE", "briefing")
     monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path / "vault"))
 
@@ -195,9 +188,7 @@ def test_run_processes_transcript_and_writes_event(
         + "\n"
     )
 
-    stdin = io.StringIO(
-        json.dumps({"transcript_path": str(transcript), "session_id": "abc"})
-    )
+    stdin = io.StringIO(json.dumps({"transcript_path": str(transcript), "session_id": "abc"}))
     ev = run(stdin=stdin)
     assert ev is not None
     assert ev.kind == "session.tool_log.written"
@@ -209,9 +200,7 @@ def test_run_processes_transcript_and_writes_event(
     assert "Bash" in files[0].read_text()
 
 
-def test_run_no_op_when_transcript_missing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_no_op_when_transcript_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("SCOUT_MODE", "briefing")
     stdin = io.StringIO(json.dumps({"transcript_path": str(tmp_path / "absent.jsonl")}))
     assert run(stdin=stdin) is None

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,18 +1,6 @@
 {
-  "description": "Scout connector telemetry and session-token accounting hooks. Activate only inside scheduled scout runs (the Python hook short-circuits when SCOUT_MODE is unset).",
+  "description": "Scout connector telemetry and session-token accounting hooks. Activate only inside scheduled scout runs (the Python hook short-circuits when SCOUT_MODE is unset). Per #72, per-tool-call accounting was moved out of PostToolUse (which fired one Python cold-start per tool call) into the session-tool-log Stop hook that walks the transcript once at session end.",
   "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": ".*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/engine/bin/scoutctl hook connector-log",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
     "Stop": [
       {
         "hooks": [
@@ -20,6 +8,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/engine/bin/scoutctl hook session-tokens",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/engine/bin/scoutctl hook session-tool-log",
+            "timeout": 15
           }
         ]
       }


### PR DESCRIPTION
## Summary
Closes #72 — the biggest single CPU win from the audit.

The PostToolUse hook fired \`scoutctl hook connector-log\` on every tool call, paying a fresh Python interpreter cold start (~200–500 ms) just to append one JSONL row. For a typical 100-tool-call Scout session that was 20–50 s of pure interpreter startup, plus the CPU spike from the fork/exec storm.

This PR moves the work to session end:
- New \`scoutctl hook session-tool-log\` reads the Claude Code transcript at \`$transcript_path\` on Stop, pairs \`tool_use\` blocks with their \`tool_result\` counterparts by id, and writes the same \`connector-calls-YYYY-MM-DD.jsonl\` rows the PostToolUse hook produced.
- \`hooks/hooks.json\` is updated:
  - **Removed** the PostToolUse entry entirely
  - **Added** \`session-tool-log\` as a second Stop hook (runs alongside the existing \`session-tokens\` hook)
- Per-session cost drops from O(N) Python spawns to O(1).

## Wire compatibility
The emitted JSONL has exactly the same fields and types as the old hook output (\`ts\`, \`session_id\`, \`mode\`, \`tool\`, \`connector\`, \`error\`, optional \`err\` snippet). \`connector_health_report\` consumes those files and keeps working unchanged. Verified with a real ~900-line scout-plugin session JSONL — 241 tool calls correctly reconstructed and classified.

## Why this approach (vs. modifying \`session_tokens.py\`)
\`session_tokens.py\` is currently blocked by a global credential-deny rule (\`Read(**/*token*)\`). Rather than wait for that rule to be relaxed, this PR adds \`session-tool-log\` as a second independent Stop hook entry. Both run once per session — still ~100× cheaper than the old per-tool-call model.

If you ever want to consolidate them into one process, you can fold \`session_tool_log.run()\` into \`session_tokens.run()\` since they walk the same transcript.

## Test plan
- [x] \`pytest engine/tests/\` — 583 passed, 9 skipped (unrelated)
- [x] 13 new tests cover: tool_use/result pairing, chronological ordering, unmatched tool_use, non-tool messages skipped, is_error propagation, string-vs-list \`content\` shapes, classify() integration (\`gh ...\` → \`github\`), short-circuit when SCOUT_MODE unset, malformed-stdin tolerance, missing-transcript tolerance, full end-to-end run
- [x] Smoke-tested against a real ~900-line scout-plugin session transcript: reconstructed 241 tool calls and wrote them to a temp \`connector-calls-*.jsonl\` matching the old hook's format
- [ ] Manual: after merge + Claude Code restart, run any scheduled Scout session and verify the new \`connector-calls-*.jsonl\` lands at session end (currently it lands per-tool-call)

## Migration note
After this merges, Claude Code needs to re-read the hooks manifest (restart or whatever Claude Code does to refresh \`hooks.json\`). Until then, the old PostToolUse hook keeps firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)