### PR TITLE
release: v0.7.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "scout",
       "source": "./",
       "description": "Autonomous knowledge management and daily briefing system for Claude Code",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "author": {
         "name": "Jordan Burger"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scout",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Autonomous knowledge management and daily briefing system. Monitors your work tools (Slack, Calendar, Linear, GitHub, etc.), synthesizes findings into a persistent knowledge base with a formal ontology, and delivers daily action items — all running unattended via scheduled Claude Code sessions. Six session types: Morning Briefing, Consolidation, Dreaming, Research, interactive Work sessions, and Meta Review. Pre-session hooks pre-compute KB staleness, recent git activity, PR state, and Claude Code session summaries before each run, trading a few seconds of shell work for large token savings inside the session.",
   "author": {
     "name": "Jordan Burger"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-06-23
+
+
 ### Added
 - **Email inbound-scan hardening** (`phases/connectors/email.md`) — three rules upstreamed from accumulated instance experience: **Automated-Alert Triage** (credential/token-expiry, quota/spend-threshold, usage, billing, and maintenance alerts are 🟢 Watching by default — promoted only on imminent functional impact, never on alarm-word tone); and **Drill Active Threads — Don't Trust the Snippet** (a search snippet previews one message, often not the latest — fetch the full thread before asserting "no reply"/"awaiting X"/"unanswered"; threads tied to an open item are mandatory drills).
 - **Action-items prioritization + task-query hardening** (`phases/core/action-items.md`) — two rules upstreamed from accumulated instance experience: a **Deadline-Distance Ceiling** (urgency is *capped* by deadline distance — 30+ days → 🟢 max, 7–30 → 🟡 max, <7 → eligible for 🔴, <3 → 🔴 when the next action is the user's; evaluate the real deadline, never the source's alarm-word tone; deprecation notices stay 🟢 until ~2–3 weeks out), and a **terminal-status filter on the ontology task query** (`query --type task --exclude-status "completed,cancelled"` instead of a bare query, so completed/cancelled task entities stop resurfacing as open work; documents the supported `--domain` / `--status` / `--deadline-before` filters).

--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scout-engine"
-version = "0.7.2"
+version = "0.7.3"
 description = "Scout engine: CLI, hooks, runners, and Python library for the Scout productivity system."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/engine/scout/__init__.py
+++ b/engine/scout/__init__.py
@@ -1,3 +1,3 @@
 """Scout engine package."""
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"


### PR DESCRIPTION
Automated release prep for v0.7.3. Review, ensure CI is green, and merge — then run `scripts/release.sh --finalize v0.7.3` to tag and publish the GitHub Release.