### PR TITLE
fix(hooks): flock connector-log JSONL appends; surface write failures (#38)

### DIFF
--- a/engine/scout/hooks/connector_log.py
+++ b/engine/scout/hooks/connector_log.py
@@ -25,6 +25,20 @@ from scout import paths
 from scout.events import Event, now_iso
 from scout.ids import new_ulid
 
+try:
+    import fcntl
+except ImportError:  # non-POSIX (Windows) — advisory locks unavailable.
+    fcntl = None  # type: ignore[assignment]
+
+
+def _lock_exclusive(f: IO[str]) -> None:
+    """Take an exclusive advisory lock; no-op where fcntl is unavailable.
+
+    Released implicitly when the file is closed.
+    """
+    if fcntl is not None:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+
 
 def classify(tool_name: str, tool_input: dict[str, Any]) -> str:
     """Map a Claude Code tool_name + tool_input to a connector key.
@@ -101,11 +115,20 @@ def run(*, stdin: IO[str] | None = None) -> Event | None:
     log_dir = paths.data_dir() / ".scout-logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     out_path = log_dir / f"connector-calls-{et_date}.jsonl"
+    line = json.dumps(record) + "\n"
     try:
         with out_path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(record) + "\n")
-    except Exception:
-        pass
+            # Hooks fire concurrently for parallel tool calls. O_APPEND only
+            # guarantees atomicity up to PIPE_BUF (~512B on some macOS FS), so
+            # large tool-response rows can interleave. An exclusive advisory
+            # lock serializes the append; the lock releases on close. (#38)
+            _lock_exclusive(f)
+            f.write(line)
+    except Exception as exc:
+        # Never break the session on a log-write failure — but don't swallow
+        # it silently either; a dropped row is an unsignalled gap in the
+        # audit log. Surface to stderr (the hook's output is captured). (#38)
+        print(f"connector-log: failed to append row: {exc!r}", file=sys.stderr)
 
     return Event(
         id=new_ulid(),

--- a/engine/tests/unit/test_hooks_connector_log.py
+++ b/engine/tests/unit/test_hooks_connector_log.py
@@ -111,3 +111,29 @@ def test_run_truncates_err_snippet_at_160_chars(tmp_path, monkeypatch):
     event = run(stdin=io.StringIO(payload))
     assert len(event.payload["err"]) == 160
     assert event.payload["err"] == "X" * 160
+
+
+def test_run_surfaces_write_failure_instead_of_swallowing(tmp_path, monkeypatch, capsys):
+    """A JSONL append failure is logged to stderr (not silently dropped), but
+    still never breaks the session — run() returns the Event regardless (#38)."""
+    import pathlib
+
+    monkeypatch.setenv("SCOUT_MODE", "manual")
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+
+    real_open = pathlib.Path.open
+
+    def fail_jsonl_open(self, *args, **kwargs):
+        if "connector-calls-" in self.name:
+            raise OSError("disk full")
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "open", fail_jsonl_open)
+
+    payload = json.dumps({"session_id": "x", "tool_name": "Read", "tool_response": {"isError": False}})
+    event = run(stdin=io.StringIO(payload))
+
+    assert isinstance(event, Event)  # session not broken
+    err = capsys.readouterr().err
+    assert "failed to append row" in err
+    assert "disk full" in err


### PR DESCRIPTION
Closes #38.

## Problem
`connector_log.run()` appended each row with a bare:
```python
try:
    with out_path.open("a", encoding="utf-8") as f:
        f.write(json.dumps(record) + "\n")
except Exception:
    pass
```
Two critical issues (audit 2026-05-24):
1. **Interleaving** — hooks fire concurrently for parallel tool calls. O_APPEND only guarantees atomic writes up to `PIPE_BUF` (~512B on some macOS FS); large tool-response rows exceed that and interleave, producing garbled JSON that breaks downstream parsers (the v0.5 SQLite emit path).
2. **Silent failure** — `except: pass` hides any write error, leaving unsignalled gaps in the audit log.

## Fix
- Wrap the append in an exclusive `fcntl.flock` (released implicitly on close), with a no-op fallback where `fcntl` is unavailable (non-POSIX).
- Replace `except: pass` with a stderr log. The hook still **never breaks the session** — `run()` returns the Event regardless — but a dropped row is now visible.

## Test
Added `test_run_surfaces_write_failure_instead_of_swallowing`: forces the JSONL open to raise, asserts the failure reaches stderr **and** `run()` still returns the Event. Existing 8 connector-log tests still pass.