### PR TITLE
fix(action-items): bind dash-form comments in render; attribute add-comment (#100)

### DIFF
--- a/engine/scout/action_items/add_comment.py
+++ b/engine/scout/action_items/add_comment.py
@@ -1,7 +1,15 @@
 """Append a comment beneath an action item.
 
-Inserts a ``  - <comment>`` sub-bullet directly beneath the matched task
-line. The task itself stays in place — the sub-bullet is the comment.
+Inserts a ``  - <author>: <comment>`` sub-bullet directly beneath the
+matched task line. The task itself stays in place — the sub-bullet is
+the comment. The ``<author>:`` prefix is what binds the line to the
+comment-thread reader (``render.py`` and ``_common.py``); without it the
+line is indistinguishable from a plain detail bullet and renders as a
+detached section note. See scout-plugin#100.
+
+``author`` defaults to ``"scout"`` (the CLI/automation writer); the GUI
+passes the signed-in user's display name via ``--author`` so the comment
+is attributed to a person (e.g. ``- Vaclav Nosek: ...``).
 
 Returns an `Event` describing the mutation. v0.4 mutators emit Events
 but nothing persists them yet; v0.5 will add the SQLite event store.
@@ -31,15 +39,21 @@ def add_comment(
     comment: str,
     by_id: str | None = None,
     by_subject: str | None = None,
+    author: str = "scout",
     date: dt.date | None = None,
     data_dir: Path | None = None,
 ) -> Event:
-    """Append `  - <comment>` beneath today's (or `date`'s) action item.
+    """Append `  - <author>: <comment>` beneath today's (or `date`'s) item.
 
     Exactly one of `by_id` or `by_subject` must be provided. `by_id` is
     a 4-char Crockford prefix; `by_subject` is a case-insensitive
     substring match against open-status raw lines (legacy fallback for
     lines that haven't been prefixed yet).
+
+    `author` is the attribution prefix written before the comment text.
+    It defaults to ``"scout"``; pass a person's display name for
+    GUI-authored comments. The reader (`render.py`, `_common.py`) keys on
+    this ``<author>:`` prefix to bind the line to the task as a comment.
     """
     target_path = paths.action_items_daily_path(data=data_dir, date=date or _today())
 
@@ -55,7 +69,7 @@ def add_comment(
         by_subject=by_subject,
     )
 
-    insert_below(target_path, line_number=match.line_number, text=f"  - {comment}")
+    insert_below(target_path, line_number=match.line_number, text=f"  - {author}: {comment}")
 
     return Event(
         id=new_ulid(),
@@ -66,6 +80,7 @@ def add_comment(
             "item_id": item_ulid,
             "via": via,
             "title": match.title,
+            "author": author,
             "comment": comment,
         },
     )

