### PR TITLE
feat: port dreaming-proposal backlog from vault into the engine

### DIFF
--- a/engine/scout/kb/schema.yaml
+++ b/engine/scout/kb/schema.yaml
@@ -52,6 +52,22 @@ entity_types:
       - assigned_to
       - about
       - blocked_by
+  recurring_task:
+    # Standing commitment with an explicit cadence (e.g. "every Friday post the Linear
+    # project update"). Pattern #78 — confirmed cadences must be first-class entities so
+    # the briefing can derive "today is Friday, these N commitments need surfacing" without
+    # carrying the heuristic in prose. Surfaced by scripts/recurring-task-status.py.
+    # cadence DSL: weekly:<weekday>, monthly:<day-of-month>, monthly:nth:<n>:<weekday>,
+    #              quarterly:cycle-start, daily
+    # surface_window DSL: T-0 morning | T-1 day | T-7d | T-2d through T-0
+    # completion_evidence: linear_project_update | slack_post | gmail_confirmation | manual
+    properties:
+      required: [name, type, cadence, surface_window, active_from, status]
+      optional: [active_until, completion_evidence, completion_query, last_completed_date, priority, domain, sources]
+    relationships:
+      - feeds
+      - confirmed_on
+      - about
   organization:
     properties:
       required: [name, type]

--- a/engine/scout/kb/schema.yaml
+++ b/engine/scout/kb/schema.yaml
@@ -39,7 +39,15 @@ entity_types:
   task:
     properties:
       required: [name, type, status]
-      optional: [deadline, priority, domain, completion_signal, created_date, completed_date]
+      optional: [deadline, priority, domain, completion_signal, created_date, completed_date, surface_rule]
+      # surface_rule (optional): controls when a long-window task is rendered into
+      # daily action items. Shape:
+      #   surface_rule:
+      #     default: do_not_surface        # or surface_daily (the implicit default if absent)
+      #     windows:                        # list of date ranges that re-surface the task
+      #       - {from: YYYY-MM-DD, to: YYYY-MM-DD, surface: "🟡", task: "label override"}
+      #     always_visible_if: [<condition strings>]   # force 🔴 regardless of windows
+      # Absent surface_rule == surface daily until status: completed (back-compat).
     relationships:
       - assigned_to
       - about

