### PR TITLE
fix(privacy): scrub real vault names from public landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -310,10 +310,10 @@
     <div class="vrow flip">
       <div class="vtext reveal"><p class="sysnum">04 — Research queue</p><h3>It goes and finds what it's missing.</h3><p>It researches what's gone stale and rotates across your projects. Leave a note in the vault and it jumps to the top of the queue.</p></div>
       <div class="vvis reveal"><div class="q">
-        <div class="pin"><span class="mono">//==&lt;&lt;</span><span class="x"><b>look into the data-app competition</b> — my note, picked up next run</span></div>
+        <div class="pin"><span class="mono">//==&lt;&lt;</span><span class="x"><b>look into the competitor’s launch</b> — my note, picked up next run</span></div>
         <div class="row"><span>refresh stale project files</span><span class="age">12d old</span></div>
         <div class="row"><span>thin entity → enrich from the web</span><span class="age">scored</span></div>
-        <div class="rot">rotation: ✓ channels → ✓ fi-app → <b style="color:var(--acc-2)">next: ai-enablement</b> &nbsp;(never the same project twice running)</div>
+        <div class="rot">rotation: ✓ mobile-app → ✓ q3-launch → <b style="color:var(--acc-2)">next: billing-revamp</b> &nbsp;(never the same project twice running)</div>
       </div></div>
     </div>
 
@@ -329,7 +329,7 @@
       <div class="vtext reveal"><p class="sysnum">06 — Review queue</p><h3>It refuses to guess about people.</h3><p>Anything uncertain — especially merging or naming a person — is <b>held for you to confirm</b>, instead of silently corrupting the graph.</p></div>
       <div class="vvis reveal"><div class="held">
         <span class="lbl">⏸ held for review</span>
-        <div class="claim">Is <b>"A. Bouška"</b> a new person, or the Adam already in your graph? One source, can't tell.</div>
+        <div class="claim">Is <b>"A. Rivera"</b> a new person, or the Alex already in your graph? One source, can't tell.</div>
         <div class="acts"><span class="a y">✓ confirm</span><span class="a n">✕ reject</span></div>
       </div></div>
     </div>
@@ -372,7 +372,7 @@
       <div class="vvis reveal"><div class="commit" style="margin-top:0;line-height:1.95;">
         <div><span class="h">briefing [06-15]:</span> 3 need you · 1 contradiction surfaced</div>
         <div><span class="h">consolidation [12:30]:</span> reconciled 2 items · 1 done</div>
-        <div><span class="h">research [15:00]:</span> refreshed ai-enablement</div>
+        <div><span class="h">research [15:00]:</span> refreshed billing-revamp</div>
         <div><span class="h">dreaming [21:30]:</span> logged pattern #58 · applied 1 fix</div>
       </div></div>
     </div>


### PR DESCRIPTION
Urgent: the live page leaked real vault project names (ai-enablement, fi-app, channels), a real internal event, and a real-ish person name. Replaced with fictional placeholders. No new features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)