--- a/engine/scout/action_items/cli.py
+++ b/engine/scout/action_items/cli.py
@@ -107,6 +107,9 @@ def cli_add_comment(
     comment: str = typer.Option(..., "--comment", help="Comment text to append beneath the task."),
     subject: str | None = typer.Option(None, "--subject", help="Substring of task title (legacy fallback)."),
     by_id: str | None = typer.Option(None, "--by-id", help="4-char Crockford prefix from `[#XXXX]`."),
+    author: str = typer.Option(
+        "scout", "--author", help="Comment attribution (default: scout). GUI passes the signed-in user."
+    ),
     path: Path | None = typer.Argument(
         None,
         help="Daily markdown file (default: today). When given, its grandparent is the data dir.",
@@ -130,7 +133,7 @@ def cli_add_comment(
         except ValueError as e:
             raise ActionItemError(f"unrecognized daily filename: {path.name}") from e
 
-    add_comment(by_id=by_id, by_subject=subject, comment=comment, date=date, data_dir=data_dir)
+    add_comment(by_id=by_id, by_subject=subject, comment=comment, author=author, date=date, data_dir=data_dir)
 
 
 @app.command("delete-comment")

--- a/engine/scout/action_items/render.py
+++ b/engine/scout/action_items/render.py
@@ -94,10 +94,37 @@ BULLET_RE = re.compile(r"^\s*-\s+(?P<rest>.+?)\s*$")
 TABLE_ROW_RE = re.compile(r"^\s*\|(.+)\|\s*$")
 # Indented quote-line comment bound to the preceding task:
 #   "  > scout (2026-04-18 10:20 AM ET): text"
-# Author/timestamp are captured; loose format tolerated (timestamp optional).
+# Author is captured non-greedily up to the colon so multi-word display
+# names ("Vaclav Nosek") match; the timestamp is optional.
 COMMENT_RE = re.compile(
-    r"^(?P<indent>\s+)>\s+(?P<author>[A-Za-z][A-Za-z0-9._-]*)"
+    r"^(?P<indent>\s+)>\s+(?P<author>[A-Za-z][\w .'-]*?)"
     r"(?:\s+\((?P<timestamp>[^)]+)\))?\s*:\s*(?P<text>.+?)\s*$"
+)
+# Indented dash-bullet comment bound to the preceding task — the shape the
+# `add-comment` writer and the CLI comment reader (`_common.py`) emit:
+#   "  - Vaclav Nosek: text"   /   "  - scout: text"
+# Mirrors COMMENT_RE's author tolerance. Distinguishing a comment from a
+# metadata sub-bullet (`- Source:`, `- Context:`) is done by the
+# COMMENT_METADATA_KEYS denylist below, not by the regex. See scout-plugin#100.
+COMMENT_DASH_RE = re.compile(
+    r"^(?P<indent>\s+)-\s+(?P<author>[A-Za-z][\w .'-]*?)"
+    r"(?:\s+\((?P<timestamp>[^)]+)\))?\s*:\s*(?P<text>.+?)\s*$"
+)
+# Dash sub-bullets whose "author" is one of these reserved keys are task
+# *metadata*, not conversation comments, and must not render as comments.
+# The closed vocabulary is defined by the briefing format in
+# phases/core/action-items.md (Source/Context/Evidence/Completed/…) plus the
+# machine `snoozed-until` marker. Matched case-insensitively.
+COMMENT_METADATA_KEYS = frozenset(
+    {
+        "source",
+        "context",
+        "evidence",
+        "completed",
+        "originally from",
+        "current status",
+        "snoozed-until",
+    }
 )
 
 
@@ -199,12 +226,20 @@ def parse(md_path: Path) -> tuple[str, list[str], list[Section]]:
             i += 1
             continue
 
-        # Comment line bound to the preceding task (indented quote).
+        # Comment line bound to the preceding task. Two serializations are
+        # accepted: the legacy indented quote (`  > author (ts): text`) and
+        # the dash form the `add-comment` writer emits (`  - author: text`).
+        # The dash form must beat BULLET_RE below, and is gated on the
+        # metadata-key denylist so `- Source:`/`- Context:` stay plain bullets.
         c = COMMENT_RE.match(line)
+        if c is None:
+            d = COMMENT_DASH_RE.match(line)
+            if d is not None and d.group("author").strip().lower() not in COMMENT_METADATA_KEYS:
+                c = d
         if c and current is not None and current.tasks:
             current.tasks[-1].comments.append(
                 Comment(
-                    author=c.group("author"),
+                    author=c.group("author").strip(),
                     timestamp=(c.group("timestamp") or "").strip(),
                     text=c.group("text"),
                 )

--- a/engine/tests/unit/test_action_items_add_comment.py
+++ b/engine/tests/unit/test_action_items_add_comment.py
@@ -42,14 +42,31 @@ def test_add_comment_by_id_inserts_subbullet(fake_data_dir: Path, monkeypatch: p
     event = add_comment(by_id="A3F7", comment="Hiring manager confirmed", data_dir=fake_data_dir)
 
     text = daily.read_text()
-    assert "- [ ] [#A3F7] 🔴 Submit Lever feedback\n  - Hiring manager confirmed" in text
+    # Default author is "scout"; the `<author>:` prefix is what binds the
+    # line to the task as a comment (scout-plugin#100).
+    assert "- [ ] [#A3F7] 🔴 Submit Lever feedback\n  - scout: Hiring manager confirmed" in text
     assert "Other unrelated task" in text  # untouched
     assert isinstance(event, Event)
     assert event.kind == "action_item.commented"
     assert event.source == "cli:add_comment"
     assert event.payload["item_id"] == "01HXAAA"
     assert event.payload["via"] == "id"
+    assert event.payload["author"] == "scout"
     assert event.payload["comment"] == "Hiring manager confirmed"
+
+
+def test_add_comment_custom_author_prefix(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A GUI-supplied author is written as the `- <author>: <text>` prefix."""
+    daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
+    daily.parent.mkdir(parents=True, exist_ok=True)
+    daily.write_text("## To Do\n\n- [ ] 🔴 Followup with vendor on contract\n")
+    monkeypatch.setattr("scout.action_items.add_comment._today", lambda: dt.date(2026, 4, 26))
+
+    event = add_comment(
+        by_subject="vendor", comment="test", author="Vaclav Nosek", data_dir=fake_data_dir
+    )
+    assert "  - Vaclav Nosek: test" in daily.read_text()
+    assert event.payload["author"] == "Vaclav Nosek"
 
 
 def test_add_comment_by_subject_fallback(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -59,7 +76,7 @@ def test_add_comment_by_subject_fallback(fake_data_dir: Path, monkeypatch: pytes
     monkeypatch.setattr("scout.action_items.add_comment._today", lambda: dt.date(2026, 4, 26))
 
     event = add_comment(by_subject="vendor", comment="Email sent 4/26", data_dir=fake_data_dir)
-    assert "- Email sent 4/26" in daily.read_text()
+    assert "  - scout: Email sent 4/26" in daily.read_text()
     assert event.payload["via"] == "subject"
     assert event.payload["comment"] == "Email sent 4/26"
 

--- a/engine/tests/unit/test_action_items_add_comment.py
+++ b/engine/tests/unit/test_action_items_add_comment.py
@@ -62,9 +62,7 @@ def test_add_comment_custom_author_prefix(fake_data_dir: Path, monkeypatch: pyte
     daily.write_text("## To Do\n\n- [ ] 🔴 Followup with vendor on contract\n")
     monkeypatch.setattr("scout.action_items.add_comment._today", lambda: dt.date(2026, 4, 26))
 
-    event = add_comment(
-        by_subject="vendor", comment="test", author="Vaclav Nosek", data_dir=fake_data_dir
-    )
+    event = add_comment(by_subject="vendor", comment="test", author="Vaclav Nosek", data_dir=fake_data_dir)
     assert "  - Vaclav Nosek: test" in daily.read_text()
     assert event.payload["author"] == "Vaclav Nosek"
 

--- a/engine/tests/unit/test_action_items_render.py
+++ b/engine/tests/unit/test_action_items_render.py
@@ -59,3 +59,77 @@ def test_render_reads_with_explicit_utf8_encoding(tmp_path: Path, monkeypatch: p
     render(md)
 
     assert "utf-8" in captured, f"read_text was called without encoding=utf-8: {captured}"
+
+
+# ---------------------------------------------------------------------------
+# Comment binding (scout-plugin#100)
+#
+# The `add-comment` writer emits `  - <author>: <text>` dash bullets. The
+# parser must bind those to the preceding task as comments — not drop them
+# into section bullets / extra-notes — while leaving the `- Source:` /
+# `- Context:` metadata vocabulary as plain bullets.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_binds_dash_comment_to_task(tmp_path: Path) -> None:
+    from scout.action_items.render import parse
+
+    md = tmp_path / "scout.md"
+    md.write_text(
+        "# Title\n\n## 📌 Section\n\n"
+        "- [ ] 🔴 Submit Lever feedback\n"
+        "  - scout: pinged the hiring manager\n"
+        "  - Vaclav Nosek: looks good to me\n",
+        encoding="utf-8",
+    )
+
+    _title, _preamble, sections = parse(md)
+    task = sections[0].tasks[0]
+    assert [(c.author, c.text) for c in task.comments] == [
+        ("scout", "pinged the hiring manager"),
+        ("Vaclav Nosek", "looks good to me"),  # multi-word author binds
+    ]
+    # Comments are not leaked into section-level bullets.
+    assert not any("hiring manager" in b.text for b in sections[0].bullets)
+
+
+def test_parse_keeps_metadata_subbullets_out_of_comments(tmp_path: Path) -> None:
+    from scout.action_items.render import parse
+
+    md = tmp_path / "scout.md"
+    md.write_text(
+        "# Title\n\n## 📌 Section\n\n"
+        "- [ ] 🔴 Ship the thing\n"
+        "  - Source: Linear (AI-3325)\n"
+        "  - Context: [[kai-backend]]\n"
+        "  - scout: actually started it\n",
+        encoding="utf-8",
+    )
+
+    _title, _preamble, sections = parse(md)
+    task = sections[0].tasks[0]
+    # Only the real comment binds; Source/Context stay metadata, not comments.
+    assert [(c.author, c.text) for c in task.comments] == [("scout", "actually started it")]
+
+
+def test_add_comment_render_round_trip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end: a comment written by add_comment renders under its task."""
+    import datetime as dt
+
+    from scout.action_items.add_comment import add_comment
+    from scout.action_items.render import parse
+
+    data_dir = tmp_path
+    daily = data_dir / "action-items" / "action-items-2026-04-26.md"
+    daily.parent.mkdir(parents=True, exist_ok=True)
+    daily.write_text("# Action Items\n\n## To Do\n\n- [ ] 🔴 Followup with vendor\n")
+    monkeypatch.setattr("scout.action_items.add_comment._today", lambda: dt.date(2026, 4, 26))
+
+    add_comment(by_subject="vendor", comment="left a voicemail", data_dir=data_dir)
+
+    _title, _preamble, sections = parse(daily)
+    task = sections[0].tasks[0]
+    assert [(c.author, c.text) for c in task.comments] == [("scout", "left a voicemail")]
+    # And it surfaces in the rendered HTML, not buried in extra-notes.
+    html_out = render(daily)
+    assert "left a voicemail" in html_out


### PR DESCRIPTION
Closes #100.

## Problem
Comments added via `scoutctl action-items add-comment` never rendered in the Action Items HTML (nor in scout-app, which uses the same `render.py`). The **writer and reader disagreed on the markdown shape**, so comments were silently mis-parsed as detached section bullets and dumped into `extra-notes`.

Three components were inconsistent:
- `add_comment.py` wrote a bare `  - <comment>` (no author) — matched by **neither** reader.
- `_common.py` (CLI list/edit/delete) expects the `  - <author>: <text>` dash form.
- `render.py` only matched the `  > <author> (<ts>): <text>` quote form.

## Fix
- **Writer** (`add_comment.py` + CLI): write `  - <author>: <comment>`. `author` defaults to `scout`; `--author` lets the GUI attribute to the signed-in user (matching the `- Vaclav Nosek: test` reported in the issue). The `<author>:` prefix is the structural signal that binds a line to its task.
- **Reader** (`render.py`): bind the dash form (`COMMENT_DASH_RE`) in addition to the legacy quote form, with **non-greedy authors** so multi-word display names match (the issue's secondary point).
- **Disambiguation**: `phases/core/action-items.md` defines a closed metadata vocabulary written as dash sub-bullets (`Source:`, `Context:`, `Evidence:`, `Completed:`, `Originally from:`, `Current status:`). A `COMMENT_METADATA_KEYS` denylist keeps those (plus the `snoozed-until` marker) out of the comment thread, so they stay plain bullets. This is the reliable separator since comments and metadata share the `- key: text` shape.

## Why this approach
Aligns the writer with the format `_common.py` and scout-app already use, so existing real-world comments (`- <person>: <text>`) render with **no scout-app change** and no disruption to the `_common` list/edit/delete contract.

## Tests
`add_comment` write-shape updated; added custom-author, metadata-exclusion, multi-word-author, and a full `add_comment → parse → render` round-trip. All action-items/render/comment tests pass (122). The 8 unrelated CLI/schedule/telegram failures in the suite pre-exist on `main` (typer/click env drift).

## Follow-up (not in this PR)
`_common._COMMENT_SUB_BULLET_RE` still treats any `- key: text` as a comment, so the CLI's own `list-comments` could surface `Source:`/`Context:` metadata as comments. Applying the same denylist there is a natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)