### PR TITLE
fix(action-items): skip fenced code blocks (#40); preserve CRLF/final-newline (#34)

### DIFF
--- a/engine/scout/action_items/parser.py
+++ b/engine/scout/action_items/parser.py
@@ -89,8 +89,22 @@ def parse_action_items(filepath: Path) -> list[ActionItem]:
     current_section = ""
     current_subsection = ""
     current_item: ActionItem | None = None
+    in_fence = False
 
     for i, line in enumerate(lines, start=1):
+        # Fenced code blocks are not content: a ``` / ~~~ line toggles the
+        # fence and everything inside is skipped. Without this, example task
+        # lines in docs (README, format guides) get parsed as real items —
+        # backfill then inserts `[#XXXX]` into the code block and mark-done/
+        # snooze operate on documentation examples (#40). Checked first so a
+        # `## Heading` or `- [ ] ...` *inside* a fence isn't misread.
+        fence = line.lstrip()
+        if fence.startswith("```") or fence.startswith("~~~"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+
         # Track section headers
         h2_match = SECTION_H2.match(line)
         if h2_match:

--- a/engine/scout/action_items/writer.py
+++ b/engine/scout/action_items/writer.py
@@ -22,17 +22,32 @@ from scout.ids import short_prefix_pattern
 _CHECKBOX_LINE_RE = re.compile(r"^(?P<indent>\s*)(?P<marker>- \[[ xX]\] )")
 
 
-def atomic_write_lines(target: Path, lines: list[str]) -> None:
-    """Replace `target`'s contents with `lines` (one per line, trailing newline)."""
+def atomic_write_lines(
+    target: Path,
+    lines: list[str],
+    *,
+    newline: str = "\n",
+    trailing_newline: bool = True,
+) -> None:
+    """Replace `target`'s contents with `lines`, one per line.
+
+    ``newline`` is the line separator written between lines (and as the
+    final terminator); ``trailing_newline`` controls whether the file ends
+    with one. Both default to the historical behavior (LF, trailing newline)
+    but mutators pass the values detected from the original file so a CRLF
+    file or a file without a final newline round-trips byte-for-byte instead
+    of being silently reflowed (#34). Opened with ``newline=""`` so the
+    explicit separators are written verbatim (no platform translation).
+    """
     parent = target.parent
     parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_path = tempfile.mkstemp(prefix=f".{target.name}.", suffix=".tmp", dir=str(parent))
     tmp = Path(tmp_path)
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write("\n".join(lines))
-            if lines:
-                f.write("\n")
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as f:
+            f.write(newline.join(lines))
+            if lines and trailing_newline:
+                f.write(newline)
             f.flush()
             os.fsync(f.fileno())
         os.replace(tmp, target)
@@ -43,13 +58,24 @@ def atomic_write_lines(target: Path, lines: list[str]) -> None:
         raise
 
 
-def _read_lines(target: Path) -> list[str]:
-    return target.read_text(encoding="utf-8").splitlines()
+def _read_lines_with_style(target: Path) -> tuple[list[str], str, bool]:
+    """Read `target` as ``(lines, newline, trailing_newline)``.
+
+    Decodes the raw bytes (not text mode, whose universal-newline translation
+    would erase the original ending) so CRLF is detectable, then splits on
+    both endings. ``newline`` is ``"\\r\\n"`` if the file uses CRLF anywhere,
+    else ``"\\n"``; ``trailing_newline`` is whether the file ends with a
+    newline. Threaded into atomic_write_lines so edits preserve both (#34).
+    """
+    text = target.read_bytes().decode("utf-8")
+    newline = "\r\n" if "\r\n" in text else "\n"
+    trailing_newline = text.endswith("\n")
+    return text.splitlines(), newline, trailing_newline
 
 
 def flip_checkbox(target: Path, *, line_number: int, to_done: bool) -> None:
     """Toggle `[ ]` ⇄ `[x]` on the 1-indexed line. Preserves all other bytes."""
-    lines = _read_lines(target)
+    lines, newline, trailing = _read_lines_with_style(target)
     idx = line_number - 1
     if not 0 <= idx < len(lines):
         raise ActionItemError(f"flip_checkbox: line {line_number} out of range (1..{len(lines)})")
@@ -58,37 +84,37 @@ def flip_checkbox(target: Path, *, line_number: int, to_done: bool) -> None:
     if old not in lines[idx]:
         raise ActionItemError(f"flip_checkbox: line {line_number} does not contain `{old}`")
     lines[idx] = lines[idx].replace(old, new, 1)
-    atomic_write_lines(target, lines)
+    atomic_write_lines(target, lines, newline=newline, trailing_newline=trailing)
 
 
 def insert_below(target: Path, *, line_number: int, text: str) -> None:
     """Insert `text` as a new line directly below the 1-indexed line."""
-    lines = _read_lines(target)
+    lines, newline, trailing = _read_lines_with_style(target)
     idx = line_number - 1
     if not 0 <= idx < len(lines):
         raise ActionItemError(f"insert_below: line {line_number} out of range (1..{len(lines)})")
     lines.insert(idx + 1, text)
-    atomic_write_lines(target, lines)
+    atomic_write_lines(target, lines, newline=newline, trailing_newline=trailing)
 
 
 def replace_line(target: Path, *, line_number: int, text: str) -> None:
     """Replace the 1-indexed line wholesale with `text`."""
-    lines = _read_lines(target)
+    lines, newline, trailing = _read_lines_with_style(target)
     idx = line_number - 1
     if not 0 <= idx < len(lines):
         raise ActionItemError(f"replace_line: line {line_number} out of range (1..{len(lines)})")
     lines[idx] = text
-    atomic_write_lines(target, lines)
+    atomic_write_lines(target, lines, newline=newline, trailing_newline=trailing)
 
 
 def delete_line(target: Path, *, line_number: int) -> None:
     """Remove the 1-indexed line entirely."""
-    lines = _read_lines(target)
+    lines, newline, trailing = _read_lines_with_style(target)
     idx = line_number - 1
     if not 0 <= idx < len(lines):
         raise ActionItemError(f"delete_line: line {line_number} out of range (1..{len(lines)})")
     del lines[idx]
-    atomic_write_lines(target, lines)
+    atomic_write_lines(target, lines, newline=newline, trailing_newline=trailing)
 
 
 def add_prefix_to_line(target: Path, *, line_number: int, prefix: str) -> None:
@@ -101,7 +127,7 @@ def add_prefix_to_line(target: Path, *, line_number: int, prefix: str) -> None:
     Refuses if the line already carries a `[#XXXX]` prefix — the caller
     should not be asking to add one if scout.id_map already has a record.
     """
-    lines = _read_lines(target)
+    lines, newline, trailing = _read_lines_with_style(target)
     idx = line_number - 1
     if not 0 <= idx < len(lines):
         raise ActionItemError(f"add_prefix_to_line: line {line_number} out of range (1..{len(lines)})")
@@ -113,4 +139,4 @@ def add_prefix_to_line(target: Path, *, line_number: int, prefix: str) -> None:
         raise ActionItemError(f"add_prefix_to_line: line {line_number} doesn't start with a checkbox marker")
     head_end = m.end()
     lines[idx] = line[:head_end] + f"[#{prefix}] " + line[head_end:]
-    atomic_write_lines(target, lines)
+    atomic_write_lines(target, lines, newline=newline, trailing_newline=trailing)

--- a/engine/tests/unit/test_action_items_parser.py
+++ b/engine/tests/unit/test_action_items_parser.py
@@ -149,3 +149,41 @@ def test_parse_file_reads_with_explicit_utf8_encoding(tmp_path: Path, monkeypatc
 
     assert "utf-8" in captured, f"read_text was called without encoding=utf-8: {captured}"
     assert any(i.priority == "🔴" for i in items)
+
+
+# Fenced code blocks must not be parsed as action items (#40). Otherwise doc
+# files showing the format get example lines treated as real tasks — backfill
+# then writes [#XXXX] into the code block and mark-done/snooze act on examples.
+
+
+def test_parse_skips_fenced_code_blocks(tmp_path):
+    from scout.action_items.parser import parse_action_items
+
+    md = tmp_path / "ai.md"
+    md.write_text(
+        "## To Do\n\n"
+        "- [ ] real task\n\n"
+        "```\n"
+        "- [ ] example inside a fence, not a task\n"
+        "## Not A Heading Either\n"
+        "```\n"
+        "- [ ] another real task\n",
+        encoding="utf-8",
+    )
+    titles = [i.title for i in parse_action_items(md)]
+    assert "real task" in titles
+    assert "another real task" in titles
+    assert not any("example inside a fence" in t for t in titles)
+    assert len(titles) == 2
+
+
+def test_parse_skips_tilde_fenced_blocks(tmp_path):
+    from scout.action_items.parser import parse_action_items
+
+    md = tmp_path / "ai.md"
+    md.write_text(
+        "## To Do\n~~~text\n- [ ] fenced example\n~~~\n- [ ] real\n",
+        encoding="utf-8",
+    )
+    titles = [i.title for i in parse_action_items(md)]
+    assert titles == ["real"]

--- a/engine/tests/unit/test_action_items_writer.py
+++ b/engine/tests/unit/test_action_items_writer.py
@@ -204,3 +204,38 @@ def test_backfill_prefixes_handles_indented_checkbox_end_to_end(
     # Both lines must now carry a prefix, and the indent on line 3 must be preserved.
     assert " - [ ] [#" in out, f"indent of indented line not preserved: {out!r}"
     assert "\n- [ ] [#" in out, f"non-indented line not prefixed: {out!r}"
+
+
+# Line-ending / trailing-newline preservation across the edit round-trip (#34).
+
+
+def test_flip_checkbox_preserves_crlf(tmp_path):
+    from scout.action_items.writer import flip_checkbox
+
+    target = tmp_path / "ai.md"
+    target.write_bytes(b"## To Do\r\n- [ ] task one\r\n- [ ] task two\r\n")
+    flip_checkbox(target, line_number=2, to_done=True)
+    data = target.read_bytes()
+    assert data == b"## To Do\r\n- [x] task one\r\n- [ ] task two\r\n"
+    # No lone LF introduced.
+    assert b"\n" not in data.replace(b"\r\n", b"")
+
+
+def test_insert_below_preserves_absent_trailing_newline(tmp_path):
+    from scout.action_items.writer import insert_below
+
+    target = tmp_path / "ai.md"
+    target.write_bytes(b"## To Do\n- [ ] task")  # no final newline
+    insert_below(target, line_number=2, text="  - note")
+    data = target.read_bytes()
+    assert data == b"## To Do\n- [ ] task\n  - note"
+    assert not data.endswith(b"\n")
+
+
+def test_lf_file_round_trips_unchanged(tmp_path):
+    from scout.action_items.writer import replace_line
+
+    target = tmp_path / "ai.md"
+    target.write_bytes(b"## To Do\n- [ ] a\n- [ ] b\n")
+    replace_line(target, line_number=2, text="- [ ] a edited")
+    assert target.read_bytes() == b"## To Do\n- [ ] a edited\n- [ ] b\n"


### PR DESCRIPTION
Closes #34. Closes #40. Two action-items parser/writer correctness bugs (audit 2026-05-24).

## #40 — fenced code blocks parsed as action items (high)
`parse_action_items` tracked no ``` / ~~~ fence state, so example task lines in docs (README, format guides) were parsed as real items. Because `backfill` sources its candidates from `parse_file`, it then inserted `[#XXXX]` **into the code block**, and `mark-done`/`snooze` operated on documentation examples.

**Fix:** track fence state at the top of the parse loop and skip fenced lines — checked *before* section/bullet matching so a `## Heading` or `- [ ] ...` inside a fence isn't misread. Fixing it at the parser fixes every downstream consumer (backfill, mark-done, snooze) transitively.

## #34 — CRLF / trailing-newline lost on edit (critical)
Mutators read via `splitlines()` and `atomic_write_lines` always wrote LF + a trailing newline. So editing a CRLF file flipped **every** line ending (whole-file git diff for Windows users), and a file without a final newline silently gained one.

**Fix:** `_read_lines_with_style` decodes the raw bytes (text-mode universal-newline translation would erase the original ending), detects the newline (`\r\n` if present anywhere, else `\n`) and whether a trailing newline exists, and threads both into `atomic_write_lines` (opened `newline=""` so separators are written verbatim). All five mutators (`flip_checkbox`, `insert_below`, `replace_line`, `delete_line`, `add_prefix_to_line`) now round-trip byte-for-byte. `parser.py:87`'s `splitlines()` is read-only (never writes back) so it's left as-is.

## Tests
- Parser: fenced (``` and ~~~) blocks excluded; real tasks around them still parsed.
- Writer: CRLF preserved on `flip_checkbox`; absent trailing newline preserved on `insert_below`; LF file round-trips unchanged on `replace_line`.
- Full action-items suite green (113).