### PR TITLE
fix(schedule): event-log date from ts, not a second clock read (#37)

### DIFF
--- a/engine/scout/scripts/schedule_tick.py
+++ b/engine/scout/scripts/schedule_tick.py
@@ -535,9 +535,11 @@ def _emit_event(
     The file name is ``schedule-events-<UTC-date>.jsonl`` — UTC-dated
     intentionally (event timestamps are UTC; the file name follows).
 
-    The UTC date is derived from ``_now()`` (not ``datetime.now``) so that
-    a single ``patch("scout.scripts.schedule_tick._now", ...)`` in tests
-    sets both the event clock and the file name consistently.
+    The UTC date is sliced from ``ev.ts`` (the already-formatted event
+    timestamp) rather than read from a second clock. ``ts`` and the file
+    name must agree: a separate ``_now()`` read could land on the far side
+    of UTC midnight from ``now_iso()``, filing a day-N event into the
+    day-(N+1) log and breaking replays/filters keyed on the file name (#37).
     """
     log_dir.mkdir(parents=True, exist_ok=True)
     ev = Event(
@@ -547,7 +549,9 @@ def _emit_event(
         source=source,
         payload=payload,
     )
-    utc_date = _now().astimezone(_dt.UTC).date().isoformat()
+    # now_iso() is "YYYY-MM-DDTHH:MM:SS.mmmZ" in UTC, so the first 10 chars
+    # are the UTC date — the same instant the ts records, by construction.
+    utc_date = ev.ts[:10]
     log_path = log_dir / f"{EVENT_LOG_PREFIX}{utc_date}.jsonl"
     row = {
         "id": ev.id,

--- a/engine/tests/unit/test_schedule_tick.py
+++ b/engine/tests/unit/test_schedule_tick.py
@@ -759,3 +759,24 @@ def test_main_prints_traceback_to_stderr_when_run_raises(capsys):
     captured = capsys.readouterr()
     assert "synthetic failure for visibility test" in captured.err
     assert "Traceback" in captured.err
+
+
+# Event-log filename / ts agreement (#37). The UTC date in the file name must
+# come from the same instant as the event ts — a second clock read could land
+# on the far side of UTC midnight and file the event into the wrong day's log.
+
+
+def test_emit_event_filename_matches_ts_date_across_midnight(tmp_path, monkeypatch):
+    from scout.scripts import schedule_tick as st
+
+    # ts is stamped at 23:59 on day N; a second (stale) clock read would be
+    # day N+1. The filename must follow ts (day N), not the second read.
+    monkeypatch.setattr(st, "now_iso", lambda: "2026-03-14T23:59:59.999Z")
+    monkeypatch.setattr(st, "_now", lambda: datetime(2026, 3, 15, 0, 0, 1, tzinfo=ZoneInfo("UTC")))
+
+    ev = st._emit_event(tmp_path, kind="slot.fired", source="test", payload={})
+
+    logs = list(tmp_path.glob("schedule-events-*.jsonl"))
+    assert len(logs) == 1
+    assert logs[0].name == "schedule-events-2026-03-14.jsonl"
+    assert ev.ts[:10] == "2026-03-14"


### PR DESCRIPTION
Closes #37.

## Problem
`_emit_event` stamped the event `ts` with `now_iso()` but then derived the `schedule-events-<UTC-date>.jsonl` filename from an **independent** `_now()` call. Two wall-clock reads with a tiny window between them — if UTC midnight falls in that window, a day-N event is written into the day-(N+1) log, so replays/filters keyed on the filename are inconsistent. (Critical, audit 2026-05-24.)

## Fix
Slice the UTC date from the already-formatted `ev.ts` (`now_iso()` returns `YYYY-MM-DDTHH:MM:SS.mmmZ` in UTC, so `ev.ts[:10]` is the UTC date). The timestamp and filename now come from the same instant by construction — no second clock.

## Test
Added a regression test that patches the two clocks to straddle midnight (`ts` on day N, second read on day N+1) and asserts the log filename follows `ts` (day N). Would fail on the old `_now()`-derived filename. Full `test_schedule_tick.py` green (39).