### PR TITLE
feat: Agentic Trading session type (engine implementation, default-disabled)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **Agentic Trading session type** (optional, **default-disabled**) — a fourth scheduled session type that runs an autonomous equity-trading loop against an operator-configured Robinhood account via the `robinhood-trading` MCP. Real money, opt-in, **not financial advice**; ships off and does nothing until explicitly enabled. Design: `docs/superpowers/specs/2026-06-26-agentic-trading-design.md`.
+  - New `SlotType.TRADING` (+ `SlotPriority.TRADING = 25`) in `schedule.py`, so a `type: trading` schedule slot dispatches through the standard 5-minute tick like any other session — no new launchd plist.
+  - New `TRADING` brain assembled from `phases/core` + `phases/trading/` (`mode: [trading]`), wired into `bootstrap.py` `_assemble()` and both stage-5 loops; `git-setup.md` opted into `trading` so the brain inherits the shared git/timezone/cost conventions.
+  - New `phases/trading/trading-loop.md` — the 6-step loop (reconcile → risk gate → manage → consider entries → execute → log/report) with hard guardrails (capital cap, single-name cap, mandatory stop, daily-loss cap, circuit breaker, settled-cash-only, no penny/leveraged) and a **graceful degrade**: if a headless session is blocked from placing an order, it records a `PENDING-APPROVAL` order + one-tap-approve DM instead of failing silently.
+  - New `run-trading.sh` runner (`templates/run-trading.sh.tmpl`) that **guards on the master switch before any spend**, plus `scripts/trading.sh` (on/off/status) and `scripts/trading-config.py` (config get/set).
+  - Per-install config seeded once at `knowledge-base/projects/agentic-trading/config.yaml` (master switch + guardrails; account is a fill-in placeholder, never overwritten on upgrade) alongside `watchlist.md` / `decision-log.md` / `nav-history.md` ledgers.
+  - Commented-out example `trading-market-open` / `trading-pre-close` slots (ET-pinned) in the default schedule — opt-in; uncomment in the vault's `schedule.yaml` to activate.
+
 ## [0.7.3] - 2026-06-23
 
 

--- a/engine/scout/defaults/schedule.yaml
+++ b/engine/scout/defaults/schedule.yaml
@@ -102,3 +102,32 @@ slots:
     missed_window_hours: 4
     on_miss: skip
     cooldown_minutes: 240
+
+  # --- Optional Agentic Trading subsystem (default-disabled) ---
+  # These slots are COMMENTED OUT so they never fire on a default install.
+  # To use the trading subsystem: (1) set `account` + `enabled: true` in
+  # knowledge-base/projects/agentic-trading/config.yaml (or `scripts/trading.sh on`),
+  # and (2) uncomment the slots below in your vault's .scout-state/schedule.yaml.
+  # `tz` pins them to US market hours (ET) regardless of the system timezone.
+  # run-trading.sh self-guards on the master switch, so even an uncommented slot
+  # is a harmless no-op until the config is enabled.
+  #
+  # trading-market-open:
+  #   type: trading
+  #   runner: run-trading.sh
+  #   fires_at_local: "10:00"
+  #   weekdays: [Mon, Tue, Wed, Thu, Fri]
+  #   missed_window_hours: 1
+  #   on_miss: skip
+  #   cooldown_minutes: 120
+  #   tz: "America/New_York"
+  #
+  # trading-pre-close:
+  #   type: trading
+  #   runner: run-trading.sh
+  #   fires_at_local: "15:30"
+  #   weekdays: [Mon, Tue, Wed, Thu, Fri]
+  #   missed_window_hours: 1
+  #   on_miss: skip
+  #   cooldown_minutes: 120
+  #   tz: "America/New_York"

--- a/engine/scout/schedule.py
+++ b/engine/scout/schedule.py
@@ -33,6 +33,7 @@ class SlotType(enum.Enum):
     CONSOLIDATION = "consolidation"
     DREAMING = "dreaming"
     RESEARCH = "research"
+    TRADING = "trading"
     MANUAL = "manual"
 
 
@@ -59,6 +60,7 @@ class SlotPriority(enum.IntEnum):
     BRIEFING = 50
     CONSOLIDATION = 40
     DREAMING = 30
+    TRADING = 25
     RESEARCH = 20
     MANUAL = 10
 
