### PR TITLE
feat(action-items): deadline-distance ceiling + terminal-status task-query filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **Action-items prioritization + task-query hardening** (`phases/core/action-items.md`) — two rules upstreamed from accumulated instance experience: a **Deadline-Distance Ceiling** (urgency is *capped* by deadline distance — 30+ days → 🟢 max, 7–30 → 🟡 max, <7 → eligible for 🔴, <3 → 🔴 when the next action is the user's; evaluate the real deadline, never the source's alarm-word tone; deprecation notices stay 🟢 until ~2–3 weeks out), and a **terminal-status filter on the ontology task query** (`query --type task --exclude-status "completed,cancelled"` instead of a bare query, so completed/cancelled task entities stop resurfacing as open work; documents the supported `--domain` / `--status` / `--deadline-before` filters).
+
 ## [0.7.2] - 2026-06-22
 
 

--- a/phases/core/action-items.md
+++ b/phases/core/action-items.md
@@ -34,6 +34,17 @@ Categorize every action item using these levels:
 - **🟢 Watching**: Tracking but no action needed yet
 - **✅ Done**: Completed with evidence of completion
 
+### Hard Rule — Deadline-Distance Ceiling
+
+Urgency is **capped by how far away the deadline is** — distance sets a *ceiling*, not a floor. Before assigning any tier, compute the days between today and the item's real deadline:
+
+- **30+ days out** → 🟢 Watching (max). Far-future items never lead the list.
+- **7–30 days out** → 🟡 To Do (max).
+- **< 7 days out** → eligible for 🔴 Urgent.
+- **< 3 days out** → 🔴 when the next action is {{USER_NAME}}'s to take.
+
+**Evaluate the actual deadline, not the source's tone.** Notification language — "action required", "expiring soon", "final notice", "limit reached" — is alarm-word framing, not real urgency, and never promotes an item past the distance ceiling. Deprecation / end-of-life notices specifically stay 🟢 Watching until ~2–3 weeks before the cutover. This ceiling is the counterpart to the deadline *escalation* rule under Knowledge Graph Personal Tasks below: escalation raises priority as a deadline nears; the ceiling stops a distant deadline from being surfaced as urgent on tone alone.
+
 ## Action Items File Format
 
 Create `action-items/action-items-YYYY-MM-DD.md` using today's date. Include:
@@ -188,8 +199,10 @@ If {{USER_NAME}} corrects a name ("who is X?", "X doesn't exist", "this is hallu
 If the ontology parser is set up, query it for personal tasks and deadlines:
 
 ```bash
-cd {{SCOUT_DIR}} && python knowledge-base/ontology/parser.py query --type task
+cd {{SCOUT_DIR}} && python knowledge-base/ontology/parser.py query --type task --exclude-status "completed,cancelled"
 ```
+
+**Always filter terminal statuses — never query bare `--type task`.** A bare query returns *every* task entity, including ones already finished, so completed work resurfaces on the daily list as if it were still open (the classic regression: a task whose `status` flipped to `completed` weeks ago reappears tomorrow). Pass `--exclude-status "completed,cancelled"` to get the currently-actionable set — task entities use mixed statuses (`open` / `in-progress` / `scheduled` / …), so excluding the terminal ones is more robust than trying to enumerate the live ones. Narrow further with `--domain personal` / `--domain work` when you want a single slice, `--status <s>` for an exact status, and `--deadline-before <ISO-date>` for deadline sweeps.
 
 **`surface_rule` windows are authoritative.** Before rendering any `type: task` entity into the daily file, read its `surface_rule:` block. If `default: do_not_surface` and **no** `windows` entry covers today's date AND **no** `always_visible_if` condition fires, the task is intentionally muted — do not render it, do not flag it stale, do not mention it in the wrap notification. If a window covers today, render at that window's `surface:` priority using its `task:` label override if present. If `always_visible_if` fires, force 🔴. A task with no `surface_rule` falls back to surfacing daily until `status: completed` (back-compat). This stops long-window tasks (multi-week trips, future-dated deadlines) from polluting the daily surface during their idle phases.
 


### PR DESCRIPTION
Part of the **de-personalized Patterns batch** — upstreaming accumulated instance rules into the engine phases (Phase-1 work for the connector-based migration, #156). Follows the method established in #157.

## What
Two rules added to `phases/core/action-items.md` (assembles into **SKILL only** — `mode: [briefing, consolidation]`):

- **Deadline-Distance Ceiling** (Pattern #24) — urgency is *capped* by how far away the deadline is: **30+ days → 🟢 max**, **7–30 → 🟡 max**, **<7 → eligible for 🔴**, **<3 → 🔴 when the next action is the user's**. Evaluate the actual deadline, **not** the source's alarm-word tone ("action required" / "expiring soon" never promotes past the ceiling); deprecation/EOL notices stay 🟢 until ~2–3 weeks before cutover. Framed as the *ceiling* counterpart to the existing deadline *escalation* (floor) rule.
- **Terminal-status filter on the ontology task query** (Pattern #30) — the documented invocation becomes `query --type task --exclude-status "completed,cancelled"` instead of a bare `query --type task`, so completed/cancelled task entities stop resurfacing as open work. Documents the supported `--domain` / `--status` / `--deadline-before` filters.

## Verification
- **Parser flags verified present** in `templates/knowledge-base/ontology/parser.py` before documenting them: `--exclude-status`, `--domain`, `--status`, `--deadline-before` all exist on the `query` command (the parser's own help recommends `--exclude-status` for currently-actionable tasks since entities use mixed statuses).
- **Assembly checked** via `_assemble(cfg, kind)`: both rules land in **SKILL** and do **not** leak into DREAMING/RESEARCH (matches the file's `mode: [briefing, consolidation]`).
- Diff grepped clean of names / employer / customers / Slack IDs / repo-PR-Linear IDs / user paths.

Both rules are generic; the originating examples (which named a customer, colleagues, and personal deadlines) were dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)