### PR TITLE
fix(bootstrap): close acquire_lock empty-window race (residual #36 hole)

### DIFF
--- a/engine/scout/scripts/bootstrap_lock.py
+++ b/engine/scout/scripts/bootstrap_lock.py
@@ -23,20 +23,20 @@ class LockBusyError(Exception):
         super().__init__(f"lock {lock_path} held by live PID {pid}")
 
 
-def is_lock_held_by_live_pid(lock_path: Path) -> bool:
-    """Return True iff the lock file exists and its PID is alive.
+def _read_lock_pid(lock_path: Path) -> int | None:
+    """Return the PID written in the lock file, or None if absent/unparseable.
 
-    TOCTOU note: a process could exit between this check and a subsequent
-    operation. That's acceptable for single-user single-machine use; the
-    lock is a coordination signal between scout-app sessions, not a
-    cross-host mutex.
+    None covers the empty file a racing winner leaves between its O_EXCL
+    create and its PID write, as well as a corrupt lock.
     """
-    if not lock_path.exists():
-        return False
     try:
-        pid = int(lock_path.read_text(encoding="utf-8").strip())
+        return int(lock_path.read_text(encoding="utf-8").strip())
     except (ValueError, OSError):
-        return False
+        return None
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return True iff `pid` is a live process we should treat as the holder."""
     if pid <= 0:
         # Corrupt lock — refuse to call os.kill(0, 0) (process group) or
         # os.kill(-1, 0) (every process owned by user).
@@ -51,6 +51,22 @@ def is_lock_held_by_live_pid(lock_path: Path) -> bool:
         return True
 
 
+def is_lock_held_by_live_pid(lock_path: Path) -> bool:
+    """Return True iff the lock file exists and its PID is alive.
+
+    TOCTOU note: a process could exit between this check and a subsequent
+    operation. That's acceptable for single-user single-machine use; the
+    lock is a coordination signal between scout-app sessions, not a
+    cross-host mutex.
+    """
+    if not lock_path.exists():
+        return False
+    pid = _read_lock_pid(lock_path)
+    if pid is None:
+        return False
+    return _pid_alive(pid)
+
+
 def acquire_lock(lock_path: Path) -> None:
     """Take the lock by atomically creating the file with our PID.
 
@@ -58,36 +74,42 @@ def acquire_lock(lock_path: Path) -> None:
     they hold the lock — one wins the create, the other gets
     ``FileExistsError`` and we surface it as :class:`LockBusyError`.
 
-    Stale locks (file exists, but its PID is dead) are unlinked before
-    the atomic claim, so a normal warm path is unchanged.
+    Stale recovery happens ONLY in response to that create conflict, and
+    ONLY for a parseable, dead PID (a crashed holder): such a lock is
+    unlinked and the atomic claim retried once. An existing lock whose
+    contents we cannot parse — most importantly the empty file a racing
+    winner leaves in the window between its O_EXCL create and its PID
+    write — is treated as busy and never removed. The previous pre-check
+    unlinked any "not held by a live PID" lock, which classified that
+    empty file as stale and let both racers win; doing stale recovery
+    only on the O_EXCL conflict, and only for a confirmed-dead PID, closes
+    that window (#36).
     """
     lock_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # If a stale lock exists, remove it before claiming. The unlink is
-    # racy on its own, but combined with the O_EXCL claim below, at most
-    # one racing process succeeds.
-    if lock_path.exists() and not is_lock_held_by_live_pid(lock_path):
-        with contextlib.suppress(FileNotFoundError):
-            lock_path.unlink()
-
-    try:
-        fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
-    except FileExistsError as e:
-        # Either held by a live PID, or another caller raced us to claim.
+    for attempt in range(2):
         try:
-            pid = int(lock_path.read_text(encoding="utf-8").strip())
-        except (ValueError, OSError):
-            pid = -1
-        raise LockBusyError(lock_path, pid) from e
-
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(str(os.getpid()))
-    except Exception:
-        # Roll back the partial claim so the next caller can retry cleanly.
-        with contextlib.suppress(FileNotFoundError):
-            lock_path.unlink()
-        raise
+            fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        except FileExistsError as e:
+            pid = _read_lock_pid(lock_path)
+            # Clear and retry once only for a parseable, dead PID. Empty /
+            # unparseable (racing winner mid-write or corrupt) or a live
+            # holder is busy — never unlink it.
+            if pid is not None and not _pid_alive(pid) and attempt == 0:
+                with contextlib.suppress(FileNotFoundError):
+                    lock_path.unlink()
+                continue
+            raise LockBusyError(lock_path, pid if pid is not None else -1) from e
+        else:
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(str(os.getpid()))
+            except Exception:
+                # Roll back the partial claim so the next caller can retry cleanly.
+                with contextlib.suppress(FileNotFoundError):
+                    lock_path.unlink()
+                raise
+            return
 
 
 def release_lock(lock_path: Path) -> None:

--- a/engine/tests/unit/test_bootstrap_lock.py
+++ b/engine/tests/unit/test_bootstrap_lock.py
@@ -136,6 +136,19 @@ def test_acquire_lock_clears_stale_dead_pid(tmp_path):
 # both write their PID, and both believe they held the lock. Issue #36.
 
 
+def test_acquire_lock_treats_empty_lock_as_busy_not_stale(tmp_path):
+    """An empty lock file is the exact state a racing winner leaves between
+    its O_EXCL create and its PID write. A second caller must NOT treat that
+    empty file as stale and clobber it — that is the residual hole in #36's
+    O_EXCL fix that let two callers both 'win'. Empty/unparseable existing
+    lock → LockBusyError, and the file is left intact."""
+    lock = tmp_path / ".scout-session.lock"
+    lock.write_text("")  # winner created it via O_EXCL, hasn't written PID yet
+    with pytest.raises(LockBusyError):
+        acquire_lock(lock)
+    assert lock.exists()  # must not have been removed
+
+
 def test_acquire_lock_is_atomic_under_concurrent_callers(tmp_path):
     """When two concurrent callers race to acquire the same lock,
     exactly one must succeed and the other must see LockBusyError —


### PR DESCRIPTION
## Why

CI on PR #124 went red on `test (ubuntu-latest, 3.12)` — `test_acquire_lock_is_atomic_under_concurrent_callers` got `['success', 'success']`. Investigation showed this is **not** caused by #124; it's a pre-existing, flaky-surfacing **real concurrency bug** in `acquire_lock`, living on `main` and inherited by every open PR. It's a residual hole in the (closed) #36 `O_EXCL` atomicity fix.

## Root cause

`acquire_lock` did a pre-check — `if lock_path.exists() and not is_lock_held_by_live_pid(...): unlink()` — **before** the `O_EXCL` claim. A racing winner leaves the lock file *empty* in the window between its `O_EXCL` create and its PID write. That empty file parses to no PID, so `is_lock_held_by_live_pid` returns `False`; a losing caller therefore classifies the winner's fresh lock as *stale*, unlinks it, and its own `O_EXCL` create then succeeds — **two winners**. The window is microseconds, so it only flaked occasionally (here, on the ubuntu-3.12 cell).

## Fix

Drop the pre-check. Do stale recovery **only** in response to an `O_EXCL` conflict, and **only** for a parseable, dead PID (a genuinely crashed holder) — unlink and retry the atomic claim once. An existing lock whose contents we can't parse (empty racing-winner-mid-write, or corrupt) or that's held by a live PID is treated as busy and **never** unlinked. Crash recovery for the normal written-PID case is preserved (`acquire_lock_with_wait` still clears a dead holder).

## Testing

- New **deterministic** regression test `test_acquire_lock_treats_empty_lock_as_busy_not_stale` — fails before this change (`DID NOT RAISE LockBusyError`), passes after.
- The previously-flaky `test_acquire_lock_is_atomic_under_concurrent_callers`: **0 failures across 300 runs** after the fix.
- Full lock test file 14/14; `ruff`, `ruff format`, `mypy` clean.
- `is_lock_held_by_live_pid` behavior is unchanged (refactored to share `_read_lock_pid`/`_pid_alive` helpers).

Merge this first; #124 and #128 then re-run green against the updated `main` (their checks run on the branch-merged-with-main ref).

Refs #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)