@@ -107,6 +109,7 @@ _PRIORITY_BY_TYPE: dict[SlotType, SlotPriority] = {
     SlotType.BRIEFING: SlotPriority.BRIEFING,
     SlotType.CONSOLIDATION: SlotPriority.CONSOLIDATION,
     SlotType.DREAMING: SlotPriority.DREAMING,
+    SlotType.TRADING: SlotPriority.TRADING,
     SlotType.RESEARCH: SlotPriority.RESEARCH,
     SlotType.MANUAL: SlotPriority.MANUAL,
 }

--- a/engine/scout/scripts/bootstrap.py
+++ b/engine/scout/scripts/bootstrap.py
@@ -99,6 +99,9 @@ _CAT1_FILES_FROM_PLUGIN = {
     "knowledge-base/ontology/__init__.py": "templates/knowledge-base/ontology/__init__.py",
     "action-items/render.py": "templates/action-items/render.py",
     "scripts/recurring-task-status.py": "templates/scripts/recurring-task-status.py",
+    # Optional Agentic Trading subsystem (default-disabled). Invoked via `python3`,
+    # so no chmod needed → direct copy rather than a rendered+chmod cat-1 template.
+    "scripts/trading-config.py": "templates/scripts/trading-config.py",
 }
 
 # Cat-1 files that are BOTH engine-owned AND user-editable in the vault, so they
@@ -121,6 +124,8 @@ _CAT1_TEMPLATES = (
     ("scripts/claude-with-retry.sh", "templates/scripts/claude-with-retry.sh.tmpl"),
     ("scripts/post-session-backfill.sh", "templates/scripts/post-session-backfill.sh.tmpl"),
     ("hooks/kb-pre-filter.sh", "templates/hooks/kb-pre-filter.sh.tmpl"),
+    # Optional Agentic Trading subsystem (default-disabled) — the on/off/status CLI.
+    ("scripts/trading.sh", "templates/scripts/trading.sh.tmpl"),
     (".gitignore", "templates/.gitignore.tmpl"),
 )
 
@@ -131,12 +136,34 @@ _INSTALL_ONLY_TEMPLATES = (
     ("knowledge-base/review-queue.md", "templates/review-queue.md.tmpl"),
     ("inbox.md", "templates/inbox.md.tmpl"),
     ("meetings/meetings.md", "templates/meetings/meetings.md.tmpl"),
+    # Optional Agentic Trading subsystem (default-disabled). Seeded once so the
+    # config master-switch + state ledgers persist across upgrades (user edits
+    # `config.yaml: enabled` / account; the ledgers accumulate). Never overwritten.
+    (
+        "knowledge-base/projects/agentic-trading/config.yaml",
+        "templates/knowledge-base/projects/agentic-trading/config.yaml.tmpl",
+    ),
+    (
+        "knowledge-base/projects/agentic-trading/watchlist.md",
+        "templates/knowledge-base/projects/agentic-trading/watchlist.md.tmpl",
+    ),
+    (
+        "knowledge-base/projects/agentic-trading/decision-log.md",
+        "templates/knowledge-base/projects/agentic-trading/decision-log.md.tmpl",
+    ),
+    (
+        "knowledge-base/projects/agentic-trading/nav-history.md",
+        "templates/knowledge-base/projects/agentic-trading/nav-history.md.tmpl",
+    ),
 )
 
 _CAT1B_RUNNERS = (
     ("run-scout.sh", "templates/run-scout.sh.tmpl"),
     ("run-dreaming.sh", "templates/run-dreaming.sh.tmpl"),
     ("run-research.sh", "templates/run-research.sh.tmpl"),
+    # Optional Agentic Trading subsystem (default-disabled). Self-guards on the
+    # config master switch, so a fired slot is a harmless no-op until enabled.
+    ("run-trading.sh", "templates/run-trading.sh.tmpl"),
 )
 
 
@@ -265,6 +292,12 @@ def _assemble(cfg: BootstrapConfig, kind: str) -> str:
     elif kind == "DREAMING":
         sources = [phases_root / "core", phases_root / "modes"]
         target_modes = {"dreaming"}
+    elif kind == "TRADING":
+        # Optional Agentic Trading subsystem. Pulls cross-cutting core phases
+        # whose `mode:` list includes `trading` (git-setup) + everything in
+        # phases/trading/. Stays empty/inert in vaults that never enable it.
+        sources = [phases_root / "core", phases_root / "trading"]
+        target_modes = {"trading"}
     else:  # RESEARCH
         sources = [phases_root / "core", phases_root / "research"]
         target_modes = {"research"}
