### PR TITLE
release: v0.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "scout",
       "source": "./",
       "description": "Autonomous knowledge management and daily briefing system for Claude Code",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "author": {
         "name": "Jordan Burger"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scout",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Autonomous knowledge management and daily briefing system. Monitors your work tools (Slack, Calendar, Linear, GitHub, etc.), synthesizes findings into a persistent knowledge base with a formal ontology, and delivers daily action items — all running unattended via scheduled Claude Code sessions. Six session types: Morning Briefing, Consolidation, Dreaming, Research, interactive Work sessions, and Meta Review. Pre-session hooks pre-compute KB staleness, recent git activity, PR state, and Claude Code session summaries before each run, trading a few seconds of shell work for large token savings inside the session.",
   "author": {
     "name": "Jordan Burger"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-07
+
+### Added
+- **Variable-length `[#TAG]` action-item IDs** — the recognition grammar now accepts 2–8 `[A-Z0-9]` tags containing at least one letter (e.g. `[#NAHSEND]`, `[#AI3026]`, `[#RSM]`), not just 4-char Crockford. Pure-numeric `[#123]` stays reserved for GitHub issue refs. The generation prompt now encourages meaningful mnemonics, with `action-items new-prefix` as the random fallback. Fixes the real-vault gap where scout-app fell back to brittle `--subject` matching on the most-referenced lines (scout-app#10, #117).
+- **Deterministic post-session prefix backfill** — briefing/consolidation runners run `action-items backfill-prefixes` at session end, so every open task carries a stable `[#TAG]` independent of prompt compliance (#113).
+- **Cross-language parser contract test** — a golden corpus + SHA-256 checksum guard proving the Python (scout-plugin) and Swift (scout-app) parsers agree, seeded with the historically-broken lines (#113, #117).
+
+### Changed
+- **`action-items --by-id` is ambiguity-aware** — errors when a tag is shared by multiple open tasks instead of silently acting on the first (reusable semantic tags can collide; #117).
+- **`new_short_prefix` guarantees a letter** — minted Crockford-4 prefixes always contain at least one letter, so every mint is recognized by the widened grammar (#117).
+
 ## [0.5.0] - 2026-06-03
 
 

--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scout-engine"
-version = "0.5.0"
+version = "0.6.0"
 description = "Scout engine: CLI, hooks, runners, and Python library for the Scout productivity system."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/engine/scout/__init__.py
+++ b/engine/scout/__init__.py
@@ -1,3 +1,3 @@
 """Scout engine package."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"


### PR DESCRIPTION
Release prep for **v0.6.0** — the stable-ID `[#TAG]` grammar work (#113 + #117).

## Highlights (see CHANGELOG.md [0.6.0])
- Variable-length `[#TAG]` recognition (2–8 `[A-Z0-9]`, ≥1 letter; rejects numeric GitHub refs)
- Deterministic post-session prefix backfill (briefing/consolidation runners)
- Cross-language parser contract test (corpus + checksum guard)
- `--by-id` ambiguity-aware; `new_short_prefix` guarantees a letter

Version bumped across all 4 manifests (`versioning set 0.6.0`); CHANGELOG `[0.6.0]` section filled. Review, ensure CI is green, merge — then `scripts/release.sh --finalize v0.6.0` tags the merge and publishes the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)