### PR TITLE
fix(manifest): atomic manifest.json write (#44)

### DIFF
--- a/engine/scout/manifest.py
+++ b/engine/scout/manifest.py
@@ -9,6 +9,8 @@ banner) to use features the engine cannot provide.
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
@@ -73,7 +75,26 @@ def build_manifest() -> EngineManifest:
 
 
 def write_manifest(path: Path | None = None) -> Path:
-    """Write the manifest to disk. Returns the path written."""
+    """Write the manifest to disk atomically. Returns the path written.
+
+    scout-app reads manifest.json at launch to gate feature flags, so a
+    torn/truncated file (crash or full disk mid-write) would block all engine
+    ops until manually deleted. Use the same tempfile + fsync + os.replace
+    pattern as IdMap.save so a reader always sees a complete file (#44).
+    """
     target = path or (ENGINE_DIR / "manifest.json")
-    target.write_text(build_manifest().to_json() + "\n")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    content = build_manifest().to_json() + "\n"
+    fd, tmp = tempfile.mkstemp(prefix=".manifest.", suffix=".json.tmp", dir=str(target.parent))
+    tmp_path = Path(tmp)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, target)
+    except BaseException:
+        if tmp_path.exists():
+            tmp_path.unlink()
+        raise
     return target

--- a/engine/tests/unit/test_manifest.py
+++ b/engine/tests/unit/test_manifest.py
@@ -54,6 +54,26 @@ def test_write_manifest_round_trip(tmp_path: Path) -> None:
     assert written == target
     decoded = json.loads(target.read_text())
     assert decoded["version"] == __version__
+    # Atomic write leaves no stray tempfile behind (#44).
+    assert not list(tmp_path.glob(".manifest.*"))
+
+
+def test_write_manifest_atomic_failure_preserves_existing(tmp_path: Path, monkeypatch) -> None:
+    """A crash during the rename must not corrupt an existing manifest, and
+    must clean up the tempfile rather than leave a torn .tmp around (#44)."""
+    import scout.manifest as m
+
+    target = tmp_path / "manifest.json"
+    target.write_text('{"version": "prior-good"}\n', encoding="utf-8")
+
+    monkeypatch.setattr(m.os, "replace", lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")))
+
+    with pytest.raises(OSError, match="disk full"):
+        write_manifest(target)
+
+    # Original file is untouched (rename never happened) and no tempfile left.
+    assert json.loads(target.read_text())["version"] == "prior-good"
+    assert not list(tmp_path.glob(".manifest.*"))
 
 
 def test_build_manifest_enumerates_subcommands_from_typer_app(


### PR DESCRIPTION
Closes #44.

## Problem
`write_manifest` did `target.write_text(...)` — non-atomic, non-fsynced. A process kill or full disk mid-write leaves `manifest.json` truncated. scout-app reads it at launch to gate feature flags, so a torn file causes a JSON parse error that blocks all engine operations until the user manually deletes/regenerates it. High, audit 2026-05-24.

## Fix
Reuse the exact tempfile + `fsync` + `os.replace` pattern `IdMap.save` already uses: write to a sibling `.manifest.*.json.tmp`, fsync, atomic rename over the target; on any exception unlink the tempfile and re-raise. A reader now always sees a complete file, and a failed write never corrupts an existing manifest.

## Test
- `test_write_manifest_round_trip` extended to assert no stray `.manifest.*` tempfile remains.
- New `test_write_manifest_atomic_failure_preserves_existing`: patches `os.replace` to raise mid-write, asserts the prior manifest is intact and the tempfile is cleaned up.