### PR TITLE
feat(landing): warm-paper landing page + README re-lead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,25 @@
 # Scout
 
-Autonomous knowledge management and daily briefing system for Claude Code. Scout monitors your work tools — Slack, Calendar, Gmail, Linear, GitHub, meeting transcripts, and more — synthesizes findings into a persistent, interlinked knowledge base with a formal ontology, and delivers daily action items. It runs unattended as scheduled Claude Code sessions, multiple times per day.
+> **The autonomous daily briefing that cross-checks all your work tools — so nothing falls through the cracks, and you can trust what it surfaces.**
 
-You shouldn't have to manually track what happened across seven different tools yesterday, what's still pending from last week, or what changed while you were in meetings. Scout does that automatically. It reads your tools, cross-checks findings against each other, writes a coherent knowledge base, and surfaces only what matters. The knowledge base is browsable in Obsidian as an interlinked graph of projects, people, channels, and action items.
+<p align="center">
+  <img src="docs/assets/scout-demo.svg" alt="A Scout morning briefing: action items cross-checked across Gmail, Slack, Calendar, GitHub and Linear, each tagged by confidence — with a source contradiction surfaced for the user instead of guessed" width="100%">
+</p>
+
+Scout runs unattended as scheduled [Claude Code](https://claude.com/claude-code) sessions. It reads Slack, Calendar, Gmail, Linear, GitHub, and meeting transcripts; cross-checks every finding against the others; and each morning hands you a short list of what actually needs you — every item tagged by how many sources confirm it. What you get is a persistent, interlinked knowledge base you can browse in Obsidian, and a daily action list you can trust *because you can see its work*.
+
+You shouldn't have to manually reconcile what happened across seven tools yesterday, what's still pending from last week, or what changed while you were in meetings. Scout does it — and when your tools disagree, it flags the contradiction instead of quietly picking a side.
+
+## Why Scout is different
+
+Readable-markdown memory, scheduled runs, and a self-improvement loop are table stakes now — every serious agent has them. Scout's difference is what it does *before* it tells you anything:
+
+- **It cross-checks.** No single tool is treated as the truth. A calendar invite is verified against the transcript; a Linear ticket against the PR; an email against Slack. Claims only one source supports are flagged, not asserted.
+- **It shows its confidence.** Every entry is tagged — `verified` (2+ sources), `single-source`, `unverified`, `stale`, or `contradicted`. You always know how much weight to give it.
+- **It's structured, not just stored.** A formal knowledge graph — typed people, projects, tasks, and relationships you can actually query — not a flat pile of notes.
+- **It surfaces disagreement.** When your sources conflict, that contradiction *is* the signal. Scout shows you both sides instead of guessing which is right.
+
+Most assistants summarize. Scout corroborates — and that's the difference between output you skim and output you act on.
 
 ## Install
 

--- a/docs/assets/scout-demo.svg
+++ b/docs/assets/scout-demo.svg
@@ -1,0 +1,83 @@
+<svg width="1120" height="744" viewBox="0 0 1120 744" fill="none" xmlns="http://www.w3.org/2000/svg" font-family="'Iowan Old Style', 'Palatino Linotype', Georgia, serif">
+  <defs>
+    <radialGradient id="page" cx="50%" cy="0%" r="120%">
+      <stop offset="0%" stop-color="#F3ECD9"/>
+      <stop offset="100%" stop-color="#E8E0CC"/>
+    </radialGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="26" stdDeviation="34" flood-color="#2A1C0A" flood-opacity="0.22"/>
+    </filter>
+  </defs>
+
+  <rect width="1120" height="744" rx="22" fill="url(#page)"/>
+
+  <!-- briefing card -->
+  <g filter="url(#soft)">
+    <rect x="48" y="40" width="1024" height="664" rx="16" fill="#F4EFE1" stroke="#DDD6C3" stroke-width="1"/>
+  </g>
+
+  <!-- titlebar -->
+  <path d="M48 56 a16 16 0 0 1 16 -16 h992 a16 16 0 0 1 16 16 v30 h-1024 Z" fill="#F8F3E6"/>
+  <line x1="48" y1="86" x2="1072" y2="86" stroke="#DDD6C3" stroke-width="1"/>
+  <circle cx="78" cy="63" r="5.5" fill="#ff5f57"/><circle cx="98" cy="63" r="5.5" fill="#febc2e"/><circle cx="118" cy="63" r="5.5" fill="#28c840"/>
+  <text x="150" y="68" font-family="-apple-system, 'Segoe UI', sans-serif" font-size="13.5" fill="#82858F">Scout</text>
+  <text x="190" y="68" font-family="-apple-system, 'Segoe UI', sans-serif" font-size="13.5" fill="#A6A8AF">›</text>
+  <text x="206" y="68" font-family="-apple-system, 'Segoe UI', sans-serif" font-size="13.5" font-weight="600" fill="#30343F">Today</text>
+  <g>
+    <rect x="864" y="50" width="184" height="26" rx="7" fill="#EEE7D6"/>
+    <text x="956" y="67" text-anchor="middle" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="11" fill="#82858F">run 07:02 · 5 tools · 14 items</text>
+  </g>
+
+  <!-- dateline -->
+  <text x="80" y="138" font-size="26" font-weight="600" fill="#30343F">June 12</text>
+  <text x="196" y="138" font-family="-apple-system, 'Segoe UI', sans-serif" font-size="14" fill="#82858F">Friday</text>
+  <text x="1040" y="137" text-anchor="end" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="11.5" fill="#A6A8AF"><tspan fill="#5A5E69" font-weight="500">3</tspan> need you · <tspan fill="#5A5E69" font-weight="500">1</tspan> contradiction surfaced</text>
+  <line x1="80" y1="158" x2="1040" y2="158" stroke="#E4DDCB" stroke-width="1"/>
+
+  <!-- item 1 — verified -->
+  <circle cx="92" cy="200" r="9" fill="#F4EFE1" stroke="#E0D9C6"/><circle cx="92" cy="200" r="4.5" fill="#C5503C"/>
+  <text x="120" y="198" font-size="16.5" font-weight="600" fill="#30343F">Reply to Priya on the API deprecation thread — she has asked twice.</text>
+  <text x="120" y="223" font-size="14" fill="#5A5E69">Second nudge landed yesterday at 4:40 pm; the migration doc she needs is already in your drafts.</text>
+  <g font-family="'JetBrains Mono', ui-monospace, monospace" font-size="11">
+    <rect x="120" y="238" width="74" height="22" rx="6" fill="#EDE6D5"/><circle cx="133" cy="249" r="3.5" fill="#4E9E6E"/><text x="143" y="253" fill="#4E9E6E" font-weight="500">verified</text>
+    <rect x="202" y="238" width="104" height="22" rx="6" fill="#F4EFE1" stroke="#E0D9C6"/><text x="214" y="253" font-family="-apple-system, 'Segoe UI', sans-serif" fill="#5A5E69" font-weight="500">Slack #platform</text>
+    <rect x="314" y="238" width="58" height="22" rx="6" fill="#F4EFE1" stroke="#E0D9C6"/><text x="326" y="253" font-family="-apple-system, 'Segoe UI', sans-serif" fill="#5A5E69" font-weight="500">Gmail</text>
+    <text x="386" y="253" fill="#A6A8AF">confirmed in 2 sources</text>
+  </g>
+  <line x1="80" y1="288" x2="1040" y2="288" stroke="#E4DDCB" stroke-width="1"/>
+
+  <!-- item 2 — single-source -->
+  <circle cx="92" cy="330" r="9" fill="#F4EFE1" stroke="#E0D9C6"/><circle cx="92" cy="330" r="4.5" fill="#C68A35"/>
+  <text x="120" y="328" font-size="16.5" font-weight="600" fill="#30343F">Northwind renewal call may have moved to 3:00.</text>
+  <text x="120" y="353" font-size="14" fill="#5A5E69">Only the calendar says so — no confirmation from Dana by email or Slack. Treat the new time as tentative.</text>
+  <g font-family="'JetBrains Mono', ui-monospace, monospace" font-size="11">
+    <rect x="120" y="368" width="104" height="22" rx="6" fill="#EDE6D5"/><circle cx="133" cy="379" r="3.5" fill="#C68A35"/><text x="143" y="383" fill="#C68A35" font-weight="500">single-source</text>
+    <rect x="232" y="368" width="74" height="22" rx="6" fill="#F4EFE1" stroke="#E0D9C6"/><text x="244" y="383" font-family="-apple-system, 'Segoe UI', sans-serif" fill="#5A5E69" font-weight="500">Calendar</text>
+    <text x="320" y="383" fill="#A6A8AF">no corroborating source found</text>
+  </g>
+  <line x1="80" y1="418" x2="1040" y2="418" stroke="#E4DDCB" stroke-width="1"/>
+
+  <!-- item 3 — contradicted -->
+  <circle cx="92" cy="460" r="9" fill="#F4EFE1" stroke="#E0D9C6"/><circle cx="92" cy="460" r="4.5" fill="#A6A8AF"/>
+  <text x="120" y="458" font-size="16.5" font-weight="600" fill="#30343F">Did PROJ-214 actually ship?</text>
+  <text x="120" y="483" font-size="14" fill="#5A5E69">Your sources disagree. Scout won't guess — here is what each one says:</text>
+  <!-- conflict sides -->
+  <g>
+    <rect x="120" y="498" width="450" height="74" rx="9" fill="#EFE8D7"/>
+    <text x="138" y="521" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="10" letter-spacing="0.5" fill="#A6A8AF">LINEAR</text>
+    <text x="138" y="546" font-size="13.5" fill="#5A5E69">Ticket moved to <tspan font-weight="700" fill="#30343F">Done</tspan> by Marcus,</text>
+    <text x="138" y="565" font-size="13.5" fill="#5A5E69">yesterday 6:12 pm.</text>
+    <rect x="590" y="498" width="450" height="74" rx="9" fill="#EFE8D7"/>
+    <text x="608" y="521" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="10" letter-spacing="0.5" fill="#A6A8AF">GITHUB</text>
+    <text x="608" y="546" font-size="13.5" fill="#5A5E69">PR <tspan font-weight="700" fill="#30343F">#482 is still open</tspan> — two</text>
+    <text x="608" y="565" font-size="13.5" fill="#5A5E69">reviews requested, none approved.</text>
+  </g>
+  <g font-family="'JetBrains Mono', ui-monospace, monospace" font-size="11">
+    <rect x="120" y="588" width="98" height="22" rx="6" fill="#EDE6D5"/><circle cx="133" cy="599" r="3.5" fill="#C5503C"/><text x="143" y="603" fill="#C5503C" font-weight="500">contradicted</text>
+    <text x="228" y="603" fill="#A6A8AF">disagreement is the signal — both sides shown</text>
+  </g>
+
+  <!-- footer line -->
+  <line x1="80" y1="650" x2="1040" y2="650" stroke="#E4DDCB" stroke-width="1"/>
+  <text x="80" y="678" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="11.5" fill="#A6A8AF">No source is trusted on its own. Every claim is cross-checked, and tagged by how sure Scout is.</text>
+</svg>

--- a/docs/assets/scout-icon.svg
+++ b/docs/assets/scout-icon.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024" role="img" aria-label="App icon">
+  <defs>
+    
+    <clipPath id="squircle">
+      <rect x="40" y="40" width="944" height="944" rx="210" ry="210"></rect>
+    </clipPath>
+
+    <radialGradient id="paper" cx="50%" cy="45%" r="75%">
+      <stop offset="0%" stop-color="#F6ECD2"></stop>
+      <stop offset="60%" stop-color="#EFE2C2"></stop>
+      <stop offset="100%" stop-color="#E5D4A9"></stop>
+    </radialGradient>
+
+    <radialGradient id="glow" cx="50%" cy="55%" r="40%">
+      <stop offset="0%" stop-color="#F4A73A" stop-opacity="0.95"></stop>
+      <stop offset="55%" stop-color="#E89326" stop-opacity="0.35"></stop>
+      <stop offset="100%" stop-color="#E89326" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="vignette" cx="50%" cy="50%" r="70%">
+      <stop offset="70%" stop-color="#000" stop-opacity="0"></stop>
+      <stop offset="100%" stop-color="#3A2A14" stop-opacity="0.18"></stop>
+    </radialGradient>
+
+    <filter id="grain" x="0" y="0" width="100%" height="100%">
+      <feTurbulence type="fractalNoise" baseFrequency="1.6" numOctaves="2" seed="4" result="n"></feTurbulence>
+      <feColorMatrix in="n" type="matrix" values="0 0 0 0 0.25&#xA;                0 0 0 0 0.18&#xA;                0 0 0 0 0.08&#xA;                0 0 0 0.35 0"></feColorMatrix>
+      <feComposite in2="SourceGraphic" operator="in"></feComposite>
+    </filter>
+
+    <filter id="roughen" x="-5%" y="-5%" width="110%" height="110%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" seed="7"></feTurbulence>
+      <feDisplacementMap in="SourceGraphic" scale="1.6"></feDisplacementMap>
+    </filter>
+  </defs>
+
+  
+  <g clip-path="url(#squircle)">
+    <rect x="40" y="40" width="944" height="944" fill="url(#paper)"></rect>
+    <rect x="40" y="40" width="944" height="944" fill="url(#glow)"></rect>
+    <rect x="40" y="40" width="944" height="944" fill="url(#vignette)"></rect>
+
+    <g filter="url(#roughen)">
+      
+      <circle cx="512" cy="268" r="44" fill="#2F4A55"></circle>
+
+      
+      <path d="M 512 338&#xA;               L 706 748&#xA;               L 512 704&#xA;               L 318 748 Z" fill="#2B2F33"></path>
+
+      
+      <path d="M 512 372&#xA;               L 512 700&#xA;               L 372 735&#xA;               Z" fill="url(#paper)"></path>
+
+      
+      <path d="M 512 338&#xA;               L 318 748&#xA;               L 372 735&#xA;               L 512 372 Z" fill="#2B2F33"></path>
+
+      
+      <rect x="420" y="792" width="184" height="42" rx="18" fill="#2B2F33"></rect>
+    </g>
+
+    
+    <rect x="40" y="40" width="944" height="944" fill="#F6ECD2" filter="url(#grain)" opacity="0.55"></rect>
+  </g>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,421 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Scout — the daily briefing that cross-checks your tools</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="description" content="Scout is an autonomous daily briefing for Claude Code. It cross-checks Slack, Gmail, Calendar, Linear and GitHub before it tells you anything — and tags every item by how sure it is." />
+
+<!-- Open Graph / social -->
+<meta property="og:type" content="website" />
+<meta property="og:title" content="Scout — nothing falls through the cracks, and you can trust what it surfaces" />
+<meta property="og:description" content="An autonomous daily briefing for Claude Code that cross-checks all your work tools, tags every item by confidence, and surfaces contradictions instead of guessing." />
+<meta property="og:url" content="https://jordanrburger.github.io/scout-plugin/" />
+<meta property="og:image" content="https://raw.githubusercontent.com/jordanrburger/scout-plugin/main/docs/assets/scout-icon.svg" />
+<meta name="twitter:card" content="summary_large_image" />
+
+<script>try{if(window.matchMedia&&matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('theme-dark');}catch(e){}</script>
+
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400;1,6..72,500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="landing.css" />
+<link rel="icon" type="image/svg+xml" href="assets/scout-icon.svg" />
+</head>
+<body>
+
+<header class="nav">
+  <div class="wrap nav-inner">
+    <a class="wordmark" href="#">
+      <img class="sigil-img" src="assets/scout-icon.svg" alt="" width="28" height="28" />
+      <span class="name">Scout</span>
+    </a>
+    <nav class="nav-links">
+      <a class="plain" href="#corroborates">Why Scout</a>
+      <a class="plain" href="#how">How it works</a>
+      <a class="plain" href="#private">Your data</a>
+      <a class="plain" href="#install">Install</a>
+      <a class="plain" href="#app">Mac app</a>
+      <a class="nm-btn" href="https://github.com/jordanrburger/scout-plugin">
+        <svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.42 7.42 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"></path></svg>
+        GitHub
+      </a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <!-- HERO -->
+  <section class="hero wrap">
+    <span class="eyebrow"><span class="dot"></span>A Claude Code plugin</span>
+    <h1>Nothing falls through the cracks — and you can <em>trust</em> what it surfaces.</h1>
+    <p class="lede">Scout is an autonomous daily briefing that cross-checks Slack, Gmail, Calendar, Linear and GitHub before it tells you anything. Every item is tagged by <b>how sure it is</b> — and when your tools disagree, it shows you both sides.</p>
+    <div class="hero-ctas">
+      <a class="btn-accent" href="#install">Install Scout</a>
+      <a class="btn-quiet" href="https://github.com/jordanrburger/scout-plugin">View on GitHub</a>
+    </div>
+    <p class="hero-note">open source &middot; runs on your machine, on your subscription</p>
+  </section>
+
+  <!-- BRIEFING DEMO -->
+  <section class="demo wrap" id="demo">
+    <div class="briefing" role="img" aria-label="A Scout morning briefing with items tagged by confidence">
+      <div class="titlebar">
+        <div class="traffic"><span class="tdot c1"></span><span class="tdot c2"></span><span class="tdot c3"></span></div>
+        <span class="crumbs">Scout<span class="chev">&rsaquo;</span><b>Today</b></span>
+        <span class="run-chip">run 07:02 &middot; 5 tools &middot; 14 items</span>
+      </div>
+      <div class="briefing-body">
+        <div class="dateline">
+          <h2>June 12</h2><span class="wd">Friday</span>
+          <span class="meta"><b>3</b> need you &middot; <b>1</b> contradiction surfaced</span>
+        </div>
+
+        <div class="b-item" style="--p: var(--err);">
+          <span class="pdot"></span>
+          <div>
+            <h3>Reply to Priya on the API deprecation thread — she has asked twice.</h3>
+            <p>Second nudge landed yesterday at 4:40&nbsp;pm; the migration doc she needs is already in your drafts.</p>
+            <div class="b-row">
+              <span class="tag verified">verified</span>
+              <span class="src">Slack&nbsp;#platform</span>
+              <span class="src">Gmail</span>
+              <span class="b-why">confirmed in 2 sources</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="b-item" style="--p: var(--warn);">
+          <span class="pdot"></span>
+          <div>
+            <h3>Northwind renewal call may have moved to 3:00.</h3>
+            <p>Only the calendar says so — no confirmation from Dana by email or Slack. Treat the new time as tentative until she replies.</p>
+            <div class="b-row">
+              <span class="tag single">single-source</span>
+              <span class="src">Calendar</span>
+              <span class="b-why">no corroborating source found</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="b-item" style="--p: var(--ink-4);">
+          <span class="pdot"></span>
+          <div>
+            <h3>Did PROJ-214 actually ship?</h3>
+            <p>Your sources disagree. Scout won't guess — here is what each one says:</p>
+            <div class="conflict">
+              <div class="side"><span class="lbl">Linear</span>Ticket moved to <b>Done</b> by Marcus, yesterday 6:12&nbsp;pm.</div>
+              <div class="side"><span class="lbl">GitHub</span>PR <b>#482 is still open</b> — two reviews requested, none approved.</div>
+            </div>
+            <div class="b-row">
+              <span class="tag contradicted">contradicted</span>
+              <span class="b-why">disagreement is the signal — both sides shown</span>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- THE PROBLEM -->
+  <section class="section wrap" id="problem">
+    <p class="section-kicker">The problem</p>
+    <h2 class="big">You get more signal than you can possibly track.</h2>
+    <p class="sub">Every Slack DM, calendar invite, PR review and offhand decision is real and time-sensitive — and it arrives faster than anyone can read. So you cope one of two ways, and both quietly fail.</p>
+
+    <div class="fail-grid">
+      <div class="fail">
+        <span class="fail-tag">The completionist</span>
+        <h3>Read everything, burn out</h3>
+        <p>You try to keep up with every channel and inbox. Your attention degrades, and the one message that actually mattered drowns in the eleven that didn't.</p>
+      </div>
+      <div class="fail">
+        <span class="fail-tag">The triager</span>
+        <h3>Skim the top, miss the rest</h3>
+        <p>You give up and read only what's loud. The quiet, critical signal — the buried contract clause, the blocked teammate — slips straight through.</p>
+      </div>
+    </div>
+
+    <p class="problem-resolve">Scout is the third option. <b>Delegate everything that doesn't need your judgment</b> to an agent that reads all of it, cross-checks it against itself, and reaches back into your day only when something <em>genuinely</em> needs you. You stay the authority on what only you can know; it handles the rest.</p>
+  </section>
+
+  <!-- WHY -->
+  <section class="section wrap" id="corroborates">
+    <p class="section-kicker">Why it's different</p>
+    <h2 class="big">Most assistants summarize. Scout corroborates.</h2>
+    <p class="sub">Markdown memory, scheduled runs and self-improvement loops are table stakes now. Scout's difference is what it does <em>before</em> it tells you anything.</p>
+
+    <div class="points">
+      <div class="point">
+        <span class="num">01</span>
+        <div>
+          <h3>Cross-checked, not collected</h3>
+          <p>No single tool is treated as the truth. A calendar invite is verified against the transcript, a Linear ticket against its PR, an email against Slack. And your own actions outrank everything — what you <em>sent, merged or cancelled</em> beats what a meeting note says you'll do.</p>
+        </div>
+      </div>
+      <div class="point">
+        <span class="num">02</span>
+        <div>
+          <h3>Confidence on every line</h3>
+          <p>Every item carries its evidence level, so you always know how much weight to give it. Claims only one source supports are flagged — never silently promoted to fact.</p>
+          <div class="tag-rack">
+            <span class="tag verified">verified</span>
+            <span class="tag single">single-source</span>
+            <span class="tag unverified">unverified</span>
+            <span class="tag stale">stale</span>
+            <span class="tag contradicted">contradicted</span>
+          </div>
+        </div>
+      </div>
+      <div class="point">
+        <span class="num">03</span>
+        <div>
+          <h3>Disagreement is the signal</h3>
+          <p>When your sources conflict, Scout doesn't pick a winner. It surfaces the contradiction with both sides laid out — because that conflict is usually the most important thing in your day.</p>
+        </div>
+      </div>
+      <div class="point">
+        <span class="num">04</span>
+        <div>
+          <h3>A real knowledge graph</h3>
+          <p>Typed people, projects, tasks and relationships you can query — not a flat pile of notes. A formal ontology underneath, browsable in Obsidian as an interlinked graph above.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- HOW -->
+  <section class="section wrap" id="how">
+    <p class="section-kicker">How it works</p>
+    <h2 class="big">Six sessions, one job each.</h2>
+    <p class="sub">Scout runs as scheduled Claude Code sessions on your own machine and subscription — nothing leaves your computer that doesn't already.</p>
+
+    <div class="timeline">
+      <div class="t-row">
+        <span class="when">07:00</span>
+        <span class="node"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><circle cx="8" cy="8" r="3"></circle><path d="M8 1.5v2M8 12.5v2M1.5 8h2M12.5 8h2M3.4 3.4l1.4 1.4M11.2 11.2l1.4 1.4M12.6 3.4l-1.4 1.4M4.8 11.2l-1.4 1.4"></path></svg></span>
+        <div>
+          <h3>Morning Briefing<span class="freq">daily</span></h3>
+          <p>Full cold start: reads the whole knowledge base, queries every tool, cross-checks, and hands you today's action items.</p>
+        </div>
+      </div>
+      <div class="t-row">
+        <span class="when">12:30</span>
+        <span class="node"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9M13.5 1.5v3h-3"></path></svg></span>
+        <div>
+          <h3>Consolidation<span class="freq">2&times; daily</span></h3>
+          <p>Lightweight delta scans through the day — what changed, what's newly done, what needs reconciling.</p>
+        </div>
+      </div>
+      <div class="t-row">
+        <span class="when">15:00</span>
+        <span class="node"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><circle cx="7" cy="7" r="4.5"></circle><path d="M10.5 10.5L14 14"></path></svg></span>
+        <div>
+          <h3>Research<span class="freq">daily</span></h3>
+          <p>Goes outward — expands what Scout knows about the people, projects and topics in your knowledge base.</p>
+        </div>
+      </div>
+      <div class="t-row">
+        <span class="when">anytime</span>
+        <span class="node"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8.5l3 3 7-7"></path></svg></span>
+        <div>
+          <h3>Work<span class="freq">interactive</span></h3>
+          <p>Walks today's items one at a time, each with a drafted action you approve, skip, or edit. You stay the editor.</p>
+        </div>
+      </div>
+      <div class="t-row">
+        <span class="when">21:30</span>
+        <span class="node"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13.5 9.5A6 6 0 1 1 6.5 2.5a4.8 4.8 0 0 0 7 7Z"></path></svg></span>
+        <div>
+          <h3>Dreaming<span class="freq">nightly</span></h3>
+          <p>Evening self-improvement: processes your feedback, deepens the knowledge base, and learns from its own mistakes.</p>
+        </div>
+      </div>
+      <div class="t-row">
+        <span class="when">Sundays</span>
+        <span class="node"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2.5 13.5v-4M8 13.5v-8M13.5 13.5v-11"></path></svg></span>
+        <div>
+          <h3>Meta Review<span class="freq">weekly</span></h3>
+          <p>A system-level audit — is Scout actually running well, and is it getting better over time?</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- IT COMPOUNDS -->
+  <section class="section wrap" id="compounds">
+    <p class="section-kicker">It gets better</p>
+    <h2 class="big">Most tools are no smarter on day 100 than day 1. Scout is.</h2>
+    <p class="sub">Every night it reviews its own work. The knowledge base deepens, the mistakes get rarer, and the entire history stays in git — so the longer it runs, the more it's worth, and the harder it is to give up.</p>
+
+    <div class="compound-grid">
+      <div class="compound">
+        <span class="c-ico"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5.5 2.5h5a1.5 1.5 0 0 1 1.5 1.5v8.5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V4a1.5 1.5 0 0 1 1.5-1.5Z"></path><path d="M6 7.4l1.3 1.3L10 6"></path></svg></span>
+        <h3>It keeps a record of its own mistakes</h3>
+        <p>When Scout gets something wrong, the pattern goes into a mistake audit — root cause and fix encoded back into its own instructions, so the same error gets harder to repeat. It grows monotonically more reliable.</p>
+      </div>
+      <div class="compound">
+        <span class="c-ico"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13.5 9.5A6 6 0 1 1 6.5 2.5a4.8 4.8 0 0 0 7 7Z"></path></svg></span>
+        <h3>It forgets on purpose</h3>
+        <p>Every evening it lets a few things that no longer matter fall away. An agent that only ever accumulates becomes a worse partner over time; deliberate decay keeps the signal sharp and the briefing honest.</p>
+      </div>
+      <div class="compound">
+        <span class="c-ico"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="3.2" r="2"></circle><circle cx="8" cy="12.8" r="2"></circle><path d="M8 5.2v5.6"></path></svg></span>
+        <h3>Every change is in git</h3>
+        <p>Scout's memory is a git repository. Every edit is a commit with a reason — so you can see exactly what changed, when, and why, and revert anything you disagree with. The history is the system's memory of itself.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- YOUR DATA -->
+  <section class="section wrap" id="private">
+    <p class="section-kicker">Yours, end to end</p>
+    <h2 class="big">Runs on your machine. On your subscription. In plain files you own.</h2>
+    <p class="sub">Scout isn't a service you upload your life to. It's a plugin that runs locally and writes to a folder on your own disk — there is no Scout cloud.</p>
+
+    <div class="assurances">
+      <div class="assure">
+        <span class="chk"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8.5l3 3 7-7"></path></svg></span>
+        <div>
+          <h4>Nothing new leaves your computer</h4>
+          <p>Scout reads the tools you've already connected to Claude Code and writes to local files. No Scout server ever sees your data — there isn't one to see it.</p>
+        </div>
+      </div>
+      <div class="assure">
+        <span class="chk"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8.5l3 3 7-7"></path></svg></span>
+        <div>
+          <h4>Your memory is plain markdown</h4>
+          <p>The whole knowledge base is human-readable <code>.md</code> files with <code>[[wikilinks]]</code>. Open it in Obsidian, grep it, edit it, or walk away with it — markdown is canonical, everything else is just a view.</p>
+        </div>
+      </div>
+      <div class="assure">
+        <span class="chk"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8.5l3 3 7-7"></path></svg></span>
+        <div>
+          <h4>You can audit and undo anything</h4>
+          <p>Because it's all in git, every change Scout makes is a commit you can read and <code>git revert</code>. Nothing about the agent's memory is opaque to you.</p>
+        </div>
+      </div>
+      <div class="assure">
+        <span class="chk"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8.5l3 3 7-7"></path></svg></span>
+        <div>
+          <h4>You stay in control of the agent</h4>
+          <p>When Scout improves its own behaviour, the change lands as a separate, labelled commit — loud and reversible, never a silent edit you can't trace.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- INSTALL -->
+  <section class="section wrap" id="install">
+    <p class="section-kicker">Get started</p>
+    <h2 class="big">Installed in under five minutes.</h2>
+
+    <div class="install-grid">
+      <div class="term">
+        <div class="term-head">claude</div>
+        <pre><code><span class="cm"># In Claude Code:</span>
+<span class="cmd">/plugin</span> marketplace add jordanrburger/scout-plugin
+<span class="cmd">/plugin</span> install scout@scout-plugin
+
+<span class="cm"># then create your vault:</span>
+<span class="cmd">/scout-setup</span></code></pre>
+      </div>
+      <div class="install-aside">
+        <div class="step">
+          <span class="n">1</span>
+          <div><h4>Add the plugin</h4><p>Two commands inside Claude Code — no separate install.</p></div>
+        </div>
+        <div class="step">
+          <span class="n">2</span>
+          <div><h4>Run setup</h4><p><code>/scout-setup</code> detects your connected tools and scaffolds your vault.</p></div>
+        </div>
+        <div class="step">
+          <span class="n">3</span>
+          <div><h4>Wake up briefed</h4><p>Tomorrow's briefing arrives cross-checked and confidence-tagged.</p></div>
+        </div>
+        <p class="install-note"><b>Works with any subset of connectors.</b> Even a Calendar-only Scout is useful — more tools just mean richer cross-checking.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- MAC APP -->
+  <section class="section wrap" id="app">
+    <div class="app-grid">
+      <div class="app-icon-col">
+        <img class="app-icon" src="assets/scout-icon.svg" alt="Scout.app icon — a sail under a morning sun" width="168" height="168" />
+      </div>
+      <div>
+        <p class="section-kicker">Companion app</p>
+        <h2 class="big">Scout.app — a native window onto everything Scout writes.</h2>
+        <p class="sub">The plugin does the work; the free macOS app gives you a live interface on top of it.</p>
+        <div class="app-feats">
+          <div class="feat"><h4>Control Center</h4><p>Session activity, upcoming runs, cost per run, and a usage heatmap.</p></div>
+          <div class="feat"><h4>Action Items</h4><p>Today's briefing as a live list — inline comments, deep links to Linear, PRs and Slack.</p></div>
+          <div class="feat"><h4>Schedules</h4><p>Edit every scheduled session — times, weekdays, on-miss policy — with validated saves.</p></div>
+        </div>
+        <div class="hero-ctas" style="justify-content: flex-start;">
+          <a class="btn-accent" href="https://github.com/jordanrburger/Scout/releases">Download for macOS</a>
+        </div>
+        <p class="hero-note" style="text-align: left;">free &middot; macOS 13+ &middot; first launch: right-click &rarr; Open (ad-hoc signed)</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- FAQ -->
+  <section class="section wrap" id="faq">
+    <p class="section-kicker">Questions</p>
+    <h2 class="big">Good questions, honest answers.</h2>
+
+    <div class="faq-list">
+      <details class="qa">
+        <summary>Do I need Claude Code?<span class="pm">+</span></summary>
+        <p class="ans">Yes. Scout is a Claude Code plugin and runs as scheduled Claude Code sessions on your own machine. If you already use Claude Code, you're most of the way there.</p>
+      </details>
+      <details class="qa">
+        <summary>What does it cost to run?<span class="pm">+</span></summary>
+        <p class="ans">Scout itself is free and open source. It spends tokens on <b>your own</b> Claude subscription or API when sessions run. A built-in budget check skips runs once you're over your daily limit, and every session's cost is logged — so there are no surprises.</p>
+      </details>
+      <details class="qa">
+        <summary>Do I have to use Obsidian?<span class="pm">+</span></summary>
+        <p class="ans">No. The knowledge base is just markdown with <code>[[wikilinks]]</code> — any editor works. Obsidian gives the nicest reading experience, a graph view of how people, projects and channels connect, but it's entirely optional.</p>
+      </details>
+      <details class="qa">
+        <summary>What if I only have one or two tools connected?<span class="pm">+</span></summary>
+        <p class="ans">Still useful. Scout adapts its cross-checking to whatever you have — even a Calendar-only setup helps. More connectors simply mean more verification points behind each item.</p>
+      </details>
+      <details class="qa">
+        <summary>How is this different from giving an AI &ldquo;memory&rdquo;?<span class="pm">+</span></summary>
+        <p class="ans">Memory remembers what it's <em>told</em>. Scout corroborates what it <em>observes</em> across your tools, gives it structure (typed people, projects, tasks), flags what it isn't sure of, and surfaces contradictions instead of guessing — and you can audit every change in git. Remembering is the easy part; the <b>trust</b> is the point.</p>
+      </details>
+      <details class="qa">
+        <summary>Can my whole team use it?<span class="pm">+</span></summary>
+        <p class="ans">Each person runs their own Scout with their own knowledge base — it's built around individual context. Team knowledge still flows through your normal tools; Scout keeps <em>each</em> person on top of what matters to them.</p>
+      </details>
+    </div>
+  </section>
+</main>
+
+<!-- CLOSING CTA -->
+<section class="cta-band">
+  <h2>Wake up tomorrow already <em>briefed</em>.</h2>
+  <p>Install the plugin, run <code>/scout-setup</code>, and let Scout work the night shift. You'll get a short, cross-checked, confidence-tagged list of exactly what needs you.</p>
+  <div class="hero-ctas">
+    <a class="btn-accent" href="#install">Install Scout</a>
+    <a class="btn-quiet" href="https://github.com/jordanrburger/scout-plugin">View on GitHub</a>
+  </div>
+</section>
+
+<footer class="footer">
+  <div class="wrap footer-inner">
+    <span class="foot-brand"><img src="assets/scout-icon.svg" alt="" width="18" height="18" />Scout &middot; open source on GitHub</span>
+    <span class="spacer"></span>
+    <a href="https://github.com/jordanrburger/scout-plugin">Repository</a>
+    <a href="https://github.com/jordanrburger/Scout/releases">Mac app</a>
+    <a href="https://github.com/jordanrburger/scout-plugin/issues">Issues</a>
+    <a href="https://code.claude.com/docs/en/discover-plugins">Claude Code plugins</a>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/landing.css
+++ b/docs/landing.css
@@ -1,0 +1,542 @@
+/* Scout landing — warm-paper design system (shared with the Scout app prototype) */
+:root {
+  --paper:        oklch(0.95 0.012 85);
+  --paper-sunk:   oklch(0.92 0.014 85);
+  --paper-raised: oklch(0.97 0.010 85);
+  --paper-hi:     oklch(1.00 0.006 85);
+  --paper-lo:     oklch(0.85 0.020 85);
+  --rule:         oklch(0.86 0.012 85);
+  --rule-soft:    oklch(0.90 0.010 85);
+  --ink:          oklch(0.25 0.015 275);
+  --ink-2:        oklch(0.42 0.015 275);
+  --ink-3:        oklch(0.58 0.012 275);
+  --ink-4:        oklch(0.72 0.010 275);
+
+  --nm-hi: rgba(255, 252, 245, 0.95);
+  --nm-sh: rgba(130, 110, 85, 0.22);
+  --nm-sh-2: rgba(130, 110, 85, 0.14);
+
+  --accent:       oklch(0.62 0.14 55);
+  --accent-ink:   oklch(0.42 0.12 55);
+  --accent-wash:  oklch(0.94 0.04 70);
+
+  --ok:   oklch(0.58 0.13 150);
+  --warn: oklch(0.62 0.16 60);
+  --err:  oklch(0.58 0.19 25);
+
+  --sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --serif: "Newsreader", "New York", "Iowan Old Style", Georgia, serif;
+  --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  --nm-raised: 6px 6px 14px -4px var(--nm-sh), -4px -4px 12px -2px var(--nm-hi), inset 0.5px 0.5px 0 0 rgba(255,255,255,0.5);
+  --nm-raised-sm: 3px 3px 7px -2px var(--nm-sh), -2px -2px 5px -1px var(--nm-hi), inset 0.5px 0.5px 0 0 rgba(255,255,255,0.5);
+  --nm-pressed: inset 3px 3px 6px -1px var(--nm-sh), inset -2px -2px 5px -1px var(--nm-hi);
+  --nm-pressed-sm: inset 2px 2px 4px -1px var(--nm-sh), inset -1px -1px 3px -0.5px var(--nm-hi);
+}
+
+html.theme-dark {
+  --paper:        oklch(0.22 0.012 275);
+  --paper-sunk:   oklch(0.18 0.014 275);
+  --paper-raised: oklch(0.26 0.010 275);
+  --paper-hi:     oklch(0.30 0.010 275);
+  --paper-lo:     oklch(0.14 0.015 275);
+  --rule:         oklch(0.32 0.012 275);
+  --rule-soft:    oklch(0.28 0.010 275);
+  --ink:          oklch(0.94 0.008 85);
+  --ink-2:        oklch(0.78 0.010 85);
+  --ink-3:        oklch(0.60 0.012 85);
+  --ink-4:        oklch(0.45 0.010 85);
+  --nm-hi: rgba(255, 250, 240, 0.04);
+  --nm-sh: rgba(0, 0, 0, 0.55);
+  --nm-sh-2: rgba(0, 0, 0, 0.35);
+  --accent-wash: oklch(0.28 0.05 70);
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: var(--sans);
+  color: var(--ink);
+  background: var(--paper);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* paper grain */
+body::before {
+  content: '';
+  position: fixed; inset: 0;
+  pointer-events: none;
+  opacity: 0.30;
+  mix-blend-mode: multiply;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='220' height='220'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.6  0 0 0 0 0.48  0 0 0 0 0.32  0 0 0 0.07 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+  z-index: 50;
+}
+html.theme-dark body::before { opacity: 0.2; mix-blend-mode: screen; }
+
+.wrap { max-width: 1060px; margin: 0 auto; padding: 0 28px; }
+
+/* ---------- NAV ---------- */
+.nav {
+  position: sticky; top: 0; z-index: 40;
+  background: color-mix(in oklch, var(--paper) 88%, transparent);
+  backdrop-filter: blur(10px);
+  border-bottom: 0.5px solid var(--rule);
+}
+.nav-inner {
+  height: 60px;
+  display: flex; align-items: center; gap: 24px;
+}
+.wordmark {
+  display: flex; align-items: baseline; gap: 9px;
+  text-decoration: none; color: var(--ink);
+}
+.wordmark .name { font: 500 21px/1 var(--serif); letter-spacing: -0.01em; }
+.sigil-img {
+  align-self: center;
+  width: 28px; height: 28px;
+  border-radius: 8px;
+  filter: drop-shadow(1.5px 2px 3px var(--nm-sh));
+}
+.nav-links { margin-left: auto; display: flex; align-items: center; gap: 6px; }
+.nav-links a.plain {
+  font: 500 12.5px/1 var(--sans); color: var(--ink-3);
+  text-decoration: none; padding: 8px 11px; border-radius: 8px;
+  transition: color 0.12s, box-shadow 0.12s;
+}
+.nav-links a.plain:hover { color: var(--ink); box-shadow: var(--nm-raised-sm); }
+
+.nm-btn {
+  height: 30px; padding: 0 13px;
+  background: var(--paper);
+  border: none; border-radius: 8px;
+  color: var(--ink-2);
+  display: inline-flex; align-items: center; justify-content: center; gap: 7px;
+  font: 500 12.5px/1 var(--sans);
+  cursor: pointer; text-decoration: none;
+  box-shadow: var(--nm-raised-sm);
+  transition: box-shadow 0.12s, color 0.12s;
+}
+.nm-btn:hover { color: var(--ink); }
+.nm-btn:active { box-shadow: var(--nm-pressed-sm); }
+
+.btn-accent {
+  height: 38px; padding: 0 20px;
+  border: none; border-radius: 10px;
+  background: var(--accent);
+  color: oklch(0.99 0.005 85);
+  font: 500 14px/1 var(--sans);
+  display: inline-flex; align-items: center; gap: 8px;
+  cursor: pointer; text-decoration: none;
+  box-shadow: var(--nm-raised-sm), inset 0 1px 0 rgba(255,255,255,0.25);
+  transition: filter 0.12s, box-shadow 0.12s;
+}
+.btn-accent:hover { filter: brightness(1.06); }
+.btn-accent:active { box-shadow: var(--nm-pressed-sm); }
+.btn-quiet {
+  height: 38px; padding: 0 18px;
+  border: none; border-radius: 10px;
+  background: var(--paper);
+  color: var(--ink-2);
+  font: 500 14px/1 var(--sans);
+  display: inline-flex; align-items: center; gap: 8px;
+  cursor: pointer; text-decoration: none;
+  box-shadow: var(--nm-raised-sm);
+  transition: color 0.12s, box-shadow 0.12s;
+}
+.btn-quiet:hover { color: var(--ink); }
+.btn-quiet:active { box-shadow: var(--nm-pressed-sm); }
+
+/* ---------- HERO ---------- */
+.hero { padding-top: 76px; padding-bottom: 30px; text-align: center; }
+.eyebrow {
+  display: inline-flex; align-items: center; gap: 8px;
+  font: 500 11px/1 var(--sans); letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--accent-ink);
+  padding: 7px 12px; border-radius: 8px;
+  background: var(--paper);
+  box-shadow: var(--nm-pressed-sm);
+}
+.eyebrow .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--accent); }
+.hero h1 {
+  margin: 26px auto 0;
+  font: 500 clamp(40px, 6.4vw, 64px)/1.06 var(--serif);
+  font-optical-sizing: auto;
+  letter-spacing: -0.022em;
+  color: var(--ink);
+  max-width: 17ch;
+  text-wrap: balance;
+}
+.hero h1 em { font-style: italic; color: var(--accent-ink); }
+.hero .lede {
+  margin: 22px auto 0;
+  font: 400 18px/1.65 var(--serif);
+  color: var(--ink-2);
+  max-width: 56ch;
+  text-wrap: pretty;
+}
+.hero .lede b { font-weight: 600; color: var(--ink); }
+.hero-ctas { margin-top: 32px; display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+.hero-note { margin-top: 16px; font: 400 11.5px/1.5 var(--mono); color: var(--ink-4); }
+
+/* ---------- BRIEFING MOCK ---------- */
+.demo { padding-top: 44px; padding-bottom: 10px; }
+.briefing {
+  max-width: 820px; margin: 0 auto;
+  background: var(--paper);
+  border-radius: 14px;
+  box-shadow: 0 60px 120px -30px rgba(40, 24, 10, 0.35), 0 20px 40px -16px rgba(40, 24, 10, 0.22), var(--nm-raised);
+  overflow: hidden;
+  text-align: left;
+}
+html.theme-dark .briefing { box-shadow: 0 60px 120px -30px rgba(0,0,0,0.6), var(--nm-raised); }
+.briefing .titlebar {
+  display: flex; align-items: center; gap: 10px;
+  height: 42px; padding: 0 14px;
+  background: linear-gradient(to bottom, var(--paper-hi), var(--paper));
+  border-bottom: 0.5px solid var(--rule);
+}
+.traffic { display: flex; gap: 8px; }
+.traffic .tdot { width: 11px; height: 11px; border-radius: 50%; border: 0.5px solid rgba(0,0,0,0.12); }
+.traffic .c1 { background: #ff5f57; } .traffic .c2 { background: #febc2e; } .traffic .c3 { background: #28c840; }
+.briefing .crumbs { font: 400 12.5px/1 var(--sans); color: var(--ink-3); margin-left: 6px; }
+.briefing .crumbs b { color: var(--ink); font-weight: 500; }
+.briefing .crumbs .chev { color: var(--ink-4); padding: 0 5px; }
+.briefing .run-chip {
+  margin-left: auto;
+  font: 500 10.5px/1 var(--mono); color: var(--ink-3);
+  padding: 4px 8px; border-radius: 6px;
+  background: var(--paper); box-shadow: var(--nm-pressed-sm);
+}
+.briefing-body { padding: 24px 30px 26px; }
+.dateline {
+  display: flex; align-items: baseline; gap: 12px;
+  padding-bottom: 14px; margin-bottom: 6px;
+  border-bottom: 0.5px solid var(--rule-soft);
+}
+.dateline h2 { margin: 0; font: 500 23px/1.1 var(--serif); letter-spacing: -0.01em; color: var(--ink); }
+.dateline .wd { font: 400 13px/1 var(--sans); color: var(--ink-3); }
+.dateline .meta { margin-left: auto; font: 400 11px/1.4 var(--mono); color: var(--ink-4); text-align: right; }
+.dateline .meta b { color: var(--ink-2); font-weight: 500; }
+
+.b-item {
+  display: grid; grid-template-columns: 22px 1fr; gap: 14px;
+  padding: 16px 4px;
+}
+.b-item + .b-item { border-top: 0.5px solid var(--rule-soft); }
+.b-item .pdot {
+  width: 18px; height: 18px; border-radius: 50%;
+  background: var(--paper); box-shadow: var(--nm-raised-sm);
+  display: grid; place-items: center; margin-top: 2px;
+}
+.b-item .pdot::after { content: ''; width: 9px; height: 9px; border-radius: 50%; background: var(--p, var(--ink-4)); }
+.b-item h3 { margin: 0 0 5px; font: 500 15.5px/1.4 var(--serif); color: var(--ink); text-wrap: pretty; }
+.b-item p { margin: 0; font: 400 13.5px/1.6 var(--serif); color: var(--ink-2); max-width: 62ch; text-wrap: pretty; }
+.b-item p .q { font-style: italic; color: var(--ink-3); }
+.b-row { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; align-items: center; }
+
+.tag {
+  display: inline-flex; align-items: center; gap: 6px;
+  height: 22px; padding: 0 9px;
+  border-radius: 6px;
+  background: var(--paper); box-shadow: var(--nm-pressed-sm);
+  font: 500 10.5px/1 var(--mono);
+  color: var(--t, var(--ink-3));
+}
+.tag::before { content: ''; width: 6px; height: 6px; border-radius: 50%; background: var(--t, var(--ink-4)); }
+.tag.verified { --t: var(--ok); }
+.tag.single { --t: var(--warn); }
+.tag.contradicted { --t: var(--err); }
+.tag.unverified { --t: var(--ink-3); }
+.tag.stale { --t: var(--ink-4); }
+
+.src {
+  display: inline-flex; align-items: center; gap: 6px;
+  height: 22px; padding: 0 9px;
+  border-radius: 6px;
+  background: var(--paper); box-shadow: var(--nm-raised-sm);
+  font: 500 10.5px/1 var(--sans); color: var(--ink-2);
+}
+.src svg { width: 11px; height: 11px; color: var(--ink-3); }
+.b-why { font: 400 11px/1.5 var(--mono); color: var(--ink-4); margin-left: 2px; }
+
+.conflict {
+  margin-top: 10px;
+  display: grid; grid-template-columns: 1fr 1fr; gap: 8px;
+}
+.conflict .side {
+  padding: 9px 12px; border-radius: 9px;
+  background: var(--paper); box-shadow: var(--nm-pressed-sm);
+  font: 400 12.5px/1.55 var(--serif); color: var(--ink-2);
+}
+.conflict .side .lbl {
+  display: block; font: 500 10px/1 var(--mono); letter-spacing: 0.05em;
+  text-transform: uppercase; color: var(--ink-4); margin-bottom: 5px;
+}
+.conflict .side b { color: var(--ink); font-weight: 600; }
+
+/* ---------- SECTIONS ---------- */
+.section { padding-top: 88px; }
+.section-kicker {
+  font: 500 11px/1 var(--sans); letter-spacing: 0.09em; text-transform: uppercase;
+  color: var(--accent-ink); margin: 0 0 14px;
+}
+.section h2.big {
+  margin: 0;
+  font: 500 clamp(28px, 3.6vw, 38px)/1.15 var(--serif);
+  letter-spacing: -0.015em; color: var(--ink);
+  max-width: 24ch; text-wrap: balance;
+}
+.section .sub {
+  margin: 16px 0 0;
+  font: 400 16px/1.65 var(--serif); color: var(--ink-2);
+  max-width: 58ch; text-wrap: pretty;
+}
+
+/* corroborate list */
+.points {
+  margin-top: 44px;
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 0 56px;
+}
+.point {
+  display: grid; grid-template-columns: 34px 1fr; gap: 16px;
+  padding: 26px 0;
+  border-top: 0.5px solid var(--rule);
+}
+.point .num {
+  width: 30px; height: 30px; border-radius: 9px;
+  background: var(--paper); box-shadow: var(--nm-raised-sm);
+  display: grid; place-items: center;
+  font: 500 12px/1 var(--mono); color: var(--accent-ink);
+  margin-top: 1px;
+}
+.point h3 { margin: 0 0 8px; font: 500 18px/1.3 var(--serif); letter-spacing: -0.005em; color: var(--ink); }
+.point p { margin: 0; font: 400 14px/1.65 var(--serif); color: var(--ink-2); text-wrap: pretty; }
+.point p code { font: 500 12px/1.3 var(--mono); color: var(--ink-2); padding: 1px 6px; border-radius: 5px; background: var(--paper); box-shadow: var(--nm-pressed-sm); }
+.tag-rack { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 12px; }
+
+/* ---------- TIMELINE ---------- */
+.timeline { margin-top: 48px; position: relative; }
+.timeline::before {
+  content: ''; position: absolute; left: 95px; top: 14px; bottom: 14px;
+  width: 2px; border-radius: 2px;
+  background: color-mix(in oklch, var(--ink) 8%, transparent);
+}
+.t-row {
+  display: grid; grid-template-columns: 78px 36px 1fr; gap: 0 18px;
+  padding: 17px 0;
+  position: relative;
+}
+.t-row .when {
+  font: 500 12px/1.4 var(--mono); color: var(--ink-3);
+  text-align: right; padding-top: 7px;
+}
+.t-row .node {
+  width: 32px; height: 32px; border-radius: 50%;
+  background: var(--paper); box-shadow: var(--nm-raised-sm);
+  display: grid; place-items: center;
+  color: var(--accent-ink);
+  position: relative; z-index: 1;
+}
+.t-row .node svg { width: 14px; height: 14px; }
+.t-row h3 { margin: 0 0 4px; font: 500 17px/1.3 var(--serif); color: var(--ink); padding-top: 4px; }
+.t-row h3 .freq { font: 400 11px/1 var(--mono); color: var(--ink-4); margin-left: 9px; letter-spacing: 0; }
+.t-row p { margin: 0; font: 400 13.5px/1.6 var(--serif); color: var(--ink-2); max-width: 58ch; text-wrap: pretty; }
+
+/* ---------- INSTALL ---------- */
+.install-grid {
+  margin-top: 44px;
+  display: grid; grid-template-columns: minmax(0, 1fr) 360px; gap: 40px;
+  align-items: start;
+}
+.term {
+  background: var(--paper);
+  border-radius: 12px;
+  box-shadow: var(--nm-pressed);
+  overflow: hidden;
+}
+.term .term-head {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 0.5px solid var(--rule-soft);
+  font: 500 11px/1 var(--mono); color: var(--ink-4);
+}
+.term pre {
+  margin: 0; padding: 18px 20px 20px;
+  font: 400 13px/1.9 var(--mono);
+  color: var(--ink);
+  overflow-x: auto;
+}
+.term pre .cm { color: var(--ink-4); }
+.term pre .cmd { color: var(--accent-ink); font-weight: 500; }
+.install-aside .step { display: grid; grid-template-columns: 26px 1fr; gap: 12px; padding: 12px 0; }
+.install-aside .step + .step { border-top: 0.5px solid var(--rule-soft); }
+.install-aside .step .n {
+  width: 24px; height: 24px; border-radius: 7px;
+  background: var(--paper); box-shadow: var(--nm-raised-sm);
+  display: grid; place-items: center;
+  font: 500 11px/1 var(--mono); color: var(--accent-ink);
+}
+.install-aside .step h4 { margin: 0 0 3px; font: 500 14px/1.3 var(--sans); color: var(--ink); }
+.install-aside .step p { margin: 0; font: 400 13px/1.55 var(--sans); color: var(--ink-3); text-wrap: pretty; }
+.install-note {
+  margin-top: 18px;
+  padding: 13px 16px; border-radius: 10px;
+  background: var(--paper); box-shadow: var(--nm-pressed-sm);
+  font: 400 12.5px/1.6 var(--sans); color: var(--ink-3); text-wrap: pretty;
+}
+.install-note b { color: var(--ink-2); font-weight: 500; }
+
+/* ---------- MAC APP ---------- */
+.app-grid {
+  display: grid; grid-template-columns: 220px 1fr; gap: 48px;
+  align-items: start;
+}
+.app-icon-col { display: flex; justify-content: center; padding-top: 26px; }
+.app-icon {
+  width: 168px; height: 168px;
+  filter: drop-shadow(6px 10px 18px var(--nm-sh)) drop-shadow(-3px -3px 10px var(--nm-hi));
+}
+.app-feats {
+  margin: 30px 0 8px;
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px;
+}
+.app-feats .feat { border-top: 0.5px solid var(--rule); padding-top: 14px; }
+.app-feats h4 { margin: 0 0 5px; font: 500 14.5px/1.3 var(--sans); color: var(--ink); }
+.app-feats p { margin: 0; font: 400 13px/1.6 var(--serif); color: var(--ink-2); text-wrap: pretty; }
+.foot-brand { display: inline-flex; align-items: center; gap: 8px; }
+.foot-brand img { border-radius: 5px; }
+
+/* ---------- FOOTER ---------- */
+.footer {
+  margin-top: 96px;
+  border-top: 0.5px solid var(--rule);
+}
+.footer-inner {
+  padding: 28px 0 36px;
+  display: flex; align-items: center; gap: 18px;
+  font: 400 12.5px/1 var(--sans); color: var(--ink-3);
+}
+.footer-inner .spacer { flex: 1; }
+.footer-inner a { color: var(--ink-3); text-decoration: none; padding: 6px 9px; border-radius: 7px; }
+.footer-inner a:hover { color: var(--ink); box-shadow: var(--nm-raised-sm); }
+
+/* ---------- RESPONSIVE ---------- */
+@media (max-width: 880px) {
+  .points { grid-template-columns: 1fr; }
+  .app-grid { grid-template-columns: 1fr; gap: 8px; }
+  .app-icon-col { justify-content: flex-start; padding-top: 0; }
+  .app-icon { width: 120px; height: 120px; }
+  .app-feats { grid-template-columns: 1fr; gap: 14px; }
+  .install-grid { grid-template-columns: 1fr; }
+  .conflict { grid-template-columns: 1fr; }
+  .briefing-body { padding: 20px 18px; }
+  .dateline .meta { display: none; }
+}
+@media (max-width: 620px) {
+  .nav-links a.plain { display: none; }
+  .timeline::before { left: 15px; }
+  .t-row { grid-template-columns: 36px 1fr; }
+  .t-row .when { display: none; }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .hero > *, .demo .briefing {
+    animation: rise 0.7s cubic-bezier(0.2, 0.7, 0.2, 1) both;
+  }
+  .hero .lede { animation-delay: 0.08s; }
+  .hero-ctas { animation-delay: 0.14s; }
+  .hero-note { animation-delay: 0.18s; }
+  .demo .briefing { animation-delay: 0.22s; }
+  @keyframes rise {
+    from { opacity: 0; transform: translateY(14px); }
+    to   { opacity: 1; transform: none; }
+  }
+}
+
+/* ---------- PROBLEM ---------- */
+.fail-grid { margin-top: 40px; display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+.fail {
+  padding: 26px 26px 28px; border-radius: 14px;
+  background: var(--paper); box-shadow: var(--nm-raised);
+}
+.fail .fail-tag {
+  font: 500 10.5px/1 var(--mono); letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--err); display: inline-flex; align-items: center; gap: 7px; margin-bottom: 13px;
+}
+.fail .fail-tag::before { content: ''; width: 6px; height: 6px; border-radius: 50%; background: var(--err); }
+.fail h3 { margin: 0 0 8px; font: 500 19px/1.3 var(--serif); color: var(--ink); }
+.fail p { margin: 0; font: 400 14px/1.65 var(--serif); color: var(--ink-2); text-wrap: pretty; }
+.problem-resolve { margin-top: 28px; font: 400 17px/1.65 var(--serif); color: var(--ink-2); max-width: 62ch; text-wrap: pretty; }
+.problem-resolve b { color: var(--ink); font-weight: 600; }
+.problem-resolve em { font-style: italic; color: var(--accent-ink); }
+
+/* ---------- COMPOUNDS ---------- */
+.compound-grid { margin-top: 44px; display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+.compound {
+  padding: 24px 22px 26px; border-radius: 14px;
+  background: var(--paper); box-shadow: var(--nm-raised-sm);
+}
+.compound .c-ico {
+  width: 34px; height: 34px; border-radius: 10px; margin-bottom: 16px;
+  background: var(--paper); box-shadow: var(--nm-raised-sm);
+  display: grid; place-items: center; color: var(--accent-ink);
+}
+.compound .c-ico svg { width: 17px; height: 17px; }
+.compound h3 { margin: 0 0 7px; font: 500 16px/1.32 var(--serif); color: var(--ink); }
+.compound p { margin: 0; font: 400 13px/1.6 var(--serif); color: var(--ink-2); text-wrap: pretty; }
+
+/* ---------- ASSURANCES (data) ---------- */
+.assurances { margin-top: 38px; display: grid; grid-template-columns: 1fr 1fr; gap: 0 56px; }
+.assure { display: grid; grid-template-columns: 28px 1fr; gap: 14px; padding: 22px 0; border-top: 0.5px solid var(--rule); }
+.assure .chk {
+  width: 24px; height: 24px; border-radius: 8px; margin-top: 2px;
+  background: var(--paper); box-shadow: var(--nm-raised-sm);
+  display: grid; place-items: center; color: var(--ok);
+}
+.assure .chk svg { width: 13px; height: 13px; }
+.assure h4 { margin: 0 0 5px; font: 500 15px/1.3 var(--serif); color: var(--ink); }
+.assure p { margin: 0; font: 400 13.5px/1.62 var(--serif); color: var(--ink-2); text-wrap: pretty; }
+.assure p code { font: 500 12px/1.3 var(--mono); color: var(--ink-2); padding: 1px 6px; border-radius: 5px; background: var(--paper); box-shadow: var(--nm-pressed-sm); }
+
+/* ---------- FAQ ---------- */
+.faq-list { margin-top: 38px; }
+.qa { border-top: 0.5px solid var(--rule); }
+.qa:last-of-type { border-bottom: 0.5px solid var(--rule); }
+.qa summary {
+  list-style: none; cursor: pointer;
+  display: flex; align-items: center; gap: 14px;
+  padding: 19px 4px;
+  font: 500 16px/1.4 var(--serif); color: var(--ink);
+}
+.qa summary::-webkit-details-marker { display: none; }
+.qa summary .pm {
+  margin-left: auto; flex: none;
+  width: 24px; height: 24px; border-radius: 7px;
+  background: var(--paper); box-shadow: var(--nm-raised-sm);
+  display: grid; place-items: center; color: var(--accent-ink);
+  font: 400 17px/1 var(--mono); transition: transform 0.18s ease;
+}
+.qa[open] summary .pm { transform: rotate(45deg); }
+.qa .ans { padding: 0 4px 20px; margin: 0; font: 400 14.5px/1.7 var(--serif); color: var(--ink-2); max-width: 70ch; text-wrap: pretty; }
+.qa .ans b { color: var(--ink); font-weight: 600; }
+.qa .ans em { font-style: italic; }
+.qa .ans code { font: 500 12.5px/1.3 var(--mono); color: var(--ink-2); padding: 1px 6px; border-radius: 5px; background: var(--paper); box-shadow: var(--nm-pressed-sm); }
+
+/* ---------- CTA BAND ---------- */
+.cta-band {
+  margin-top: 96px; text-align: center;
+  padding: 64px 28px 68px;
+  background: var(--paper-raised);
+  border-top: 0.5px solid var(--rule); border-bottom: 0.5px solid var(--rule);
+}
+.cta-band h2 { margin: 0 auto; font: 500 clamp(28px,4vw,40px)/1.12 var(--serif); letter-spacing: -0.02em; color: var(--ink); max-width: 18ch; text-wrap: balance; }
+.cta-band h2 em { font-style: italic; color: var(--accent-ink); }
+.cta-band p { margin: 18px auto 0; font: 400 16px/1.6 var(--serif); color: var(--ink-2); max-width: 52ch; text-wrap: pretty; }
+.cta-band .hero-ctas { margin-top: 30px; }
+
+@media (max-width: 880px) {
+  .fail-grid { grid-template-columns: 1fr; }
+  .compound-grid { grid-template-columns: 1fr; }
+  .assurances { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Why

Scout had zero public-facing surface beyond a mechanism-led README. This adds a real landing page and re-leads the README on the validated wedge — **cross-checking / verifiability**, not "readable markdown memory" (now table stakes, owned by a 347k-star incumbent).

## What

- **`docs/index.html`** — the Claude Design landing implemented faithfully: warm-paper neumorphic aesthetic (Newsreader + JetBrains Mono), live briefing-window hero, six-session day timeline. For GitHub Pages (`main`/`docs`). React/Babel design-tool scaffolding stripped.
- **`docs/landing.css`** + **`docs/assets/scout-icon.svg`** — the design's stylesheet and app icon.
- **New sections** mined from the Scout philosophy/competitive docs: *The problem* (completionist vs triager), *It gets better* (mistake audit / deliberate decay / git-as-memory), *Your data* (local-first, markdown-canonical, auditable), and an *FAQ* (incl. the "how is this different from memory?" rebuttal).
- **README re-lead** on the cross-check/verification wedge, with a matching warm-paper briefing mock (`docs/assets/scout-demo.svg`).

## Open follow-ups (not blocking)
- **Naming:** the "Scout" name collides with Microsoft Scout (Build 2026) — a "Magpie" rename is flagged for before any wider launch. Wordmark find-replace when decided.
- **Social preview:** `og:image` is currently the icon SVG; a 1280×640 PNG is the real fix for link-share cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)