@@ -300,7 +333,7 @@ def _stage_cat4_install(cfg: BootstrapConfig) -> None:
     """Stage 5 (install): assemble + write live + write snapshot."""
     snapshot_dir = cfg.vault / ".scout-state" / "last-assembled"
     snapshot_dir.mkdir(parents=True, exist_ok=True)
-    for kind in ("SKILL", "DREAMING", "RESEARCH"):
+    for kind in ("SKILL", "DREAMING", "RESEARCH", "TRADING"):
         content = _assemble(cfg, kind)
         _atomic_write(cfg.vault / f"{kind}.md", content)
         _atomic_write(snapshot_dir / f"{kind}.md", content)
@@ -329,7 +362,7 @@ def _stage_cat4_upgrade(cfg: BootstrapConfig) -> list[str]:
     snapshot_dir = cfg.vault / ".scout-state" / "last-assembled"
     snapshot_dir.mkdir(parents=True, exist_ok=True)
     conflicts: list[str] = []
-    for kind in ("SKILL", "DREAMING", "RESEARCH"):
+    for kind in ("SKILL", "DREAMING", "RESEARCH", "TRADING"):
         ours = _assemble(cfg, kind)
         live = cfg.vault / f"{kind}.md"
         theirs = live.read_text(encoding="utf-8") if live.exists() else ours

--- a/engine/tests/unit/test_bootstrap_install.py
+++ b/engine/tests/unit/test_bootstrap_install.py
@@ -67,9 +67,44 @@ def test_install_writes_assembled_files_and_snapshots(tmp_path):
     plugin = Path(__file__).parent.parent.parent.parent
     vault = tmp_path / "Scout"
     install(_config(vault, plugin_root=plugin))
-    for name in ("SKILL", "DREAMING", "RESEARCH"):
+    for name in ("SKILL", "DREAMING", "RESEARCH", "TRADING"):
         assert (vault / f"{name}.md").exists()
         assert (vault / ".scout-state" / "last-assembled" / f"{name}.md").exists()
+
+
+def test_install_seeds_agentic_trading_subsystem_disabled(tmp_path):
+    """The optional Agentic Trading subsystem renders fully but ships disabled:
+    TRADING brain assembled, runner guards on the master switch, config seeded
+    with enabled:false, and the on/off CLI + config reader present."""
+    plugin = Path(__file__).parent.parent.parent.parent
+    vault = tmp_path / "Scout"
+    cfg = _config(vault, plugin_root=plugin)
+    cfg.connector_inputs = {"user_slack_id": "U9TEST", "claude_bin": "/usr/local/bin/claude"}
+    install(cfg)
+
+    # TRADING brain assembled from phases/core + phases/trading, no briefing leakage.
+    trading_md = (vault / "TRADING.md").read_text()
+    assert "**BASE_DIR:**" in trading_md
+    assert "Reconcile" in trading_md and "source of truth" in trading_md
+    assert "Hard rules recap" in trading_md
+    assert "action-items file" not in trading_md.lower()  # briefing-only phases excluded
+
+    # Runner self-guards on the master switch before any spend; vars substituted.
+    runner = (vault / "run-trading.sh").read_text()
+    assert "{{" not in runner
+    assert "MASTER SWITCH GUARD" in runner
+
+    # Config seeded disabled; slack id rendered; account left as a fill-in placeholder.
+    config_yaml = (vault / "knowledge-base/projects/agentic-trading/config.yaml").read_text()
+    assert "enabled: false" in config_yaml
+    assert "U9TEST" in config_yaml
+    assert "<your-robinhood-account-number>" in config_yaml
+
+    # CLI + reader + ledgers present.
+    assert (vault / "scripts/trading.sh").exists()
+    assert (vault / "scripts/trading-config.py").exists()
+    for ledger in ("watchlist.md", "decision-log.md", "nav-history.md"):
+        assert (vault / "knowledge-base/projects/agentic-trading" / ledger).exists()
 
 
 def test_install_refuses_existing_vault(tmp_path):

--- a/phases/core/git-setup.md
+++ b/phases/core/git-setup.md
@@ -2,7 +2,7 @@
 phase: core
 name: git-setup
 slot: setup
-mode: [briefing, consolidation, dreaming, research]
+mode: [briefing, consolidation, dreaming, research, trading]
 requires: null
 ---
 

