### PR TITLE
fix(retry): classify "Connection closed mid-response" as transient

### DIFF
--- a/engine/tests/integration/test_claude_with_retry.py
+++ b/engine/tests/integration/test_claude_with_retry.py
@@ -1,0 +1,121 @@
+"""Integration test for templates/scripts/claude-with-retry.sh.tmpl.
+
+Renders the template and drives it with a fake `claude` binary that fails on
+the first attempt and succeeds on the second, asserting the wrapper's transient
+classifier retries (or doesn't) the right error classes.
+
+Regression context: an overnight Scout run slept mid-stream, woke to a dropped
+socket reported as "API Error: Connection closed mid-response", which was NOT
+in TRANSIENT_PATTERNS — so the wrapper hard-failed (exit 1) instead of retrying
+a fresh session on wake. That exit-1 poisoned the next run's failure-backoff.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]  # …/scout-plugin
+TEMPLATE = REPO_ROOT / "templates" / "scripts" / "claude-with-retry.sh.tmpl"
+
+
+def _render(tmpl: Path, scout_dir: Path) -> Path:
+    text = tmpl.read_text(encoding="utf-8").replace("{{INSTANCE_NAME}}", "Scout")
+    out = scout_dir / "scripts" / "claude-with-retry.sh"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(text, encoding="utf-8")
+    out.chmod(0o755)
+    return out
+
+
+def _fake_claude(scout_dir: Path, *, first_attempt_output: str, first_attempt_exit: int) -> Path:
+    """A stand-in `claude` binary: emits given output + exit on attempt 1, then succeeds.
+
+    Tracks attempts in a sibling counter file so the test can assert how many
+    times the wrapper invoked it.
+    """
+    counter = scout_dir / "attempts.count"
+    bin_path = scout_dir / "fake-claude.sh"
+    bin_path.write_text(
+        "#!/bin/bash\n"
+        f'COUNTER="{counter}"\n'
+        'n=$(cat "$COUNTER" 2>/dev/null || echo 0); n=$((n + 1)); echo "$n" > "$COUNTER"\n'
+        'if [ "$n" -eq 1 ]; then\n'
+        f"  echo {first_attempt_output!r}\n"
+        f"  exit {first_attempt_exit}\n"
+        "fi\n"
+        'echo "session complete"\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    bin_path.chmod(0o755)
+    return bin_path
+
+
+def _run(script: Path, fake_claude: Path, log_file: Path) -> subprocess.CompletedProcess:
+    # BACKOFF_S=0 → sleep 0 → no real delay between attempts in the test.
+    env = {**os.environ, "SCOUT_RETRY_BACKOFF_S": "0", "SCOUT_RETRY_MAX": "2"}
+    return subprocess.run(
+        [str(script), str(log_file), str(fake_claude)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _attempts(scout_dir: Path) -> int:
+    return int((scout_dir / "attempts.count").read_text().strip())
+
+
+def test_retries_on_connection_closed_mid_response(tmp_path: Path) -> None:
+    scout_dir = tmp_path / "Scout"
+    scout_dir.mkdir()
+    script = _render(TEMPLATE, scout_dir)
+    fake = _fake_claude(
+        scout_dir,
+        first_attempt_output="API Error: Connection closed mid-response. The response above may be incomplete.",
+        first_attempt_exit=1,
+    )
+    log_file = scout_dir / "run.log"
+
+    result = _run(script, fake, log_file)
+
+    assert result.returncode == 0, log_file.read_text()
+    assert _attempts(scout_dir) == 2, "wrapper should have retried after the dropped connection"
+
+
+def test_existing_transient_pattern_still_retries(tmp_path: Path) -> None:
+    """Guard: editing the regex alternation must not break a pre-existing pattern."""
+    scout_dir = tmp_path / "Scout"
+    scout_dir.mkdir()
+    script = _render(TEMPLATE, scout_dir)
+    fake = _fake_claude(
+        scout_dir,
+        first_attempt_output="Stream idle timeout - partial response received",
+        first_attempt_exit=1,
+    )
+    log_file = scout_dir / "run.log"
+
+    result = _run(script, fake, log_file)
+
+    assert result.returncode == 0, log_file.read_text()
+    assert _attempts(scout_dir) == 2
+
+
+def test_does_not_retry_non_transient_error(tmp_path: Path) -> None:
+    """Guard: the classifier stays narrow — auth failures are not retried."""
+    scout_dir = tmp_path / "Scout"
+    scout_dir.mkdir()
+    script = _render(TEMPLATE, scout_dir)
+    fake = _fake_claude(
+        scout_dir,
+        first_attempt_output="API Error: 401 Unauthorized",
+        first_attempt_exit=1,
+    )
+    log_file = scout_dir / "run.log"
+
+    result = _run(script, fake, log_file)
+
+    assert result.returncode == 1
+    assert _attempts(scout_dir) == 1, "non-transient failure must not be retried"

--- a/templates/scripts/claude-with-retry.sh.tmpl
+++ b/templates/scripts/claude-with-retry.sh.tmpl
@@ -6,6 +6,8 @@
 #   - "Unable to connect to API (ECONNRESET)"
 #   - "Unable to connect to API (ConnectionRefused)"
 #   - "Stream idle timeout - partial response received"
+#   - "Connection closed mid-response"             (socket torn down mid-stream,
+#                                                    e.g. machine slept overnight)
 #   - "529 Overloaded"                              (Anthropic upstream temp)
 #
 # Does NOT retry on:
@@ -46,7 +48,7 @@ if [ "${SCOUT_RETRY_DISABLE:-0}" = "1" ]; then
 fi
 
 # Pipe-separated grep -E regex. Keep narrow — anything matched here triggers a retry.
-TRANSIENT_PATTERNS='socket connection was closed unexpectedly|Unable to connect to API \(ECONNRESET\)|Unable to connect to API \(ConnectionRefused\)|Stream idle timeout|529 Overloaded'
+TRANSIENT_PATTERNS='socket connection was closed unexpectedly|Unable to connect to API \(ECONNRESET\)|Unable to connect to API \(ConnectionRefused\)|Stream idle timeout|Connection closed mid-response|529 Overloaded'
 
 attempt=1
 exit_code=0


### PR DESCRIPTION
## Problem

A scheduled Scout weekend briefing (2026-06-21 08:17 ET) was skipped. The log read `=== Budget check: skipping this run ===`, but **this was not a spend issue** — `budget_spent` was `$0`. It was the budget-check's **failure-backoff** branch (exit code 2): the prior overnight-research run exited non-zero 13 min earlier, inside the 30-min `failure_backoff_minutes` window.

That research run had failed like this:

```
=== Scout run starting at Sun Jun 21 03:50:14 EDT 2026 ===
API Error: Connection closed mid-response. The response above may be incomplete.
=== Failure not classified as transient — no retry (exit 1) ===
=== finished at 08:04:13 EDT (exit code: 1, duration: 15237s) ===
```

The host **slept mid-stream overnight**; on wake (~08:04) the torn-down socket surfaced as `Connection closed mid-response`. That string was **not** in `TRANSIENT_PATTERNS`, so `claude-with-retry.sh` hard-failed (exit 1) instead of retrying a fresh session. The exit-1 row then poisoned the next run's failure-backoff → the briefing skipped.

## Fix

Add `Connection closed mid-response` to `TRANSIENT_PATTERNS`. On wake the network is back, so a fresh `claude -p` retry succeeds → exit 0 → no backoff poison for the next scheduled run.

## Why not an idle/wall-clock watchdog

The 4h14m "duration" was overnight **system sleep** — the process was suspended, not runaway. A watchdog can't run to kill a suspended process, and the process exits on its own within seconds of wake, so a timeout wouldn't have helped this failure mode. A genuine *awake* network black-hole is already covered by the CLI's own `Stream idle timeout` (already in the transient set). And GNU `timeout` isn't reliably on PATH under launchd / in distributable installs. So a watchdog would add fragility without addressing the observed bug.

## Tests

New `engine/tests/integration/test_claude_with_retry.py` (TDD — the connection-closed test was watched failing with the exact production log line before the fix):

- **retries** on `Connection closed mid-response`
- an **existing** transient pattern (`Stream idle timeout`) still retries — guards the regex alternation edit
- a non-transient `401` still does **not** retry — guards the classifier's intentional narrowness

Full engine suite: `856 passed, 1 skipped` (skip is an unrelated parity test needing a real vault).

🤖 Generated with [Claude Code](https://claude.com/claude-code)