### PR TITLE
fix(schedule): XML-escape plist substitutions (#49)

### DIFF
--- a/engine/scout/scripts/install_heartbeat_plist.py
+++ b/engine/scout/scripts/install_heartbeat_plist.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+from html import escape
 from pathlib import Path
 
 PLIST_NAME = "com.scout.heartbeat.plist"
@@ -28,7 +29,10 @@ def install_plist(
     target = agents_dir / PLIST_NAME
     if target.exists() and not force:
         raise FileExistsError(target)
-    rendered = TEMPLATE.read_text(encoding="utf-8").replace("__USER_HOME__", str(home))
+    # XML-escape __USER_HOME__: it lands inside <string> elements, and a path
+    # with `&`, `<`, `>`, `"` (legal on macOS) would otherwise produce
+    # malformed XML that launchd silently refuses to load. (#49)
+    rendered = TEMPLATE.read_text(encoding="utf-8").replace("__USER_HOME__", escape(str(home), quote=True))
     target.write_text(rendered, encoding="utf-8")
     if bootstrap:
         # `launchctl bootstrap gui/$UID <plist>` loads the job. Best-effort.

--- a/engine/scout/scripts/install_schedule_plist.py
+++ b/engine/scout/scripts/install_schedule_plist.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+from html import escape
 from pathlib import Path
 
 PLIST_NAME = "com.scout.schedule-tick.plist"
@@ -51,10 +52,14 @@ def install_plist(
     target = agents_dir / PLIST_NAME
     if target.exists() and not force:
         raise FileExistsError(target)
+    # XML-escape substituted values: they land inside <string> elements, and a
+    # path with `&`, `<`, `>`, `"` (all legal on macOS, e.g. ~/R&D) would
+    # otherwise produce malformed XML that launchd silently refuses to load,
+    # stopping every scheduled run with no error. (#49)
     rendered = (
         TEMPLATE.read_text(encoding="utf-8")
-        .replace("__USER_HOME__", str(home))
-        .replace("__SCOUTCTL_BIN__", str(resolve_scoutctl_bin()))
+        .replace("__USER_HOME__", escape(str(home), quote=True))
+        .replace("__SCOUTCTL_BIN__", escape(str(resolve_scoutctl_bin()), quote=True))
     )
     target.write_text(rendered, encoding="utf-8")
     if bootstrap:

--- a/engine/tests/unit/test_install_heartbeat_plist.py
+++ b/engine/tests/unit/test_install_heartbeat_plist.py
@@ -51,3 +51,24 @@ def test_uninstall_plist_silent_when_missing(tmp_path):
     target_dir = tmp_path / "LaunchAgents"
     target_dir.mkdir()
     uninstall_plist(agents_dir=target_dir)  # no exception
+
+
+def test_install_heartbeat_plist_escapes_xml_metacharacters(tmp_path):
+    """Home path with XML metacharacters → well-formed, loadable plist (#49)."""
+    import plistlib
+
+    from scout.scripts.install_heartbeat_plist import install_plist
+
+    home = tmp_path / 'R&D <lab> "x"'
+    home.mkdir()
+    agents = tmp_path / "LaunchAgents"
+    agents.mkdir()
+    target = install_plist(home=home, agents_dir=agents)
+
+    raw = target.read_text(encoding="utf-8")
+    assert "&amp;" in raw
+    assert "R&D <lab>" not in raw
+
+    with target.open("rb") as f:
+        data = plistlib.load(f)
+    assert data["EnvironmentVariables"]["HOME"] == str(home)

--- a/engine/tests/unit/test_install_schedule_plist.py
+++ b/engine/tests/unit/test_install_schedule_plist.py
@@ -78,3 +78,24 @@ def test_uninstall_plist_silent_when_missing(tmp_path):
     target_dir.mkdir()
     # No exception when target plist doesn't exist.
     uninstall_plist(agents_dir=target_dir)
+
+
+def test_install_plist_escapes_xml_metacharacters(tmp_path):
+    """A home path with XML metacharacters (legal on macOS) must produce a
+    well-formed plist launchd can load, not malformed XML (#49)."""
+    import plistlib
+
+    home = tmp_path / 'R&D <lab> "x"'
+    home.mkdir()
+    agents = tmp_path / "LaunchAgents"
+    agents.mkdir()
+    target = install_plist(home=home, agents_dir=agents)
+
+    raw = target.read_text(encoding="utf-8")
+    assert "&amp;" in raw  # the bare & was escaped
+    assert "R&D <lab>" not in raw  # not left as raw, XML-breaking text
+
+    # Critically: the plist parses, and values round-trip to the real path.
+    with target.open("rb") as f:
+        data = plistlib.load(f)
+    assert data["EnvironmentVariables"]["HOME"] == str(home)


### PR DESCRIPTION
Closes #49.

## Problem
`install_schedule_plist` and `install_heartbeat_plist` rendered the plist by `str.replace()` and wrote the substituted `__USER_HOME__` / `__SCOUTCTL_BIN__` values directly into `<string>` elements — unescaped. A path containing `&`, `<`, `>`, or `"` (all legal on macOS, e.g. `~/R&D`) produces **malformed XML**; launchd silently refuses to load the plist and **all scheduled runs stop**, with no error to the user. High, audit 2026-05-24.

## Fix
Escape each substituted value with `html.escape(str(v), quote=True)` before substitution. The placeholders are all in `<string>` element content, so `&`/`<`/`>`/quotes become valid XML entities that `plistlib` (and launchd) decode back to the original path. Minimal and behavior-preserving for normal paths (escape is a no-op); the `plistlib.dump` rebuild the issue mentions as "better" is a larger change left for later.

## Test
Each installer gets a case with a metacharacter-laden home (`R&D <lab> "x"`): asserts the bare `&`/`<` are escaped (not left as XML-breaking text) and — critically — that `plistlib.load` parses the result and `EnvironmentVariables.HOME` round-trips to the real path. Fails on the old code (malformed XML → `plistlib` raises).