### PR TITLE
Back-port 5 run-brain proposals into engine phase fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **DM legibility rule** (`phases/connectors/slack.md`) — wrap DMs must never surface a bare internal `#SHORTCODE` tag (expand inline or drop) and must include a clickable link to the day's action-items file (Obsidian URI / `file://` path). Presentation-layer only; the file-side tag-keying machinery is untouched.
+- **No-unverified-negatives discipline** (`phases/core/action-items.md`) — before asserting a negative completion-state ("not done", "still your move", "not created") on a connector-observable item, the run must query that connector or mark the claim `[unverified — not queried this run]`.
+- **Repo-creation verification** (`phases/connectors/github.md`) — the GitHub scan now lists recently-created/updated repos via `gh repo list`, since a brand-new repo has no PR and is invisible to the PR scans; verify "stand up repo X" items this way before carrying them as not-done.
+- **Batch-comment triage mode** (`phases/modes/kb-deep-work.md` Step 2-pre, with a pointer in `phases/core/action-items.md`) — when an inline-comment sweep finds more than N=5 unprocessed `//==<<` markers, switch from resolve-each to inventory/categorize/route into a dated `comment-triage-YYYY-MM-DD.md` index, leaving markers in place and surfacing the index.
+- **Research priority preemption** (`phases/research/research-targets.md`) — target selection runs 🔴/`START IMMEDIATELY`/user-directed queue items before the staleness-rotation or opportunistic pick, and surfaces a >1-run-open 🔴 directive as overdue.
+
+### Changed
+- **Audits remediate or hand off, never just report** (`phases/modes/kb-deep-work.md` Step 2-ontology) — after producing findings, audits split them `auto-remediable` (fix in-run or hand to the next run as a must-action queue) vs `backlog` (leave; don't auto-create), and the notification states what was *fixed*, not only what's wrong.
+
 ## [0.6.0] - 2026-06-07
 
 ### Added

--- a/phases/connectors/github.md
+++ b/phases/connectors/github.md
@@ -99,6 +99,14 @@ For repos in `{{GITHUB_REPOS}}`, check for significant activity:
 - Branch protection changes
 - New contributors or team changes
 
+**Also scan for recently-created/updated repos** — repo-creation and repo-push activity is invisible to the PR scans above (a brand-new repo has no PR):
+
+```bash
+gh repo list {{GITHUB_USERNAME}} --limit 30 --json name,createdAt,updatedAt --jq 'sort_by(.updatedAt)|reverse'
+```
+
+A newly-created repo here may **close an open "stand up repo X" action item** — check it before carrying that item as "not done." Match on a fuzzy/listing basis, not an exact provisional name (an item might say `scout-ios` while the real repo is `scout-iOS-app`). Use `gh repo list`, never `gh search prs`, to verify a repo-creation item.
+
 ---
 phase: connector
 name: github

--- a/phases/connectors/slack.md
+++ b/phases/connectors/slack.md
@@ -233,6 +233,13 @@ Sources checked: N CC sessions · N vault/git commits · N Slack threads · N Li
 
 Only count sources you genuinely queried this run. A "quiet window" claim must be paired with non-zero scan counts — otherwise it reads as "didn't look," not "nothing happened."
 
+### DM Legibility (no bare shortcodes; link the list)
+
+Applies to every wrap DM. Two parts:
+
+1. **No bare internal `#SHORTCODE` tags in the user-facing DM.** Action-items use `#SHORTCODE` tags as an *internal* continuity-keying convention (they match an item across daily files); they mean nothing to the reader as bare tokens. Either **expand inline** — `*semantic-layer weekly update* (#TAG)` or just the plain-English label — or **drop the tag from the DM**. A DM line whose only handle on an item is a bare `#CODE` is forbidden: the reader must understand it from plain English. The file-side `#SHORTCODE` machinery is untouched — this is presentation-layer only.
+2. **Link the action-items file.** Any wrap DM that references "today's list" / action items must include a clickable link to today's file — an Obsidian URI `obsidian://open?vault={{INSTANCE_NAME}}&file=action-items%2Faction-items-<YYYY-MM-DD>` and/or a `file://{{SCOUT_DIR}}/action-items/action-items-<YYYY-MM-DD>.md` — so a tap opens the list.
+
 ### Notification Rules
 
 - Never include sensitive details in the notification — just summaries and counts.

--- a/phases/core/action-items.md
+++ b/phases/core/action-items.md
@@ -158,6 +158,8 @@ Whenever you flip an item from `[ ]` to `[x]` — or process a {{USER_NAME}}-aut
 
 **Inline `//==<<` close-out directives are first-class delete instructions** — acknowledging one in the next DM is insufficient; the file must be physically updated (check box → write completed entry → delete origin row → remove the marker).
 
+**Batch exception (threshold N=5).** If a run encounters **more than 5 unprocessed `//==<<` markers** across the vault (a large batch dropped at once), do NOT try to resolve them all this run — switch to **triage mode**: inventory + categorize + route them into a dated `knowledge-base/comment-triage-YYYY-MM-DD.md` index and the right queues, leaving the markers in place, and surface the index in the wrap notification. Full rule in the KB-deep-work phase (Step 2-pre).
+
 **Pre-commit audit** — no `[x]` rows may sit outside the Recently Completed section:
 
 ```bash
@@ -265,6 +267,8 @@ Search for evidence that {{USER_NAME}} completed or progressed the item:
 - Session history showing work done with AI tools
 
 If evidence of completion exists, mark the item ✅ Done with a citation to the evidence.
+
+**No unverified negatives.** Before asserting a *negative* completion-state — "not done yet", "still your move", "awaiting X", "unsent", "not created" — where the completion would be **observable on a connector**, you MUST query that connector this run. A "nothing happened" is a claim, not the default: an unverified negative is the easiest thing to assert lazily and the hardest to notice is wrong, and telling {{USER_NAME}} that completed work was ignored erodes trust. If you can't query (connector down, out of scope), write the claim `[unverified — not queried this run]`, never as fact. (Repo-creation items are the classic trap — verify with `gh repo list`, not a PR scan; see the GitHub Repository Activity phase.)
 
 ### 2. Do a targeted topic search
 Search specifically for the topic keywords across all available connectors. Don't rely on the broad scan — do a focused search for this specific item. This catches context that a general sweep might miss.

--- a/phases/modes/kb-deep-work.md
+++ b/phases/modes/kb-deep-work.md
@@ -45,6 +45,17 @@ grep -rn '//==<<' {{SCOUT_DIR}} --include='*.md'
 
 These inline comments are high-priority — they represent explicit {{USER_NAME}} feedback embedded in the source files. Treat them with the same urgency as messaging reactions/replies.
 
+**Batch-comment triage mode (threshold N=5).** The resolve-each behavior above assumes a handful of markers per run. When a sweep finds **more than N=5 unprocessed `//==<<` markers** (a large batch dropped in one sitting), trying to resolve them all in one run produces shallow work. Switch from *resolve* mode to **triage mode**:
+
+1. **Do not attempt to resolve them all.** Stay high-level.
+2. **Inventory** every marker (file, gist, line) into a single dated index: `knowledge-base/comment-triage-YYYY-MM-DD.md`.
+3. **Categorize** each: KB-staleness · vault-org/structure · system/self-improvement feature · search-depth/coverage miss · cruft · verify · approval/decision-gated · process-directive.
+4. **Route** each to the right queue with a back-link (research-queue, wishlist, mistake-audit, review-queue, the vault-reorg plan, the idea-capture page, or `dreaming-proposals/` for governance).
+5. **Leave the markers in place** — they mark the spot; strip one only when its underlying request is *resolved* (the REM-cleanup pruning duty then removes processed ones).
+6. **Surface** the triage index + any approval-gated or 🔴 items in the wrap notification, so the batch is visibly captured and routed.
+
+Below N=5, keep the resolve-each behavior above.
+
 ### Step 2-ontology: Knowledge Graph Integrity Check
 
 Before scoring individual files, run the knowledge graph parser for structural checks:
@@ -59,6 +70,11 @@ cd {{SCOUT_DIR}} && python knowledge-base/ontology/parser.py stats
 - **Invalid relationship types** — correct the relationship type to match `schema.yaml`
 - **Orphaned entities** — entities with no relationships at all. If they should have relationships, add them. If they're stubs, either enrich or note for future work.
 - **Broken wikilink targets** — relationship targets that don't resolve to an entity file. Either create the missing entity file or fix the target name.
+
+**Audits remediate or hand off — never just report.** Applies to this KG-integrity check and to any standing audit (Linear-state, action-item-health, graph-health). After the audit produces findings, split them into `auto-remediable` vs `backlog` and **act** — a report with no downstream actor is a slow leak that reads as noise:
+- **Auto-remediable → fix this run** (or hand to the next run as an explicit *must-action* queue, not a passive note): a Linear-state claim the KB has wrong → re-query the issue + flip the row; a personnel/status label past its own dated window (e.g. a "leave imminent" flag whose start date has passed) → correct it + bump the verified date; a dangling relationship target that resolves to an existing entity under a slug → fix the target to the slug/wikilink form.
+- **Backlog → leave as backlog, do NOT auto-create:** genuinely-missing entities, judgment calls, structural decisions.
+- The audit's notification/report then states **what it fixed**, not only what's wrong.
 
 **Personal task staleness detection:**
 

--- a/phases/research/research-targets.md
+++ b/phases/research/research-targets.md
@@ -19,6 +19,14 @@ Read `knowledge-base/research-queue.md`. If {{USER_NAME}} has explicitly queued 
 
 Checked items (`- [x]`) are done. Unchecked items are the work queue.
 
+**Priority preemption (🔴 START-IMMEDIATELY items run first).** Before the staleness-rotation guard or any opportunistic "work what this morning surfaced" pick, the run MUST:
+
+1. **Scan the queue for any item marked 🔴 / `START IMMEDIATELY` / {{USER_NAME}}-directed-this-week and run it first.** A user 🔴 directive is not just another queue row — it preempts the rotation and the day's incidental find.
+2. **Only fall through** to the rotation (Step 1b scoring) or an opportunistic lane when no such item is outstanding.
+3. **Surface as overdue:** any 🔴 directive item still open across **>1 research run** must be called out as **overdue** in the wrap notification, so a starved top priority can't go silent.
+
+This does NOT stop the opportunistic lane (a good incidental find is still worth pursuing) — it fixes the **ordering** (🔴 directive first). A "this is the top priority" intention stays inert until the picker mechanically honors it.
+
 ## Step 1b: Score Entities for Research Need
 
 If the queue is empty (or after completing queued items), score entities:


### PR DESCRIPTION
## What

Back-ports five behaviors that were applied to a Scout vault's run-brain (`SKILL.md` / `DREAMING.md` / `RESEARCH.md`) into the canonical **phase fragments**, so `/scout-update` re-renders carry them forward instead of emitting `.proposed-merge` sidecars. All edits are in generic template form (placeholders only — no instance-specific data).

## Changes

| Phase fragment | Behavior |
|---|---|
| `phases/connectors/slack.md` (Notification) | **DM legibility** — wrap DMs never surface a bare internal `#SHORTCODE` (expand inline or drop) and must include a clickable link to the day's action-items file (Obsidian URI / `file://`). Presentation-layer only. |
| `phases/core/action-items.md` (Per-Item Reconciliation) | **No unverified negatives** — query the connector before asserting "not done / still your move / not created" on a connector-observable item, else mark `[unverified — not queried this run]`. + batch-triage pointer. |
| `phases/connectors/github.md` (Repository Activity) | **Repo-creation verification** — list recently created/updated repos via `gh repo list` (a new repo has no PR, so PR scans are blind to it); verify "stand up repo X" items this way before carrying them as not-done. |
| `phases/modes/kb-deep-work.md` (Step 2-pre / Step 2-ontology) | **Batch-comment triage mode** (>N=5 unprocessed `//==<<` markers → inventory/categorize/route into a dated `comment-triage-YYYY-MM-DD.md` index, markers left in place) and **audits-remediate-or-hand-off** (split findings `auto-remediable` vs `backlog`; state what was fixed, not only what's wrong). |
| `phases/research/research-targets.md` (Step 1a) | **Priority preemption** — run 🔴/`START IMMEDIATELY`/user-directed queue items before the staleness-rotation or opportunistic pick; surface a >1-run-open 🔴 directive as overdue. |

`CHANGELOG.md` updated under `[Unreleased]`.

## Why

These were validated in a live vault run-brain but only lived there; without back-porting, the next plugin re-render of these regions would sidecar them (the known back-port gap). This lands them upstream so the engine stays the source of truth.

## Testing

- `engine/tests/unit/test_phase_assembly.py` — **16 passed**.
- Phase frontmatter unchanged; diff is additive (53 insertions, 0 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)