### PR TITLE
release: v0.5.0 — release & distribution system

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "scout",
       "source": "./",
       "description": "Autonomous knowledge management and daily briefing system for Claude Code",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "author": {
         "name": "Jordan Burger"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scout",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Autonomous knowledge management and daily briefing system. Monitors your work tools (Slack, Calendar, Linear, GitHub, etc.), synthesizes findings into a persistent knowledge base with a formal ontology, and delivers daily action items — all running unattended via scheduled Claude Code sessions. Six session types: Morning Briefing, Consolidation, Dreaming, Research, interactive Work sessions, and Meta Review. Pre-session hooks pre-compute KB staleness, recent git activity, PR state, and Claude Code session summaries before each run, trading a few seconds of shell work for large token savings inside the session.",
   "author": {
     "name": "Jordan Burger"

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ venv/
 
 # scoutctl manifest build output (per-machine artifact)
 engine/manifest.json
+
+# Local per-checkout artifacts (not part of the plugin)
+.claude/
+.scoutctl-py-cache
+PLAN-8-RESUME.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-03
+
+
+### Added
+- **One-command installer** — `curl -fsSL …/install.sh | bash` brings up the plugin + engine and hands off to interactive `/scout-setup`.
+- **Release pipeline** — single-source-of-truth versioning across all four manifests (`scout.scripts.versioning`), `scripts/release.sh`, a CI version-drift guard, and this `CHANGELOG.md`; `v*` tags publish a GitHub Release.
+- **`scoutctl self-update check`** — read-only installed-vs-available version check (robust semver parse; graceful offline error).
+- **`auto_update` config** (disabled by default) + `/scout-setup` preference prompt + `/scout-status` update dashboard.
+
+### Changed
+- **`/scout-update` updates both surfaces** — refreshes the plugin, then upgrades the vault against the refreshed plugin (sidecar-safe; resolves the new plugin root per shell block).
+- **Releases land via PR** — `main` is ruleset-protected, so `release.sh` prepares a release branch + PR and finalizes by tagging the merge.
+
 ## [0.4.0] - 2026-06-02
 
 ### Added

--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scout-engine"
-version = "0.4.0"
+version = "0.5.0"
 description = "Scout engine: CLI, hooks, runners, and Python library for the Scout productivity system."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/engine/scout/__init__.py
+++ b/engine/scout/__init__.py
@@ -1,3 +1,3 @@
 """Scout engine package."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,43 +1,77 @@
 #!/usr/bin/env bash
-# Cut a release: bump the canonical version, propagate to all four manifests,
-# promote the CHANGELOG, run the full check suite, then commit + tag + push.
+# Cut a release.
 #
-# Usage: scripts/release.sh [patch|minor|major|X.Y.Z]   (default: patch)
+# `main` is ruleset-protected (requires pull requests, no direct pushes), so a
+# release lands via a PR — not a direct push. This script has two phases:
+#
+#   scripts/release.sh [patch|minor|major|X.Y.Z]   # PREPARE: bump on a release branch + open the release PR
+#   scripts/release.sh --finalize vX.Y.Z           # FINALIZE (after the PR merges): tag the merge commit + push
+#
+# The pushed tag triggers .github/workflows/release.yml, which re-runs the test
+# matrix and publishes the GitHub Release from the CHANGELOG section.
+#
+# Test gating: the PR's required CI runs the full pytest matrix in a clean
+# environment. Locally we run only the fast, deterministic checks (ruff, mypy,
+# version-sync) — the test suite has environment-dependent cases that are green
+# in CI but can be noisy on a maintainer's machine with a live vault.
 set -euo pipefail
 
-LEVEL="${1:-patch}"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PY="$ROOT/engine/.venv/bin/python"
 cd "$ROOT"
-
-# --- preconditions ---
 [ -x "$PY" ] || { echo "error: engine venv missing — run scripts/install-venv.sh" >&2; exit 1; }
-[ "$(git rev-parse --abbrev-ref HEAD)" = "main" ] || { echo "error: releases are cut from main" >&2; exit 1; }
+
+# ---------------------------------------------------------------- finalize ----
+if [ "${1:-}" = "--finalize" ]; then
+    TAG="${2:-}"
+    [ -n "$TAG" ] || { echo "error: --finalize requires a tag, e.g. --finalize v0.5.0" >&2; exit 1; }
+    VER="${TAG#v}"
+    git fetch -q origin
+    # The release PR must be merged first: origin/main's CHANGELOG carries this version.
+    if ! git show "origin/main:CHANGELOG.md" | grep -q "## \[$VER\]"; then
+        echo "error: origin/main CHANGELOG has no [$VER] section — merge the release PR first" >&2
+        exit 1
+    fi
+    if git rev-parse "$TAG" >/dev/null 2>&1; then
+        echo "error: tag $TAG already exists" >&2
+        exit 1
+    fi
+    git tag "$TAG" origin/main
+    git push origin "$TAG"
+    echo "Tagged $TAG at origin/main and pushed. release.yml will publish the GitHub Release."
+    exit 0
+fi
+
+# ----------------------------------------------------------------- prepare ----
+LEVEL="${1:-patch}"
+[ "$(git rev-parse --abbrev-ref HEAD)" = "main" ] || { echo "error: prepare a release from main" >&2; exit 1; }
 [ -z "$(git status --porcelain)" ] || { echo "error: working tree not clean" >&2; exit 1; }
 git fetch -q origin
 [ "$(git rev-list --count origin/main..HEAD)" = "0" ] && [ "$(git rev-list --count HEAD..origin/main)" = "0" ] \
     || { echo "error: local main not in sync with origin/main" >&2; exit 1; }
 
-# --- bump + propagate + changelog ---
 "$PY" -m scout.scripts.versioning check >/dev/null   # refuse if already drifted
 NEW="$("$PY" -m scout.scripts.versioning bump "$LEVEL")"
+BRANCH="release/v$NEW"
 TODAY="$(TZ=America/New_York date '+%Y-%m-%d')"
+
+git checkout -b "$BRANCH"
+"$PY" -m scout.scripts.versioning set "$NEW" >/dev/null
 "$PY" - "$NEW" "$TODAY" <<'EOF'
 import sys
 from scout.scripts import versioning
 versioning.promote_changelog(version=sys.argv[1], date=sys.argv[2])
 EOF
-echo "Releasing v$NEW"
+echo "Prepared v$NEW on $BRANCH"
 
-# --- never tag a red tree ---
+# Fast, deterministic local gate (the PR's CI runs the full pytest matrix).
 ( cd engine && .venv/bin/ruff check scout tests && .venv/bin/ruff format --check scout tests \
-    && .venv/bin/mypy scout && .venv/bin/python -m pytest -q )
+    && .venv/bin/mypy scout && .venv/bin/python -m scout.scripts.versioning check )
 
-# --- commit + tag + push ---
 git add .claude-plugin/plugin.json .claude-plugin/marketplace.json \
         engine/pyproject.toml engine/scout/__init__.py CHANGELOG.md
 git commit -m "release: v$NEW"
-git tag "v$NEW"
-git push origin main
-git push origin "v$NEW"
-echo "Pushed v$NEW + tag. Release workflow will publish the GitHub Release."
+git push -u origin "$BRANCH"
+gh pr create --base main --head "$BRANCH" --title "release: v$NEW" \
+    --body "Automated release prep for v$NEW. Review, ensure CI is green, and merge — then run \`scripts/release.sh --finalize v$NEW\` to tag and publish the GitHub Release."
+echo "Release PR opened for v$NEW. After it merges: scripts/release.sh --finalize v$NEW"


### PR DESCRIPTION
First tagged release. Ships the full **release & distribution system** (Phases 1+2) and fixes the release flow to work with this repo's PR ruleset.

## Included
- **Versioning SoT + CI drift guard** (Phase 1, already on main): bumps all four manifests in lockstep to **0.5.0**.
- **`scripts/release.sh` reworked** for ruleset-protected `main`: `prepare` (release branch + PR) and `--finalize vX.Y.Z` (tag the merge → `release.yml` publishes the GitHub Release). It can no longer push to `main` directly because the repo ruleset forbids it.
- **`.gitignore`** for local per-checkout artifacts (`.claude/`, scoutctl cache, `PLAN-8-RESUME.md`) so the tree is clean for releases.
- **CHANGELOG** promoted: `[0.5.0]` documents the installer, two-surface `/scout-update`, `self-update check`, `auto_update` config, and the release pipeline.

## After merge
`scripts/release.sh --finalize v0.5.0` tags the merge commit and pushes it, triggering `release.yml` to publish the GitHub Release from the `[0.5.0]` CHANGELOG section.

## Test plan
- [x] ruff + mypy + version-sync (`0.5.0`) clean locally
- [x] `bash -n scripts/release.sh`
- PR CI runs the full matrix (authoritative test gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)