### PR TITLE
fix(health): osascript notification — argv, not source interpolation (#51)

### DIFF
--- a/engine/scout/scripts/connector_health_report.py
+++ b/engine/scout/scripts/connector_health_report.py
@@ -558,14 +558,20 @@ def fire_macos_notification(alerts: list[Alert]) -> None:
     summary = "; ".join(a.name for a in alerts[:3])
     if len(alerts) > 3:
         summary += f" (+{len(alerts) - 3} more)"
-    body = summary.replace('"', "'")
+    # Pass the title and body as argv to an `on run argv` handler and read the
+    # script from stdin. Connector names and reasons come from user-controlled
+    # YAML and the JSONL log; interpolating them into the AppleScript *source*
+    # (the old `display notification "{body}"`) allowed a name containing
+    # quotes/backslashes/newlines to break the script or inject arbitrary
+    # AppleScript. As argv they are pure data — never parsed as code. (#51)
+    script = (
+        'on run argv\n    display notification (item 2 of argv) with title (item 1 of argv) sound name "Basso"\nend run'
+    )
     try:
         subprocess.run(
-            [
-                "osascript",
-                "-e",
-                f'display notification "{body}" with title "Scout: connector degradation" sound name "Basso"',
-            ],
+            ["osascript", "-", "Scout: connector degradation", summary],
+            input=script,
+            text=True,
             check=False,
             timeout=5,
         )

--- a/engine/tests/unit/test_scripts_connector_health.py
+++ b/engine/tests/unit/test_scripts_connector_health.py
@@ -635,3 +635,47 @@ def test_outbound_only_connectors_excluded_from_warnings(fake_data_dir, monkeypa
     alerts = event.payload["alerts"]
     tg_alerts = [a for a in alerts if a["connector_key"] == "notify:telegram"]
     assert tg_alerts == []
+
+
+# osascript injection hardening (#51). Connector names come from user YAML and
+# the JSONL log; they must reach `display notification` as argv data, never be
+# interpolated into the AppleScript source.
+
+
+def test_fire_macos_notification_passes_data_as_argv_not_source(monkeypatch):
+    import scout.scripts.connector_health_report as chr_mod
+    from scout.scripts.connector_health_report import Alert, fire_macos_notification
+
+    calls = {}
+
+    def fake_run(args, **kwargs):
+        calls["args"] = args
+        calls["input"] = kwargs.get("input")
+
+        class _R:
+            returncode = 0
+
+        return _R()
+
+    monkeypatch.setattr(chr_mod.subprocess, "run", fake_run)
+
+    evil = 'evil" with title "x" \n do shell script "touch /tmp/pwned'
+    fire_macos_notification([Alert("CRITICAL", evil, "down", "slack", "")])
+
+    # The malicious name is a discrete argv element, verbatim — not escaped
+    # into and not present in the script source read from stdin.
+    assert evil in calls["args"]
+    assert "on run argv" in calls["input"]
+    assert evil not in calls["input"]
+    # osascript reads the script from stdin (`-`), data follows as arguments.
+    assert calls["args"][:2] == ["osascript", "-"]
+
+
+def test_fire_macos_notification_noop_on_empty(monkeypatch):
+    import scout.scripts.connector_health_report as chr_mod
+    from scout.scripts.connector_health_report import fire_macos_notification
+
+    called = {"n": 0}
+    monkeypatch.setattr(chr_mod.subprocess, "run", lambda *a, **k: called.__setitem__("n", called["n"] + 1))
+    fire_macos_notification([])
+    assert called["n"] == 0


### PR DESCRIPTION
Closes #51.

## Problem
`fire_macos_notification` built the AppleScript by interpolating the connector summary into the source string:
```python
body = summary.replace('"', "'")
osascript -e f'display notification "{body}" with title "..."'
```
The only sanitization was `" → '`. Connector names and reasons come from **user-controlled YAML and the JSONL log**, so a value containing backslashes, backticks, `$`, newlines, or crafted quotes could break the script or **inject arbitrary AppleScript** that runs on the user's machine. High, audit 2026-05-24.

## Fix
Read the script from stdin (`osascript -`) and pass the title and body as **argv** to an `on run argv` handler:
```python
script = 'on run argv\n    display notification (item 2 of argv) with title (item 1 of argv) sound name "Basso"\nend run'
subprocess.run(["osascript", "-", "Scout: connector degradation", summary], input=script, text=True, ...)
```
argv values are pure data — never parsed as AppleScript — so escaping is unnecessary and injection is structurally impossible.

## Test
`test_fire_macos_notification_passes_data_as_argv_not_source`: feeds a malicious connector name (`evil" with title "x" \n do shell script "..."`), asserts it appears verbatim as a discrete argv element and is **absent** from the script source read via stdin. Plus an empty-alerts no-op test.