--- a/phases/trading/trading-loop.md
+++ b/phases/trading/trading-loop.md
@@ -1,0 +1,56 @@
+---
+phase: trading
+name: trading-loop
+slot: trading-loop
+mode: [trading]
+requires: null
+---
+
+You are {{INSTANCE_NAME}} in **TRADING** mode — the autonomous equity-trading loop for the **optional, default-disabled** Agentic Trading subsystem. Read [[agentic-trading]] for full context.
+
+> ⚠️ **Real money. System-test-first: protect capital, log every decision, and never gamble to force the target.** This subsystem places real brokerage orders via the `robinhood-trading` MCP. It is not financial advice.
+
+All file paths are relative to `{{SCOUT_DIR}}`. Use `TZ={{TIMEZONE}}` for every timestamp. Config lives at `knowledge-base/projects/agentic-trading/config.yaml`; read it with `python3 scripts/trading-config.py get <key>`.
+
+## Step 0: Guards (re-confirm in-session)
+- Read `enabled` from config. **If it is not `true`, STOP immediately — do nothing, exit.** (`run-trading.sh` already guards on this, but confirm in-session too.)
+- Read `account`, `notify_slack_id`, `mode`, the `test.*` block, and every `guardrails.*` value. **Never hard-code the account or Slack ID** — always read them from config.
+- **Deadline wind-down:** if `test.deadline` is set and today (ET) is past it, run in **report-only** mode — place no new entries; manage/exit existing positions and report only.
+- Load the `robinhood-trading` MCP tools via ToolSearch (they are deferred): at minimum `get_portfolio`, `get_equity_positions`, `get_equity_quotes`, `get_equity_orders`, `get_realized_pnl`, `review_equity_order`, `place_equity_order`, `get_equity_fundamentals`.
+
+## Step 1: Reconcile (the broker is the source of truth)
+- `get_portfolio(account_number=<account>)` → record `total_value` (NAV), `cash`, `pending_deposits`. **Settled cash = cash − pending_deposits.** If settled cash is 0 and there are no positions, there is nothing to trade — append an "awaiting settlement" row to `nav-history.md` and skip to Step 6.
+- `get_equity_positions(account_number=<account>)` → open positions (use `shares_available_for_sells` and `average_buy_price`).
+- `get_equity_orders` → any working/unfilled orders (don't double-submit).
+- `get_realized_pnl` → realized P&L to date.
+- Compute NAV, the delta vs the last `nav-history.md` row, progress toward `test.goal_nav`, and trading days left to `test.deadline`. Never trust a cached number — reconcile live every run.
+
+## Step 2: Risk gate (HARD rules from `guardrails`)
+- **Circuit breaker:** if NAV ≤ `circuit_breaker_nav` → HALT all activity, DM the operator that re-authorization is required, and exit. Place no orders.
+- **Daily loss cap:** if NAV is down more than `daily_loss_cap_pct` vs the first snapshot today → place **no new entries** this run (managing/exiting still allowed).
+- **Stop-loss:** flag any open position now ≥ `stop_loss_pct` below its `average_buy_price` for exit in Step 3.
+
+## Step 3: Manage open positions
+- For each holding: pull a live quote (`get_equity_quotes`) and re-test the original thesis (recorded in `decision-log.md`).
+- **Exit** (sell, limit order) if the stop is breached, the thesis is broken, or the target is reached. Record the reason.
+- Otherwise hold, and note the re-evaluation in the decision log.
+
+## Step 4: Consider entries (skip entirely if in wind-down or the daily loss cap fired)
+- Read `watchlist.md`. Pick the single best thesis that fits **all** guardrails:
+  - price ≥ `min_price`; not leveraged/inverse (when `no_leveraged_inverse`); liquid (sanity-check volume via `get_equity_fundamentals` / the quote).
+  - position size ≤ `max_position_pct` of NAV; funded by **settled** cash only (when `settled_cash_only`).
+  - total exposure respects `capital_cap`.
+- An earnings date is a *catalyst to watch*, **not** a pre-print gamble — prefer post-print momentum-continuation entries over betting through a binary print. A high-conviction catalyst may size up to the cap; absent a real edge, **skip — and log the skip with its reason.** Skipping is a valid, common, correct outcome.
+
+## Step 5: Execute
+- For each intended order: `review_equity_order(...)` first (dry-run / validation), then `place_equity_order(...)` as a **limit** order with a defined stop intent recorded.
+- **Degrade path (headless gating):** if `place_equity_order` is denied or blocked, do **not** abandon the decision. Append the fully-specified intended order (ticker, side, qty, limit, stop, thesis) to `decision-log.md` marked `PENDING-APPROVAL`, and include a one-tap-approve summary in the Step 6 DM. This degrades `mode: auto` to effective `propose` for that order rather than failing silently.
+
+## Step 6: Log + report
+- Append **every** decision — including skips and holds — to `decision-log.md` (timestamp ET, action, ticker, qty/$, limit, thesis/reason, stop, order ID, result).
+- Append a NAV row to `nav-history.md`.
+- Commit: `git add -A && git commit -m "trading [HH:MM]: <NAV $X (Δ), actions taken/skipped>"` (use `TZ={{TIMEZONE}}` for HH:MM).
+- DM the operator via `slack_send_message` (Slack ID `<notify_slack_id>`), ≤8 lines: NAV + delta + progress toward `test.goal_nav` + days left, what you did and why (including notable skips), and any `PENDING-APPROVAL` orders awaiting a tap. If the circuit breaker tripped, lead with that.
+
+## Hard rules recap
+Only the configured `account`. Never exceed `capital_cap`. Every position carries a stop. Settled cash only. No penny/OTC/leveraged/inverse names. Reconcile live — never trust a cached number. Protect capital over chasing the target.

--- a/templates/knowledge-base/projects/agentic-trading/config.yaml.tmpl
+++ b/templates/knowledge-base/projects/agentic-trading/config.yaml.tmpl
@@ -1,0 +1,21 @@
+# Agentic Trading — master config (optional subsystem). Seeded once; never overwritten on upgrade.
+# Field docs live in the agentic-trading charter. To enable: set `account`, set `enabled: true`
+# (or run `scripts/trading.sh on`), and add a `type: trading` slot to .scout-state/schedule.yaml.
+# NOTE: editing via trading-config.py round-trips through PyYAML and strips these comments.
+enabled: false          # ← MASTER SWITCH. Ships OFF. Nothing trades until true.
+mode: auto              # auto = place orders; propose = draft + one-tap-approve DM
+account: "<your-robinhood-account-number>"   # the agentic_allowed Robinhood account number
+notify_slack_id: "{{USER_SLACK_ID}}"
+test:
+  goal_nav: 100         # example self-test target
+  start_nav: 50         # example starting stake
+  deadline: ""          # YYYY-MM-DD; blank = no wind-down
+guardrails:
+  capital_cap: 50               # never trade beyond this; hard ceiling
+  max_position_pct: 50          # max single-name exposure (% of NAV)
+  stop_loss_pct: 18             # mandatory hard stop on every position
+  daily_loss_cap_pct: 12        # NAV down >this% in a day → no new entries that day
+  circuit_breaker_nav: 35       # NAV <= this → full halt + require re-authorization
+  min_price: 3                  # no penny/OTC names
+  no_leveraged_inverse: true    # no leveraged/inverse ETFs in v1
+  settled_cash_only: true       # avoid good-faith violations

--- a/templates/knowledge-base/projects/agentic-trading/decision-log.md.tmpl
+++ b/templates/knowledge-base/projects/agentic-trading/decision-log.md.tmpl
@@ -1,0 +1,5 @@
+# Agentic Trading — Decision Log (append-only)
+Every buy / sell / hold / skip, with reasoning and outcome. Newest at bottom.
+
+| Timestamp (ET) | Action | Ticker | Qty/$ | Limit | Thesis / reason | Stop | Order ID | Result |
+|----------------|--------|--------|-------|-------|-----------------|------|----------|--------|

--- a/templates/knowledge-base/projects/agentic-trading/nav-history.md.tmpl
+++ b/templates/knowledge-base/projects/agentic-trading/nav-history.md.tmpl
@@ -1,0 +1,5 @@
+# Agentic Trading — NAV History
+One row per trading-session reconcile. Tracks NAV toward `test.goal_nav`.
+
+| Date | Time (ET) | NAV | Cash (settled) | Positions value | Δ vs prior | Note |
+|------|-----------|-----|----------------|-----------------|-----------|------|

--- a/templates/knowledge-base/projects/agentic-trading/watchlist.md.tmpl
+++ b/templates/knowledge-base/projects/agentic-trading/watchlist.md.tmpl
@@ -1,0 +1,9 @@
+# Agentic Trading — Watchlist
+Candidate names + theses. Written by [[RESEARCH]] sessions (toggle-gated), consumed by [[TRADING]].
+Universe rule: liquid US equities/ETFs, price ≥ $3, real volume; no penny/OTC; no leveraged/inverse.
+
+> **Earnings discipline (system-test-first):** an earnings date is a *catalyst to watch*, not a pre-print gamble. Prefer post-print momentum-continuation entries; if entering before a print, size small and keep the hard stop. When in doubt, skip and log it.
+
+| Ticker | Added (ET) | Price @ add | Thesis (1 line) | Catalyst / timing | Source | Status |
+|--------|-----------|-------------|-----------------|-------------------|--------|--------|
+| _(none yet)_ | | | | | | |

--- a/templates/run-trading.sh.tmpl
+++ b/templates/run-trading.sh.tmpl
@@ -1,0 +1,103 @@
+#!/bin/bash
+# {{INSTANCE_NAME}} Trading runner — optional Agentic Trading subsystem (default-disabled).
+# Invoked by the schedule dispatcher (a `type: trading` slot) or manually.
+# GUARD FIRST: exits before any cost if the subsystem's master switch is off.
+
+set -euo pipefail
+
+SCOUT_DIR="{{SCOUT_DIR}}"
+# Exported so any consumer of scout-plugin's engine package resolves the vault.
+export SCOUT_DATA_DIR="$SCOUT_DIR"
+LOG_DIR="$SCOUT_DIR/.scout-logs"
+CLAUDE_BIN="{{CLAUDE_BIN}}"
+TIMESTAMP=$(date +%Y-%m-%d_%H-%M)
+LOG_FILE="$LOG_DIR/trading-$TIMESTAMP.log"
+LOCK_FILE="$LOG_DIR/.scout-session.lock"
+
+mkdir -p "$LOG_DIR"
+
+# --- MASTER SWITCH GUARD (before any spend) ---
+# The Agentic Trading subsystem ships disabled. A fired slot is a harmless no-op
+# until the operator sets `enabled: true` in
+# knowledge-base/projects/agentic-trading/config.yaml (e.g. via scripts/trading.sh on).
+ENABLED=$(python3 "$SCOUT_DIR/scripts/trading-config.py" get enabled 2>/dev/null || echo "false")
+if [ "$ENABLED" != "true" ]; then
+    echo "=== Agentic Trading DISABLED (config.yaml enabled != true) — skipping $(date) ===" >> "$LOG_FILE"
+    exit 0
+fi
+
+# Concurrency guard — only one {{INSTANCE_NAME}} session at a time
+if [ -f "$LOCK_FILE" ]; then
+    LOCK_PID=$(cat "$LOCK_FILE" 2>/dev/null)
+    if kill -0 "$LOCK_PID" 2>/dev/null; then
+        echo "=== Another {{INSTANCE_NAME}} session running (PID $LOCK_PID) — skipping ===" >> "$LOG_FILE"
+        exit 0
+    else
+        rm -f "$LOCK_FILE"
+    fi
+fi
+echo $$ > "$LOCK_FILE"
+trap 'rm -f "$LOCK_FILE"' EXIT
+
+PROMPT="You are {{INSTANCE_NAME}} running in TRADING mode — the optional Agentic Trading subsystem. Your working directory is {{SCOUT_DIR}}.
+
+Step 1: Read {{SCOUT_DIR}}/TRADING.md in full and follow it exactly.
+Step 2: Re-confirm the master switch in-session (config.yaml \`enabled\` must be true) and honor the deadline wind-down rule.
+
+Important:
+- The robinhood-trading MCP tools are deferred — load them via ToolSearch before use.
+- The broker is the source of truth: reconcile live before any decision.
+- Enforce every guardrail in config.yaml as a HARD rule. System-test-first: never gamble to force the target.
+- Commit with message format: trading [HH:MM]: <summary>. Use TZ={{TIMEZONE}} for timestamps.
+- Your output should focus on what you decided and why, not infrastructure steps."
+
+echo "=== {{INSTANCE_NAME}} Trading run starting at $(date) ===" >> "$LOG_FILE"
+
+# Budget check — skip if we're over the spending threshold
+BUDGET_CHECK="$SCOUT_DIR/scripts/budget-check.sh"
+if [ -x "$BUDGET_CHECK" ]; then
+    if ! "$BUDGET_CHECK" --verbose >> "$LOG_FILE" 2>&1; then
+        echo "=== Budget check: skipping this run ===" >> "$LOG_FILE"
+        exit 0
+    fi
+fi
+
+# Mode is set by the dispatcher (SCOUT_FORCE_MODE). For manual invocations
+# without SCOUT_FORCE_MODE set, default to "trading-manual".
+MODE="${SCOUT_FORCE_MODE:-trading-manual}"
+
+START_TIME=$(date +%s)
+
+# Run Claude in print mode through the retry wrapper — capture exit code without triggering set -e.
+EXIT_CODE=0
+cd "$SCOUT_DIR" && "$SCOUT_DIR/scripts/claude-with-retry.sh" \
+    "$LOG_FILE" \
+    "$CLAUDE_BIN" \
+    --permission-mode auto \
+    --model opus \
+    --max-budget-usd {{MAX_BUDGET}} \
+    --name "{{INSTANCE_NAME_LOWER}}-${MODE}-$(date +%Y%m%d-%H%M)" \
+    -p "$PROMPT" \
+    || EXIT_CODE=$?
+END_TIME=$(date +%s)
+DURATION=$((END_TIME - START_TIME))
+
+echo "=== {{INSTANCE_NAME}} Trading run finished at $(date) (exit code: $EXIT_CODE, duration: ${DURATION}s) ===" >> "$LOG_FILE"
+
+# If the run failed, log it and check for rate limiting
+if [ $EXIT_CODE -ne 0 ]; then
+    echo "{{INSTANCE_NAME}} Trading run FAILED with exit code $EXIT_CODE at $(date)" >> "$LOG_DIR/failures.log"
+    RATE_DETECT="$SCOUT_DIR/scripts/rate-limit-detect.sh"
+    if [ -x "$RATE_DETECT" ]; then
+        if "$RATE_DETECT" "$LOG_FILE" --write-tracker 2>/dev/null; then
+            echo "Rate limit detected — logged to usage tracker" >> "$LOG_FILE"
+        fi
+    fi
+fi
+
+# Track session cost (the session self-reports actual cost from inside; this runner
+# call is a fallback so failed/crashed runs still leave a row).
+COST_TRACKER="$SCOUT_DIR/scripts/write-session-cost.sh"
+if [ -x "$COST_TRACKER" ]; then
+    "$COST_TRACKER" "trading" {{MAX_BUDGET}} 0 "$EXIT_CODE" "runner" 2>/dev/null || true
+fi

--- a/templates/scripts/trading-config.py
+++ b/templates/scripts/trading-config.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Read/write the Agentic Trading config — single source of truth for the master switch.
+
+Usage:
+    trading-config.py get <dotted.key>
+    trading-config.py set <dotted.key> <value>
+
+Resolves the vault from $SCOUT_DATA_DIR (falls back to ~/Scout). NOTE: `set`
+round-trips the YAML through PyYAML, which strips comments — field docs live in
+the agentic-trading project charter, not inline.
+"""
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+VAULT = Path(os.environ.get("SCOUT_DATA_DIR", Path.home() / "Scout"))
+CONFIG = VAULT / "knowledge-base" / "projects" / "agentic-trading" / "config.yaml"
+
+
+def _load():
+    with open(CONFIG) as f:
+        return yaml.safe_load(f)
+
+
+def _coerce(v):
+    low = v.lower()
+    if low in ("true", "false"):
+        return low == "true"
+    try:
+        return int(v)
+    except ValueError:
+        pass
+    try:
+        return float(v)
+    except ValueError:
+        return v
+
+
+def main():
+    if len(sys.argv) < 3:
+        sys.exit("usage: trading-config.py get|set <dotted.key> [value]")
+    op, key = sys.argv[1], sys.argv[2]
+    data = _load()
+    parts = key.split(".")
+    node = data
+    for p in parts[:-1]:
+        node = node[p]
+    if op == "get":
+        val = node[parts[-1]]
+        print(str(val).lower() if isinstance(val, bool) else val)
+    elif op == "set":
+        if len(sys.argv) < 4:
+            sys.exit("set requires a value")
+        node[parts[-1]] = _coerce(sys.argv[3])
+        with open(CONFIG, "w") as f:
+            yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
+    else:
+        sys.exit(f"unknown op: {op}")
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/scripts/trading.sh.tmpl
+++ b/templates/scripts/trading.sh.tmpl
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Agentic Trading master switch (optional subsystem). on | off | status
+# See knowledge-base/projects/agentic-trading/agentic-trading.md
+set -euo pipefail
+
+VAULT="${SCOUT_DATA_DIR:-{{SCOUT_DIR}}}"
+CFG="$VAULT/scripts/trading-config.py"
+NAV="$VAULT/knowledge-base/projects/agentic-trading/nav-history.md"
+
+cmd="${1:-status}"
+case "$cmd" in
+  on)
+    python3 "$CFG" set enabled true
+    echo "Agentic Trading: ENABLED (mode=$(python3 "$CFG" get mode)). Runs on its market-hours schedule slot(s)."
+    ;;
+  off)
+    python3 "$CFG" set enabled false
+    echo "Agentic Trading: DISABLED. No new orders or management. Open positions are left untouched."
+    ;;
+  status)
+    en=$(python3 "$CFG" get enabled)
+    mode=$(python3 "$CFG" get mode)
+    acct=$(python3 "$CFG" get account)
+    deadline=$(python3 "$CFG" get test.deadline 2>/dev/null || echo "(unset)")
+    echo "Agentic Trading status"
+    echo "  enabled:    $en"
+    echo "  mode:       $mode"
+    echo "  account:    ••••${acct: -4}"
+    echo "  deadline:   $deadline"
+    if [ -f "$NAV" ]; then
+      echo "  last NAV:   $(grep -E '^\| [0-9]' "$NAV" | tail -1 || echo '(none yet)')"
+    fi
+    ;;
+  *)
+    echo "usage: trading.sh on|off|status" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## What this is

The **implementation** of the Agentic Trading subsystem in the engine — the follow-up to the design-only PR #171. This makes Agentic Trading a real, **distributable** Scout feature: any install can enable it, and it's generated by `scoutctl bootstrap` like every other session type.

> ⚠️ **Optional, default-disabled, real-money.** Places real brokerage orders via the `robinhood-trading` MCP. Ships **off** and does nothing until explicitly enabled. **Not financial advice.** See [the design spec](docs/superpowers/specs/2026-06-26-agentic-trading-design.md).

## How it integrates (engine-native, not a vault copy)

The vault build used a dedicated launchd plist; the engine version instead uses the **standard schedule dispatcher** — a `type: trading` slot fires through the existing 5-minute tick. No new plist.

| Layer | Change |
|-------|--------|
| `schedule.py` | `SlotType.TRADING` + `SlotPriority.TRADING = 25`; `_PRIORITY_BY_TYPE` entry |
| `bootstrap.py` | `_assemble()` gains a `TRADING` brain (sources `phases/core` + `phases/trading`, `mode: [trading]`); added to both stage-5 loops; `run-trading.sh` → `_CAT1B_RUNNERS`; `trading.sh` → `_CAT1_TEMPLATES`; `trading-config.py` → `_CAT1_FILES_FROM_PLUGIN`; config + 3 ledgers → `_INSTALL_ONLY_TEMPLATES` (never overwritten) |
| `phases/trading/trading-loop.md` | the 6-step brain (reconcile → risk gate → manage → enter → execute → log) + hard guardrails + headless degrade-to-PENDING-APPROVAL |
| `phases/core/git-setup.md` | opted into `trading` mode so the brain inherits the shared git/timezone/cost conventions |
| `templates/` | `run-trading.sh.tmpl` (guards on the master switch **before any spend**), `scripts/trading.sh.tmpl` (on/off/status), `scripts/trading-config.py`, `config.yaml.tmpl` (`enabled: false` + account placeholder), watchlist/decision-log/nav-history scaffolds |
| `defaults/schedule.yaml` | commented-out ET-pinned `trading-market-open` / `trading-pre-close` slots (opt-in) |
| `CHANGELOG.md` | `[Unreleased]` entry (manifests left for the release-time bump) |

## Two gates keep it safe

1. **Master switch** — `config.yaml: enabled` ships `false`; `run-trading.sh` exits before any spend when off, and the brain re-confirms in-session.
2. **Opt-in schedule** — the trading slots ship commented out; a fired slot is a harmless no-op until both the slot is uncommented *and* the config is enabled.

## Verification

- **End-to-end install** into a temp vault renders all 9 artifacts; `TRADING.md` assembles with the loop + git-setup conventions and **no briefing-phase leakage**.
- `ruff check` ✓ · `ruff format --check` ✓ · `mypy` ✓ (69 files) · `versioning check` ✓ (4 manifests in sync) · `shellcheck -S error` ✓ on the templates.
- **882 tests pass** (added `test_install_seeds_agentic_trading_subsystem_disabled`; extended the assembled-brains test to cover `TRADING`).

## Deliberately out of scope (follow-ups)

- No `connectors.yaml` entry for Robinhood (the brain manages its own MCP availability) — avoids touching connector-health vocabulary.
- Manifest version bump is left to the normal release flow (this PR only adds to `[Unreleased]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
