### PR TITLE
feat(migrate): per-file wishlist + research queue migration (prototype)

### DIFF
--- a/scripts/migrate_wishlist_research.py
+++ b/scripts/migrate_wishlist_research.py
@@ -160,23 +160,45 @@ def migrate_wishlist_file(src: Path, out_dir: Path, in_done_file: bool,
     return count
 
 
+def _heading_area(heading: str) -> str | None:
+    """Slugified area from a heading: leading emoji stripped, and a trailing
+    *status* suffix after a ` — `/` – `/` - ` separator dropped. Only a
+    status-looking suffix is dropped (one that begins with a status emoji or a
+    done/wip word); a content suffix like `— Productionize + release Scout` is
+    kept. A generic `Queue` heading yields no area."""
+    core = heading.strip()
+    core = re.sub(r"^(🔴|🟡|🟢|🔵|🛌|✅|🎯)\s*", "", core).strip()
+    # Drop a trailing status suffix (` — ✅ done …`, ` — wip …`, etc.) but keep
+    # a real content suffix (` — Productionize + release Scout`).
+    parts = re.split(r"\s+(?:—|–|-)\s+", core, maxsplit=1)
+    if len(parts) == 2 and re.match(
+            r"^(🔴|🟡|🟢|🔵|🛌|✅|🎯|done\b|wip\b|in[\s-]?progress\b)",
+            parts[1].strip(), re.I):
+        core = parts[0].strip()
+    if core.lower() == "queue":
+        return None
+    return slugify(core) or None
+
+
 def split_research_items(text: str):
-    """Yield (line, area) for each `- [ ]`/`- [x]` line under `## Queue` and its
-    `###` subsections. area = slugified nearest `###` heading."""
-    area = None
-    in_queue = False
+    """Yield (line, area) for every `- [ ]`/`- [x]` checklist line in the file.
+    The whole research-queue is the work list; `area` is the nearest `###`
+    subsection, else the enclosing `##` section (cleaned). Generic `## Queue`
+    yields no area."""
+    h2_area = None
+    h3_area = None
     for line in text.splitlines():
         h2 = re.match(r"^##\s+(.+)$", line)
         h3 = re.match(r"^###\s+(.+)$", line)
         if h2:
-            in_queue = h2.group(1).strip().lower().startswith("queue")
-            area = None
+            h2_area = _heading_area(h2.group(1))
+            h3_area = None
             continue
         if h3:
-            area = slugify(h3.group(1))
+            h3_area = _heading_area(h3.group(1))
             continue
-        if in_queue and re.match(r"^[-*]\s*\[( |x|X)\]", line):
-            yield line, area
+        if re.match(r"^[-*]\s*\[( |x|X)\]", line):
+            yield line, (h3_area or h2_area)
 
 
 def migrate_research_file(src: Path, out_dir: Path, default_date: str) -> int:

--- a/scripts/migrate_wishlist_research.py
+++ b/scripts/migrate_wishlist_research.py
@@ -84,7 +84,10 @@ def parse_research_item(line: str, area: str | None = None) -> Item:
     t = re.sub(r"^(🔴|🟡|🟢|🔵)\s*", "", t)
     bm = re.match(r"\*\*(.+?)\*\*(.*)$", t, re.S)
     lead, rest = (bm.group(1), bm.group(2)) if bm else (t, "")
-    title = re.sub(r"^START IMMEDIATELY\s*(—|-|–)\s*", "", lead.strip()).strip()
+    lead_stripped = lead.strip()
+    if lead_stripped.upper().startswith("START IMMEDIATELY"):
+        priority = "urgent"
+    title = re.sub(r"^START IMMEDIATELY\s*(—|-|–)\s*", "", lead_stripped, flags=re.I).strip()
     date = None
     dm = DATE_RE.search(rest)
     if dm:

--- a/scripts/migrate_wishlist_research.py
+++ b/scripts/migrate_wishlist_research.py
@@ -91,3 +91,28 @@ def parse_research_item(line: str, area: str | None = None) -> Item:
         date = dm.group(1)
     return Item(title=title, status=status, priority=priority,
                 date=date, source=None, body=rest.strip(), area=area)
+
+
+def slugify(title: str, max_words: int = 8) -> str:
+    s = title.lower()
+    s = re.sub(r"[^a-z0-9\s-]", "", s)          # drop punctuation/emoji/·
+    words = [w for w in re.split(r"[\s-]+", s) if w]
+    return "-".join(words[:max_words])
+
+
+def filename_for(item: Item, default_date: str = "2026-06-16") -> str:
+    date = item.date or default_date
+    return f"{date}-{slugify(item.title)}.md"
+
+
+def render_item(item: Item) -> str:
+    fm = ["---", f"title: {item.title}", f"status: {item.status}",
+          f"priority: {item.priority}"]
+    if item.date:
+        fm.append(f"date: {item.date}")
+    if item.source:
+        fm.append(f"source: {item.source}")
+    if item.area:
+        fm.append(f"area: {item.area}")
+    fm.append("---")
+    return "\n".join(fm) + f"\n\n# {item.title}\n\n{item.body}\n"

--- a/scripts/migrate_wishlist_research.py
+++ b/scripts/migrate_wishlist_research.py
@@ -1,0 +1,65 @@
+"""One-time migration: split the single-file Wishlist and Research Queue into
+per-file items with YAML frontmatter (see
+docs/superpowers/specs/2026-06-16-wishlist-research-queue-per-file-design.md).
+
+Pure parse helpers are unit-tested; the `migrate()` driver does the file I/O."""
+from __future__ import annotations
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+DATE_RE = re.compile(r"\b(\d{4}-\d{2}-\d{2})\b")
+
+
+@dataclass
+class Item:
+    title: str
+    status: str
+    priority: str
+    date: str | None
+    source: str | None
+    body: str
+    area: str | None = None
+
+
+def _strip_markers(text: str):
+    """Pull leading `[in progress]`/`[done]` state + `HIGH`/`MEDIUM` priority
+    off the start of a wishlist title segment. Returns (status, priority, rest)."""
+    status = "open"
+    priority = "medium"
+    t = text.strip()
+    m = re.match(r"^\[(in progress|done)\]\s*", t, re.I)
+    if m:
+        status = "in-progress" if m.group(1).lower() == "in progress" else "done"
+        t = t[m.end():]
+    m = re.match(r"^(HIGH|MEDIUM|LOW)\b\s*(—|-|–)?\s*", t)
+    if m:
+        priority = m.group(1).lower()
+        t = t[m.end():]
+    return status, priority, t.strip()
+
+
+def parse_wishlist_item(bullet: str, in_done_file: bool = False) -> Item:
+    """Parse one wishlist bullet (without its leading `* `). The bolded lead
+    `**…**` carries state/priority/title; a trailing `(date — source)` is lifted."""
+    text = bullet.strip()
+    m = re.match(r"\*\*(.+?)\*\*(.*)$", text, re.S)
+    lead, rest = (m.group(1), m.group(2)) if m else (text, "")
+    status, priority, title_seg = _strip_markers(lead)
+    title = title_seg.strip()
+    if in_done_file:
+        status = "done"
+    date = None
+    source = None
+    pm = re.match(r"\s*\((.+?)\)", rest, re.S)
+    if pm:
+        paren = pm.group(1)
+        dm = DATE_RE.search(paren)
+        if dm:
+            date = dm.group(1)
+        src = re.sub(r"^\d{4}-\d{2}-\d{2}\s*(—|-|–)?\s*", "", paren).strip()
+        source = src or None
+        rest = rest[pm.end():]
+    body = rest.strip()
+    return Item(title=title, status=status, priority=priority,
+                date=date, source=source, body=body)

--- a/scripts/migrate_wishlist_research.py
+++ b/scripts/migrate_wishlist_research.py
@@ -22,7 +22,7 @@ class Item:
     area: str | None = None
 
 
-def _strip_markers(text: str):
+def _strip_markers(text: str) -> tuple[str, str, str]:
     """Pull leading `[in progress]`/`[done]` state + `HIGH`/`MEDIUM` priority
     off the start of a wishlist title segment. Returns (status, priority, rest)."""
     status = "open"
@@ -60,6 +60,7 @@ def parse_wishlist_item(bullet: str, in_done_file: bool = False) -> Item:
         src = re.sub(r"^\d{4}-\d{2}-\d{2}\s*(—|-|–)?\s*", "", paren).strip()
         source = src or None
         rest = rest[pm.end():]
+        rest = rest.lstrip(". \t")
     body = rest.strip()
     return Item(title=title, status=status, priority=priority,
                 date=date, source=source, body=body)
@@ -108,14 +109,19 @@ def filename_for(item: Item, default_date: str = "2026-06-16") -> str:
     return f"{date}-{slugify(item.title)}.md"
 
 
+def _yq(s: str) -> str:
+    """Double-quote a YAML scalar so colons/brackets/quotes are safe."""
+    return '"' + s.replace('\\', '\\\\').replace('"', '\\"') + '"'
+
+
 def render_item(item: Item) -> str:
-    fm = ["---", f"title: {item.title}", f"status: {item.status}",
+    fm = ["---", f"title: {_yq(item.title)}", f"status: {item.status}",
           f"priority: {item.priority}"]
     if item.date:
         fm.append(f"date: {item.date}")
     if item.source:
-        fm.append(f"source: {item.source}")
+        fm.append(f"source: {_yq(item.source)}")
     if item.area:
-        fm.append(f"area: {item.area}")
+        fm.append(f"area: {_yq(item.area)}")
     fm.append("---")
     return "\n".join(fm) + f"\n\n# {item.title}\n\n{item.body}\n"

--- a/scripts/migrate_wishlist_research.py
+++ b/scripts/migrate_wishlist_research.py
@@ -125,3 +125,88 @@ def render_item(item: Item) -> str:
         fm.append(f"area: {_yq(item.area)}")
     fm.append("---")
     return "\n".join(fm) + f"\n\n# {item.title}\n\n{item.body}\n"
+
+
+def split_bullets(text: str) -> list[str]:
+    """Each top-level `* `/`- ` bullet as a block (indented/blank continuation
+    lines fold in). Headings and non-bullet prose are skipped."""
+    items: list[str] = []
+    cur: list[str] | None = None
+    for line in text.splitlines():
+        if re.match(r"^[*-]\s+\S", line):
+            if cur is not None:
+                items.append("\n".join(cur).strip())
+            cur = [re.sub(r"^[*-]\s+", "", line)]
+        elif cur is not None and (line.startswith((" ", "\t")) or line.strip() == ""):
+            cur.append(line)
+        elif cur is not None:
+            items.append("\n".join(cur).strip())
+            cur = None
+    if cur is not None:
+        items.append("\n".join(cur).strip())
+    return [i for i in items if i]
+
+
+def migrate_wishlist_file(src: Path, out_dir: Path, in_done_file: bool,
+                          default_date: str) -> int:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    count = 0
+    for bullet in split_bullets(src.read_text()):
+        item = parse_wishlist_item(bullet, in_done_file=in_done_file)
+        if not item.title:
+            continue
+        (out_dir / filename_for(item, default_date)).write_text(render_item(item))
+        count += 1
+    return count
+
+
+def split_research_items(text: str):
+    """Yield (line, area) for each `- [ ]`/`- [x]` line under `## Queue` and its
+    `###` subsections. area = slugified nearest `###` heading."""
+    area = None
+    in_queue = False
+    for line in text.splitlines():
+        h2 = re.match(r"^##\s+(.+)$", line)
+        h3 = re.match(r"^###\s+(.+)$", line)
+        if h2:
+            in_queue = h2.group(1).strip().lower().startswith("queue")
+            area = None
+            continue
+        if h3:
+            area = slugify(h3.group(1))
+            continue
+        if in_queue and re.match(r"^[-*]\s*\[( |x|X)\]", line):
+            yield line, area
+
+
+def migrate_research_file(src: Path, out_dir: Path, default_date: str) -> int:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    count = 0
+    for line, area in split_research_items(src.read_text()):
+        item = parse_research_item(line, area=area)
+        if not item.title:
+            continue
+        (out_dir / filename_for(item, default_date)).write_text(render_item(item))
+        count += 1
+    return count
+
+
+def migrate(vault: Path, default_date: str) -> dict:
+    counts = {"wishlist": 0}
+    wl = vault / "docs" / "wishlist"
+    for name, done in [("Wishlist.md", False), ("Wishlist-in-progress.md", False),
+                       ("Wishlist-done.md", True)]:
+        src = vault / "docs" / name
+        if src.exists():
+            counts["wishlist"] += migrate_wishlist_file(src, wl, done, default_date)
+    rq_src = vault / "knowledge-base" / "research-queue.md"
+    rq_dir = vault / "knowledge-base" / "research-queue"
+    counts["research"] = migrate_research_file(rq_src, rq_dir, default_date) if rq_src.exists() else 0
+    return counts
+
+
+if __name__ == "__main__":
+    import sys
+    vault = Path(sys.argv[1] if len(sys.argv) > 1 else Path.home() / "Scout")
+    default_date = sys.argv[2] if len(sys.argv) > 2 else "2026-06-16"
+    print(migrate(vault, default_date))

--- a/scripts/migrate_wishlist_research.py
+++ b/scripts/migrate_wishlist_research.py
@@ -63,3 +63,31 @@ def parse_wishlist_item(bullet: str, in_done_file: bool = False) -> Item:
     body = rest.strip()
     return Item(title=title, status=status, priority=priority,
                 date=date, source=source, body=body)
+
+
+def parse_research_item(line: str, area: str | None = None) -> Item:
+    """Parse one research-queue checklist line:
+    `- [ ] 🔴 **START IMMEDIATELY — Title** body` (emoji = priority)."""
+    t = line.strip()
+    m = re.match(r"^[-*]\s*\[( |x|X)\]\s*", t)
+    status = "open"
+    if m:
+        status = "done" if m.group(1).lower() == "x" else "open"
+        t = t[m.end():]
+    priority = "medium"
+    if t.startswith("🔴"):
+        priority = "urgent"
+    elif t.startswith("🟢"):
+        priority = "low"
+    elif t.startswith("🟡"):
+        priority = "medium"
+    t = re.sub(r"^(🔴|🟡|🟢|🔵)\s*", "", t)
+    bm = re.match(r"\*\*(.+?)\*\*(.*)$", t, re.S)
+    lead, rest = (bm.group(1), bm.group(2)) if bm else (t, "")
+    title = re.sub(r"^START IMMEDIATELY\s*(—|-|–)\s*", "", lead.strip()).strip()
+    date = None
+    dm = DATE_RE.search(rest)
+    if dm:
+        date = dm.group(1)
+    return Item(title=title, status=status, priority=priority,
+                date=date, source=None, body=rest.strip(), area=area)

--- a/scripts/test_migrate_wishlist_research.py
+++ b/scripts/test_migrate_wishlist_research.py
@@ -45,6 +45,11 @@ def test_research_green_low():
     assert item.priority == "low"
     assert item.title == "G6 · CEE conference entities"
 
+def test_research_start_immediately_keyword_without_emoji_is_urgent():
+    item = parse_research_item("- [ ] **START IMMEDIATELY — Some title** body")
+    assert item.priority == "urgent"
+    assert item.title == "Some title"
+
 from migrate_wishlist_research import slugify, render_item, filename_for, Item
 
 def test_slugify_basic():

--- a/scripts/test_migrate_wishlist_research.py
+++ b/scripts/test_migrate_wishlist_research.py
@@ -113,3 +113,15 @@ def test_migrate_wishlist_file_writes_one_file_per_bullet(tmp_path):
     assert "priority: high" in alpha and "status: open" in alpha
     beta = (out_dir / "2026-06-16-beta-thing.md").read_text()
     assert "status: in-progress" in beta
+
+from migrate_wishlist_research import split_research_items
+
+def test_split_research_captures_all_h2_sections_with_clean_area():
+    text = ("## Queue\n- [ ] 🟡 **Q item** body\n\n"
+            "## 🟡 Standing lane — Productionize + release Scout\n- [ ] 🟢 **Standing item** body\n\n"
+            "### 🔵 KG gap analysis — ✅ done 2026-06-02\n- [x] **G1 thing** done\n")
+    rows = list(split_research_items(text))
+    assert len(rows) == 3
+    assert rows[0] == ("- [ ] 🟡 **Q item** body", None)               # generic Queue → no area
+    assert rows[1][1] == "standing-lane-productionize-release-scout"   # H2 area, suffix dropped
+    assert rows[2][1] == "kg-gap-analysis"                             # H3 area, ✅-done suffix dropped

--- a/scripts/test_migrate_wishlist_research.py
+++ b/scripts/test_migrate_wishlist_research.py
@@ -91,3 +91,25 @@ def test_render_item_quotes_titles_with_colons_for_valid_yaml():
                 priority="medium", date=None, source=None, body="b")
     out = render_item(item)
     assert 'title: "Build a config: key/value store"' in out
+
+from migrate_wishlist_research import migrate_wishlist_file, split_bullets
+
+def test_split_bullets_separates_top_level_items():
+    text = "intro\n\n* **A** body a\n* **[done] B** body b\n\n## Section\n* **C** c"
+    bullets = split_bullets(text)
+    assert len(bullets) == 3
+    assert bullets[0].startswith("**A**")
+
+def test_migrate_wishlist_file_writes_one_file_per_bullet(tmp_path):
+    src = tmp_path / "Wishlist.md"
+    src.write_text("# Wishlist\n\n* **HIGH — Alpha thing** (2026-06-10 — DM) do alpha.\n"
+                   "* **[in progress] MEDIUM — Beta thing** do beta.\n")
+    out_dir = tmp_path / "wishlist"
+    n = migrate_wishlist_file(src, out_dir, in_done_file=False, default_date="2026-06-16")
+    assert n == 2
+    files = sorted(p.name for p in out_dir.glob("*.md"))
+    assert files == ["2026-06-10-alpha-thing.md", "2026-06-16-beta-thing.md"]
+    alpha = (out_dir / "2026-06-10-alpha-thing.md").read_text()
+    assert "priority: high" in alpha and "status: open" in alpha
+    beta = (out_dir / "2026-06-16-beta-thing.md").read_text()
+    assert "status: in-progress" in beta

--- a/scripts/test_migrate_wishlist_research.py
+++ b/scripts/test_migrate_wishlist_research.py
@@ -1,4 +1,4 @@
-from migrate_wishlist_research import parse_wishlist_item
+from migrate_wishlist_research import parse_wishlist_item, parse_research_item
 
 def test_parses_in_progress_high_with_date_and_source():
     bullet = ("**[in progress] HIGH — Upgrade the graph system Scout relies on** "
@@ -22,3 +22,25 @@ def test_done_marker_maps_to_done():
     item = parse_wishlist_item("**[done] MEDIUM — Shipped thing** delivered notes.", in_done_file=False)
     assert item.status == "done"
     assert item.priority == "medium"
+
+def test_research_urgent_checked_done():
+    line = "- [x] 🔴 **START IMMEDIATELY — Upgrade the graph system** evaluate TinkerPop."
+    item = parse_research_item(line, area="graph")
+    assert item.status == "done"
+    assert item.priority == "urgent"
+    assert item.title == "Upgrade the graph system"
+    assert item.area == "graph"
+    assert "evaluate TinkerPop" in item.body
+
+def test_research_open_yellow_default():
+    line = "- [ ] 🟡 **Locate the engg-general message** reconcile the date."
+    item = parse_research_item(line)
+    assert item.status == "open"
+    assert item.priority == "medium"
+    assert item.title == "Locate the engg-general message"
+
+def test_research_green_low():
+    line = "- [ ] 🟢 **G6 · CEE conference entities** create event nodes."
+    item = parse_research_item(line)
+    assert item.priority == "low"
+    assert item.title == "G6 · CEE conference entities"

--- a/scripts/test_migrate_wishlist_research.py
+++ b/scripts/test_migrate_wishlist_research.py
@@ -1,0 +1,24 @@
+from migrate_wishlist_research import parse_wishlist_item
+
+def test_parses_in_progress_high_with_date_and_source():
+    bullet = ("**[in progress] HIGH — Upgrade the graph system Scout relies on** "
+              "(2026-06-12 — Jordan Slack DM `123`). Evaluate TinkerPop + Gremlin.")
+    item = parse_wishlist_item(bullet)
+    assert item.status == "in-progress"
+    assert item.priority == "high"
+    assert item.title == "Upgrade the graph system Scout relies on"
+    assert item.date == "2026-06-12"
+    assert item.source == "Jordan Slack DM `123`"
+    assert "Evaluate TinkerPop" in item.body
+
+def test_defaults_open_medium_when_unmarked():
+    item = parse_wishlist_item("**Some idea with no markers** and a description.")
+    assert item.status == "open"
+    assert item.priority == "medium"
+    assert item.title == "Some idea with no markers"
+    assert item.date is None
+
+def test_done_marker_maps_to_done():
+    item = parse_wishlist_item("**[done] MEDIUM — Shipped thing** delivered notes.", in_done_file=False)
+    assert item.status == "done"
+    assert item.priority == "medium"

--- a/scripts/test_migrate_wishlist_research.py
+++ b/scripts/test_migrate_wishlist_research.py
@@ -44,3 +44,39 @@ def test_research_green_low():
     item = parse_research_item(line)
     assert item.priority == "low"
     assert item.title == "G6 · CEE conference entities"
+
+from migrate_wishlist_research import slugify, render_item, filename_for, Item
+
+def test_slugify_basic():
+    assert slugify("Upgrade the graph system Scout relies on!") == "upgrade-the-graph-system-scout-relies-on"
+    assert slugify("G6 · CEE conference entities") == "g6-cee-conference-entities"
+
+def test_filename_uses_date_then_slug():
+    item = Item(title="Tighten the budget gate", status="open", priority="high",
+                date="2026-06-10", source=None, body="b")
+    assert filename_for(item) == "2026-06-10-tighten-the-budget-gate.md"
+
+def test_filename_falls_back_to_default_date_when_none():
+    item = Item(title="No date here", status="open", priority="medium",
+                date=None, source=None, body="b")
+    assert filename_for(item, default_date="2026-06-16") == "2026-06-16-no-date-here.md"
+
+def test_render_item_emits_frontmatter_and_body():
+    item = Item(title="Tighten the budget gate", status="open", priority="high",
+                date="2026-06-10", source="Jordan DM", body="The gate overruns.")
+    out = render_item(item)
+    assert out.startswith("---\n")
+    assert "title: Tighten the budget gate" in out
+    assert "status: open" in out
+    assert "priority: high" in out
+    assert "date: 2026-06-10" in out
+    assert "source: Jordan DM" in out
+    assert out.rstrip().endswith("The gate overruns.")
+    assert "\n# Tighten the budget gate\n" in out
+
+def test_render_omits_absent_optional_fields():
+    item = Item(title="t", status="open", priority="low", date=None, source=None, body="b")
+    out = render_item(item)
+    assert "source:" not in out
+    assert "area:" not in out
+    assert "date:" not in out

--- a/scripts/test_migrate_wishlist_research.py
+++ b/scripts/test_migrate_wishlist_research.py
@@ -71,11 +71,11 @@ def test_render_item_emits_frontmatter_and_body():
                 date="2026-06-10", source="Jordan DM", body="The gate overruns.")
     out = render_item(item)
     assert out.startswith("---\n")
-    assert "title: Tighten the budget gate" in out
+    assert 'title: "Tighten the budget gate"' in out
     assert "status: open" in out
     assert "priority: high" in out
     assert "date: 2026-06-10" in out
-    assert "source: Jordan DM" in out
+    assert 'source: "Jordan DM"' in out
     assert out.rstrip().endswith("The gate overruns.")
     assert "\n# Tighten the budget gate\n" in out
 
@@ -85,3 +85,9 @@ def test_render_omits_absent_optional_fields():
     assert "source:" not in out
     assert "area:" not in out
     assert "date:" not in out
+
+def test_render_item_quotes_titles_with_colons_for_valid_yaml():
+    item = Item(title="Build a config: key/value store", status="open",
+                priority="medium", date=None, source=None, body="b")
+    out = render_item(item)
+    assert 'title: "Build a config: key/value store"' in out


### PR DESCRIPTION
Part 1 of the per-file Wishlist & Research Queue restructure (scout-plugin side).

Adds a tested, stdlib-only migration that splits the legacy single-file `docs/Wishlist.md` + `knowledge-base/research-queue.md` (`## Queue`) into per-file YAML-frontmatter items (`docs/wishlist/`, `knowledge-base/research-queue/`), mirroring `dreaming-proposals/`.

**This PR is the migration prototype** (`scripts/migrate_wishlist_research.py`, 16 unit tests). It already migrated the maintainer's vault successfully (60 wishlist + 43 research items, all valid YAML). Pure helpers: `parse_wishlist_item` / `parse_research_item` (status/priority/date mapping, incl. 🔴/START-IMMEDIATELY→urgent), `slugify`, `render_item` (YAML-quoted scalars — handles titles with colons), `split_bullets` / `split_research_items` / `_heading_area`, and the `migrate*` drivers.

**Not yet wired into distribution** — the next step (planned, not in this PR) ports this logic into the engine and runs it idempotently in the `/scout-update` migrations stage, plus moves the workflow prose into `phases/`. See the design + plan in the scout-app repo (`docs/superpowers/specs/2026-06-16-…` and `docs/superpowers/plans/2026-06-17-…-plugin-distribution.md`).

Tests: `cd scripts && python3 -m pytest test_migrate_wishlist_research.py -q` → 16 passed.

Note: branch was cut from the pre-v0.7.0 line; the diff against `main` is clean (only the 2 new `scripts/` files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
