### PR TITLE
fix(kb): packaged schema path survives wheel installs (#39)

### DIFF
--- a/engine/scout/kb/paths.py
+++ b/engine/scout/kb/paths.py
@@ -6,10 +6,46 @@ by placing their own schema at $SCOUT_DATA_DIR/knowledge-base/ontology/schema.ya
 
 from __future__ import annotations
 
+import atexit
+import shutil
+import tempfile
 from importlib.resources import as_file, files
 from pathlib import Path
 
 from scout import paths
+
+# Process-lifetime cache of the materialized packaged schema (see
+# _packaged_schema_path). None until first resolved.
+_CACHED_PACKAGED_SCHEMA: Path | None = None
+
+
+def _packaged_schema_path() -> Path:
+    """Materialize the packaged ``scout/kb/schema.yaml`` to a stable path.
+
+    ``importlib.resources.as_file`` only guarantees the extracted file exists
+    *inside* the ``with`` block. For a zipped/wheel install the temp file is
+    removed on context exit, so returning ``Path(p)`` from inside the block
+    yields a path that's already deleted by the time the caller opens it (#39).
+
+    Read the bytes while the resource is live, copy them to a process-lifetime
+    temp file (cleaned up at interpreter exit), and return that. For a
+    filesystem (editable) install the copy is a few-KB no-cost safety net.
+    The result is cached so repeated calls reuse the same file.
+    """
+    global _CACHED_PACKAGED_SCHEMA
+    if _CACHED_PACKAGED_SCHEMA is not None and _CACHED_PACKAGED_SCHEMA.exists():
+        return _CACHED_PACKAGED_SCHEMA
+
+    resource = files("scout") / "kb" / "schema.yaml"
+    with as_file(resource) as p:
+        data = Path(p).read_bytes()  # read while the resource is guaranteed live
+
+    tmp_dir = Path(tempfile.mkdtemp(prefix="scout-schema-"))
+    atexit.register(shutil.rmtree, tmp_dir, ignore_errors=True)
+    dest = tmp_dir / "schema.yaml"
+    dest.write_bytes(data)
+    _CACHED_PACKAGED_SCHEMA = dest
+    return dest
 
 
 def resolve_schema_path(data: Path | None = None) -> Path:
@@ -17,17 +53,14 @@ def resolve_schema_path(data: Path | None = None) -> Path:
 
     Precedence: user override at
     $SCOUT_DATA_DIR/knowledge-base/ontology/schema.yaml, else the
-    packaged default in scout/kb/schema.yaml extracted via
-    importlib.resources.
+    packaged default in scout/kb/schema.yaml.
 
-    Caller is responsible for not mutating the returned path; under a
-    wheel install the packaged copy may sit inside an importlib.resources
-    extraction directory, but with a filesystem-installed wheel it is a
-    real on-disk path.
+    The returned path is stable for the lifetime of the process — for the
+    packaged default it points at a materialized copy, so it stays valid
+    under a wheel install where the importlib.resources extraction would
+    otherwise be torn down before the caller reads it (#39).
     """
     user = paths.kb_dir(data) / "ontology" / "schema.yaml"
     if user.exists():
         return user
-    resource = files("scout") / "kb" / "schema.yaml"
-    with as_file(resource) as p:
-        return Path(p)
+    return _packaged_schema_path()

--- a/engine/tests/unit/test_kb_paths.py
+++ b/engine/tests/unit/test_kb_paths.py
@@ -1,0 +1,60 @@
+"""Unit tests for scout.kb.paths.resolve_schema_path (#39)."""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+
+import scout.kb.paths as kbp
+from scout import paths
+
+
+def test_resolve_prefers_user_override(tmp_path: Path) -> None:
+    user_schema = paths.kb_dir(tmp_path) / "ontology" / "schema.yaml"
+    user_schema.parent.mkdir(parents=True, exist_ok=True)
+    user_schema.write_text("version: 99\nentity_types: {}\n", encoding="utf-8")
+
+    assert kbp.resolve_schema_path(data=tmp_path) == user_schema
+
+
+def test_resolve_packaged_default_is_readable(tmp_path: Path, monkeypatch) -> None:
+    """With no user override, the packaged default resolves to a readable file."""
+    monkeypatch.setattr(kbp, "_CACHED_PACKAGED_SCHEMA", None)
+    result = kbp.resolve_schema_path(data=tmp_path)  # empty vault → packaged
+    assert result.exists()
+    assert result.read_text(encoding="utf-8")  # openable by the caller
+
+
+def test_packaged_schema_survives_as_file_teardown(tmp_path: Path, monkeypatch) -> None:
+    """Simulate a wheel install where as_file's extraction is deleted on context
+    exit. resolve_schema_path must still return a path the caller can open (#39).
+
+    On the old code (return Path(p) from inside the `with`) the returned path
+    was already unlinked, so this would fail.
+    """
+    monkeypatch.setattr(kbp, "_CACHED_PACKAGED_SCHEMA", None)
+
+    extracted = tmp_path / "wheel-extract" / "schema.yaml"
+    extracted.parent.mkdir(parents=True, exist_ok=True)
+    extracted.write_text("version: 1\nentity_types: {}\n", encoding="utf-8")
+
+    @contextlib.contextmanager
+    def fake_as_file(_resource):
+        try:
+            yield extracted
+        finally:
+            extracted.unlink()  # wheel behavior: temp extraction removed on exit
+
+    monkeypatch.setattr(kbp, "as_file", fake_as_file)
+
+    result = kbp.resolve_schema_path(data=tmp_path)
+    assert not extracted.exists()  # the original extraction was torn down
+    assert result.exists()  # ...but the returned path is a live copy
+    assert "entity_types" in result.read_text(encoding="utf-8")
+
+
+def test_packaged_schema_path_is_cached(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(kbp, "_CACHED_PACKAGED_SCHEMA", None)
+    first = kbp.resolve_schema_path(data=tmp_path)
+    second = kbp.resolve_schema_path(data=tmp_path)
+    assert first == second


### PR DESCRIPTION
Closes #39.

## Problem
`resolve_schema_path` entered `as_file(resource)`, extracted `Path(p)`, then **exited** the `with` before returning it. `importlib.resources.as_file` only guarantees the extracted file exists *inside* the context — under a zipped/wheel install the temp file is removed on exit, so the returned path points at a file that's already gone. `KnowledgeGraph._load_schema` then `open()`s it and fails (silently for some paths, `OSError` for others). Critical, audit 2026-05-24.

## Fix
Read the bytes while the resource is live, copy them to a **process-lifetime** temp file (`tempfile.mkdtemp` + `atexit` cleanup), cache the result, and return that path. Works for both wheel and editable installs (editable: a few-KB no-cost copy).

`config.py`'s `as_file` use was checked and is **not** affected — it reads the file *inside* the `with`, so it never returns a dangling path.

## Test
New `test_kb_paths.py`: user-override precedence, packaged-default readability, caching, and a **wheel-teardown regression test** that fakes `as_file` to unlink its extraction on context exit and asserts the returned path is still readable (fails on the old code).