### PR TITLE
release: v0.7.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "scout",
       "source": "./",
       "description": "Autonomous knowledge management and daily briefing system for Claude Code",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "author": {
         "name": "Jordan Burger"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scout",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Autonomous knowledge management and daily briefing system. Monitors your work tools (Slack, Calendar, Linear, GitHub, etc.), synthesizes findings into a persistent knowledge base with a formal ontology, and delivers daily action items — all running unattended via scheduled Claude Code sessions. Six session types: Morning Briefing, Consolidation, Dreaming, Research, interactive Work sessions, and Meta Review. Pre-session hooks pre-compute KB staleness, recent git activity, PR state, and Claude Code session summaries before each run, trading a few seconds of shell work for large token savings inside the session.",
   "author": {
     "name": "Jordan Burger"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-06-22
+
+
 ### Added
 - **Validation Pass dreaming work mode** (`phases/modes/kb-deep-work.md`) — a fourth KB-deep-work mode for flat-score nights whose deliverable is *existing* high-stakes claims re-grounded against live sources (corrected / downgraded / confirmed), explicitly **not** new sections or entities. Includes a verified-scope guard (a "0-drift / confirmed" label and the "N checked / K confirmed" count cover only claims actually queried this run; derived/comparative conclusions inherit their weakest input's status) and a default-lean toward validation over Gap Hunt on quiet nights. The Step 2d depth gate gets a companion exception so a genuine re-verification run passes on its check count rather than being flagged as superficial for adding no net-new content.
 - **Knowledge-graph traversal layer (`parser.py`)** — `traverse()` (BFS reachability returning each reachable entity with its hop distance, first-reached relationship, and shortest typed path), `path()` (shortest typed path between two entities), and `to_networkx()` (lazy optional bridge to a `MultiDiGraph` for centrality/components) on `KnowledgeGraph`, plus `traverse` / `path` CLI commands (`--name` source, `--to` target, `--hops`, `--rels` type filter). Pure-stdlib BFS with no third-party dependency; `to_networkx()` imports networkx lazily and raises a friendly error if it's absent, so the core commands never require it.

--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scout-engine"
-version = "0.7.1"
+version = "0.7.2"
 description = "Scout engine: CLI, hooks, runners, and Python library for the Scout productivity system."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/engine/scout/__init__.py
+++ b/engine/scout/__init__.py
@@ -1,3 +1,3 @@
 """Scout engine package."""
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"


### PR DESCRIPTION
Automated release prep for v0.7.2. Review, ensure CI is green, and merge — then run `scripts/release.sh --finalize v0.7.2` to tag and publish the GitHub Release.