### PR TITLE
feat(email): automated-alert triage + thread-drill rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **Email inbound-scan hardening** (`phases/connectors/email.md`) — three rules upstreamed from accumulated instance experience: **Automated-Alert Triage** (credential/token-expiry, quota/spend-threshold, usage, billing, and maintenance alerts are 🟢 Watching by default — promoted only on imminent functional impact, never on alarm-word tone); and **Drill Active Threads — Don't Trust the Snippet** (a search snippet previews one message, often not the latest — fetch the full thread before asserting "no reply"/"awaiting X"/"unanswered"; threads tied to an open item are mandatory drills).
+
 ## [0.7.2] - 2026-06-22
 
 

--- a/phases/connectors/email.md
+++ b/phases/connectors/email.md
@@ -62,6 +62,10 @@ Use `gmail_search_messages` to find recent emails in the inbox. Prioritize:
 - Mass email (BCC'd, mailing list) from unknown source = **skip**
 - If uncertain whether an email is legitimate or cold outreach, file under **Watching** at most, **never under To Do**
 
+### Automated-Alert Triage
+
+Automated/transactional alerts — credential & token expiry, quota/spend thresholds, usage metrics, billing milestones, scheduled-maintenance notices — are **informational by default**: file them under **Watching** (🟢), never To Do or Urgent on tone alone. Promote one only when there is an *imminent functional impact*: a production credential expiring within days that breaks an active workflow, or a hard shutoff with a near deadline. The alert's own language ("action required", "expiring soon", "limit reached") is not urgency — evaluate the actual deadline and whether anything {{USER_NAME}} relies on would actually break. Test/dev/non-production credentials and routine threshold notices stay 🟢.
+
 ### What to Record
 
 For each legitimate inbound email:
@@ -70,6 +74,10 @@ For each legitimate inbound email:
 - **What's being asked or communicated**
 - **Whether {{USER_NAME}} already replied** (check sent mail for a response in the same thread)
 - **Urgency** — explicit deadline, tone, or sender importance
+
+### Drill Active Threads — Don't Trust the Snippet
+
+`gmail_search_messages` returns a preview snippet of just *one* message in a thread — often not the latest. For any thread that has moved since the last run (newer than your last-checked watermark, or tied to an open action item or a tracked contact), fetch the **full thread** (`get_thread`) and read the tail before drawing any conclusion. **Never assert a thread's state — "still no reply", "awaiting X", "unanswered" — from the search snippet alone:** the reply you're looking for may already be sitting in the thread tail. Threads attached to an open 🔴/🟡 item are mandatory drills.
 
 ---
 phase: connector


### PR DESCRIPTION
First PR in the **de-personalized Patterns batch** — upstreaming accumulated instance rules into the engine phases (Phase-1 work for the connector-based migration, #156).

## What
Two rules added to `phases/connectors/email.md` inbound-scan:
- **Automated-Alert Triage** — credential/token-expiry, quota/spend-threshold, usage, billing, maintenance alerts are 🟢 Watching by default; promoted only on *imminent functional impact*, never on alarm-word tone. (Patterns #12 + #25.)
- **Drill Active Threads — Don't Trust the Snippet** — a search snippet previews one message (often not the latest); fetch the full thread before asserting "no reply"/"awaiting X"; threads tied to an open item are mandatory drills. (Pattern #45.)

Both rules are generic; the originating examples (which named a customer, colleagues, and personal threads) were dropped. Verified they assemble into **SKILL only**, not DREAMING/RESEARCH.

## ⚠️ Pre-existing bug — these rules are inert until it's fixed (tracked in #172)
The email phase declares `requires: email`, but vault configs enable this connector under the key **`gmail`** (the value detection emits) — so `select_sections` drops the **entire** email phase from the assembled `SKILL.md`. Now **confirmed**, not just suspected: a live vault's deployed `SKILL.md` has 0 occurrences of every email-phase marker. **Consequence: the rules in this PR don't take effect until the key mismatch is reconciled.** This predates this PR and is filed separately as **#172** (with fix options + a pointer to fold it into the connector-catalog work, #152) — flagging, not fixing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)