### PR TITLE
feat(action-items): widen stable-ID grammar to variable-length [#TAG] (#117)

### DIFF
--- a/engine/scout/action_items/_common.py
+++ b/engine/scout/action_items/_common.py
@@ -119,7 +119,13 @@ def resolve_target(
 
     if by_id is not None:
         entry = id_map.lookup_by_prefix(by_id)
-        match = next((i for i in items if i.short_prefix == by_id), None)
+        candidates = [i for i in items if i.short_prefix == by_id]
+        if len(candidates) > 1:
+            raise ActionItemError(
+                f"ambiguous id [#{by_id}]; matched {len(candidates)} tasks:\n"
+                + "\n".join(f"  - {c.title}" for c in candidates)
+            )
+        match = candidates[0] if candidates else None
         if entry is None:
             # The briefing / consolidation skill can write a fresh `[#XXXX]`
             # line straight into the markdown without calling

--- a/engine/scout/action_items/add_comment.py
+++ b/engine/scout/action_items/add_comment.py
@@ -46,7 +46,7 @@ def add_comment(
     """Append `  - <author>: <comment>` beneath today's (or `date`'s) item.
 
     Exactly one of `by_id` or `by_subject` must be provided. `by_id` is
-    a 4-char Crockford prefix; `by_subject` is a case-insensitive
+    a stable `[#TAG]` id (2-8 [A-Z0-9], >=1 letter); `by_subject` is a case-insensitive
     substring match against open-status raw lines (legacy fallback for
     lines that haven't been prefixed yet).
 

--- a/engine/scout/action_items/cli.py
+++ b/engine/scout/action_items/cli.py
@@ -23,7 +23,7 @@ app = typer.Typer(help="Action-items operations.", no_args_is_help=True)
 @app.command("mark-done")
 def cli_mark_done(
     subject: str | None = typer.Option(None, "--subject", help="Substring of task title (legacy fallback)."),
-    by_id: str | None = typer.Option(None, "--by-id", help="4-char Crockford prefix from `[#XXXX]`."),
+    by_id: str | None = typer.Option(None, "--by-id", help="Stable [#TAG] id (2-8 [A-Z0-9], >=1 letter)."),
     path: Path | None = typer.Argument(
         None,
         help="Daily markdown file (default: today). When given, its grandparent is the data dir.",
@@ -55,7 +55,7 @@ def cli_mark_done(
 def cli_snooze(
     until: str = typer.Option(..., "--until", help="YYYY-MM-DD"),
     subject: str | None = typer.Option(None, "--subject", help="Substring of task title (legacy fallback)."),
-    by_id: str | None = typer.Option(None, "--by-id", help="4-char Crockford prefix from `[#XXXX]`."),
+    by_id: str | None = typer.Option(None, "--by-id", help="Stable [#TAG] id (2-8 [A-Z0-9], >=1 letter)."),
     from_kind: str | None = typer.Option(
         None,
         "--from-kind",
@@ -106,7 +106,7 @@ def cli_snooze(
 def cli_add_comment(
     comment: str = typer.Option(..., "--comment", help="Comment text to append beneath the task."),
     subject: str | None = typer.Option(None, "--subject", help="Substring of task title (legacy fallback)."),
-    by_id: str | None = typer.Option(None, "--by-id", help="4-char Crockford prefix from `[#XXXX]`."),
+    by_id: str | None = typer.Option(None, "--by-id", help="Stable [#TAG] id (2-8 [A-Z0-9], >=1 letter)."),
     author: str = typer.Option(
         "scout", "--author", help="Comment attribution (default: scout). GUI passes the signed-in user."
     ),
@@ -139,7 +139,7 @@ def cli_add_comment(
 @app.command("delete-comment")
 def cli_delete_comment(
     subject: str | None = typer.Option(None, "--subject", help="Substring of task title (legacy fallback)."),
-    by_id: str | None = typer.Option(None, "--by-id", help="4-char Crockford prefix from `[#XXXX]`."),
+    by_id: str | None = typer.Option(None, "--by-id", help="Stable [#TAG] id (2-8 [A-Z0-9], >=1 letter)."),
     index: int | None = typer.Option(None, "--index", help="1-based index of the comment to delete."),
     text: str | None = typer.Option(None, "--text", help="Case-insensitive substring of the comment body."),
     path: Path | None = typer.Argument(
@@ -178,7 +178,7 @@ def cli_delete_comment(
 def cli_edit_comment(
     new_text: str = typer.Option(..., "--new-text", help="Replacement body for the comment."),
     subject: str | None = typer.Option(None, "--subject", help="Substring of task title (legacy fallback)."),
-    by_id: str | None = typer.Option(None, "--by-id", help="4-char Crockford prefix from `[#XXXX]`."),
+    by_id: str | None = typer.Option(None, "--by-id", help="Stable [#TAG] id (2-8 [A-Z0-9], >=1 letter)."),
     index: int | None = typer.Option(None, "--index", help="1-based index of the comment to edit."),
     text: str | None = typer.Option(None, "--text", help="Case-insensitive substring of the comment body."),
     path: Path | None = typer.Argument(

--- a/engine/scout/action_items/mark_done.py
+++ b/engine/scout/action_items/mark_done.py
@@ -33,7 +33,7 @@ def mark_done(
     """Mark today's (or `date`'s) action item done.
 
     Exactly one of `by_id` or `by_subject` must be provided. `by_id` is
-    a 4-char Crockford prefix; `by_subject` is a case-insensitive
+    a stable `[#TAG]` id (2-8 [A-Z0-9], >=1 letter); `by_subject` is a case-insensitive
     substring match against open-status raw lines (legacy fallback for
     lines that haven't been prefixed yet).
     """

--- a/engine/scout/action_items/parser.py
+++ b/engine/scout/action_items/parser.py
@@ -15,7 +15,7 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from scout.ids import short_prefix_pattern
+from scout.ids import leading_prefix_pattern
 
 
 @dataclass
@@ -197,7 +197,7 @@ def _parse_item_line(
     # Extract `[#XXXX]` short prefix (if present) and strip from title.
     # raw_line is preserved untouched so substring matching still works.
     _short_prefix: str | None = None
-    _prefix_match = short_prefix_pattern().search(title)
+    _prefix_match = leading_prefix_pattern().match(title)
     if _prefix_match is not None:
         _short_prefix = _prefix_match.group(1)
         # Remove the bracketed prefix from the title.

--- a/engine/scout/action_items/snooze.py
+++ b/engine/scout/action_items/snooze.py
@@ -45,7 +45,7 @@ def snooze(
     Callers may want to pre-validate `until > today` themselves.
 
     Exactly one of `by_id` or `by_subject` must be provided. `by_id` is
-    a 4-char Crockford prefix; `by_subject` is a case-insensitive
+    a stable `[#TAG]` id (2-8 [A-Z0-9], >=1 letter); `by_subject` is a case-insensitive
     substring match against open-status raw lines (legacy fallback for
     lines that haven't been prefixed yet).
     """

--- a/engine/scout/ids.py
+++ b/engine/scout/ids.py
@@ -5,6 +5,11 @@ markdown; the full ULID is the canonical storage form. See v0.4 spec §13.1.
 
 The Crockford alphabet excludes 0/O and 1/I/L visual confusables (and
 also U) so that hand-typed prefixes are unambiguous.
+
+Recognition is now broader than minting: an existing `[#TAG]` is recognized
+when it is 2–8 chars of `[A-Z0-9]` with at least one letter (so semantic
+tags like `[#MIRO]` count), while `new_short_prefix` still MINTS 4-char
+Crockford codes — a strict subset of the recognition grammar.
 """
 
 from __future__ import annotations
@@ -20,7 +25,14 @@ SHORT_PREFIX_LEN = 4
 
 _DEFAULT_MAX_ATTEMPTS = 64  # plenty for any realistic in-use set
 
-_PREFIX_REGEX = re.compile(r"\[#(" + f"[{re.escape(CROCKFORD_ALPHABET)}]" + r"{" + str(SHORT_PREFIX_LEN) + r"})\]")
+# Recognition grammar for a stable-ID tag: 2–8 chars of [A-Z0-9] with at least
+# one letter. The letter requirement disambiguates from pure-numeric GitHub
+# issue refs like `[#555]` (rendered by scout-app's GitHubRefLinkifier).
+# NOTE: this is the RECOGNITION grammar (what counts as an existing tag).
+# `new_short_prefix` still MINTS 4-char Crockford codes, a strict subset.
+_TAG_BODY = r"(?=[A-Z0-9]{2,8}\])([A-Z0-9]*[A-Z][A-Z0-9]*)"
+_PREFIX_REGEX = re.compile(r"\[#" + _TAG_BODY + r"\]")
+_LEADING_PREFIX_REGEX = re.compile(r"^\s*\[#" + _TAG_BODY + r"\]")
 
 
 def new_ulid() -> str:
@@ -49,9 +61,20 @@ def new_short_prefix(
 
 
 def short_prefix_pattern() -> re.Pattern[str]:
-    """Regex matching `[#XXXX]` where XXXX is 4 Crockford chars.
+    """Regex matching a `[#TAG]` token ANYWHERE in a string (unanchored).
 
-    `match.group(0)` returns the full bracketed prefix; `match.group(1)`
-    returns the bare 4-char prefix.
+    `group(0)` is the full bracketed token; `group(1)` is the bare tag. Used
+    by the "does this line already carry a tag?" guard. TAG = 2–8 `[A-Z0-9]`
+    with >=1 letter.
     """
     return _PREFIX_REGEX
+
+
+def leading_prefix_pattern() -> re.Pattern[str]:
+    """Regex matching a `[#TAG]` only at the START of a (whitespace-led) string.
+
+    Use for EXTRACTING the leading identifier off a task title, so a `[#TAG]`
+    appearing mid-text (e.g. a GitHub ref in the body) is never mistaken for
+    the task's id.
+    """
+    return _LEADING_PREFIX_REGEX

--- a/engine/scout/ids.py
+++ b/engine/scout/ids.py
@@ -6,10 +6,11 @@ markdown; the full ULID is the canonical storage form. See v0.4 spec §13.1.
 The Crockford alphabet excludes 0/O and 1/I/L visual confusables (and
 also U) so that hand-typed prefixes are unambiguous.
 
-Recognition is now broader than minting: an existing `[#TAG]` is recognized
-when it is 2–8 chars of `[A-Z0-9]` with at least one letter (so semantic
-tags like `[#MIRO]` count), while `new_short_prefix` still MINTS 4-char
-Crockford codes — a strict subset of the recognition grammar.
+Recognition is broader than minting: an existing `[#TAG]` is recognized when
+it is 2–8 chars of `[A-Z0-9]` with at least one letter (so semantic tags
+like `[#MIRO]` count), while `new_short_prefix` MINTS 4-char Crockford codes.
+Minting guarantees at least one letter (pure-digit draws are re-rolled), so
+every minted prefix is a strict subset of the recognition grammar.
 """
 
 from __future__ import annotations
@@ -29,7 +30,8 @@ _DEFAULT_MAX_ATTEMPTS = 64  # plenty for any realistic in-use set
 # one letter. The letter requirement disambiguates from pure-numeric GitHub
 # issue refs like `[#555]` (rendered by scout-app's GitHubRefLinkifier).
 # NOTE: this is the RECOGNITION grammar (what counts as an existing tag).
-# `new_short_prefix` still MINTS 4-char Crockford codes, a strict subset.
+# `new_short_prefix` MINTS 4-char Crockford codes and guarantees >=1 letter,
+# so every minted prefix is a strict subset of this recognition grammar.
 _TAG_BODY = r"(?=[A-Z0-9]{2,8}\])([A-Z0-9]*[A-Z][A-Z0-9]*)"
 _PREFIX_REGEX = re.compile(r"\[#" + _TAG_BODY + r"\]")
 _LEADING_PREFIX_REGEX = re.compile(r"^\s*\[#" + _TAG_BODY + r"\]")
@@ -46,6 +48,10 @@ def new_short_prefix(
 ) -> str:
     """Generate a fresh 4-char Crockford base32 prefix not in `exclude`.
 
+    Every minted prefix contains at least one letter, so it always satisfies
+    the recognition grammar (see `short_prefix_pattern`). Pure-digit
+    candidates (~1% of draws) are rejected and re-rolled.
+
     `exclude` is the set of currently-in-use short prefixes (typically
     sourced from `scout.id_map.IdMap.in_use_prefixes()`). Raises
     `RuntimeError` if `max_attempts` retries all hit the exclude set —
@@ -55,7 +61,9 @@ def new_short_prefix(
     exclude = exclude or set()
     for _ in range(max_attempts):
         candidate = "".join(secrets.choice(CROCKFORD_ALPHABET) for _ in range(SHORT_PREFIX_LEN))
-        if candidate not in exclude:
+        # Require >=1 letter so the mint always satisfies the recognition
+        # grammar (a pure-digit code like "0000" would be unrecognizable).
+        if candidate not in exclude and any(c.isalpha() for c in candidate):
             return candidate
     raise RuntimeError(f"prefix space exhausted after {max_attempts} attempts (exclude size {len(exclude)})")
 

--- a/engine/tests/fixtures/contract/parser-corpus.json
+++ b/engine/tests/fixtures/contract/parser-corpus.json
@@ -1,5 +1,5 @@
 {
-  "_doc": "Cross-language parser contract. Each entry is a raw action-item task line; both the Swift (scout-app) and Python (scout-plugin) parsers MUST reproduce expected exactly. Seeded with scout-app #10 failure modes. Canonical copy lives here. The same corpus will be asserted by scout-app's Swift ParserContractTests; the copies are kept byte-identical by a checksum guard added in M3.4. Field contract (matches scout-app/Scout/ActionItems/ActionItemsParser.swift, the reference parser): short_prefix = bare 4-char Crockford [#XXXX] code extracted+removed from the line, else null; subject = leading title with bold/strike/wikilink markup RETAINED but with the [#XXXX] prefix removed; plain_subject = subject with markdown tokens stripped (the form the --subject substring matcher compares against); body = remainder after the first ' — '/' – '/' - ' separator found OUTSIDE bold/strike/code/wikilink/link tokens (else ''). Note: italic _(...)_ is NOT a separator, so trailing _(...)_ parentheticals stay in subject.",
+  "_doc": "Cross-language parser contract. Each entry is a raw action-item task line; both the Swift (scout-app) and Python (scout-plugin) parsers MUST reproduce expected exactly. Seeded with scout-app #10 failure modes. Canonical copy lives here. The same corpus will be asserted by scout-app's Swift ParserContractTests; the copies are kept byte-identical by a checksum guard added in M3.4. Field contract (matches scout-app/Scout/ActionItems/ActionItemsParser.swift, the reference parser): short_prefix = bare 2-8 char [A-Z0-9] tag (>=1 letter) extracted+removed from the line, else null; subject = leading title with bold/strike/wikilink markup RETAINED but with the [#XXXX] prefix removed; plain_subject = subject with markdown tokens stripped (the form the --subject substring matcher compares against); body = remainder after the first ' — '/' – '/' - ' separator found OUTSIDE bold/strike/code/wikilink/link tokens (else ''). Note: italic _(...)_ is NOT a separator, so trailing _(...)_ parentheticals stay in subject.",
   "entries": [
     {
       "name": "prefixed-emoji-bold",
@@ -68,6 +68,50 @@
         "plain_subject": "Check AI-2619",
         "body": "run `scoutctl status`"
       }
+    },
+    {
+      "name": "semantic-tag-4char-non-crockford",
+      "line": "- [ ] [#MIRO] **Miro 1:1 follow-through** — 3 quick sends",
+      "expected": {
+        "short_prefix": "MIRO",
+        "subject": "**Miro 1:1 follow-through**",
+        "plain_subject": "Miro 1:1 follow-through",
+        "body": "3 quick sends"
+      },
+      "_note": "4-char tag containing I and O (NOT Crockford). Exercises the widened recognition grammar (#117). subject/plain_subject xfail on Python (render.py prefix-strip #114)."
+    },
+    {
+      "name": "semantic-tag-6char",
+      "line": "- [ ] [#AI3026] **Validate kai-agent tracing**",
+      "expected": {
+        "short_prefix": "AI3026",
+        "subject": "**Validate kai-agent tracing**",
+        "plain_subject": "Validate kai-agent tracing",
+        "body": ""
+      },
+      "_note": "6-char tag containing I. Length > the old 4-char limit."
+    },
+    {
+      "name": "semantic-tag-3char",
+      "line": "- [ ] [#RSM] Rossum SL tester",
+      "expected": {
+        "short_prefix": "RSM",
+        "subject": "Rossum SL tester",
+        "plain_subject": "Rossum SL tester",
+        "body": ""
+      },
+      "_note": "3-char tag, no bold, no separator."
+    },
+    {
+      "name": "semantic-tag-digit-led",
+      "line": "- [ ] [#5864M] **Merge ui PR** — APPROVED",
+      "expected": {
+        "short_prefix": "5864M",
+        "subject": "**Merge ui PR**",
+        "plain_subject": "Merge ui PR",
+        "body": "APPROVED"
+      },
+      "_note": "Digit-led 5-char tag with one trailing letter — accepted (has a letter); pure-digit would be rejected as a GitHub ref."
     }
   ]
 }

--- a/engine/tests/unit/test_action_items_backfill.py
+++ b/engine/tests/unit/test_action_items_backfill.py
@@ -1,0 +1,27 @@
+"""Unit tests for scout.action_items.backfill."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scout.action_items.backfill import backfill_prefixes
+
+
+def test_backfill_skips_lines_with_semantic_tag(fake_data_dir: Path, tmp_path: Path) -> None:
+    """A line already carrying a variable-length [#TAG] must NOT get a second
+    prefix prepended (the double-prefix hazard that motivated #117). Only
+    genuinely bare task lines should be backfilled."""
+    f = tmp_path / "action-items-2026-06-06.md"
+    f.write_text(
+        "# T\n\n## 🔴 Urgent\n\n"
+        "- [ ] [#MIRO] **Miro 1:1** — sends\n"  # semantic tag: skip
+        "- [ ] [#AI3026] **Validate tracing**\n"  # 6-char tag: skip
+        "- [ ] **Bare unprefixed task** — needs id\n",  # bare: gets a prefix
+        encoding="utf-8",
+    )
+    # backfill_prefixes returns (line_number, prefix, title) tuples for the
+    # lines it would prefix. dry_run avoids touching the file or id-map.
+    added = backfill_prefixes(target=f, data_dir=fake_data_dir, dry_run=True)
+    titles = {title for _, _, title in added}
+    assert all("Miro" not in t and "Validate tracing" not in t for t in titles)
+    assert len(added) == 1  # only the bare line

--- a/engine/tests/unit/test_action_items_common.py
+++ b/engine/tests/unit/test_action_items_common.py
@@ -207,3 +207,36 @@ def test_resolve_target_by_subject_matches_title_substring(fake_data_dir: Path) 
     target, _, via = resolve_target(items=items, data_dir=fake_data_dir, by_id=None, by_subject="task x")
     assert target.title == "task X"
     assert via == "subject"
+
+
+def test_resolve_target_ambiguous_id_raises(fake_data_dir: Path) -> None:
+    """Two open tasks sharing a [#TAG] is ambiguous for --by-id; raise rather
+    than silently acting on the first (reusable human tags can collide)."""
+    items = [
+        ActionItem(
+            priority="🔴",
+            title="Miro 1:1 follow-through",
+            status="open",
+            section="To Do",
+            context_links=[],
+            notes=[],
+            details=[],
+            raw_line="- [ ] [#MIRO] Miro 1:1 follow-through",
+            line_number=5,
+            short_prefix="MIRO",
+        ),
+        ActionItem(
+            priority="🟡",
+            title="Miro design doc review",
+            status="open",
+            section="To Do",
+            context_links=[],
+            notes=[],
+            details=[],
+            raw_line="- [ ] [#MIRO] Miro design doc review",
+            line_number=9,
+            short_prefix="MIRO",
+        ),
+    ]
+    with pytest.raises(ActionItemError, match="ambiguous id"):
+        resolve_target(items=items, data_dir=fake_data_dir, by_id="MIRO", by_subject=None)

--- a/engine/tests/unit/test_action_items_parser.py
+++ b/engine/tests/unit/test_action_items_parser.py
@@ -187,3 +187,41 @@ def test_parse_skips_tilde_fenced_blocks(tmp_path):
     )
     titles = [i.title for i in parse_action_items(md)]
     assert titles == ["real"]
+
+
+def test_parser_extracts_semantic_tag(tmp_path: Path) -> None:
+    f = tmp_path / "action-items-2026-06-06.md"
+    f.write_text(
+        "# T\n\n## 🔴 Urgent\n\n- [ ] [#AI3026] **Validate tracing** — overnight\n",
+        encoding="utf-8",
+    )
+    items = parse_file(f)
+    assert len(items) == 1
+    assert items[0].short_prefix == "AI3026"
+    assert "[#AI3026]" not in items[0].title  # stripped from the title
+
+
+def test_parser_does_not_extract_midbody_or_numeric_tag(tmp_path: Path) -> None:
+    f = tmp_path / "action-items-2026-06-06.md"
+    # A GitHub-ref-shaped token mid-title and a pure-numeric token must NOT be
+    # mistaken for the leading stable-ID prefix.
+    f.write_text(
+        "# T\n\n## 🔴 Urgent\n\n- [ ] **Review [#555] in acme/api** — body\n",
+        encoding="utf-8",
+    )
+    items = parse_file(f)
+    assert len(items) == 1
+    assert items[0].short_prefix is None
+
+
+def test_parser_does_not_extract_midtitle_tag(tmp_path: Path) -> None:
+    f = tmp_path / "action-items-2026-06-06.md"
+    # No leading id; a [#TAG]-shaped token (with a letter) appears mid-title.
+    # Unanchored .search() would wrongly extract it; anchored .match() must not.
+    f.write_text(
+        "# T\n\n## 🔴 Urgent\n\n- [ ] Discuss [#AI3026] rollout with team\n",
+        encoding="utf-8",
+    )
+    items = parse_file(f)
+    assert len(items) == 1
+    assert items[0].short_prefix is None

--- a/engine/tests/unit/test_ids.py
+++ b/engine/tests/unit/test_ids.py
@@ -32,6 +32,15 @@ def test_new_short_prefix_is_4_crockford_chars() -> None:
     assert all(c in CROCKFORD_ALPHABET for c in p)
 
 
+def test_new_short_prefix_always_recognizable() -> None:
+    """Every minted prefix must satisfy the recognition grammar (>=1 letter)."""
+    rx = short_prefix_pattern()
+    for _ in range(200):
+        p = new_short_prefix()
+        assert any(c.isalpha() for c in p), p
+        assert rx.fullmatch(f"[#{p}]"), p
+
+
 def test_new_short_prefix_excludes_ambiguous_chars() -> None:
     # Crockford base32 excludes I, L, O, U to avoid 0/O and 1/I/L visual collisions.
     for c in "ILOU":
@@ -47,6 +56,8 @@ def test_short_prefix_pattern_matches_well_formed_prefix() -> None:
     assert rx.fullmatch("[#MIRO]")  # contains I and O
     assert rx.fullmatch("[#AI3026]")  # 6 chars, contains I
     assert rx.fullmatch("[#5864M]")  # digit-led, 5 chars
+    assert rx.fullmatch("[#AB]")  # length 2 lower bound
+    assert rx.fullmatch("[#ABCDEFGH]")  # length 8 upper bound
     # Rejections.
     assert not rx.fullmatch("[#a3f7]")  # lowercase
     assert not rx.fullmatch("[#A-37]")  # hyphen

--- a/engine/tests/unit/test_ids.py
+++ b/engine/tests/unit/test_ids.py
@@ -40,14 +40,31 @@ def test_new_short_prefix_excludes_ambiguous_chars() -> None:
 
 def test_short_prefix_pattern_matches_well_formed_prefix() -> None:
     rx = short_prefix_pattern()
+    # 4-char Crockford (minted) still valid.
     assert rx.fullmatch("[#A3F7]")
-    assert rx.fullmatch("[#0000]")
-    # Hyphens and lowercase are not allowed.
-    assert not rx.fullmatch("[#a3f7]")
-    assert not rx.fullmatch("[#A-37]")
-    # Wrong length.
-    assert not rx.fullmatch("[#A3F]")
-    assert not rx.fullmatch("[#A3F7E]")
+    # Variable length 2–8, semantic tags (incl. non-Crockford I/L/O/U).
+    assert rx.fullmatch("[#RSM]")  # 3 chars
+    assert rx.fullmatch("[#MIRO]")  # contains I and O
+    assert rx.fullmatch("[#AI3026]")  # 6 chars, contains I
+    assert rx.fullmatch("[#5864M]")  # digit-led, 5 chars
+    # Rejections.
+    assert not rx.fullmatch("[#a3f7]")  # lowercase
+    assert not rx.fullmatch("[#A-37]")  # hyphen
+    assert not rx.fullmatch("[#A]")  # too short (<2)
+    assert not rx.fullmatch("[#ABCDEFGHI]")  # too long (>8)
+    assert not rx.fullmatch("[#555]")  # pure digits → GitHub issue ref, not a tag
+    assert not rx.fullmatch("[#0000]")  # pure digits
+
+
+def test_leading_prefix_pattern_anchors_at_start() -> None:
+    from scout.ids import leading_prefix_pattern
+
+    rx = leading_prefix_pattern()
+    m = rx.match("[#MIRO] **Miro 1:1**")
+    assert m is not None and m.group(1) == "MIRO"
+    # Does NOT match a tag that isn't at the very start (e.g. a body GitHub ref).
+    assert rx.match("see [#AI3026] in body") is None
+    assert rx.match("[#555] pure digits") is None
 
 
 def test_short_prefix_pattern_finds_prefix_in_line() -> None:

--- a/phases/core/action-items.md
+++ b/phases/core/action-items.md
@@ -82,43 +82,39 @@ _Always the LAST section of the file — run metadata is a footer for review, ne
 
 All action items files must include `[[wikilinks]]` to any KB files referenced by action items.
 
-### Hard Rule — Every Task Line Has a Stable `[#XXXX]` Prefix
+### Hard Rule — Every Task Line Has a Stable `[#TAG]`
 
-**Every new task line you write MUST start with a fresh `[#XXXX]` 4-char Crockford prefix.** The prefix is the structural identifier scout-app uses to mark tasks done, snooze them, and attach comments — without it, the app falls back to brittle markdown-substring matching that fails on emoji, italics, em-dashes, embedded links, or any non-ASCII drift. Issue #10 of scout-app catalogs the failure modes.
+**Every new task line you write MUST start with a stable `[#TAG]` identifier** — 2–8 uppercase letters/digits with at least one letter (e.g. `[#NAHSEND]`, `[#AI3026]`, `[#RSM]`). The tag is the structural identifier scout-app uses to mark tasks done, snooze them, and attach comments — without it, the app falls back to brittle markdown-substring matching that fails on emoji, italics, em-dashes, embedded links, or any non-ASCII drift. Issue #10 of scout-app catalogs the failure modes.
 
-**Canonical task line shape:**
-```
-- [ ] [#XXXX] **<bold subject>** <optional body, links, italic context>
-```
-
-The prefix goes **after** the checkbox marker and **before** the bold subject. Exactly that order — the parser keys off it.
-
-**Mint a fresh prefix per task** by shelling out to scoutctl. The CLI collision-checks against `id-map.json` so two consecutive calls always return different prefixes:
+**Prefer a short, meaningful mnemonic** that hints at the task and is easy to cross-reference from other lines (e.g. `[#NAHSEND]`, `[#MIRO]`, `[#AI3026]`). When nothing meaningful fits, mint a random one:
 
 ```bash
-# Inside your task-writing loop:
-PFX=$(scoutctl action-items new-prefix)
+PFX=$(scoutctl action-items new-prefix)   # random 4-char fallback id
 echo "- [ ] [#${PFX}] **${SUBJECT}** ${BODY}" >> "$DAILY_FILE"
 ```
 
-**Carry-forward keeps the original prefix.** When propagating an item from yesterday's file into today's, copy the `[#XXXX]` verbatim — do NOT mint a new one. The prefix is the task's identity across days; minting a new one breaks the link in scout-app's session↔task store and severs the commit-history trail.
+**Canonical task line shape:**
+```
+- [ ] [#TAG] **<bold subject>** <optional body, links, italic context>
+```
+The tag goes **after** the checkbox marker and **before** the bold subject. Exactly that order — the parser keys off the leading position.
 
-**Existing unprefixed lines (legacy carryover):** when you find a task carried forward from a pre-prefix era that lacks `[#XXXX]`, mint a fresh prefix for it on first touch. Or run the one-shot backfill at the top of the briefing:
+**Tag rules:**
+- 2–8 chars, `[A-Z0-9]`, at least one letter. (Pure-numeric like `[#555]` is reserved for GitHub issue refs and is NOT a valid tag.)
+- **Unique within the file** — never give two open tasks the same tag (scout-app's `--by-id` will refuse an ambiguous tag).
+- **Carry-forward keeps the original tag verbatim.** When propagating an item from yesterday into today, copy its `[#TAG]` exactly — do NOT mint a new one. The tag is the task's identity across days.
 
+**Existing unprefixed lines (legacy carryover):** when you find a task that lacks a `[#TAG]`, give it one on first touch, or run the idempotent one-shot backfill (it leaves already-tagged lines alone):
 ```bash
 scoutctl action-items backfill-prefixes "$DAILY_FILE"
 ```
 
-The backfill is idempotent — already-prefixed lines are left alone — so it's safe to run defensively at the start of every briefing/consolidation step that writes new lines.
-
-**Self-check before commit:** every `- [ ]` and `- [x]` line in the file MUST match the regex `^\s*- \[[ x]\] \[#[0-9A-HJKMNP-TV-Z]{4}\] `. A `grep` sanity check at compose time catches drift:
-
+**Self-check before commit:** every `- [ ]`/`- [x]` line MUST carry a `[#TAG]`. A heuristic grep catches drift:
 ```bash
-grep -nE '^\s*- \[[ x]\] ' "$DAILY_FILE" | grep -vE ' \[#[0-9A-HJKMNP-TV-Z]{4}\] ' && \
-    echo "ERROR: lines missing [#XXXX] prefix above — fix before commit" >&2
+grep -nE '^\s*- \[[ x]\] ' "$DAILY_FILE" | grep -vE ' \[#[A-Z0-9]{2,8}\] ' && \
+    echo "ERROR: lines missing [#TAG] prefix above — fix before commit" >&2
 ```
-
-If that grep finds anything, the file is non-compliant and scout-app's writes will silently fall back to fragile subject-matching for those lines.
+If that grep finds anything, the file is non-compliant and scout-app's writes will fall back to fragile subject-matching for those lines.
 
 ### Hard Rule — Trim by Demotion, Never by Omission
 


### PR DESCRIPTION
## What & why

Closes #117. The merged stable-ID work assumed a fixed **4-char Crockford** `[#XXXX]`, but the live vault uses variable-length **semantic mnemonics** (`[#MIRO]`, `[#NAHSEND]`, `[#AI3026]`, `[#RSM]`) that the parser didn't recognize — so scout-app fell back to brittle `--subject` matching on exactly the most-cross-referenced lines, and `backfill-prefixes` would have **double-prefixed** them. This widens **recognition** to fit the actual convention.

## Grammar (recognition-only)

A tag is **2–8 chars of `[A-Z0-9]` with ≥1 letter**: `\[#(?=[A-Z0-9]{2,8}\])([A-Z0-9]*[A-Z][A-Z0-9]*)\]`. The ≥1-letter rule rejects pure-numeric tokens like `[#555]` (reserved for GitHub issue refs rendered by scout-app's `GitHubRefLinkifier`). **Minting is unchanged** — `new_short_prefix` still produces Crockford-4, now *guaranteed to contain a letter* so every mint stays recognizable.

## Changes
- **`scout/ids.py`** — widen `_PREFIX_REGEX`; add start-anchored `leading_prefix_pattern()` for extraction (vs the unanchored `short_prefix_pattern()` guard); `new_short_prefix` re-rolls all-digit draws.
- **`action_items/parser.py`** — extract the leading tag with the anchored pattern (a `[#TAG]`-shaped token mid-title is no longer mistaken for the id).
- **`action_items/_common.py`** — `--by-id` now raises on a tag shared by >1 open task (reusable human tags can collide) instead of silently picking the first; single-match + lazy-register unchanged.
- **`backfill.py` / `add_prefix_to_line`** — no logic change; they inherit the widened pattern, so `[#TAG]` lines are now recognized as prefixed (regression test added: never double-prefix).
- **`phases/core/action-items.md`** — generation prompt now encourages a meaningful `[#TAG]`, with `new-prefix` as the fallback; widened self-check grep.
- **`tests/fixtures/contract/parser-corpus.json`** — 4 new variable-length `[#TAG]` entries (canonical copy for the cross-language contract; the scout-app copy + checksum land in the paired app PR).
- Stale "4-char Crockford" `--by-id` help text + docstrings refreshed.

## Testing
Full suite: **756 passed, 20 xfailed** (the 3 failures in `test_cc_session_cache`/`test_cli_schedule_subapp` are pre-existing local-env-only and untouched here). `test_parser_contract`: 24 passed / 20 xfailed (new entries' `short_prefix`+`body` pass; `subject`/`plain_subject` strict-xfail under the render.py prefix-strip gap, #114). ruff + mypy clean.

## Paired PR
scout-app: widens `extractShortPrefix` + the writer line reader, syncs the corpus copy + checksum, rewrites the obsolete `ShortPrefixTests`. (Both must merge for the contract to hold.)

## Adoption note
Once both merge, the M1 post-session backfill is safe again (no more double-prefixing `[#TAG]` lines), so the prior "hold off on `/scout-update`" caveat lifts.

Refs jordanrburger/Scout#10. Design+plan in scout-app `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)