### PR TITLE
feat: installer + two-surface /scout-update + guided auto-update config (Phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ Autonomous knowledge management and daily briefing system for Claude Code. Scout
 
 You shouldn't have to manually track what happened across seven different tools yesterday, what's still pending from last week, or what changed while you were in meetings. Scout does that automatically. It reads your tools, cross-checks findings against each other, writes a coherent knowledge base, and surfaces only what matters. The knowledge base is browsable in Obsidian as an interlinked graph of projects, people, channels, and action items.
 
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jordanrburger/scout-plugin/main/install.sh | bash
+```
+
+Then open Claude Code and run `/scout-setup` to create your vault.
+
+**Updating later:** run `/scout-update` — it refreshes the plugin and upgrades your vault (sidecar-safe).
+
 ## Quick Start
 
 Scout is distributed as a Claude Code plugin via a built-in marketplace catalog (`.claude-plugin/marketplace.json`). Install it with:

--- a/commands/scout-setup.md
+++ b/commands/scout-setup.md
@@ -124,6 +124,32 @@ Capture exit code and stdout. The command emits one line per concern: `installed
 
 ---
 
+## Step 3b: Auto-update preference
+
+Ask the user:
+
+> "Should Scout keep itself up to date automatically? When on, scheduled runs apply sidecar-clean upgrades and ping you if a change needs manual review. (You can change this later via `/scout-update`.)"
+
+Wait for a yes/no answer. Then persist the preference by writing/merging the `auto_update` block directly into the freshly-created `~/Scout/scout-config.yaml`. (The vault template is not rendered at install time, so this is the only way to make the preference stick — do NOT rely on the template.)
+
+```bash
+python3 - <<'EOF'
+import pathlib, yaml
+ENABLED = True   # set to False if the user declined
+p = pathlib.Path.home() / "Scout" / "scout-config.yaml"
+cfg = yaml.safe_load(p.read_text()) or {}
+cfg.setdefault("auto_update", {})
+cfg["auto_update"]["enabled"] = ENABLED
+cfg["auto_update"].setdefault("channel", "stable")
+p.write_text(yaml.safe_dump(cfg, sort_keys=False))
+print(f"auto_update.enabled set to {ENABLED} (channel: stable).")
+EOF
+```
+
+Set `ENABLED = True` if the user said yes, `False` if they said no.
+
+---
+
 ## Step 4: Report and offer first-run
 
 Report the result to the user:

--- a/commands/scout-status.md
+++ b/commands/scout-status.md
@@ -162,6 +162,34 @@ SCOUTCTL_BIN=$(crontab -l 2>/dev/null | awk '
 
 Then check `[ -e "$SCOUTCTL_BIN" ]` and `[ -x "$SCOUTCTL_BIN" ]`. (TCC restrictions are macOS-specific; skip the protected-dir check on Linux.)
 
+### 3f. Update status
+
+Check the installed plugin version against the latest available, and read the auto-update preference:
+
+```bash
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$HOME/scout-plugin}"
+"$PLUGIN_ROOT/.venv/bin/scoutctl" self-update check
+```
+
+Capture the output. The command prints the installed version, the available version, and whether an update is available (e.g. `up-to-date` or `update-available: <version>`).
+
+Then read `auto_update.enabled` from `~/Scout/scout-config.yaml` (absent ⇒ treat as `false`):
+
+```bash
+python3 - <<'EOF'
+import pathlib, yaml
+p = pathlib.Path.home() / "Scout" / "scout-config.yaml"
+if p.exists():
+    cfg = yaml.safe_load(p.read_text()) or {}
+    enabled = cfg.get("auto_update", {}).get("enabled", False)
+    print("AUTO_UPDATE_ON" if enabled else "AUTO_UPDATE_OFF")
+else:
+    print("AUTO_UPDATE_OFF")
+EOF
+```
+
+Store both results for rendering in the dashboard below.
+
 ---
 
 ## Step 4: Compose and Display the Dashboard
@@ -330,6 +358,19 @@ If the bin-path validation (step 3e sub-checks above) found issues, render one o
 On Linux, swap "in plist" for "in crontab" and "install-plist" for "install-cron".
 
 If bin-path validation passes, no extra output — the launchctl table alone is enough.
+
+---
+
+### Update status
+
+Using the version info and auto-update flag collected in step 3f, display:
+
+```
+  Plugin:       <installed-version>  (<up-to-date> or <update available: X.Y.Z>)
+  Auto-update:  on  /  off
+```
+
+If an update is available, add: "Run `/scout-update` to apply it."
 
 ---
 

--- a/commands/scout-status.md
+++ b/commands/scout-status.md
@@ -168,10 +168,10 @@ Check the installed plugin version against the latest available, and read the au
 
 ```bash
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$HOME/scout-plugin}"
-"$PLUGIN_ROOT/.venv/bin/scoutctl" self-update check
+"$PLUGIN_ROOT/.venv/bin/scoutctl" self-update check || echo "SELF_UPDATE_UNAVAILABLE"
 ```
 
-Capture the output. The command prints the installed version, the available version, and whether an update is available (e.g. `up-to-date` or `update-available: <version>`).
+Capture the output. The command prints the installed version, the available version, and whether an update is available (e.g. `up to date (<version>)` or `update available: <installed> -> <available>`). If the command exits non-zero or the output contains `SELF_UPDATE_UNAVAILABLE`, treat the update status as unavailable (network or other error).
 
 Then read `auto_update.enabled` from `~/Scout/scout-config.yaml` (absent ⇒ treat as `false`):
 
@@ -366,7 +366,14 @@ If bin-path validation passes, no extra output — the launchctl table alone is 
 Using the version info and auto-update flag collected in step 3f, display:
 
 ```
-  Plugin:       <installed-version>  (<up-to-date> or <update available: X.Y.Z>)
+  Plugin:       <installed-version>  (up to date (<version>) or update available: <installed> -> <available>)
+  Auto-update:  on  /  off
+```
+
+If the update check was unavailable (network error or non-zero exit), display:
+
+```
+  Plugin:       <installed-version>  (update status: unavailable (couldn't reach marketplace))
   Auto-update:  on  /  off
 ```
 

--- a/commands/scout-update.md
+++ b/commands/scout-update.md
@@ -24,6 +24,40 @@ Use `"$SCOUTCTL"` in every subsequent invocation.
 
 ---
 
+## Step 0.5: Refresh the plugin (Surface A) before upgrading the vault (Surface B)
+
+This command updates **both** surfaces — the plugin first, then the vault against the freshly-refreshed plugin. That order matters: upgrading the vault against a stale plugin would apply old templates and miss engine fixes that landed since the last `claude plugin install`.
+
+Pull the latest plugin code:
+
+```bash
+bash <<'EOF'
+set -e
+if [ -d "$HOME/scout-plugin/.git" ]; then
+  git -C "$HOME/scout-plugin" pull --ff-only && echo "PULLED_DIRECTORY:$HOME/scout-plugin"
+else
+  claude plugin marketplace update scout-plugin || true
+  claude plugin install scout@scout-plugin || true
+  echo "REFRESHED_MARKETPLACE"
+fi
+EOF
+```
+
+Then resolve the plugin root the rest of this upgrade runs from — prefer the maintainer git checkout when it's present; otherwise derive the path from the installed marketplace cache. Re-pin `$SCOUTCTL` to the new root so every subsequent step uses the updated engine:
+
+```bash
+NEW_ROOT="$HOME/scout-plugin"
+[ -d "$NEW_ROOT/.git" ] || NEW_ROOT="$(claude plugin list --json 2>/dev/null \
+  | python3 -c "import sys,json;print(next(p['installPath'] for m in json.load(sys.stdin).get('plugins',{}).values() for p in m if 'scout-plugin' in p['installPath']))" 2>/dev/null)"
+echo "Upgrading vault against plugin root: $NEW_ROOT"
+[ -x "$NEW_ROOT/.venv/bin/scoutctl" ] || bash "$NEW_ROOT/scripts/install-venv.sh"
+SCOUTCTL="$NEW_ROOT/.venv/bin/scoutctl"
+```
+
+All pre-flight and upgrade steps below use this overridden `"$SCOUTCTL"`.
+
+---
+
 ## Step 0: Pre-flight (refuse if no vault, no venv, pending sidecars, or mismatched venv)
 
 Run:
@@ -100,3 +134,42 @@ Capture exit code (0 = green, 1 = yellow, 2 = red) and stdout/stderr.
 - If exit 2: list every `error:` line. Suggest `scoutctl bootstrap doctor` for a clean read of the current state.
 
 If runner backups appeared (`run-*.sh.bak.*`), tell the user the live runners had hand-edits that have been preserved as backups; the fresh templates were installed.
+
+---
+
+## Auto-update nudge
+
+After reporting the upgrade result, check whether the user has auto-updates enabled:
+
+```bash
+python3 - <<'EOF'
+import pathlib, yaml
+p = pathlib.Path.home() / "Scout" / "scout-config.yaml"
+if p.exists():
+    cfg = yaml.safe_load(p.read_text()) or {}
+    enabled = cfg.get("auto_update", {}).get("enabled", False)
+    print("AUTO_UPDATE_ON" if enabled else "AUTO_UPDATE_OFF")
+else:
+    print("AUTO_UPDATE_OFF")
+EOF
+```
+
+- If `AUTO_UPDATE_ON`: nothing to say — auto-updates are already configured.
+- If `AUTO_UPDATE_OFF`: tell the user once: "Auto-updates are off — I can turn them on so Scout keeps itself current (sidecar-clean upgrades only; you'll be pinged on conflict). Want me to enable it?"
+
+If the user agrees, write/merge the `auto_update` block into `~/Scout/scout-config.yaml`, preserving any other keys already in the file:
+
+```bash
+python3 - <<'EOF'
+import pathlib, yaml
+p = pathlib.Path.home() / "Scout" / "scout-config.yaml"
+cfg = yaml.safe_load(p.read_text()) or {}
+cfg.setdefault("auto_update", {})
+cfg["auto_update"]["enabled"] = True
+cfg["auto_update"].setdefault("channel", "stable")
+p.write_text(yaml.safe_dump(cfg, sort_keys=False))
+print("Auto-update enabled (channel: stable).")
+EOF
+```
+
+If the user declines, acknowledge and move on — don't ask again in this session.

--- a/commands/scout-update.md
+++ b/commands/scout-update.md
@@ -11,14 +11,20 @@ This command is for **existing vaults only**. If no vault exists, refuse and tel
 
 ---
 
-## Locating scoutctl
+## Locating scoutctl — canonical resolver
 
-Use the venv that lives inside the plugin Claude Code loaded — `$CLAUDE_PLUGIN_ROOT/.venv/bin/scoutctl`. That guarantees the upgrade reads templates and engine code from THIS plugin checkout, not from some other clone whose venv happens to be on `$PATH`. Belt-and-suspenders: fall back to `~/scout-plugin/.venv/bin/scoutctl` if `$CLAUDE_PLUGIN_ROOT` is somehow unset.
+Every shell block in this command runs in a **fresh process**, so variables set in one block do not carry into the next. Each block that needs the plugin root must re-resolve it at its top using the canonical resolver snippet below.
+
+**Canonical resolver** (copy verbatim into every block that needs `$NEW_ROOT` / `$SCOUTCTL`):
 
 ```bash
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$HOME/scout-plugin}"
-SCOUTCTL="$PLUGIN_ROOT/.venv/bin/scoutctl"
+NEW_ROOT="$HOME/scout-plugin"
+[ -d "$NEW_ROOT/.git" ] || NEW_ROOT="$(claude plugin list --json 2>/dev/null \
+  | python3 -c "import sys,json;print(next(p['installPath'] for m in json.load(sys.stdin).get('plugins',{}).values() for p in m if 'scout-plugin' in p['installPath']))" 2>/dev/null)"
+SCOUTCTL="$NEW_ROOT/.venv/bin/scoutctl"
 ```
+
+This prefers the maintainer git checkout (`~/scout-plugin` when a `.git` dir is present) and otherwise falls back to the freshly-installed marketplace cache path. **Do NOT use `${CLAUDE_PLUGIN_ROOT:-$HOME/scout-plugin}` in any block** — after Step 0.5 refreshes the plugin, `$CLAUDE_PLUGIN_ROOT` may still point at the pre-refresh path.
 
 Use `"$SCOUTCTL"` in every subsequent invocation.
 
@@ -43,7 +49,7 @@ fi
 EOF
 ```
 
-Then resolve the plugin root the rest of this upgrade runs from — prefer the maintainer git checkout when it's present; otherwise derive the path from the installed marketplace cache. Re-pin `$SCOUTCTL` to the new root so every subsequent step uses the updated engine:
+Resolve the plugin root that the rest of this upgrade runs from. **Use this resolved `$NEW_ROOT` as the plugin root for every step below.** Because each shell block runs in a fresh process, re-resolve it at the top of each block that needs it using the canonical resolver (do NOT fall back to `$CLAUDE_PLUGIN_ROOT`, which may point at the pre-refresh plugin):
 
 ```bash
 NEW_ROOT="$HOME/scout-plugin"
@@ -54,8 +60,6 @@ echo "Upgrading vault against plugin root: $NEW_ROOT"
 SCOUTCTL="$NEW_ROOT/.venv/bin/scoutctl"
 ```
 
-All pre-flight and upgrade steps below use this overridden `"$SCOUTCTL"`.
-
 ---
 
 ## Step 0: Pre-flight (refuse if no vault, no venv, pending sidecars, or mismatched venv)
@@ -65,18 +69,20 @@ Run:
 ```bash
 bash <<'EOF'
 set -e
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$HOME/scout-plugin}"
-SCOUTCTL="$PLUGIN_ROOT/.venv/bin/scoutctl"
+NEW_ROOT="$HOME/scout-plugin"
+[ -d "$NEW_ROOT/.git" ] || NEW_ROOT="$(claude plugin list --json 2>/dev/null \
+  | python3 -c "import sys,json;print(next(p['installPath'] for m in json.load(sys.stdin).get('plugins',{}).values() for p in m if 'scout-plugin' in p['installPath']))" 2>/dev/null)"
+SCOUTCTL="$NEW_ROOT/.venv/bin/scoutctl"
 
 test -f "$HOME/Scout/scout-config.yaml" || { echo "NO_VAULT"; exit 0; }
 ls "$HOME/Scout/"{SKILL,DREAMING,RESEARCH}.md.proposed-merge 2>/dev/null && { echo "PENDING_SIDECARS"; exit 0; }
-test -x "$SCOUTCTL" || { echo "VENV_MISSING:$PLUGIN_ROOT"; exit 0; }
+test -x "$SCOUTCTL" || { echo "VENV_MISSING:$NEW_ROOT"; exit 0; }
 
 # Verify the venv is editable-installed FROM this plugin checkout.
 # Otherwise we'd run the upgrade against the OTHER tree's templates.
 PYTHON="$(dirname "$SCOUTCTL")/python"
 INSTALLED=$("$PYTHON" -c "import scout, os; print(os.path.realpath(os.path.dirname(os.path.dirname(scout.__file__))))" 2>/dev/null)
-EXPECTED=$(cd "$PLUGIN_ROOT/engine" 2>/dev/null && pwd -P)
+EXPECTED=$(cd "$NEW_ROOT/engine" 2>/dev/null && pwd -P)
 if [ -n "$INSTALLED" ] && [ -n "$EXPECTED" ] && [ "$INSTALLED" != "$EXPECTED" ]; then
     echo "VENV_MISMATCH:$INSTALLED|$EXPECTED"
     exit 0
@@ -89,12 +95,12 @@ EOF
 - `PENDING_SIDECARS`: "Unresolved merge conflicts from a prior `/scout-update`:" — list the sidecar files. Then: "Edit each file to remove conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`), then run `mv X.md.proposed-merge X.md` for each. Then re-run `/scout-update`."
 - `VENV_MISSING:<plugin-root>`: "Engine venv missing at `<plugin-root>/.venv/`. Install it with:" then show:
   ```
-  bash "$CLAUDE_PLUGIN_ROOT/scripts/install-venv.sh"
+  bash "$NEW_ROOT/scripts/install-venv.sh"
   ```
-  (or substitute the actual plugin root if `$CLAUDE_PLUGIN_ROOT` isn't set in the user's shell). Then re-run `/scout-update`.
-- `VENV_MISMATCH:<installed>|<expected>`: "The venv at `$PLUGIN_ROOT/.venv/` is editable-installed from `<installed>`, but this plugin is loaded from `<expected>`. Running the upgrade now would apply the OTHER tree's templates, not the ones in this checkout. Re-install the venv pinned to this plugin source:" then show:
+  Then re-run `/scout-update`.
+- `VENV_MISMATCH:<installed>|<expected>`: "The venv at `$NEW_ROOT/.venv/` is editable-installed from `<installed>`, but this plugin is loaded from `<expected>`. Running the upgrade now would apply the OTHER tree's templates, not the ones in this checkout. Re-install the venv pinned to this plugin source:" then show:
   ```
-  bash "$CLAUDE_PLUGIN_ROOT/scripts/install-venv.sh"
+  bash "$NEW_ROOT/scripts/install-venv.sh"
   ```
   Then re-run `/scout-update`.
 - `READY`: continue.
@@ -106,8 +112,12 @@ EOF
 Read the current and target plugin versions:
 
 ```bash
+NEW_ROOT="$HOME/scout-plugin"
+[ -d "$NEW_ROOT/.git" ] || NEW_ROOT="$(claude plugin list --json 2>/dev/null \
+  | python3 -c "import sys,json;print(next(p['installPath'] for m in json.load(sys.stdin).get('plugins',{}).values() for p in m if 'scout-plugin' in p['installPath']))" 2>/dev/null)"
+SCOUTCTL="$NEW_ROOT/.venv/bin/scoutctl"
 "$SCOUTCTL" version
-python3 -c "import json; print(json.load(open('${CLAUDE_PLUGIN_ROOT}/plugin.json'))['version'])"
+python3 -c "import json; print(json.load(open('$NEW_ROOT/plugin.json'))['version'])"
 grep version_at_last_update ~/Scout/scout-config.yaml || true
 ```
 

--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -1017,13 +1017,14 @@ app.add_typer(self_update_app, name="self-update")
 @self_update_app.command("check")
 def self_update_check(json_out: bool = typer.Option(False, "--json")) -> None:
     """Report installed-vs-available plugin version (read-only)."""
+    import dataclasses as _dc
     import json as _json
 
     from scout.scripts.self_update import check as _check
 
     status = _check()
     if json_out:
-        typer.echo(_json.dumps(status.__dict__))
+        typer.echo(_json.dumps(_dc.asdict(status)))
     else:
         msg = (
             f"update available: {status.installed} -> {status.available}"

--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -1010,6 +1010,29 @@ def _register_bootstrap() -> None:
 _register_bootstrap()
 
 
+self_update_app = typer.Typer(help="Plugin self-update (check only in v0.4).")
+app.add_typer(self_update_app, name="self-update")
+
+
+@self_update_app.command("check")
+def self_update_check(json_out: bool = typer.Option(False, "--json")) -> None:
+    """Report installed-vs-available plugin version (read-only)."""
+    import json as _json
+
+    from scout.scripts.self_update import check as _check
+
+    status = _check()
+    if json_out:
+        typer.echo(_json.dumps(status.__dict__))
+    else:
+        msg = (
+            f"update available: {status.installed} -> {status.available}"
+            if status.update_available
+            else f"up to date ({status.installed})"
+        )
+        typer.echo(msg)
+
+
 @app.command()
 def tui() -> None:
     """Launch the Textual action-items TUI."""

--- a/engine/scout/defaults/scout-config.yaml
+++ b/engine/scout/defaults/scout-config.yaml
@@ -21,3 +21,7 @@ features:
   tui: true
   connector_health: true
   dreaming: true
+
+auto_update:
+  enabled: false
+  channel: stable

--- a/engine/scout/scripts/bootstrap.py
+++ b/engine/scout/scripts/bootstrap.py
@@ -152,6 +152,7 @@ def _template_vars(cfg: BootstrapConfig) -> dict[str, str]:
         "MAX_BUDGET": cfg.connector_inputs.get("max_budget", "5.00"),
         "CLAUDE_BIN": cfg.connector_inputs.get("claude_bin", "/usr/local/bin/claude"),
         "TODAY_DATE": _dt.date.today().isoformat(),
+        "AUTO_UPDATE_ENABLED": cfg.connector_inputs.get("auto_update_enabled", "false"),
     }
 
 

--- a/engine/scout/scripts/self_update.py
+++ b/engine/scout/scripts/self_update.py
@@ -25,7 +25,9 @@ class UpdateStatus:
 
 
 def _semver_tuple(v: str) -> tuple[int, int, int]:
-    parts = (v.split("-")[0].split("."))[:3]
+    # strip pre-release (-...) and build metadata (+...) before parsing
+    core = v.split("+")[0].split("-")[0]
+    parts = core.split(".")[:3]
     nums = [int(p) for p in parts] + [0, 0, 0]
     return (nums[0], nums[1], nums[2])
 
@@ -46,8 +48,11 @@ def _installed_version() -> str:
 
 def _available_version() -> str:
     with urllib.request.urlopen(RAW_MARKETPLACE_URL, timeout=10) as resp:  # noqa: S310
-        data = json.loads(resp.read().decode("utf-8"))
-    return data["plugins"][0]["version"]
+        raw = resp.read().decode("utf-8")
+    try:
+        return json.loads(raw)["plugins"][0]["version"]
+    except (json.JSONDecodeError, KeyError, IndexError, TypeError) as e:
+        raise RuntimeError(f"could not parse marketplace.json from {RAW_MARKETPLACE_URL}: {e}") from e
 
 
 def check(

--- a/engine/scout/scripts/self_update.py
+++ b/engine/scout/scripts/self_update.py
@@ -8,6 +8,7 @@ can use it.
 from __future__ import annotations
 
 import json
+import urllib.error
 import urllib.request
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -47,8 +48,11 @@ def _installed_version() -> str:
 
 
 def _available_version() -> str:
-    with urllib.request.urlopen(RAW_MARKETPLACE_URL, timeout=10) as resp:  # noqa: S310
-        raw = resp.read().decode("utf-8")
+    try:
+        with urllib.request.urlopen(RAW_MARKETPLACE_URL, timeout=10) as resp:  # noqa: S310
+            raw = resp.read().decode("utf-8")
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        raise RuntimeError(f"could not reach marketplace at {RAW_MARKETPLACE_URL}: {e}") from e
     try:
         return json.loads(raw)["plugins"][0]["version"]
     except (json.JSONDecodeError, KeyError, IndexError, TypeError) as e:

--- a/engine/scout/scripts/self_update.py
+++ b/engine/scout/scripts/self_update.py
@@ -1,0 +1,58 @@
+"""Read-only 'is a newer plugin version available?' check.
+
+Auto-APPLY is intentionally out of scope here (deferred). This module only
+reports installed-vs-available so /scout-status and the /scout-update nudge
+can use it.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass
+
+RAW_MARKETPLACE_URL = (
+    "https://raw.githubusercontent.com/jordanrburger/scout-plugin/main/.claude-plugin/marketplace.json"
+)
+
+
+@dataclass(frozen=True)
+class UpdateStatus:
+    installed: str
+    available: str
+    update_available: bool
+
+
+def _semver_tuple(v: str) -> tuple[int, int, int]:
+    parts = (v.split("-")[0].split("."))[:3]
+    nums = [int(p) for p in parts] + [0, 0, 0]
+    return (nums[0], nums[1], nums[2])
+
+
+def compare(*, installed: str, available: str) -> UpdateStatus:
+    return UpdateStatus(
+        installed=installed,
+        available=available,
+        update_available=_semver_tuple(available) > _semver_tuple(installed),
+    )
+
+
+def _installed_version() -> str:
+    from scout import __version__
+
+    return __version__
+
+
+def _available_version() -> str:
+    with urllib.request.urlopen(RAW_MARKETPLACE_URL, timeout=10) as resp:  # noqa: S310
+        data = json.loads(resp.read().decode("utf-8"))
+    return data["plugins"][0]["version"]
+
+
+def check(
+    *,
+    installed_fetcher: Callable[[], str] = _installed_version,
+    available_fetcher: Callable[[], str] = _available_version,
+) -> UpdateStatus:
+    return compare(installed=installed_fetcher(), available=available_fetcher())

--- a/engine/tests/unit/test_config_auto_update.py
+++ b/engine/tests/unit/test_config_auto_update.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from scout.config import load_config
+
+
+def test_auto_update_defaults_present(tmp_path):
+    # With no vault config, packaged defaults must supply auto_update (disabled).
+    cfg = load_config(data_dir=tmp_path)
+    assert cfg["auto_update"]["enabled"] is False
+    assert cfg["auto_update"]["channel"] == "stable"

--- a/engine/tests/unit/test_self_update.py
+++ b/engine/tests/unit/test_self_update.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from scout.scripts import self_update
+
+
+def test_compare_detects_update():
+    r = self_update.compare(installed="0.4.0", available="0.5.0")
+    assert r.update_available is True
+    assert r.installed == "0.4.0" and r.available == "0.5.0"
+
+
+def test_compare_no_update_when_equal():
+    assert self_update.compare(installed="0.5.0", available="0.5.0").update_available is False
+
+
+def test_compare_no_update_when_installed_ahead():
+    assert self_update.compare(installed="0.6.0", available="0.5.0").update_available is False
+
+
+def test_check_uses_injected_fetchers(monkeypatch):
+    r = self_update.check(
+        installed_fetcher=lambda: "0.4.0",
+        available_fetcher=lambda: "0.5.0",
+    )
+    assert r.update_available is True

--- a/engine/tests/unit/test_self_update.py
+++ b/engine/tests/unit/test_self_update.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from scout.scripts import self_update
 
 
@@ -17,9 +19,17 @@ def test_compare_no_update_when_installed_ahead():
     assert self_update.compare(installed="0.6.0", available="0.5.0").update_available is False
 
 
-def test_check_uses_injected_fetchers(monkeypatch):
+def test_check_uses_injected_fetchers():
     r = self_update.check(
         installed_fetcher=lambda: "0.4.0",
         available_fetcher=lambda: "0.5.0",
     )
     assert r.update_available is True
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [("0.5.0", (0, 5, 0)), ("0.5", (0, 5, 0)), ("0.5.0-beta.1", (0, 5, 0)), ("1.2.3+build.7", (1, 2, 3))],
+)
+def test_semver_tuple_parsing(raw, expected):
+    assert self_update._semver_tuple(raw) == expected

--- a/engine/tests/unit/test_self_update.py
+++ b/engine/tests/unit/test_self_update.py
@@ -33,3 +33,16 @@ def test_check_uses_injected_fetchers():
 )
 def test_semver_tuple_parsing(raw, expected):
     assert self_update._semver_tuple(raw) == expected
+
+
+def test_check_propagates_runtime_error_from_available_fetcher():
+    """check() must surface RuntimeError from available_fetcher (e.g. network failure)."""
+
+    def failing_fetcher() -> str:
+        raise RuntimeError("could not reach marketplace at https://example.com: <urlopen error ...>")
+
+    with pytest.raises(RuntimeError, match="could not reach marketplace"):
+        self_update.check(
+            installed_fetcher=lambda: "0.5.0",
+            available_fetcher=failing_fetcher,
+        )

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Scout one-command installer.
+#   curl -fsSL https://raw.githubusercontent.com/jordanrburger/scout-plugin/main/install.sh | bash
+# Sets up the PLUGIN + ENGINE. The interactive vault is then created with /scout-setup.
+#
+# Flags: --check  (verify preconditions only; make no changes)
+set -euo pipefail
+
+MARKETPLACE="jordanrburger/scout-plugin"
+CHECK_ONLY=0
+[ "${1:-}" = "--check" ] && CHECK_ONLY=1
+
+have() { command -v "$1" >/dev/null 2>&1; }
+fail() { echo "error: $*" >&2; exit 1; }
+
+# --- preconditions ---
+have claude || fail "Claude Code CLI not found. Install it first: https://docs.claude.com/claude-code (then re-run this)."
+have git    || fail "git is required."
+if ! have uv; then
+  echo "uv not found — installing (https://docs.astral.sh/uv)…"
+  [ "$CHECK_ONLY" = 1 ] || curl -fsSL https://astral.sh/uv/install.sh | sh
+fi
+
+if [ "$CHECK_ONLY" = 1 ]; then
+  echo "preconditions OK (claude, git present; uv $(have uv && echo present || echo 'will-install'))"
+  exit 0
+fi
+
+# --- plugin + engine ---
+echo "Adding the Scout marketplace…"
+claude plugin marketplace add "$MARKETPLACE" 2>/dev/null || claude plugin marketplace update scout-plugin
+echo "Installing the Scout plugin…"
+claude plugin install scout@scout-plugin
+
+# Resolve the installed plugin root and build its engine venv.
+ROOT="$(claude plugin list --json 2>/dev/null \
+  | python3 -c "import sys,json;print(next(p['installPath'] for m in json.load(sys.stdin).get('plugins',{}).values() for p in m if 'scout-plugin' in p['installPath']))" 2>/dev/null || true)"
+if [ -n "$ROOT" ] && [ -f "$ROOT/scripts/install-venv.sh" ]; then
+  echo "Setting up the engine venv…"
+  bash "$ROOT/scripts/install-venv.sh"
+fi
+
+cat <<'DONE'
+
+✅ Scout plugin + engine installed.
+
+Next step — create your vault (interactive: detects your connectors, collects
+your details, sets the schedule):
+
+    Open Claude Code and run:  /scout-setup
+
+DONE

--- a/templates/scout-config.yaml.tmpl
+++ b/templates/scout-config.yaml.tmpl
@@ -57,3 +57,10 @@ off_peak:
   # Off-peak hours (local time) — heartbeat prefers these for opportunistic sessions.
   start: 23
   end: 6
+
+# Whether Scout keeps itself up to date. Set during /scout-setup; toggle via
+# /scout-update. When enabled, a scheduled run applies sidecar-clean upgrades
+# and notifies you on conflict (auto-apply ships in a later version).
+auto_update:
+  enabled: {{AUTO_UPDATE_ENABLED}}
+  channel: stable


### PR DESCRIPTION
## Summary

**Phase 2 of the release & distribution system** (spec/plan: `docs/specs|plans/2026-06-02-release-and-distribution-system.md`). Builds on Phase 1 (#95) to make Scout installable in one command, updatable in one command, and lays the auto-update seam — with the guided sessions as first-class touchpoints.

- **`install.sh` (curl | bash)** — new-user bring-up: preconditions (claude/git/uv) → add the GitHub marketplace → install the plugin → build the engine venv → hand off to interactive `/scout-setup`. Has a `--check` dry-run (no side effects). Deliberately does **not** bootstrap the vault headlessly (setup is interactive). README documents the one-liner + how to update.
- **Two-surface `/scout-update`** — now updates **both** surfaces: refresh the plugin (git pull for the maintainer's directory marketplace, else `marketplace update` + `install`), then upgrade the vault **against the refreshed plugin**. Each shell block re-resolves the refreshed plugin root (fresh-process safe), so the GitHub-marketplace-cache path upgrades against the *new* plugin, not the stale `$CLAUDE_PLUGIN_ROOT`. Ends with a one-time auto-update nudge.
- **`scoutctl self-update check`** — read-only installed-vs-available version compare (reads the version Phase 1 keeps synced in `marketplace.json`); robust semver parse (handles pre-release/build metadata); graceful error if the marketplace is unreachable. CLI imports stay lazy (perf guard).
- **`auto_update` config** — `{enabled: false, channel: stable}` in packaged defaults, surfaced via `load_config` and preserved across upgrades. `/scout-setup` asks the preference and persists it into the vault `scout-config.yaml`; `/scout-status` shows installed/available version + auto-update on/off.
- **Auto-*apply* remains deferred** (seam only) per the spec.

## Test plan
- [x] `ruff` + `mypy scout` clean; version-sync guard green
- [x] 615 unit tests pass (incl. new `test_self_update.py` + `test_config_auto_update.py`); perf import-guard green
- [x] `install.sh`: `bash -n` + shellcheck clean; `--check` exits 0 with no side effects
- [x] all command-md bash snippets `bash -n` clean
- Note: the 2 pre-existing `test_cli_schedule_subapp` failures are environment-dependent (real-vault `overnight-research` slot) and unrelated — green in clean CI (as #95 showed).

Built via subagent-driven development (implementer → spec review → quality review per task) + a final whole-phase review (verdict: mergeable; the one Important finding — cross-block plugin-root propagation — was fixed in `c01b445`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