--- a/engine/scout/scripts/bootstrap.py
+++ b/engine/scout/scripts/bootstrap.py
@@ -81,6 +81,7 @@ _CAT1_DIR_LAYOUT = (
     "knowledge-base/ontology/entities",
     "knowledge-base/people",
     "knowledge-base/personal",
+    "knowledge-base/recurring-tasks",
     "action-items/archive",
     "action-items/meeting-prep",
     "meetings",
@@ -96,6 +97,7 @@ _CAT1_FILES_FROM_PLUGIN = {
     "knowledge-base/ontology/parser.py": "templates/knowledge-base/ontology/parser.py",
     "knowledge-base/ontology/__init__.py": "templates/knowledge-base/ontology/__init__.py",
     "action-items/render.py": "templates/action-items/render.py",
+    "scripts/recurring-task-status.py": "templates/scripts/recurring-task-status.py",
 }
 
 _CAT1_TEMPLATES = (

--- a/engine/scout/scripts/connector_health_report.py
+++ b/engine/scout/scripts/connector_health_report.py
@@ -45,6 +45,9 @@ WARN_TOTAL_THRESHOLD = 3
 WARN_ERR_RATIO = 0.5
 HEALTHY_OK_THRESHOLD = 3
 DARK_GAP_THRESHOLD = 3
+# Pattern #54: if a connector logged a healthy run in ANY mode within this window,
+# a 0-call (not 0-error) current run is "alive but unused this mode", not an outage.
+CROSS_MODE_LIVENESS_WINDOW = timedelta(hours=4)
 
 
 # ----- data structures -----------------------------------------------------
@@ -337,6 +340,16 @@ def compute_critical_alerts(
             continue
 
         last_ok = last_healthy_ts(stats, c, prior_sessions, sessions_by_id, HEALTHY_OK_THRESHOLD)
+
+        # Pattern #54: cross-mode liveness. If this run made no error calls (the
+        # connector simply wasn't exercised in this mode) AND the connector was
+        # healthy in ANY mode within the liveness window, it's alive — not an
+        # outage. Suppress the false CRITICAL. Error calls this run still alert.
+        curr_err = _err_count(stats, c, current_sid)
+        current_ts = sessions_by_id[current_sid][0]["_ts"]
+        if curr_err == 0 and last_ok is not None and current_ts - last_ok <= CROSS_MODE_LIVENESS_WINDOW:
+            continue
+
         reason = (
             f"0 successful calls in `{current_mode}` run; "
             f"{healthy}/{samples} prior `{current_mode}` runs were healthy; "
@@ -501,6 +514,8 @@ def render_health_md(
         "fires an alert in modes where it's required by `connectors.yaml`.",
         "- **Pattern #48:** if a connector has never logged a successful call across the entire "
         "window, the alert is suppressed (it's unwired, not broken — see [[Wishlist]] §wire-up).",
+        "- **Pattern #54:** if a connector was healthy in any mode within the last 4h and the "
+        "current run had 0 error calls, the CRITICAL is suppressed (alive but unused this mode).",
         "- **Warning:** any connector with ≥3 calls this run and >50% errors.",
         "",
         "Alerts are written to `.scout-logs/connector-alerts.log` and surfaced as a macOS "

--- a/engine/tests/unit/test_scripts_connector_health.py
+++ b/engine/tests/unit/test_scripts_connector_health.py
@@ -254,6 +254,90 @@ def test_slack_dark_two_prior_healthy_fires_critical(fake_data_dir, monkeypatch)
     assert "Slack" in log_body
 
 
+# ----- Test 4b: Pattern #54 cross-mode liveness suppression ----------------
+
+
+def test_pattern_54_cross_mode_liveness_suppresses_critical(fake_data_dir, monkeypatch):
+    """A connector healthy in ANOTHER mode within the liveness window, dark
+    (0 calls, 0 errors) in the current mode, must NOT fire a false CRITICAL —
+    it's alive but unused this mode, not an outage (Pattern #54)."""
+    monkeypatch.setattr(chr_mod, "_default_now", _frozen_now)
+    log_dir = fake_data_dir / ".scout-logs"
+
+    # 2 prior morning-briefing runs healthy on Slack (mode-baseline → would alert).
+    base = _frozen_now() - timedelta(days=2)
+    for i, sid in enumerate(["s_prev1", "s_prev2"]):
+        _seed_session(
+            log_dir,
+            sid=sid,
+            mode="morning-briefing",
+            ts=base + timedelta(days=i),
+            calls={"mcp:claude_ai_Slack": (5, 0), "mcp:claude_ai_Linear": (5, 0)},
+        )
+
+    # A DIFFERENT-mode run (consolidation) with Slack healthy ~2h ago — inside
+    # the 4h cross-mode liveness window.
+    _seed_session(
+        log_dir,
+        sid="s_consol",
+        mode="consolidation-1pm",
+        ts=_frozen_now() - timedelta(hours=2),
+        calls={"mcp:claude_ai_Slack": (5, 0), "mcp:claude_ai_Linear": (5, 0)},
+    )
+
+    # Current morning-briefing run: Slack not exercised (0 calls, 0 errors).
+    _seed_session(
+        log_dir,
+        sid="s_curr",
+        mode="morning-briefing",
+        ts=_frozen_now() - timedelta(hours=1),
+        calls={"mcp:claude_ai_Linear": (4, 0)},
+    )
+
+    event = chr_mod.run(data_dir=fake_data_dir)
+    alerts = event.payload["alerts"] if event is not None else []
+    slack_alerts = [a for a in alerts if a["connector_key"] == "mcp:claude_ai_Slack"]
+    assert slack_alerts == [], "Slack healthy cross-mode within 4h → no false CRITICAL."
+
+
+def test_pattern_54_errors_this_run_still_alert(fake_data_dir, monkeypatch):
+    """Liveness suppression must NOT mask a real failure: error calls in the
+    current run still alert even if the connector was healthy recently."""
+    monkeypatch.setattr(chr_mod, "_default_now", _frozen_now)
+    log_dir = fake_data_dir / ".scout-logs"
+
+    base = _frozen_now() - timedelta(days=2)
+    for i, sid in enumerate(["s_prev1", "s_prev2"]):
+        _seed_session(
+            log_dir,
+            sid=sid,
+            mode="morning-briefing",
+            ts=base + timedelta(days=i),
+            calls={"mcp:claude_ai_Slack": (5, 0), "mcp:claude_ai_Linear": (5, 0)},
+        )
+    _seed_session(
+        log_dir,
+        sid="s_consol",
+        mode="consolidation-1pm",
+        ts=_frozen_now() - timedelta(hours=2),
+        calls={"mcp:claude_ai_Slack": (5, 0), "mcp:claude_ai_Linear": (5, 0)},
+    )
+    # Current run: Slack was exercised but every call FAILED → real outage.
+    _seed_session(
+        log_dir,
+        sid="s_curr",
+        mode="morning-briefing",
+        ts=_frozen_now() - timedelta(hours=1),
+        calls={"mcp:claude_ai_Slack": (0, 3), "mcp:claude_ai_Linear": (4, 0)},
+    )
+
+    event = chr_mod.run(data_dir=fake_data_dir)
+    alerts = event.payload["alerts"] if event is not None else []
+    slack_alerts = [a for a in alerts if a["connector_key"] == "mcp:claude_ai_Slack"]
+    assert len(slack_alerts) == 1, "Error calls this run still alert despite recent health."
+    assert slack_alerts[0]["level"] == "CRITICAL"
+
+
 # ----- Test 5: Weekend-only `gh CLI dark` → no alert if non-required -------
 
 

--- a/phases/connectors/calendar.md
+++ b/phases/connectors/calendar.md
@@ -66,6 +66,14 @@ Check for events that were recently added or modified by others:
 - Changed meetings = priorities shifting
 - Cancelled meetings (by others) = something changed that {{USER_NAME}} should know about
 
+### Meeting-Table Compose-Time Cross-Check (mandatory)
+
+The today's-meetings table is a recurring source of two bugs: wrong wall-clock times and phantom (carried-but-cancelled) rows. Three hard rules at compose time:
+
+1. **Never derive wall-clock time from a recurring `eventId`/`recurringEventId` suffix** (e.g. `_R20260525T093000` is opaque UTC). The only authoritative time fields are `start.dateTime` + `start.timeZone` (or `originalStartTime.dateTime` for a series instance). Convert to the display timezone from those fields.
+2. **Assert every row against a fresh same-run query.** Call `list_events` for today's window **in this run**, and assert each table row's displayed time matches the live event start to the minute. If the table is carried from a prior run without a fresh `list_events` this run, every time cell must be flagged `[carried]`.
+3. **Phantom detection.** Every carried row must match a live event by `id`/`recurringEventId` in this run's `list_events` result. Rows with no live match must be removed or marked `[unverified — not on calendar this run]` with the query timestamp.
+
 ---
 phase: connector
 name: calendar

--- a/phases/connectors/claude-sessions.md
+++ b/phases/connectors/claude-sessions.md
@@ -53,3 +53,15 @@ For each session activity found:
 4. If the session reveals new work not yet tracked, note it as context for the consolidation
 
 This connector catches the gap between "{{USER_NAME}} worked on something" and "the output appeared in another system." Work done in Claude sessions often shows up in GitHub, email, or Slack shortly after — but during consolidation, the session may be the earliest signal of completed or in-progress work.
+
+### Uncommitted Working-Tree Sweep
+
+A session may have changed files that were never committed — invisible to `git log` and to GitHub. For each repo a session touched, also check the working tree so "in progress" vs "done" is grounded:
+
+```bash
+cd <repo> && git status --porcelain && git log --since='<last-run-time>' --oneline
+```
+
+### Claim Gate — No "Actively Building X" Without a Cited Signal
+
+Do not assert that {{USER_NAME}} "is actively building / working on X" unless you can cite a concrete signal: a session JSONL with matching prompts, a commit SHA, an open PR, or dirty working-tree files. A session *title* or a single prompt is weak evidence — tie the claim to the tangible artifact, or downgrade it to "{{USER_NAME}} opened a session about X" rather than asserting active work.

--- a/phases/connectors/github.md
+++ b/phases/connectors/github.md
@@ -154,6 +154,17 @@ requires: github
 
 ## GitHub Cross-Check
 
+### Per-Claim Evidence Anchors
+
+Every PR / merge / review / CI state claim — whether in a DM summary or an action-item row — must carry its **own** inline evidence anchor: the specific field value that proves it, not just a trailing "Source: GitHub" line. Anchor each claim to the datum:
+
+- "merged" → cite the `mergedAt` timestamp (e.g. _merged 2026-06-01T14:22Z_)
+- "approved" / "changes requested" → cite `reviewDecision` and the reviewer
+- "CI green/red" → cite the `statusCheckRollup` conclusion
+- "PR #N exists / open" → cite `#N` and `state`
+
+A trailing source line covering a multi-claim sentence is insufficient — if a sentence asserts three states, it needs three anchors. This makes each claim independently verifiable and prevents one stale field from contaminating a whole row (Pattern #69 family).
+
 Before promoting any candidate action item to To Do, verify against GitHub:
 
 **When an action item references a specific PR, check the PR's current state:**

--- a/phases/connectors/granola.md
+++ b/phases/connectors/granola.md
@@ -34,6 +34,19 @@ Every action item extracted from a transcript is a **candidate** that must be ve
 
 **Never write a transcript-sourced action item directly to the action items file without cross-checking it first.**
 
+### Extraction Gate — Content, Not Breadcrumbs
+
+A "✅ transcript captured" / "notes available for [meeting]" line is **not** extraction — it is a breadcrumb that silently drops the meeting's substance. For every meeting {{USER_NAME}} attended where a transcript exists, you MUST produce the substantive extraction above (action items, decisions, commitments-by-others, deadlines, open questions) or an explicit "reviewed — no actionable content (reason)" note. A bare capture/availability breadcrumb is forbidden as the only output for an attended meeting.
+
+**Pre-commit self-check:** before committing, grep the run's notes/KB/action-items for transcript breadcrumb rows that carry no extracted substance:
+
+```bash
+grep -rniE 'transcript (captured|available)|notes (captured|available)' "$DAILY_FILE" {{SCOUT_DIR}}/knowledge-base 2>/dev/null \
+  && echo "WARN: transcript breadcrumb(s) above — confirm each has substantive extraction, not just a capture note" >&2
+```
+
+If a flagged meeting has no decisions/commitments/follow-ups recorded near it, go back and extract them (or record the explicit no-content note) before commit.
+
 ### Attendee Extraction
 
 Note all meeting attendees. Cross-reference with `people.md` and add any new people with context: "Attendee in [meeting title] on [date]."

--- a/phases/connectors/linear.md
+++ b/phases/connectors/linear.md
@@ -10,6 +10,19 @@ requires: linear
 
 Check for changes to {{USER_NAME}}'s assigned issues and any newly created or assigned issues.
 
+### {{USER_NAME}}'s Own Linear Activity Since Last Run (delta-scan — surface this first)
+
+Before the issue-state scan below, build an **actor-attributed** delta of what {{USER_NAME}} did in Linear since the last run — issues he created, moved (state change), commented on, or edited. This is the Linear analog of the Slack outbound scan and is a primary signal of completed/in-progress work. Surface it **early** in the run summary (before "Today's Wins") — never silently omit it.
+
+- **Volume-sanity gate:** if the delta is suspiciously empty (zero activity) for a normally-active window, re-fetch before concluding "no Linear activity" — a silent empty result erodes trust more than a slow run.
+- **Re-fetch fast-moving issues at compose time:** any issue you're about to cite with a state framing ("In Review", "blocked") must be re-read at compose time, not carried from cache (mirrors the Gmail/Pattern #43 rule).
+
+### Project-Update Polling for {{USER_NAME}}-Led Projects (leadership pings)
+
+`list_issues` + issue comments **miss project-level status-update comments**, which is where leadership often pings. For every Linear project {{USER_NAME}} leads or owns, call `get_status_updates` (and `list_comments` on the project) for updates since the last run.
+
+**Leadership-ping headline rule:** if a project-update comment on {{USER_NAME}}'s own project comes from someone with a managerial/leadership relationship to {{USER_NAME}} (per `people.md` / the ontology `manages` relation), auto-promote it to the run summary's 🔴 headline — a manager's ask on {{USER_NAME}}'s project is the highest-priority inbound signal and must not be buried.
+
 ### Status Changes
 
 Use `list_issues` filtered to {{USER_NAME}}'s assignments to check for status changes since the last run. Status transitions to watch for:

--- a/phases/connectors/linear.md
+++ b/phases/connectors/linear.md
@@ -146,3 +146,23 @@ If issue changes affect active projects, update the relevant project files:
 - Changed issue statuses in the project's issues section
 - New issues added to the project
 - Completed milestones or resolved blockers
+
+---
+phase: connector
+name: linear
+slot: writeback
+mode: [consolidation, briefing]
+requires: linear
+---
+
+## Linear Write-Back — Attempt the Write When Directed
+
+When {{USER_NAME}} issues a directive that maps to a Linear write — move an issue to Done, (re)assign, add a comment, set a label, change priority — **attempt the write via the Linear MCP first** rather than only flagging it for {{USER_NAME}} to do manually. Use `save_issue` (state/assignee/labels/priority) or `save_comment` as appropriate.
+
+Handle the three outcomes explicitly:
+
+1. **Success** → confirm in the run summary with the change and the issue id ("moved PROJ-123 → Done").
+2. **Permission denied** → surface the exact gap and the fix ("Linear MCP lacks write scope — enable it in the connector's OAuth settings"), then fall back to flagging the change as a manual action item so it isn't lost.
+3. **API error** → note the error briefly and fall back to the manual flag.
+
+Never silently skip a write directive. Either it succeeded (confirm it) or it didn't (say why + leave a manual action item). Treat a write the same way as any other claim: cite the resulting state from Linear, don't assume the write took.

--- a/phases/connectors/slack.md
+++ b/phases/connectors/slack.md
@@ -79,6 +79,18 @@ Check project channels listed in `channels.md` for recent activity, even if {{US
 - Status updates from collaborators
 - Announcements that change priorities
 
+### 🔴 Project Channel Poll (mandatory)
+
+`slack_search` misses threads and non-mention activity — the recurring cause of "Scout went quiet on project X." For every 🔴-priority project file (`knowledge-base/projects/*/<name>.md` with `priority: "🔴"` or a 🔴 status), read its `slack_channels:` YAML frontmatter and **directly read each declared channel** since the last run via `slack_read_channel(channel_id=<id>, limit=20)` — do not rely on search alone. Surface: every {{USER_NAME}} @-mention, every message from a person in the project's `worked_on_by`/key-people set, and every decision/blocker. List the polled channels in the sources footer (`🔴 channels polled: #a, #b`). If a 🔴 project has no `slack_channels:` frontmatter yet, add it (see project-file conventions in kb-management).
+
+### Both Scans Required (gate)
+
+The outbound (`from:`) and inbound (`to:`/mention) scans are BOTH mandatory every run — a scan reported with only `from:{{USER_NAME}}` is incomplete and the run is not done until the inbound `to:`/mention scan has also executed. Never declare Slack "quiet" off a one-directional scan.
+
+### {{USER_NAME}}-Committed-Reply Tracking
+
+Any thread reply by {{USER_NAME}} that accepts ownership — "I'll take care of it", "Got it", "On it", "Sure" — with no later outbound message resolving it MUST be auto-carried as a 🔴 action item until either the resolving action is observed or {{USER_NAME}} explicitly drops it. This catches the failure where {{USER_NAME}} accepts a task in-thread but the underlying ask never makes it into the carry-forward set.
+
 ### What to Record
 
 For each inbound message found, note:

--- a/phases/connectors/slack.md
+++ b/phases/connectors/slack.md
@@ -211,6 +211,16 @@ Scout morning briefing ready.
 - Review queue: [count] items pending your review
 ```
 
+### Sources-Checked Footer
+
+End every consolidation/briefing notification with a one-line transparency footer stating what was actually scanned, so coverage is auditable and "quiet" claims are backed by evidence:
+
+```
+Sources checked: N CC sessions · N vault/git commits · N Slack threads · N Linear updates · N Drive files
+```
+
+Only count sources you genuinely queried this run. A "quiet window" claim must be paired with non-zero scan counts — otherwise it reads as "didn't look," not "nothing happened."
+
 ### Notification Rules
 
 - Never include sensitive details in the notification — just summaries and counts.

--- a/phases/connectors/slack.md
+++ b/phases/connectors/slack.md
@@ -65,6 +65,12 @@ Check DMs received by {{USER_NAME}} from frequent contacts. Inbound DMs often co
 - Updates on shared work
 - FYIs that may affect priorities
 
+### Replies on {{INSTANCE_NAME}}'s Own DM Threads (mandatory)
+
+{{USER_NAME}} often replies *inside the thread* of a {{INSTANCE_NAME}} notification DM rather than starting a new message — those replies are invisible to a flat DM/mention search and silently drop task-asks. For **every** message {{INSTANCE_NAME}} (the bot) sent into the `{{USER_SLACK_ID}}` DM within the lookback window, call `slack_read_thread` on that message's timestamp and read all replies. This mirrors the dreaming Step 1a feedback harvest, but here the goal is **action items**: any reply that asks {{INSTANCE_NAME}} to do something, corrects a fact, or assigns a task becomes a candidate action item (a direct task-ask is 🔴 for today).
+
+**Coverage assertion:** do not claim "0 inbound" / "quiet window" until you have confirmed every in-window bot DM had its thread read. State the count checked (e.g., "read threads on 4 bot DMs since last run") so the coverage is auditable.
+
 ### Key Channel Activity
 
 Check project channels listed in `channels.md` for recent activity, even if {{USER_NAME}} wasn't mentioned. Important channel activity includes:

--- a/phases/core/action-items.md
+++ b/phases/core/action-items.md
@@ -31,8 +31,6 @@ Create `action-items/action-items-YYYY-MM-DD.md` using today's date. Include:
 ```markdown
 # Action Items — YYYY-MM-DD
 
-**Last consolidated:** YYYY-MM-DD HH:MM [timezone]
-
 ## 🔴 Urgent
 
 - [ ] [#XXXX] **[Item title]** — [Description with specific details, not vague summaries]
@@ -64,6 +62,12 @@ Items carried forward from previous days that are still open.
 - [ ] [#XXXX] **[Item title]** — [Status update since last check]
   - Originally from: action-items-YYYY-MM-DD
   - Current status: [what's changed]
+
+## 🪵 Run notes & connector availability
+
+_Always the LAST section of the file — run metadata is a footer for review, never a hero block at the top. First-paint should be 🔴 Urgent, not run narrative. Append newest entry first; keep only the last 3 runs (older entries roll off)._
+
+- **YYYY-MM-DD HH:MM [timezone]** ([mode]) — X new / Y completed / Z carried forward. Connectors: [available, or "degraded: <name>"].
 ```
 
 All action items files must include `[[wikilinks]]` to any KB files referenced by action items.
@@ -105,6 +109,28 @@ grep -nE '^\s*- \[[ x]\] ' "$DAILY_FILE" | grep -vE ' \[#[0-9A-HJKMNP-TV-Z]{4}\]
 ```
 
 If that grep finds anything, the file is non-compliant and scout-app's writes will silently fall back to fragile subject-matching for those lines.
+
+### Hard Rule — Trim by Demotion, Never by Omission
+
+When the list grows long, achieve focus by **reprioritizing**, never by hiding items from view. "Don't overwhelm me" and "don't drop my items" are both real constraints — resolve the tension by demotion *within* view, not omission *from* view.
+
+1. Keep a tight, time-bound **🔴 Urgent** set at the top.
+2. Demote lower-priority open items down the tiers (🔴→🟡→🟢) and reorder — {{USER_NAME}} can scan a long, ordered list and ignore the bottom; he cannot recover items that aren't rendered at all.
+3. Mark an item `[unverified]` or drop it **only** when {{USER_NAME}} has explicitly said so (reply, reaction, or an inline `//==<<` directive).
+
+**Every open carried item MUST be rendered as its own `- [ ]` checkbox row in exactly one section.** Summary lines like "…plus the standing backlog (#A, #B, … etc.) — carried unchanged" are **FORBIDDEN** as a substitute for rendering individual items. An `etc.` that hides open items reads as a drop from {{USER_NAME}}'s perspective even when the IDs technically persist inside the prose string.
+
+**Compose-time count-guard (run before commit):** count the rendered open rows (`- [ ]` lines plus 🟢 Watching bullets) in today's file. That count MUST be ≥ the prior day's open-item count minus any items closed this run (`- [x]`) or dropped on an explicit {{USER_NAME}} directive. If today's count is lower, items were collapsed/omitted — expand them back into individual rows before committing.
+
+```bash
+# Compose-time count-guard
+PREV=$(ls -t {{SCOUT_DIR}}/action-items/action-items-*.md | sed -n 2p)
+prev_open=$(grep -cE '^\s*- \[ \] ' "$PREV" 2>/dev/null || echo 0)
+today_open=$(grep -cE '^\s*- \[ \] ' "$DAILY_FILE")
+closed_today=$(grep -cE '^\s*- \[x\] ' "$DAILY_FILE")
+[ "$today_open" -lt $((prev_open - closed_today)) ] && \
+    echo "ERROR: open-row count dropped ($prev_open→$today_open, only $closed_today closed) — items were collapsed; expand them before commit" >&2
+```
 
 ## Knowledge Graph Personal Tasks
 
@@ -182,4 +208,4 @@ Run every available cross-check (calendar, issue tracker, messaging, code host, 
 - If not started: include the full context from all sources, not just the one that surfaced it
 - Always include source citations showing which connectors confirmed the item
 
-Update the "Last consolidated" timestamp in the action items file after reconciliation is complete.
+After reconciliation is complete, refresh the `## 🪵 Run notes & connector availability` block at the **bottom** of the action items file — prepend this run's entry (timestamp, mode, counts, connector availability) as the newest line and trim the block to the last 3 runs. Do not write run metadata at the top of the file.

--- a/phases/core/action-items.md
+++ b/phases/core/action-items.md
@@ -142,7 +142,17 @@ closed_today=$(grep -cE '^\s*- \[x\] ' "$DAILY_FILE")
     echo "ERROR: open-row count dropped ($prev_open→$today_open, only $closed_today closed) — items were collapsed; expand them before commit" >&2
 ```
 
-### Hard Rule — ✅ Recently Completed Migration Is Atomic
+### Hard Rule — Continuity-Dropoff Audit (ID-level, pre-commit)
+
+The count-guard catches *how many* dropped; this catches *which*. Before committing, diff today's open `[#XXXX]` ids against the prior day's. For every id open in N-1 but absent in N:
+
+1. It has a ✅ Recently Completed entry in today's file → confirmed closure, OK.
+2. It has an explicit `//==<<` drop directive since N-1 → confirmed drop, OK.
+3. **Otherwise → silent dropoff.** Re-add it to today's file with a `[carried-via-audit]` annotation, surface `🚨 N items silently dropped from yesterday — please verify` in the notification, and write a `review-queue.md` entry. Never let an open item vanish without one of (1)/(2).
+
+### Hard Rule — Leave-State Compose Gate
+
+Before generating any 🔴/🟡 action item that names a specific person as the next-action owner, read that person's entity file (`knowledge-base/people/<slug>.md`). If it carries an active leave/out-of-office state (a `status:` containing `leave`/`oof`/`vacation`/`paternity`/`maternity`, a dated leave block overlapping today, or a 🚨/`### ACTIVE STATUS` body header) — do NOT assign them as the owner. Reframe to 🟢 Watching with `(on leave through <date>; auto-resume on return)`, unless the action item is itself about *responding to* that leave. This prevents assigning work to someone Scout already knows is away.
 
 Whenever you flip an item from `[ ]` to `[x]` — or process a {{USER_NAME}}-authored `[x]`, an inline `//==<<` close-out directive ("close this out", "I don't need this anymore", "move to completed"), or a close-it-out reply — you MUST, in the same write:
 
@@ -200,6 +210,31 @@ During consolidation, also check for completion signals:
 - If any personal task has a `completion_signal: gmail_confirmation`, check Gmail for matching confirmations. If found, update the entity file's `status` to `completed` and add `completed_date`.
 - If {{USER_NAME}} reported completion via Slack DM, update the entity file.
 - Carry open personal tasks forward in the action items file's Personal section.
+
+## Recurring-Task Cadences (briefing AND every consolidation)
+
+Recurring commitments are **cadence-driven, not event-driven** — a "quiet delta" consolidation must still surface them. This is the load-bearing fix for missed standing commitments (e.g. a weekly Friday status update). If the KB has any `recurring_task` entities, run the cadence computer at compose time:
+
+```bash
+cd {{SCOUT_DIR}} && python recurring-task-status.py --date "$(TZ={{TIMEZONE}} date '+%Y-%m-%d')"
+# (script lives at {{SCOUT_DIR}}/scripts/recurring-task-status.py)
+```
+
+**Live-completion lookup (do this before trusting the date math).** For each entity with a `completion_evidence` source (`linear_project_update`, `slack_post`, `gmail_confirmation`), resolve the *real* last-completion date from the live source — e.g. Linear `get_project` → `lastUpdateAt`, or a Slack/Gmail search — and feed it back so the verdict reflects live evidence (the override is not written to the entity file):
+
+```bash
+python recurring-task-status.py --date "<today>" \
+    --last-completed <entity-slug>=<YYYY-MM-DD>
+```
+
+For each entity the script returns:
+
+1. **`due` / `overdue`** → **mandatory** action item. 🔴 when `surface_window` is `T-0 morning` or the item is `overdue`; 🟡 when the window is wider than 24h. Link `[[recurring-tasks/<name>]]`. `domain: personal` ones go in the Personal section.
+2. **`done`** (completion evidence satisfied for this cadence window) → surface as ✅ Recently Completed, not a TODO.
+3. **`surfacing`** (inside the window, not yet the due day) → 🟡 heads-up.
+4. **`upcoming` / `unknown`** → no action item.
+
+**Do not write "quiet window" / "nothing material" framing until the `due`/`overdue` list is exhausted** — a `weekly:friday` cadence is by definition material on a Friday.
 
 ## Mandatory Cross-Check
 

--- a/phases/core/action-items.md
+++ b/phases/core/action-items.md
@@ -15,6 +15,16 @@ mkdir -p {{SCOUT_DIR}}/action-items/archive
 # Move files older than 7 days based on filename date
 ```
 
+## Step 0.5: Critical Blocks Check
+
+Before building the list, read `knowledge-base/scout-mistake-audit.md`. For every pattern with status **Open** that carries a {{USER_NAME}}-facing blocker — a setup task {{USER_NAME}} must do, an unanswered question {{INSTANCE_NAME}} asked him, or an approved-but-unapplied proposal:
+
+1. Check whether it's been resolved since last run (search messaging, verify files/state).
+2. If still unresolved and >24h old, surface it as a **🔴** item today: "**Still blocked:** [pattern] — [what {{USER_NAME}} needs to do]".
+3. If stuck 48h+, call it out explicitly in the run summary/notification so it isn't lost.
+
+This makes the mistake audit an active tracker, not a passive log — {{USER_NAME}} expects every run type (not just dreaming) to keep pushing critical blocks toward resolution. Track specifically: unresolved setup/integration tasks, open questions awaiting {{USER_NAME}}'s answer, and approved proposals not yet applied.
+
 ## Action Item Categories
 
 Categorize every action item using these levels:
@@ -132,6 +142,39 @@ closed_today=$(grep -cE '^\s*- \[x\] ' "$DAILY_FILE")
     echo "ERROR: open-row count dropped ($prev_open→$today_open, only $closed_today closed) — items were collapsed; expand them before commit" >&2
 ```
 
+### Hard Rule — ✅ Recently Completed Migration Is Atomic
+
+Whenever you flip an item from `[ ]` to `[x]` — or process a {{USER_NAME}}-authored `[x]`, an inline `//==<<` close-out directive ("close this out", "I don't need this anymore", "move to completed"), or a close-it-out reply — you MUST, in the same write:
+
+1. Add an entry under `## ✅ Recently Completed` summarizing the closure with date + evidence (commit hash / transcript / message ts / the inline-comment quote) and any wikilinks the prior framing carried.
+2. **Delete the original row from its origin section** (🔴/🟡/🟢). Never leave a checked row sitting in an active section — that's a duplicate-surface graveyard.
+3. If the closure is too trivial to deserve a Recently-Completed entry, still delete the origin row. Never write the entry without the inverse delete.
+
+**Inline `//==<<` close-out directives are first-class delete instructions** — acknowledging one in the next DM is insufficient; the file must be physically updated (check box → write completed entry → delete origin row → remove the marker).
+
+**Pre-commit audit** — no `[x]` rows may sit outside the Recently Completed section:
+
+```bash
+grep -nE '^\s*- \[x\]' "$DAILY_FILE" | grep -viE 'recently completed|## ✅' \
+  && echo "WARN: checked rows above are outside ✅ Recently Completed — migrate or annotate '_(kept intentionally — REASON)_' before commit" >&2
+```
+
+(Sunset: retire this rule when a programmatic `action-items` done-lifecycle ships and handles section migration deterministically.)
+
+### Hard Rule — Transcript-Derived Names Must Pass an Ontology Match
+
+Auto-transcribed sources (Granola, Gemini/Drive auto-notes, Fathom recaps, meeting summaries) frequently mis-hear names. **Never** write a transcribed name into action items, KB, or a DM without first resolving it against the knowledge graph. For every name-shaped token from a transcribed source:
+
+```bash
+cd {{SCOUT_DIR}} && python knowledge-base/ontology/parser.py name_lookup --token "<Token>"
+```
+
+- **Exact match** → use the matched entity with its `[[people/<slug>]]` wikilink.
+- **Fuzzy match** (within threshold ≈ Levenshtein-2 / phonetic-equivalent) → use that entity, append a `[name-fuzzy-resolved]` marker.
+- **No match** → write at most "Contact person matching '<verbatim-token>' (no KB match — please confirm)" and route a `[transcript-drift]` entry to `review-queue.md`. **NEVER elevate an unresolved transcribed name to a 🔴 headline** — 🟡 with the explicit "no KB match" framing is the ceiling.
+
+If {{USER_NAME}} corrects a name ("who is X?", "X doesn't exist", "this is hallucinated"), bind the misheard form to the correct entity as a "known transcription drift" note so it resolves next time.
+
 ## Knowledge Graph Personal Tasks
 
 If the ontology parser is set up, query it for personal tasks and deadlines:
@@ -139,6 +182,8 @@ If the ontology parser is set up, query it for personal tasks and deadlines:
 ```bash
 cd {{SCOUT_DIR}} && python knowledge-base/ontology/parser.py query --type task
 ```
+
+**`surface_rule` windows are authoritative.** Before rendering any `type: task` entity into the daily file, read its `surface_rule:` block. If `default: do_not_surface` and **no** `windows` entry covers today's date AND **no** `always_visible_if` condition fires, the task is intentionally muted — do not render it, do not flag it stale, do not mention it in the wrap notification. If a window covers today, render at that window's `surface:` priority using its `task:` label override if present. If `always_visible_if` fires, force 🔴. A task with no `surface_rule` falls back to surfacing daily until `status: completed` (back-compat). This stops long-window tasks (multi-week trips, future-dated deadlines) from polluting the daily surface during their idle phases.
 
 For the morning briefing, focus on:
 

--- a/phases/core/git-setup.md
+++ b/phases/core/git-setup.md
@@ -29,6 +29,16 @@ Git is a core part of the {{INSTANCE_NAME}} system — every change is committed
 
 The commit history is as valuable as the files themselves. When verifying KB claims or understanding what was already audited, check git before querying connectors.
 
+### Vault Git-Delta Narration (consolidation/briefing — mandatory before composing)
+
+Interactive sessions ({{INSTANCE_NAME}} work sessions, manual edits, `/scout-work`, audits) commit to the vault between scheduled runs. Those commits are a **primary signal source**, not background noise — a `work [HH:MM]:` commit may already have done the thing an action item is about. Before composing the run summary:
+
+```bash
+git -C {{SCOUT_DIR}} log --since="<last run timestamp>" --pretty=format:'%h %s' --no-merges
+```
+
+Narrate any non-session commits (anything not authored by this run) in the summary. **Do not assert a "quiet window" / "nothing changed since last run" until this git scan returns zero non-session commits.** A silent delta in the vault contradicts a "quiet" claim and erodes trust.
+
 ## GitHub Access via `gh` CLI
 
 All GitHub operations use the `gh` CLI, which is authenticated and has full access to both public and private repos. **Do not use GitHub MCP tools** — they have limited scope.

--- a/phases/core/kb-management.md
+++ b/phases/core/kb-management.md
@@ -53,6 +53,13 @@ The KB is the **persistent memory** of this system. Action items are ephemeral (
   - **Upcoming Meetings**: Next relevant meetings
   - **Issues**: Key issues with links, status, and who owns them
 - Quality bar: after reading a project file, {{USER_NAME}} should understand what's happening *right now*, who's doing what, what decisions were made and why, and what they need to do next. If the file doesn't answer those questions, it's too thin.
+- **`slack_channels:` frontmatter (required for 🔴 projects):** every high-priority project file declares the Slack channels that carry its work, so runs can poll them directly (see the Slack connector's 🔴 Project Channel Poll). Shape:
+  ```yaml
+  slack_channels:
+    - id: C07A15QDGBT
+      name: "#channel-name"
+  ```
+  When a project is promoted to 🔴 without this field, add it (find the channel ids from `channels.md` or a `slack_search_channels` call).
 
 ### When to Create New KB Files
 

--- a/phases/core/kb-management.md
+++ b/phases/core/kb-management.md
@@ -134,6 +134,17 @@ When writing KB content, use these markers:
 - **[unverified]** = carried forward from a previous run, not yet confirmed against any live source
 - **[stale]** = known to be outdated but kept as historical context until replacement info is found
 - **[contradicted]** = two sources disagree; both claims noted with sources cited — always add to review queue
+- **[speculative]** = an inferred causal/contributory link that no single source actually states; allowed only with this marker (see Causal-Claim Gate)
+
+### Causal-Claim Gate
+
+Any statement asserting that one issue / PR / metric / event **caused, contributed to, blocked, or drove** another is a high-risk inference — it reads as fact but is usually the run's own synthesis. Before writing such a cross-entity causal claim (in the KB or a DM):
+
+1. **Cite a primary source** that actually states the link (a comment, message, or commit that says "X because Y") → write it plainly.
+2. If no source states it but the inference is useful → write it with a **`[speculative]`** marker and the basis ("timing overlap", "same author") so {{USER_NAME}} can weigh it.
+3. If you can do neither → **drop the causal framing** and report the two facts independently.
+
+Never fan a causal claim out to multiple KB surfaces (project file + people + DM) off a single unverified inference — re-verify before propagating, or one speculative link becomes "established fact" across the KB.
 
 ### Cross-Reference Integrity
 

--- a/phases/core/kb-management.md
+++ b/phases/core/kb-management.md
@@ -153,6 +153,12 @@ Any statement asserting that one issue / PR / metric / event **caused, contribut
 
 Never fan a causal claim out to multiple KB surfaces (project file + people + DM) off a single unverified inference — re-verify before propagating, or one speculative link becomes "established fact" across the KB.
 
+### Fact-Check Pass + Citations for Consequential Claims
+
+**Consequential claims carry an inline primary-source citation.** Any claim that — if wrong — would cause {{USER_NAME}} to act on bad information (who owns/built something, a strategy/decision, a status that gates action, an attribution) must cite the specific source inline: "per [Linear PROJ-123 status]", "per [DM from X 2026-05-01]", "per [PR #45 mergedAt]". A bare assertion with no traceable source is treated as `[unverified]`.
+
+**Dreaming fact-check pass (deep-work mode).** During deep-work runs, take the KB content written or changed in the last few runs (use `git log`/`git diff` to find it) and re-verify the highest-stakes claims against a **freshly re-read primary source** — do not paraphrase what a prior run already wrote (prior runs can be wrong; the KB is claims-to-verify, not facts). Correct or mark `[unverified]`/`[contradicted]` anything that doesn't hold up, and route genuine conflicts to the review queue. This is the active counterpart to the passive verification markers — hallucinations compound across runs unless something re-checks them.
+
 ### Cross-Reference Integrity
 
 The KB's value depends on its graph being connected. Rules:
@@ -176,9 +182,11 @@ The KB's value depends on its graph being connected. Rules:
 
 ---
 
-## Source Equality Principle
+## Source Priority Principle
 
-**No single source is authoritative.** Every connected service — meeting transcripts, messaging, calendar, issue tracker, email, code host, session history — is an equal signal. Every claim, whether it comes from a meeting transcript, a message thread, or the existing KB itself, must be corroborated or questioned.
+**Lead signals for {{USER_NAME}}'s own work: Linear → Claude Code sessions → GitHub.** These are {{USER_NAME}}'s primary work surfaces, so they are the **lead/primary** sources for the consolidation delta-scan and for ordering the run summary: scan them first and most deeply, and lead the DM with what they show. Messaging (Slack), email, calendar, and meeting transcripts are **corroborating** signals layered on top.
+
+**No source is taken as fact without corroboration.** Lead-source priority governs *what to scan first and what to headline* — it does NOT mean a Linear/CC/GitHub datum is true by itself. Every consequential claim, from any source including the existing KB, must still be verified against a primary source before it is stated as fact (see the Fact-Check Pass and Verification Levels). Priority orders attention; it does not bypass verification.
 
 **The existing KB is NOT trusted as fact.** It contains information written by previous runs that may be incorrect, incomplete, or outdated. Every run should treat KB content as "claims to verify" rather than "facts to preserve." When you encounter a claim (e.g., "Person X built the Y feature"), ask: can I confirm this from at least one live source? If not, flag it as unverified or correct it if you find contradicting evidence.
 

--- a/phases/modes/feedback-processing.md
+++ b/phases/modes/feedback-processing.md
@@ -84,11 +84,15 @@ Based on the classified signals and mistake audit updates, determine what change
 | `knowledge-base/scout-mistake-audit.md` | **Direct edit** | Apply updates from Step 1c immediately |
 | KB files (content corrections) | **Direct edit** | Fix factual errors identified by feedback (e.g., wrong status, wrong person, outdated info) |
 | `DREAMING.md` | **Direct edit** | Improve dreaming behavior based on patterns (e.g., adjust scoring weights, add checklist items) |
-| `SKILL.md` | **PROPOSAL ONLY** | Never edit directly. Write a proposal to `dreaming-proposals.md` (see Step 1e) |
+| `SKILL.md` | **Direct edit (transparency + reversibility)** | Self-apply additive, feedback-aligned, or pattern-closing edits directly, committed with a clear message so the change is reviewable and `git revert`-able. See gate criteria below. |
 | New KB files or structural changes | **Direct edit** | Only if supported by clear evidence from multiple feedback signals |
 
+**SKILL.md self-improvement model (proposal gate retired).** The old "PROPOSAL ONLY, never edit directly" gate is retired. The governing principle is now transparency and reversibility: improvements that are **additive, feedback-aligned, or close a logged mistake pattern** are applied directly and committed with a descriptive message (so {{USER_NAME}} can review and `git revert` any change). A **proposal** in `dreaming-proposals.md` is still required only for changes that are **large, structural, behavior-removing, genuinely uncertain, or that modify {{INSTANCE_NAME}}'s own governance/safety gating**. Those proposals are **opt-out**: a `Pending (auto-apply after <date>)` proposal is applied by a future run unless {{USER_NAME}} marks it `Rejected`; only governance/safety-gating changes require an explicit `Approved`.
+
+**Harness fallback.** If the runtime blocks a direct `SKILL.md` commit (a safety classifier may prevent autonomous self-modification of the brain file), do not silently drop the improvement — file it as an opt-out `Pending` proposal instead, so it is applied by a later run or by {{USER_NAME}} interactively.
+
 **Guardrails:**
-- Never remove content from `SKILL.md` without a proposal. Even if feedback says a behavior is wrong, the fix may need nuance that a proposal review provides.
+- Behavior-removing or structural `SKILL.md` changes still go through a proposal — direct edits are for additive/corrective improvements.
 - For KB content fixes, always cite the feedback that triggered the change: "Corrected per {{USER_NAME}} feedback on [date]: [brief description]."
 - If a correction contradicts information from a live connector, investigate before changing. The correction may be about interpretation, not raw data.
 
@@ -96,19 +100,22 @@ Based on the classified signals and mistake audit updates, determine what change
 
 ### Step 1e: Handle Proposals
 
-**First: check for approved proposals.**
+**First: apply approved AND ripe opt-out proposals.**
 
-Read `dreaming-proposals.md`. For any proposal with status `Approved`:
-1. Apply the proposed change to `SKILL.md` exactly as specified in the proposal's "Proposed change" section.
-2. Update the proposal's status to `Applied — [today's date]`.
-3. Commit this change separately:
-   ```bash
-   git -C {{SCOUT_DIR}} add -A && git -C {{SCOUT_DIR}} commit -m "dreaming [HH:MM]: applied approved proposal — <short description>"
-   ```
+Read `dreaming-proposals.md`. Apply a proposal's change to `SKILL.md` when EITHER:
+- its status is `Approved` (required for governance/safety-gating changes), OR
+- its status is `Pending (auto-apply after <date>)` and that date has passed and it is not marked `Rejected`.
 
-**Then: write new proposals.**
+For each, apply the change exactly as specified, set status to `Applied — [today's date]`, and commit separately:
+```bash
+git -C {{SCOUT_DIR}} add -A && git -C {{SCOUT_DIR}} commit -m "dreaming [HH:MM]: applied proposal — <short description>"
+```
 
-For every improvement that targets `SKILL.md` (from Step 1d), write a proposal using this format:
+**Then: apply additive improvements directly; file proposals only for gated changes.**
+
+For each improvement that targets `SKILL.md` (from Step 1d):
+- **Additive / feedback-aligned / pattern-closing** → apply directly to `SKILL.md` and commit with a descriptive, revertable message. No proposal needed. (If the harness blocks the commit, fall back to an opt-out proposal per the Harness fallback note above.)
+- **Large / structural / behavior-removing / uncertain / governance-or-safety-gating** → write a proposal using the format below (opt-out for the first four; governance/safety changes get `Status: Pending` and require an explicit `Approved`):
 
 ```markdown
 ### [Date] — [Short description]
@@ -116,7 +123,7 @@ For every improvement that targets `SKILL.md` (from Step 1d), write a proposal u
 **Proposed change:** [specific edit with before/after text, or exact addition with location]
 **Rationale:** [why this change prevents the issue or improves behavior]
 **Evidence:** [specific feedback instances — dates, message content, reactions]
-**Status:** Pending
+**Status:** Pending (auto-apply after [today + 3 days])   # or just "Pending" for governance/safety changes
 ```
 
 **Quality bar for proposals:** Every proposal must be specific enough that a future dreaming run can apply it mechanically without ambiguity. "Make Scout better at X" is not a proposal. "In SKILL.md section Y, change line Z from 'always do A' to 'do A only when B, otherwise do C'" is a proposal.

--- a/phases/modes/kb-deep-work.md
+++ b/phases/modes/kb-deep-work.md
@@ -67,7 +67,7 @@ cd {{SCOUT_DIR}} && python knowledge-base/ontology/parser.py query --type task
 ```
 
 For each personal task entity (`domain: personal`, `status: open`):
-- **Stale task** = open personal task with `created_date` older than 7 days and no activity. Flag in the notification: "Still open: [task name] — done?"
+- **Stale task** = open personal task with `created_date` older than 7 days, no activity, AND no `surface_rule` currently muting it. Flag in the notification: "Still open: [task name] — done?" A task intentionally muted by its `surface_rule` (default `do_not_surface`, no window covering today, no `always_visible_if` firing) is **not** stale — it is deliberately backgrounded; do not flag it.
 - **Deadline approaching** = task with `deadline` within 3 days. Escalate priority to 🔴 in the entity file if not already.
 - **Completion signal check** = if `completion_signal: gmail_confirmation`, check Gmail for matching confirmation. Auto-resolve if found (set `status: completed`, add `completed_date`).
 

--- a/templates/scripts/recurring-task-status.py
+++ b/templates/scripts/recurring-task-status.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""recurring-task-status.py — compute per-entity status for recurring_task entities.
+
+Reads `knowledge-base/recurring-tasks/*.md`, parses YAML frontmatter, and emits a
+status report (markdown table by default; pass `--json` for machine output).
+
+This is Stage 4 of the "Recurring-task primitive" Wishlist item. The
+completion-evidence lookup (Linear API / Slack search) is left to the caller —
+this script handles the *local* computation only: given an entity's cadence,
+surface_window, and last_completed_date, decide whether the task is
+`due`, `surfacing`, `overdue`, or `done` *for today*.
+
+Stage 4b input hook: a live caller (briefing/consolidation, which has Linear MCP
+and Slack search available) looks up the real completion date and passes it via
+`--last-completed <slug>=<YYYY-MM-DD>` (repeatable). The override takes precedence
+over the entity's stored `last_completed_date` and is NOT written back to the file
+— live evidence stays caller-side; only the date math runs here.
+    e.g. recurring-task-status.py --date 2026-05-29 \
+            --last-completed kai-builds-data-apps-weekly-update=2026-05-29
+
+Status semantics:
+    done       — last_completed_date is within the current cadence window
+    surfacing  — today is inside surface_window leading up to the next due date
+    due        — cadence window contains today and no completion recorded
+    overdue    — cadence window has passed and no completion recorded
+    upcoming   — outside surface_window; informational only
+
+Cadence DSL (subset implemented in v1):
+    daily
+    weekly:<weekday>          e.g. weekly:friday
+    monthly:<day>             e.g. monthly:1
+    monthly:nth:<n>:<weekday> e.g. monthly:nth:2:tuesday
+    quarterly:cycle-start
+
+Surface-window DSL (subset):
+    T-0 morning  -> show on the due day itself
+    T-1 day      -> show 1 day before
+    T-2d through T-0   -> 2-day surfacing window
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field, asdict
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Optional
+
+try:
+    import yaml
+except ImportError:
+    print("error: pyyaml not installed. run: pip install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+
+WEEKDAYS = {
+    "monday": 0, "tuesday": 1, "wednesday": 2, "thursday": 3,
+    "friday": 4, "saturday": 5, "sunday": 6,
+}
+
+
+@dataclass
+class TaskStatus:
+    name: str
+    cadence: str
+    surface_window: str
+    status: str
+    next_due: Optional[str]
+    last_completed: Optional[str]
+    domain: str = ""
+    priority: str = ""
+    reason: str = ""
+    feeds: list = field(default_factory=list)
+
+
+def parse_frontmatter(path: Path) -> dict:
+    text = path.read_text()
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    block = text[3:end].strip()
+    return yaml.safe_load(block) or {}
+
+
+def next_due_date(cadence: str, today: date) -> Optional[date]:
+    """Return the next occurrence ON OR AFTER today for the given cadence."""
+    if cadence == "daily":
+        return today
+
+    if cadence.startswith("weekly:"):
+        weekday_name = cadence.split(":", 1)[1].strip().lower()
+        target = WEEKDAYS.get(weekday_name)
+        if target is None:
+            return None
+        delta = (target - today.weekday()) % 7
+        return today + timedelta(days=delta)
+
+    if cadence.startswith("monthly:nth:"):
+        # monthly:nth:<n>:<weekday>
+        parts = cadence.split(":")
+        if len(parts) != 4:
+            return None
+        try:
+            n = int(parts[2])
+        except ValueError:
+            return None
+        target = WEEKDAYS.get(parts[3].lower())
+        if target is None or not 1 <= n <= 5:
+            return None
+        return _nth_weekday_on_or_after(today, n, target)
+
+    if cadence.startswith("monthly:"):
+        try:
+            day = int(cadence.split(":", 1)[1])
+        except ValueError:
+            return None
+        candidate = today.replace(day=min(day, 28))
+        if candidate < today:
+            month = today.month + 1
+            year = today.year + (month > 12)
+            month = ((month - 1) % 12) + 1
+            candidate = date(year, month, min(day, 28))
+        return candidate
+
+    if cadence == "quarterly:cycle-start":
+        # No project-cycle data here; signal "unknown".
+        return None
+
+    return None
+
+
+def _nth_weekday_on_or_after(today: date, n: int, weekday: int) -> Optional[date]:
+    for month_offset in range(0, 3):
+        month = today.month + month_offset
+        year = today.year + (month - 1) // 12
+        month = ((month - 1) % 12) + 1
+        first = date(year, month, 1)
+        delta = (weekday - first.weekday()) % 7
+        candidate = first + timedelta(days=delta + 7 * (n - 1))
+        if candidate.month == month and candidate >= today:
+            return candidate
+    return None
+
+
+def parse_surface_window(window: str) -> tuple[int, int]:
+    """Return (days_before_start, days_before_end). T-N means N days before due."""
+    w = window.strip().lower()
+    if w == "t-0 morning":
+        return (0, 0)
+    if w in ("t-1 day", "t-1d"):
+        return (1, 1)
+    m = re.match(r"t-(\d+)\s*d?\s*through\s*t-(\d+)\s*d?", w)
+    if m:
+        return (int(m.group(1)), int(m.group(2)))
+    m = re.match(r"t-(\d+)\s*d", w)
+    if m:
+        return (int(m.group(1)), 0)
+    return (0, 0)
+
+
+def cadence_window_for_today(cadence: str, today: date) -> tuple[Optional[date], Optional[date]]:
+    """Return (window_start, window_end) — the cadence period today falls into.
+
+    For weekly:friday, the window is Sat..Fri (the week containing today, ending on Friday).
+    """
+    if cadence.startswith("weekly:"):
+        weekday_name = cadence.split(":", 1)[1].strip().lower()
+        target = WEEKDAYS.get(weekday_name)
+        if target is None:
+            return (None, None)
+        days_ahead = (target - today.weekday()) % 7
+        window_end = today + timedelta(days=days_ahead)
+        window_start = window_end - timedelta(days=6)
+        return (window_start, window_end)
+    if cadence == "daily":
+        return (today, today)
+    return (None, None)
+
+
+def compute_status(
+    entity: dict, today: date, last_completed_override: Optional[str] = None
+) -> TaskStatus:
+    name = entity.get("name", "?")
+    cadence = entity.get("cadence", "")
+    surface_window = entity.get("surface_window", "T-0 morning")
+    # A live caller (briefing/consolidation with Linear MCP / Slack search) can pass
+    # the freshly-looked-up completion date via --last-completed <slug>=<date>; it
+    # takes precedence over the entity's stored last_completed_date and is NOT
+    # written back to the file (Stage 4b — live evidence stays caller-side).
+    overridden = False
+    if last_completed_override is not None:
+        last_completed_raw = last_completed_override
+        overridden = True
+    else:
+        last_completed_raw = entity.get("last_completed_date")
+    last_completed = None
+    if last_completed_raw:
+        try:
+            last_completed = date.fromisoformat(str(last_completed_raw))
+        except ValueError:
+            last_completed = None
+            if overridden:
+                print(
+                    f"warning: --last-completed value '{last_completed_raw}' for "
+                    f"'{name}' is not a valid YYYY-MM-DD date; ignoring",
+                    file=sys.stderr,
+                )
+
+    nd = next_due_date(cadence, today)
+    win_start_days, win_end_days = parse_surface_window(surface_window)
+
+    status = "upcoming"
+    reason = ""
+
+    if nd is None:
+        status = "unknown"
+        reason = f"cadence DSL '{cadence}' not yet supported by v1"
+    else:
+        cad_start, cad_end = cadence_window_for_today(cadence, today)
+        within_cadence = cad_start and cad_end and cad_start <= today <= cad_end
+
+        if last_completed and cad_start and last_completed >= cad_start:
+            status = "done"
+            reason = f"last_completed {last_completed} >= cadence window start {cad_start}"
+        elif within_cadence and today == cad_end:
+            status = "due"
+            reason = f"today is the due day ({cadence})"
+        elif within_cadence:
+            surface_start = nd - timedelta(days=win_start_days)
+            surface_end = nd - timedelta(days=win_end_days)
+            if surface_start <= today <= surface_end:
+                status = "surfacing"
+                reason = f"in surface_window {surface_window} for next due {nd}"
+            else:
+                status = "upcoming"
+                reason = f"in cadence window but before surface_window"
+        elif cad_end and today > cad_end:
+            status = "overdue"
+            reason = f"cadence window ended {cad_end} with no completion logged"
+
+    if overridden and last_completed is not None:
+        reason = (reason + " " if reason else "") + "[last_completed via --last-completed override]"
+
+    feeds = []
+    for rel in entity.get("relationships", []) or []:
+        if isinstance(rel, dict) and rel.get("type") == "feeds":
+            feeds.append(rel.get("target", ""))
+
+    return TaskStatus(
+        name=name,
+        cadence=cadence,
+        surface_window=surface_window,
+        status=status,
+        next_due=nd.isoformat() if nd else None,
+        last_completed=last_completed.isoformat() if last_completed else None,
+        domain=entity.get("domain", ""),
+        priority=entity.get("priority", ""),
+        reason=reason,
+        feeds=feeds,
+    )
+
+
+def main() -> int:
+    doc = __doc__ or "recurring-task-status"
+    parser = argparse.ArgumentParser(description=doc.split("\n")[0])
+    parser.add_argument(
+        "--dir",
+        default=str(Path(__file__).resolve().parent.parent / "knowledge-base" / "recurring-tasks"),
+        help="Directory containing recurring_task entity files",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of markdown")
+    parser.add_argument("--date", help="Reference date YYYY-MM-DD (defaults to today)")
+    parser.add_argument(
+        "--status",
+        action="append",
+        help="Filter to one or more statuses (repeatable)",
+    )
+    parser.add_argument(
+        "--last-completed",
+        action="append",
+        metavar="SLUG=YYYY-MM-DD",
+        help=(
+            "Override an entity's last_completed_date with a live-looked-up value, "
+            "keyed by file stem (slug). Repeatable. The runner fetches this from "
+            "Linear (`get_project` -> lastUpdateAt) or Slack search, then passes it "
+            "in so the local date math reflects live evidence without writing to the "
+            "entity file. Example: --last-completed kai-builds-data-apps-weekly-update=2026-05-29"
+        ),
+    )
+    args = parser.parse_args()
+
+    today = date.fromisoformat(args.date) if args.date else date.today()
+
+    overrides: dict[str, str] = {}
+    for item in args.last_completed or []:
+        if "=" not in item:
+            print(
+                f"error: --last-completed expects SLUG=YYYY-MM-DD, got '{item}'",
+                file=sys.stderr,
+            )
+            return 2
+        slug, value = item.split("=", 1)
+        overrides[slug.strip()] = value.strip()
+
+    root = Path(args.dir)
+    if not root.is_dir():
+        print(f"error: {root} is not a directory", file=sys.stderr)
+        return 2
+
+    seen_slugs: set[str] = set()
+    rows: list[TaskStatus] = []
+    for path in sorted(root.glob("*.md")):
+        entity = parse_frontmatter(path)
+        if entity.get("type") != "recurring_task":
+            continue
+        if entity.get("status") and str(entity["status"]).lower() not in ("open", "active"):
+            continue
+        seen_slugs.add(path.stem)
+        rows.append(compute_status(entity, today, overrides.get(path.stem)))
+
+    for slug in overrides:
+        if slug not in seen_slugs:
+            print(
+                f"warning: --last-completed slug '{slug}' matched no open recurring_task "
+                f"entity file in {root}",
+                file=sys.stderr,
+            )
+
+    if args.status:
+        wanted = {s.lower() for s in args.status}
+        rows = [r for r in rows if r.status in wanted]
+
+    if args.json:
+        print(json.dumps([asdict(r) for r in rows], indent=2))
+        return 0
+
+    if not rows:
+        print(f"# recurring-task-status — {today.isoformat()}\n\nNo entities matched.\n")
+        return 0
+
+    print(f"# recurring-task-status — {today.isoformat()}\n")
+    print("| Name | Status | Cadence | Next due | Surface window | Last completed | Reason |")
+    print("|------|--------|---------|----------|----------------|----------------|--------|")
+    for r in rows:
+        print(
+            f"| {r.name} | **{r.status}** | {r.cadence} | {r.next_due or '—'} | "
+            f"{r.surface_window} | {r.last_completed or '—'} | {r.reason} |"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Ports the backlog of dreaming proposals that had accumulated in Jordan's **vault** `SKILL.md`/`DREAMING.md` into the **canonical engine** (`phases/`, `skills/`, `engine/`), so the distributable Scout actually carries the behavioral improvements his runs depend on. Each proposal was triaged against the current engine state (built ~May 9); already-present and stale ones were skipped.

Worked through interactively in 3 batches + a decision round.

### Batch 1 — quick wins
- `action-items.md`: run-notes moved to a bottom `🪵` footer; Trim-by-Demotion + compose-time count-guard (Pattern #83)
- `granola.md`: extraction gate — substance, not capture breadcrumbs (#77)
- `slack.md`: consolidation reads replies on the bot's own DM threads + coverage assertion (#80)
- `git-setup.md`: narrate non-session vault commits; forbid "quiet window" until git scanned (#65)
- `github.md`: per-claim evidence anchors (#69)

### Batch 2 — medium
- Critical Blocks Check (Step 0.5); atomic ✅ Recently-Completed migration (#50); transcript name-gate wiring `parser.py name_lookup` (#58); `surface_rule` render authority + schema field (#60)
- Linear actor-attributed delta-scan (#43) + project-update polling / leadership-ping (#72)
- `[speculative]` marker + Causal-Claim Gate (#36); CC uncommitted-tree sweep + sources-checked footer (#37); meeting-table time/existence cross-check (#71)

### Batch 3 — large
- 🔴 project channel poll via `slack_channels:` frontmatter; both-scans gate; committed-reply auto-carry (#23, #75)
- ID-level continuity-dropoff audit; leave-state compose gate (#75)
- **recurring-task primitive** ported from vault: `recurring_task` schema type, `recurring-task-status.py` installed as a cat-1 file, cadence-surfacing rule + `--last-completed` live-lookup wiring (#78)

### Decision items
- **hallucination-prevention** remainder: Fact-Check Pass + inline citations for consequential claims
- **prioritize-linear-cc-github**: Source Priority Principle — Linear→CC→GitHub lead signals (ordering, not authority)
- **retire-proposal-gate**: `feedback-processing.md` now uses the transparency+reversibility model (direct-apply additive edits, opt-out proposals, harness fallback)
- **linear-write-attempts**: Linear write-back slot (attempt `save_issue`/`save_comment`, confirm/permission-gap/error-fallback) — all scheduled modes
- **connector-alert-guardrail (Pattern #54)**: cross-mode liveness suppression in `connector_health_report.py` — no false CRITICAL when a connector was healthy in any mode within 4h and had 0 error calls this run; +2 tests
- Dropped: `project-specific-skill-docs` (superseded), `session-end-hook` (harness-blocked; CLAUDE.md rule covers it)

All prompt content is tenant-agnostic (`{{USER_NAME}}`/`{{INSTANCE_NAME}}` placeholders preserved).

## Test plan
- `ruff check` + `ruff format --check` clean on `scout`/`tests`
- `mypy scout` clean (59 files)
- Full suite: 591 passed (2 pre-existing env-dependent `test_cli_schedule_subapp` failures unrelated to this PR — they read a real vault's `overnight-research` slot; green in clean CI)
- +2 new tests for Pattern #54 cross-mode liveness

🤖 Generated with [Claude Code](https://claude.com/claude-code)
