### PR TITLE
release: v0.7.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "scout",
       "source": "./",
       "description": "Autonomous knowledge management and daily briefing system for Claude Code",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "author": {
         "name": "Jordan Burger"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scout",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Autonomous knowledge management and daily briefing system. Monitors your work tools (Slack, Calendar, Linear, GitHub, etc.), synthesizes findings into a persistent knowledge base with a formal ontology, and delivers daily action items — all running unattended via scheduled Claude Code sessions. Six session types: Morning Briefing, Consolidation, Dreaming, Research, interactive Work sessions, and Meta Review. Pre-session hooks pre-compute KB staleness, recent git activity, PR state, and Claude Code session summaries before each run, trading a few seconds of shell work for large token savings inside the session.",
   "author": {
     "name": "Jordan Burger"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,16 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-06-19
+
+
 ### Added
+- **Per-file Wishlist & Research Queue (#144)** — the vault's Wishlist and Research Queue move from single markdown files to per-file directories (`docs/wishlist/`, `knowledge-base/research-queue/`), one file per item, so items are easier to edit, track, and reference individually. An **idempotent migration runs automatically during `/scout-update`**: it writes every existing item to the new per-file layout *before* removing the legacy files (no content loss; safe to re-run), and the heartbeat detects open research items in the new layout with a fallback to the legacy file during the transition.
 - **`scoutctl phases backport`** — reverse-maps vault brain-file edits (`SKILL`/`DREAMING`/`RESEARCH.md`) back into their source `phases/` fragments, so a future `/scout-update` re-render carries them forward instead of sidecaring (closes the manual half of the back-port gap). Diffs each brain file against its `.scout-state/last-assembled/` snapshot, locates each divergence in its fragment by anchor matching, conservatively re-templatizes (only long/unique vars auto-reverse; short ones like the instance/user name are flagged, never auto-written — so instance data can't leak into the engine), and **only auto-writes pure insertions that round-trip** (re-assembly reproduces the vault line); modified lines (diff `replace`) are downgraded to needs-review so the old text is never left behind. Default is a read-only report (`--apply` writes; `--kind`, `--vault` flags). Never commits/pushes/opens a PR. New module `scout.scripts.phase_backport` (pure, unit-tested) + `phases` CLI sub-app. Design: `docs/superpowers/specs/2026-06-16-scoutctl-phases-backport-design.md`.
 - **Engine back-port reminder** (`phases/modes/feedback-processing.md`, Step 1e) — after a run applies a `SKILL`/`DREAMING`/`RESEARCH` proposal, it surfaces a standing reminder (in the wrap notification + as a carried action item) that the engine back-port is owed until its PR merges, pointing at `scoutctl phases backport`. Explicitly **operator-triggered only — never auto-run** (it writes the shared engine). Closes the "applied edits silently never reach `phases/`" loop with a nudge instead of automation.
+
+### Documentation
+- **Budget-skip troubleshooting** (`README.md`) — guidance for diagnosing sessions skipped by the budget gate (#143).
 
 ## [0.7.0] - 2026-06-17
 

--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scout-engine"
-version = "0.7.0"
+version = "0.7.1"
 description = "Scout engine: CLI, hooks, runners, and Python library for the Scout productivity system."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/engine/scout/__init__.py
+++ b/engine/scout/__init__.py
@@ -1,3 +1,3 @@
 """Scout engine package."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"


### PR DESCRIPTION
Release prep for **v0.7.1** — captures the three PRs merged since v0.7.0.

Bumps all four manifests to 0.7.1 and promotes `[Unreleased]` → `[0.7.1]`. Review, ensure CI is green, merge — then `scripts/release.sh --finalize v0.7.1` tags + publishes.

## Contents
- **Per-file Wishlist & Research Queue** + idempotent `/scout-update` migration (#144)
- **`scoutctl phases backport`** — reverse-map vault brain-file edits into `phases/` (#139)
- **Budget-skip troubleshooting** docs (#143)

Note on versioning: #144 ships a vault migration (more than a typical patch) and #139 adds a CLI command — strict semver would call this a minor (0.8.0). Filed as **0.7.1** per maintainer decision; reasonable in 0.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)