### PR TITLE
fix(schedule): resolve tz from $TZ + symlink, warn before UTC fallback (#50)

### DIFF
--- a/engine/scout/scripts/schedule_tick.py
+++ b/engine/scout/scripts/schedule_tick.py
@@ -133,22 +133,54 @@ def _now() -> _dt.datetime:
     return _dt.datetime.now(tz=tz)
 
 
-def _local_tz_name() -> str:
-    """Best-effort read of the system's local IANA zone.
+def _local_tz_name(localtime: Path | None = None) -> str:
+    """Best-effort resolution of the system's local IANA zone.
 
-    Reads the ``/etc/localtime`` symlink target (the convention on macOS and
-    most Linux distros). Falls back to ``UTC`` if the symlink is missing or
-    points somewhere unrecognized.
+    Priority: ``$TZ`` (if it names a loadable zone) → the ``/etc/localtime``
+    symlink target → ``UTC``. A wrong timezone here silently shifts every
+    ``fires_at_local``, so each fallback that can't produce a *validated* zone
+    logs a warning to stderr (captured in the scheduled-run logs) rather than
+    returning ``"UTC"`` silently. (#50)
+
+    ``localtime`` defaults to ``Path("/etc/localtime")``; it's a parameter so
+    tests can point it at a fixture symlink.
     """
-    localtime = Path("/etc/localtime")
+    # 1. Explicit TZ wins when it names a zone ZoneInfo can load.
+    env_tz = os.environ.get("TZ")
+    if env_tz:
+        try:
+            ZoneInfo(env_tz)
+            return env_tz
+        except (ZoneInfoNotFoundError, ValueError):
+            print(f"schedule_tick: $TZ={env_tz!r} is not a valid IANA zone; ignoring it", file=sys.stderr)
+
+    # 2. /etc/localtime symlink target. resolve() handles relative targets
+    #    (valid POSIX) and multi-hop links, which os.readlink alone would not.
+    localtime = localtime or Path("/etc/localtime")
     if localtime.is_symlink():
-        target = os.readlink(localtime)
-        # Typical: /var/db/timezone/zoneinfo/America/New_York or
-        # /usr/share/zoneinfo/America/New_York. Take the trailing
-        # area/zone segments.
+        target = str(localtime.resolve())
         marker = "zoneinfo/"
         if marker in target:
-            return target.split(marker, 1)[1]
+            name = target.split(marker, 1)[1]
+            try:
+                ZoneInfo(name)
+                return name
+            except (ZoneInfoNotFoundError, ValueError):
+                print(
+                    f"schedule_tick: zone {name!r} derived from /etc/localtime is not loadable; falling back to UTC",
+                    file=sys.stderr,
+                )
+        else:
+            print(
+                "schedule_tick: /etc/localtime target has no 'zoneinfo/' component "
+                f"({target!r}); falling back to UTC — set $TZ to your IANA zone",
+                file=sys.stderr,
+            )
+    else:
+        print(
+            "schedule_tick: /etc/localtime is not a symlink; falling back to UTC — set $TZ to your IANA zone",
+            file=sys.stderr,
+        )
     return "UTC"
 
 

--- a/engine/tests/unit/test_schedule_tick.py
+++ b/engine/tests/unit/test_schedule_tick.py
@@ -780,3 +780,53 @@ def test_emit_event_filename_matches_ts_date_across_midnight(tmp_path, monkeypat
     assert len(logs) == 1
     assert logs[0].name == "schedule-events-2026-03-14.jsonl"
     assert ev.ts[:10] == "2026-03-14"
+
+
+# Timezone resolution (#50): $TZ > /etc/localtime symlink > UTC, with a stderr
+# warning on every fallback that can't produce a validated zone (a wrong tz
+# silently shifts every fires_at_local).
+
+
+def test_local_tz_name_env_tz_valid_wins(monkeypatch):
+    from scout.scripts import schedule_tick as st
+
+    monkeypatch.setenv("TZ", "America/New_York")
+    assert st._local_tz_name() == "America/New_York"
+
+
+def test_local_tz_name_env_tz_invalid_is_ignored_and_warns(monkeypatch, tmp_path, capsys):
+    from scout.scripts import schedule_tick as st
+
+    monkeypatch.setenv("TZ", "Totally/Bogus")
+    not_a_link = tmp_path / "localtime"  # regular file → forces UTC
+    not_a_link.write_text("x")
+    assert st._local_tz_name(localtime=not_a_link) == "UTC"
+    assert "not a valid IANA zone" in capsys.readouterr().err
+
+
+def test_local_tz_name_resolves_symlink_zone(monkeypatch, tmp_path):
+    from scout.scripts import schedule_tick as st
+
+    monkeypatch.delenv("TZ", raising=False)
+    link = tmp_path / "localtime"
+    link.symlink_to("/usr/share/zoneinfo/America/New_York")
+    assert st._local_tz_name(localtime=link) == "America/New_York"
+
+
+def test_local_tz_name_resolves_relative_symlink(monkeypatch, tmp_path):
+    from scout.scripts import schedule_tick as st
+
+    monkeypatch.delenv("TZ", raising=False)
+    link = tmp_path / "localtime"
+    link.symlink_to("zoneinfo/Europe/Paris")  # relative target — resolve() handles it
+    assert st._local_tz_name(localtime=link) == "Europe/Paris"
+
+
+def test_local_tz_name_not_symlink_warns_and_falls_back_to_utc(monkeypatch, tmp_path, capsys):
+    from scout.scripts import schedule_tick as st
+
+    monkeypatch.delenv("TZ", raising=False)
+    regular = tmp_path / "localtime"
+    regular.write_text("not a symlink")
+    assert st._local_tz_name(localtime=regular) == "UTC"
+    assert "not a symlink" in capsys.readouterr().err


### PR DESCRIPTION
Closes #50.

## Problem
`_local_tz_name` read the `/etc/localtime` symlink target and split on `"zoneinfo/"`, silently returning `"UTC"` when:
- `/etc/localtime` is a regular file (some minimal Linux containers),
- the symlink target is relative (valid POSIX),
- the target has no `"zoneinfo/"` component,
- `ZoneInfo(name)` would raise (unhandled).

Every schedule calculation uses this zone, so a silent UTC fallback on (say) a Pacific-time machine shifts every `fires_at_local` by hours — slots fire at the wrong time or are permanently skipped, with no signal. High, audit 2026-05-24.

## Fix
- **`$TZ` first** — honored when it names a `ZoneInfo`-loadable zone.
- **`resolve()`** the symlink instead of bare `os.readlink`, handling relative targets and multi-hop links.
- **Validate** the derived zone via `ZoneInfo(...)` before returning it.
- **Warn to stderr** on every fallback that can't produce a validated zone, so the UTC fallback is visible in the scheduled-run logs instead of silent.

`localtime` is now an injectable parameter (default `/etc/localtime`) so the symlink branches are unit-testable.

## Test
Five new cases: valid `$TZ` wins; invalid `$TZ` ignored + warns; absolute symlink resolves to its zone; **relative** symlink resolves; non-symlink warns and falls back to UTC. Full `test_schedule_tick.py` green (44).