### PR TITLE
ci: Batch 5 — CI hardening + flake fixes (shellcheck templates, manifest/tag validation)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,41 @@ jobs:
       - name: Version sync guard
         run: .venv/bin/python -m scout.scripts.versioning check
         working-directory: engine
-      - name: Shellcheck scoutctl
+      - name: Shellcheck
+        working-directory: ${{ github.workspace }}
         run: |
           sudo apt-get update && sudo apt-get install -y shellcheck
-          shellcheck bin/scoutctl
+          # engine launcher — full severity (existing guard)
+          shellcheck engine/bin/scoutctl
+          # installer + release scripts — error severity
+          shellcheck -S error install.sh scripts/*.sh
+          # all shell templates seeded into user vaults (placeholders don't
+          # break shellcheck parsing) — error severity
+          find templates -name '*.sh.tmpl' -print0 | xargs -0 -r shellcheck -S error
+      - name: Validate plugin manifests
+        working-directory: ${{ github.workspace }}
+        run: |
+          # Parse both manifests as JSON (the version-sync guard above uses
+          # regex, so a malformed manifest that still regex-matches its version
+          # would slip past it) and assert required keys are present.
+          python3 - <<'PY'
+          import json, sys
+
+          plugin = json.load(open(".claude-plugin/plugin.json"))
+          for key in ("name", "version"):
+              if key not in plugin:
+                  sys.exit(f"plugin.json missing required key: {key!r}")
+
+          market = json.load(open(".claude-plugin/marketplace.json"))
+          if "name" not in market:
+              sys.exit("marketplace.json missing required key: 'name'")
+          plugins = market.get("plugins")
+          if not isinstance(plugins, list) or not plugins:
+              sys.exit("marketplace.json 'plugins' must be a non-empty list")
+          for i, entry in enumerate(plugins):
+              for key in ("name", "source", "version"):
+                  if key not in entry:
+                      sys.exit(f"marketplace.json plugins[{i}] missing required key: {key!r}")
+
+          print("plugin manifests valid")
+          PY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,15 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+      - name: Verify tag matches manifest version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          MANIFEST_VERSION="$(python3 -c "import json; print(json.load(open('.claude-plugin/plugin.json'))['version'])")"
+          if [ "$TAG_VERSION" != "$MANIFEST_VERSION" ]; then
+            echo "::error::tag ${GITHUB_REF_NAME} (version ${TAG_VERSION}) does not match plugin.json version ${MANIFEST_VERSION}"
+            exit 1
+          fi
+          echo "tag matches manifest version: ${MANIFEST_VERSION}"
       - name: Extract changelog section for this tag
         id: notes
         run: |
@@ -24,6 +33,10 @@ jobs:
             grab {print}
           ' CHANGELOG.md > RELEASE_NOTES.md
           echo "Extracted notes for $VERSION:"; cat RELEASE_NOTES.md
+          if [ ! -s RELEASE_NOTES.md ]; then
+            echo "::error::no CHANGELOG section found for ${VERSION} — refusing to publish an empty release"
+            exit 1
+          fi
       - name: Create GitHub Release
         run: gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file RELEASE_NOTES.md
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- **CI hardening & test reliability (internal)** — shell templates (`templates/**/*.sh.tmpl`), `install.sh`, and the release scripts are now shellchecked in CI; plugin manifests are validated as parseable JSON with required keys (the version-sync guard is regex-based, so a malformed manifest could previously slip past); and the release workflow asserts the pushed tag matches the manifest version and refuses to publish empty release notes. Two CI flakes fixed: the `schedule_tick` event tests now freeze the clock (they relied on wall-clock and failed near 00:00 UTC), and the startup-latency tests take the best of N samples (a single noisy sample on a shared runner could breach the budget).
+
 ## [0.7.1] - 2026-06-19
 
 

--- a/engine/tests/perf/test_startup.py
+++ b/engine/tests/perf/test_startup.py
@@ -16,34 +16,49 @@ import pytest
 
 HELP_BUDGET_MS = 250
 VERSION_BUDGET_MS = 150
+_RUNS = 5
+
+
+def _best_latency_ms(args: list[str]) -> tuple[float, str]:
+    """Best-of-N startup latency: the minimum elapsed over ``_RUNS`` invocations.
+
+    A single subprocess sample includes OS scheduling / cold-disk / shared-runner
+    noise (the source of past CI flakes — a lone 192ms spike against a 150ms
+    budget). The *minimum* reflects the achievable floor, which is what actually
+    regresses when a heavy top-level import is added — so the guard stays
+    meaningful while no longer flaking on one noisy sample. Returns
+    ``(best_ms, last_stdout)``.
+    """
+    best = float("inf")
+    stdout = ""
+    for _ in range(_RUNS):
+        start = time.perf_counter()
+        result = subprocess.run(
+            [sys.executable, "-m", "scout.cli", *args],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        assert result.returncode == 0
+        stdout = result.stdout
+        best = min(best, elapsed_ms)
+    return best, stdout
 
 
 @pytest.mark.perf
 def test_scoutctl_help_latency() -> None:
-    start = time.perf_counter()
-    result = subprocess.run(
-        [sys.executable, "-m", "scout.cli", "--help"],
-        capture_output=True,
-        text=True,
-        timeout=5,
-    )
-    elapsed_ms = (time.perf_counter() - start) * 1000
-    assert result.returncode == 0
-    assert elapsed_ms < HELP_BUDGET_MS, (
-        f"scoutctl --help took {elapsed_ms:.0f}ms (budget: {HELP_BUDGET_MS}ms). Check for heavy top-level imports."
+    best_ms, _ = _best_latency_ms(["--help"])
+    assert best_ms < HELP_BUDGET_MS, (
+        f"scoutctl --help took {best_ms:.0f}ms (best of {_RUNS}, budget: {HELP_BUDGET_MS}ms). "
+        "Check for heavy top-level imports."
     )
 
 
 @pytest.mark.perf
 def test_scoutctl_version_latency() -> None:
-    start = time.perf_counter()
-    result = subprocess.run(
-        [sys.executable, "-m", "scout.cli", "version"],
-        capture_output=True,
-        text=True,
-        timeout=5,
+    best_ms, stdout = _best_latency_ms(["version"])
+    assert stdout.strip(), "version should emit to stdout"
+    assert best_ms < VERSION_BUDGET_MS, (
+        f"scoutctl version took {best_ms:.0f}ms (best of {_RUNS}, budget: {VERSION_BUDGET_MS}ms)."
     )
-    elapsed_ms = (time.perf_counter() - start) * 1000
-    assert result.returncode == 0
-    assert result.stdout.strip(), "version should emit to stdout"
-    assert elapsed_ms < VERSION_BUDGET_MS, f"scoutctl version took {elapsed_ms:.0f}ms (budget: {VERSION_BUDGET_MS}ms)."

--- a/engine/tests/unit/test_schedule_tick.py
+++ b/engine/tests/unit/test_schedule_tick.py
@@ -40,6 +40,12 @@ from scout.scripts.schedule_tick import (
     run as tick_run,
 )
 
+# Frozen clock for tick_run() tests: Mon 08:05 ET — well past a 00:01 slot, so
+# the slot is unambiguously due. Tests that exercise tick_run() against the real
+# clock flake when CI runs near the 00:00 boundary (the missed-window math is
+# time-of-day-dependent), so they patch schedule_tick._now to this value.
+_FROZEN_NOW = datetime(2026, 5, 11, 8, 5, tzinfo=ZoneInfo("America/New_York"))
+
 
 # Helper for synthesizing slots in tests.
 def _slot(
@@ -558,6 +564,7 @@ def test_run_skips_when_network_offline(tmp_path, monkeypatch):
         "    missed_window_hours: 24\n    on_miss: fire\n    cooldown_minutes: 5\n"
     )
     with (
+        patch("scout.scripts.schedule_tick._now", return_value=_FROZEN_NOW),
         patch("scout.scripts.schedule_tick._network_ready", return_value=False),
         patch("scout.scripts.schedule_tick.subprocess.Popen") as mock_popen,
     ):
@@ -603,6 +610,7 @@ def test_slot_fired_event_has_full_payload_per_v0_5_spec(tmp_path, monkeypatch):
         "    missed_window_hours: 24\n    on_miss: fire\n    cooldown_minutes: 5\n"
     )
     with (
+        patch("scout.scripts.schedule_tick._now", return_value=_FROZEN_NOW),
         patch("scout.scripts.schedule_tick._network_ready", return_value=True),
         patch("scout.scripts.schedule_tick.subprocess.Popen") as mock_popen,
     ):
@@ -631,7 +639,10 @@ def test_slot_skipped_event_has_slot_type_and_target_local(tmp_path, monkeypatch
         "    weekdays: [Mon, Tue, Wed, Thu, Fri, Sat, Sun]\n"
         "    missed_window_hours: 24\n    on_miss: skip\n    cooldown_minutes: 5\n"
     )
-    with patch("scout.scripts.schedule_tick._network_ready", return_value=True):
+    with (
+        patch("scout.scripts.schedule_tick._now", return_value=_FROZEN_NOW),
+        patch("scout.scripts.schedule_tick._network_ready", return_value=True),
+    ):
         tick_run()
     log = next((tmp_path / ".scout-logs").glob("schedule-events-*.jsonl"))
     rows = [json.loads(line) for line in log.read_text().splitlines() if line.strip()]


### PR DESCRIPTION
## Why

Batch 5 of the Plan 9 roadmap (CI hardening), plus the two latent CI flakes diagnosed during #139.

## CI hardening (`lint.yml`, `release.yml`)

- **Shellcheck the shell templates** — CI previously only checked `engine/bin/scoutctl`. Now it also shellchecks all 13 `templates/**/*.sh.tmpl` (placeholders don't break shellcheck parsing), `install.sh`, and `scripts/*.sh`. All currently pass at `-S error`.
- **Validate plugin manifests** — the version-sync guard is *regex-based*, so a malformed `plugin.json`/`marketplace.json` that still regex-matches its version would slip past it. New step parses both as JSON and asserts required keys (`name`/`version`; marketplace `plugins[].name/source/version`).
- **Guard the release** — `release.yml` now asserts the pushed tag matches `plugin.json`'s version (can't publish `v0.8.0` while manifests say `0.7.1`) and refuses to publish when the CHANGELOG section for the tag is empty (we nearly shipped near-empty notes during 0.7.0).

## Flake fixes (the two that briefly blocked #139)

- **`schedule_tick` event tests** froze: 3 tests ran `tick_run()` against the *real* clock, so they failed when CI ran near 00:00 UTC (the slot missed-window math is time-of-day-dependent). They now patch the existing `schedule_tick._now` seam to a fixed Mon 08:05 ET — clock-independent.
- **Startup-latency tests** took a single subprocess sample and flaked on shared-runner noise (a lone 192ms vs the 150ms budget). Now best-of-N (min over 5 runs) — the achievable floor, which is what actually regresses when a heavy top-level import is added; budgets unchanged.

## Testing

Full suite **845 passed**; ruff/format/mypy clean; manifest-validation and tag-check logic verified locally against current manifests; both workflows parse as valid YAML; all shell targets pass shellcheck locally. The new CI steps themselves run for the first time on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)