### PR TITLE
fix(bootstrap): 3-way merge vault-edited parser.py (Pattern #68, option c)

### DIFF
--- a/engine/scout/scripts/bootstrap.py
+++ b/engine/scout/scripts/bootstrap.py
@@ -94,10 +94,19 @@ _CAT1_DIR_LAYOUT = (
 )
 
 _CAT1_FILES_FROM_PLUGIN = {
-    "knowledge-base/ontology/parser.py": "templates/knowledge-base/ontology/parser.py",
     "knowledge-base/ontology/__init__.py": "templates/knowledge-base/ontology/__init__.py",
     "action-items/render.py": "templates/action-items/render.py",
     "scripts/recurring-task-status.py": "templates/scripts/recurring-task-status.py",
+}
+
+# Cat-1 files that are BOTH engine-owned AND user-editable in the vault, so they
+# must be 3-way merged on upgrade instead of blindly overwritten. parser.py is
+# the canonical case (Pattern #68): the always-overwrite cat-1 path clobbered
+# vault-side edits to the ontology parser on every /scout-update. These files
+# go through the same snapshot + sidecar policy as the assembled SKILL/DREAMING/
+# RESEARCH brain files (see _stage_merge_files_upgrade).
+_CAT_MERGE_FILES = {
+    "knowledge-base/ontology/parser.py": "templates/knowledge-base/ontology/parser.py",
 }
 
 _CAT1_TEMPLATES = (
@@ -325,6 +334,75 @@ def _stage_cat4_upgrade(cfg: BootstrapConfig) -> list[str]:
     return conflicts
 
 
+def _merge_snapshot_path(cfg: BootstrapConfig, vault_rel: str) -> Path:
+    """Snapshot location for a 3-way-merged cat-1 file (mirrors the assembled
+    brain-file snapshots under .scout-state/last-assembled/)."""
+    return cfg.vault / ".scout-state" / "last-assembled" / vault_rel
+
+
+def _stage_merge_files_install(cfg: BootstrapConfig) -> None:
+    """Install: write each _CAT_MERGE_FILES live from the plugin AND record a
+    snapshot so future upgrades have a merge base."""
+    for vault_rel, plugin_rel in _CAT_MERGE_FILES.items():
+        src = cfg.plugin_root / plugin_rel
+        if not src.exists():
+            continue
+        content = src.read_text(encoding="utf-8")
+        live = cfg.vault / vault_rel
+        live.parent.mkdir(parents=True, exist_ok=True)
+        _atomic_write(live, content)
+        snap = _merge_snapshot_path(cfg, vault_rel)
+        snap.parent.mkdir(parents=True, exist_ok=True)
+        _atomic_write(snap, content)
+
+
+def _stage_merge_files_upgrade(cfg: BootstrapConfig) -> list[str]:
+    """Upgrade: 3-way merge each _CAT_MERGE_FILES, identical sidecar policy to
+    _stage_cat4_upgrade — ``ours`` = plugin content, ``theirs`` = vault-live,
+    ``base`` = recorded snapshot. Clean merge → live + snapshot advance;
+    conflict (or no recorded base vs a diverged plugin) → ``<file>.proposed-merge``
+    sidecar with live + snapshot left untouched. Protects Pattern #68 vault edits
+    while still letting engine improvements flow in."""
+    conflicts: list[str] = []
+    for vault_rel, plugin_rel in _CAT_MERGE_FILES.items():
+        src = cfg.plugin_root / plugin_rel
+        if not src.exists():
+            continue
+        ours = src.read_text(encoding="utf-8")
+        live = cfg.vault / vault_rel
+        theirs = live.read_text(encoding="utf-8") if live.exists() else ours
+        snap = _merge_snapshot_path(cfg, vault_rel)
+        base = snap.read_text(encoding="utf-8") if snap.exists() else theirs
+        sidecar = cfg.vault / f"{vault_rel}.proposed-merge"
+
+        if ours == theirs:
+            snap.parent.mkdir(parents=True, exist_ok=True)
+            _atomic_write(snap, ours)
+            continue
+
+        if base == theirs:
+            # No recorded vault edits vs base but plugin diverged (or first
+            # upgrade after this file became merge-managed, so no snapshot
+            # existed and base defaulted to theirs) — surface as a review
+            # prompt rather than overwriting a possibly hand-edited file.
+            sidecar.parent.mkdir(parents=True, exist_ok=True)
+            _atomic_write(sidecar, ours)
+            conflicts.append(sidecar.name)
+            continue
+
+        result = three_way_merge(base=base, ours=ours, theirs=theirs)
+        if not result.conflicts:
+            live.parent.mkdir(parents=True, exist_ok=True)
+            _atomic_write(live, result.content)
+            snap.parent.mkdir(parents=True, exist_ok=True)
+            _atomic_write(snap, ours)
+        else:
+            sidecar.parent.mkdir(parents=True, exist_ok=True)
+            _atomic_write(sidecar, result.content)
+            conflicts.append(sidecar.name)
+    return conflicts
+
+
 def _stage_jobs_install(cfg: BootstrapConfig) -> None:
     """Stage 6: install schedule-tick + heartbeat (or cron block)."""
     if cfg.skip_jobs:
@@ -413,6 +491,11 @@ def _refuse_pending_sidecars(vault: Path) -> None:
         for n in ("SKILL", "DREAMING", "RESEARCH")
         if (vault / f"{n}.md.proposed-merge").exists()
     ]
+    pending += [
+        f"{vault_rel}.proposed-merge"
+        for vault_rel in _CAT_MERGE_FILES
+        if (vault / f"{vault_rel}.proposed-merge").exists()
+    ]
     if pending:
         raise RuntimeError(
             f"Unresolved proposed-merge sidecar(s): {pending}. "
@@ -439,6 +522,7 @@ def install(cfg: BootstrapConfig) -> InstallResult:
         _stage_seed_schedule(cfg)
         _stage_cat1b_runners(cfg, is_upgrade=False)
         _stage_cat4_install(cfg)
+        _stage_merge_files_install(cfg)
         _stage_jobs_install(cfg)
         _stage_version_stamp(cfg, is_upgrade=False)
     finally:
@@ -480,6 +564,7 @@ def upgrade(cfg: BootstrapConfig) -> UpgradeResult:
         _stage_seed_schedule(cfg)
         backups = _stage_cat1b_runners(cfg, is_upgrade=True)
         conflicts = _stage_cat4_upgrade(cfg)
+        conflicts += _stage_merge_files_upgrade(cfg)
         _stage_jobs_install(cfg)
         _stage_version_stamp(cfg, is_upgrade=True)
     finally:

--- a/engine/tests/unit/test_bootstrap_upgrade.py
+++ b/engine/tests/unit/test_bootstrap_upgrade.py
@@ -146,6 +146,99 @@ def test_upgrade_backfills_missing_version_at_last_setup(tmp_path):
     assert after["plugin"]["version_at_last_update"] == "0.4.2"
 
 
+_PARSER_REL = "knowledge-base/ontology/parser.py"
+_PARSER_SNAP = ".scout-state/last-assembled/knowledge-base/ontology/parser.py"
+
+
+def test_install_seeds_parser_merge_snapshot(tmp_path):
+    """parser.py is now a 3-way-merge file: install must write it live AND
+    record a snapshot baseline (otherwise upgrades have no merge base)."""
+    plugin = Path(__file__).parent.parent.parent.parent
+    vault = tmp_path / "Scout"
+    install(_config(vault, plugin_root=plugin))
+    live = vault / _PARSER_REL
+    snap = vault / _PARSER_SNAP
+    assert live.exists()
+    assert snap.exists()
+    assert snap.read_text() == live.read_text()
+    assert live.read_text() == (plugin / "templates" / _PARSER_REL).read_text()
+
+
+def test_upgrade_preserves_vault_edit_to_parser(tmp_path):
+    """Pattern #68 regression: a vault-side edit to parser.py must SURVIVE an
+    upgrade (clean 3-way merge), not be clobbered by an always-overwrite."""
+    plugin = Path(__file__).parent.parent.parent.parent
+    vault = tmp_path / "Scout"
+    install(_config(vault, plugin_root=plugin))
+
+    parser = vault / _PARSER_REL
+    parser.write_text(parser.read_text() + "\n# VAULT_CUSTOM_MARKER = 1\n")
+
+    cfg = _config(vault, plugin_root=plugin)
+    cfg.plugin_version = "0.4.1"
+    result = upgrade(cfg)
+
+    assert "# VAULT_CUSTOM_MARKER = 1" in parser.read_text(), "vault edit clobbered!"
+    assert not (vault / f"{_PARSER_REL}.proposed-merge").exists()
+    assert not any("parser.py" in c for c in result.conflicts)
+
+
+def test_upgrade_parser_conflict_writes_sidecar_live_untouched(tmp_path):
+    """Overlapping plugin + vault edits to parser.py → conflict → sidecar;
+    the working parser.py is left untouched (never a broken .py in place)."""
+    plugin = Path(__file__).parent.parent.parent.parent
+    vault = tmp_path / "Scout"
+    install(_config(vault, plugin_root=plugin))
+
+    parser = vault / _PARSER_REL
+    snap = vault / _PARSER_SNAP
+    lines = parser.read_text().splitlines(keepends=True)
+    n = len(lines) // 2
+    # base (snapshot), ours (plugin = current parser), theirs (live) all differ
+    # at line n → unresolvable overlap.
+    snap.write_text("".join(lines[:n] + ["# BASE_MARKER\n"] + lines[n + 1 :]))
+    parser.write_text("".join(lines[:n] + ["# VAULT_MARKER\n"] + lines[n + 1 :]))
+
+    cfg = _config(vault, plugin_root=plugin)
+    cfg.plugin_version = "0.4.1"
+    result = upgrade(cfg)
+
+    sidecar = vault / f"{_PARSER_REL}.proposed-merge"
+    assert sidecar.exists()
+    assert "# VAULT_MARKER" in parser.read_text(), "live parser.py must be untouched on conflict"
+    assert any("parser.py" in c for c in result.conflicts)
+
+
+def test_upgrade_parser_migration_no_snapshot_writes_sidecar(tmp_path):
+    """Vaults predating the merge-managed parser have no snapshot. First
+    upgrade with a vault-edited parser must sidecar (not overwrite) the edit."""
+    plugin = Path(__file__).parent.parent.parent.parent
+    vault = tmp_path / "Scout"
+    install(_config(vault, plugin_root=plugin))
+
+    (vault / _PARSER_SNAP).unlink()  # simulate pre-change vault: no baseline
+    parser = vault / _PARSER_REL
+    parser.write_text(parser.read_text() + "\n# LEGACY_VAULT_EDIT = 1\n")
+
+    cfg = _config(vault, plugin_root=plugin)
+    cfg.plugin_version = "0.4.1"
+    upgrade(cfg)
+
+    assert (vault / f"{_PARSER_REL}.proposed-merge").exists()
+    assert "# LEGACY_VAULT_EDIT = 1" in parser.read_text(), "legacy vault edit must survive"
+
+
+def test_upgrade_refuses_with_pending_parser_sidecar(tmp_path):
+    """A pending parser.py sidecar must block the next upgrade, same as the
+    brain-file sidecars."""
+    plugin = Path(__file__).parent.parent.parent.parent
+    vault = tmp_path / "Scout"
+    install(_config(vault, plugin_root=plugin))
+    (vault / f"{_PARSER_REL}.proposed-merge").write_text("# pending\n")
+    with pytest.raises(RuntimeError, match="proposed-merge"):
+        upgrade(_config(vault, plugin_root=plugin))
+
+
 def test_upgrade_leaves_existing_version_at_last_setup_alone(tmp_path):
     """When version_at_last_setup is already present, upgrade must not
     clobber it — only version_at_last_update advances."""


### PR DESCRIPTION
## Summary

Resolves the last open dreaming proposal — `2026-05-18-vault-edited-parser-classification` (**Pattern #68**) — with **option c**: bring the vault's `knowledge-base/ontology/parser.py` into the three-way-merge set instead of always-overwriting it.

**The bug:** `parser.py` lived in `_CAT1_FILES_FROM_PLUGIN` (always-overwrite from the plugin), so every `/scout-update` silently clobbered any vault-side edit to the ontology parser. Pattern #68 fired ~4×.

**Option c** (chosen over install-only) preserves vault edits **and** still lets engine parser improvements flow in, by reusing the exact snapshot + sidecar machinery already proven on the assembled `SKILL`/`DREAMING`/`RESEARCH` brain files:

- New `_CAT_MERGE_FILES` set (currently just `parser.py`); removed from `_CAT1_FILES_FROM_PLUGIN`.
- **Install** (`_stage_merge_files_install`): write `parser.py` live from the plugin **and** record a snapshot baseline under `.scout-state/last-assembled/`.
- **Upgrade** (`_stage_merge_files_upgrade`): `git merge-file --diff3` with `ours`=plugin, `theirs`=vault-live, `base`=snapshot.
  - clean merge → live + snapshot advance
  - conflict → `parser.py.proposed-merge` sidecar, **live left untouched** (never a broken `.py` in place)
- `_refuse_pending_sidecars` now also blocks on a pending parser sidecar.
- **Migration:** vaults predating this change have no snapshot → `base` defaults to `theirs`, so a vault-edited parser is sidecar-surfaced, never overwritten (same safety pattern used for the M3 brain-file incident).

## Test plan
- `ruff check` + `ruff format --check` clean; `mypy scout` clean
- 582 unit tests pass (the 2 `test_cli_schedule_subapp` failures are pre-existing and environment-dependent — they read a real vault's `overnight-research` slot — and are unrelated to this change; green in clean CI)
- +5 new tests: install seeds snapshot; vault edit survives clean upgrade (the Pattern #68 regression); overlapping edits → sidecar + live untouched; migration (no snapshot) → sidecar + edit preserved; pending sidecar blocks upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)
