### PR TITLE
feat: proactive enrichment-recall subsystem (the "🧠 Help me remember" loop)

### DIFF
--- a/engine/scout/scripts/bootstrap.py
+++ b/engine/scout/scripts/bootstrap.py
@@ -99,6 +99,10 @@ _CAT1_FILES_FROM_PLUGIN = {
     "knowledge-base/ontology/__init__.py": "templates/knowledge-base/ontology/__init__.py",
     "action-items/render.py": "templates/action-items/render.py",
     "scripts/recurring-task-status.py": "templates/scripts/recurring-task-status.py",
+    # Proactive enrichment-recall generator (the "🧠 Help me remember" loop). Read-only
+    # KB scanner invoked by the dreaming feedback-processing phase; copied verbatim like
+    # recurring-task-status.py (no template rendering).
+    "scripts/generate-enrichment-questions.py": "templates/scripts/generate-enrichment-questions.py",
 }
 
 # Cat-1 files that are BOTH engine-owned AND user-editable in the vault, so they
@@ -131,6 +135,11 @@ _INSTALL_ONLY_TEMPLATES = (
     ("knowledge-base/review-queue.md", "templates/review-queue.md.tmpl"),
     ("inbox.md", "templates/inbox.md.tmpl"),
     ("meetings/meetings.md", "templates/meetings/meetings.md.tmpl"),
+    # Enrichment-recall state (the "🧠 Help me remember" loop). Vault-owned so an
+    # upgrade never clobbers accumulated suppressions / Q&A history. Shipped as empty
+    # headers; the stoplist grows as the user dismisses questions in-thread.
+    ("scripts/enrichment-stoplist.txt", "templates/enrichment-stoplist.txt.tmpl"),
+    ("knowledge-base/enrichment-qa-log.md", "templates/enrichment-qa-log.md.tmpl"),
 )
 
 _CAT1B_RUNNERS = (

--- a/engine/tests/unit/test_enrichment_questions.py
+++ b/engine/tests/unit/test_enrichment_questions.py
@@ -1,0 +1,243 @@
+"""Tests for the proactive enrichment-recall subsystem
+(spec 2026-06-21-enrichment-recall-subsystem-design).
+
+Covers:
+  - the generator's ranking, dedupe, persistent-stoplist, and --exclude rotation;
+  - its guards (research/connector-answerable dropped, excluded dirs scoped out,
+    resolved gaps skipped) and its read-only contract (never writes to the KB);
+  - bootstrap wiring (cat-1 generator + install-only state seeds);
+  - assembly scoping (the recall section lands in DREAMING, not SKILL/RESEARCH).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util as _ilu
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scout.scripts.bootstrap import (
+    _CAT1_FILES_FROM_PLUGIN,
+    _INSTALL_ONLY_TEMPLATES,
+    BootstrapConfig,
+    _assemble,
+)
+
+PLUGIN_ROOT = Path(__file__).parent.parent.parent.parent
+SCRIPT = PLUGIN_ROOT / "templates" / "scripts" / "generate-enrichment-questions.py"
+
+# Import the hyphen-named script via importlib (module names can't have hyphens).
+_spec = _ilu.spec_from_file_location("generate_enrichment_questions", SCRIPT)
+assert _spec is not None and _spec.loader is not None
+gen = _ilu.module_from_spec(_spec)
+_spec.loader.exec_module(gen)
+
+
+# --- fixture KB: exactly one item per rank -----------------------------------
+
+
+def _build_kb(tmp_path: Path) -> Path:
+    kb = tmp_path / "knowledge-base"
+    (kb / "people").mkdir(parents=True)
+    (kb / "personal").mkdir(parents=True)
+
+    # rank 0 — explicit [needs:] flag
+    (kb / "personal" / "notes.md").write_text(
+        "# Notes\n\n[needs: what was decided at the June offsite]\n", encoding="utf-8"
+    )
+    # rank 1 — review-queue "Question for the user:"
+    (kb / "review-queue.md").write_text(
+        "# Review Queue\n\n## Pending Review\n\n"
+        "### Migration deadline\n"
+        "**Question for the user:** What is the deadline for the migration?\n\n"
+        "## Reviewed\n",
+        encoding="utf-8",
+    )
+    # rank 2 — open question (personal-scoped, head-fact, not research-answerable)
+    (kb / "people" / "alex.md").write_text(
+        "# Alex\n\n### Open Question — What did Alex say about the reorg?\n",
+        encoding="utf-8",
+    )
+    # rank 3 — single-source claim
+    (kb / "personal" / "facts.md").write_text(
+        "# Facts\n\nAlex prefers async standups over live meetings [single-source]\n",
+        encoding="utf-8",
+    )
+    # rank 4 — thin/stub entity (frontmatter type:, empty body but for Relations)
+    (kb / "people" / "priya.md").write_text(
+        "---\ntype: person\nname: Priya\n---\n\n## Relations\n- [[team]]\n",
+        encoding="utf-8",
+    )
+    return kb
+
+
+def _snapshot(kb: Path) -> dict[str, str]:
+    return {
+        p.relative_to(kb).as_posix(): hashlib.sha256(p.read_bytes()).hexdigest()
+        for p in sorted(kb.rglob("*")) if p.is_file()
+    }
+
+
+# --- ranking / dedupe --------------------------------------------------------
+
+
+def test_ranking_covers_all_five_sources_in_order(tmp_path):
+    kb = _build_kb(tmp_path)
+    items = gen.collect(kb)
+    assert [it["rank"] for it in items] == [0, 1, 2, 3, 4]
+    assert "offsite" in items[0]["question"].lower()
+    assert items[1]["source"] == "review-queue.md"
+    assert "reorg" in items[2]["question"].lower()
+    assert items[3]["question"].startswith("Can you confirm or correct")
+    assert "stub" in items[4]["question"].lower()
+
+
+def test_limit_via_cli_json(tmp_path):
+    kb = _build_kb(tmp_path)
+    out = subprocess.run(
+        [sys.executable, str(SCRIPT), "--kb", str(kb), "--json",
+         "--no-reject-file", "--limit", "2"],
+        capture_output=True, text=True, check=True,
+    )
+    payload = json.loads(out.stdout)
+    assert payload["count"] == 2
+    assert payload["total_available"] == 5
+    assert [q["rank"] for q in payload["questions"]] == [0, 1]
+
+
+# --- persistent stoplist + one-run rotation ----------------------------------
+
+
+def test_reject_file_suppresses_forever(tmp_path):
+    kb = _build_kb(tmp_path)
+    stoplist = tmp_path / "enrichment-stoplist.txt"
+    stoplist.write_text("# comment ignored\nreorg\n\n", encoding="utf-8")
+    rejects = gen.load_reject_file(stoplist)
+    assert rejects == ["reorg"]
+    items = gen.collect(kb, exclude=rejects)
+    assert all("reorg" not in it["question"].lower() for it in items)
+    assert len(items) == 4  # the rank-2 open question is gone
+
+
+def test_exclude_is_a_single_run_rotation(tmp_path):
+    kb = _build_kb(tmp_path)
+    # Passing the prior run's fingerprint (topic "priya") drops that one item.
+    items = gen.collect(kb, exclude=["priya"])
+    assert all(it["rank"] != 4 for it in items)
+    assert len(items) == 4
+
+
+def test_missing_reject_file_is_tolerated(tmp_path):
+    assert gen.load_reject_file(tmp_path / "does-not-exist.txt") == []
+
+
+# --- guards ------------------------------------------------------------------
+
+
+def test_research_answerable_open_questions_are_dropped(tmp_path):
+    kb = _build_kb(tmp_path)
+    # "who introduced" is connector-history-answerable → not a user-only gap.
+    (kb / "people" / "sam.md").write_text(
+        "# Sam\n\n### Open Question — Who introduced Sam to the team?\n",
+        encoding="utf-8",
+    )
+    questions = " ".join(it["question"].lower() for it in gen.collect(kb))
+    assert "who introduced sam" not in questions
+
+
+def test_excluded_dirs_are_scoped_out(tmp_path):
+    kb = _build_kb(tmp_path)
+    (kb / "projects").mkdir()
+    (kb / "ontology" / "entities").mkdir(parents=True)
+    (kb / "projects" / "migration.md").write_text(
+        "# Migration\n\n### Open Question — Should we use a new repo or a folder?\n",
+        encoding="utf-8",
+    )
+    (kb / "ontology" / "entities" / "acme.md").write_text(
+        "# Acme\n\n### Open Question — Is Acme a current customer?\n"
+        "Some fact about the vendor [single-source] that should not surface here.\n",
+        encoding="utf-8",
+    )
+    sources = {it["source"] for it in gen.collect(kb)}
+    assert not any(s.startswith(("projects/", "ontology/entities/")) for s in sources)
+
+
+def test_resolved_gaps_are_skipped(tmp_path):
+    kb = _build_kb(tmp_path)
+    (kb / "personal" / "done.md").write_text(
+        "# Done\n\n### Open Question — What was the outcome? ✅ RESOLVED\n",
+        encoding="utf-8",
+    )
+    assert all(it["source"] != "personal/done.md" for it in gen.collect(kb))
+
+
+# --- read-only contract ------------------------------------------------------
+
+
+def test_generator_never_writes_to_the_kb(tmp_path):
+    kb = _build_kb(tmp_path)
+    before = _snapshot(kb)
+    subprocess.run(
+        [sys.executable, str(SCRIPT), "--kb", str(kb), "--json", "--no-reject-file"],
+        capture_output=True, text=True, check=True,
+    )
+    gen.collect(kb)
+    assert _snapshot(kb) == before  # identical file set + contents
+
+
+def test_missing_kb_dir_exits_nonzero(tmp_path):
+    r = subprocess.run(
+        [sys.executable, str(SCRIPT), "--kb", str(tmp_path / "nope"), "--no-reject-file"],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 2
+
+
+# --- bootstrap wiring --------------------------------------------------------
+
+
+def test_generator_wired_as_cat1_file():
+    assert (_CAT1_FILES_FROM_PLUGIN["scripts/generate-enrichment-questions.py"]
+            == "templates/scripts/generate-enrichment-questions.py")
+
+
+def test_state_files_seeded_install_only():
+    seeded = dict(_INSTALL_ONLY_TEMPLATES)
+    assert seeded["scripts/enrichment-stoplist.txt"] == "templates/enrichment-stoplist.txt.tmpl"
+    assert seeded["knowledge-base/enrichment-qa-log.md"] == "templates/enrichment-qa-log.md.tmpl"
+
+
+# --- assembly scoping --------------------------------------------------------
+
+
+def _config(*, enabled_connectors: set[str] | None = None) -> BootstrapConfig:
+    return BootstrapConfig(
+        vault=Path("/tmp/does-not-matter"),
+        plugin_root=PLUGIN_ROOT,
+        instance_name="TestScout",
+        instance_name_lower="testscout",
+        user_name="Test User",
+        user_email="test@example.com",
+        timezone="America/New_York",
+        platform="macos",
+        plugin_version="0.0.0",
+        enabled_connectors=enabled_connectors or set(),
+        connector_inputs={},
+        skip_jobs=True,
+        skip_claude=True,
+    )
+
+
+def test_dreaming_includes_enrichment_recall():
+    dreaming = _assemble(_config(enabled_connectors={"slack"}), "DREAMING")
+    assert "Help me remember" in dreaming
+    assert "generate-enrichment-questions.py" in dreaming
+
+
+def test_enrichment_recall_scoped_to_dreaming():
+    skill = _assemble(_config(enabled_connectors={"slack"}), "SKILL")
+    research = _assemble(_config(enabled_connectors={"slack"}), "RESEARCH")
+    assert "Help me remember" not in skill
+    assert "Help me remember" not in research

--- a/engine/tests/unit/test_enrichment_questions.py
+++ b/engine/tests/unit/test_enrichment_questions.py
@@ -76,7 +76,8 @@ def _build_kb(tmp_path: Path) -> Path:
 def _snapshot(kb: Path) -> dict[str, str]:
     return {
         p.relative_to(kb).as_posix(): hashlib.sha256(p.read_bytes()).hexdigest()
-        for p in sorted(kb.rglob("*")) if p.is_file()
+        for p in sorted(kb.rglob("*"))
+        if p.is_file()
     }
 
 
@@ -97,9 +98,10 @@ def test_ranking_covers_all_five_sources_in_order(tmp_path):
 def test_limit_via_cli_json(tmp_path):
     kb = _build_kb(tmp_path)
     out = subprocess.run(
-        [sys.executable, str(SCRIPT), "--kb", str(kb), "--json",
-         "--no-reject-file", "--limit", "2"],
-        capture_output=True, text=True, check=True,
+        [sys.executable, str(SCRIPT), "--kb", str(kb), "--json", "--no-reject-file", "--limit", "2"],
+        capture_output=True,
+        text=True,
+        check=True,
     )
     payload = json.loads(out.stdout)
     assert payload["count"] == 2
@@ -181,7 +183,9 @@ def test_generator_never_writes_to_the_kb(tmp_path):
     before = _snapshot(kb)
     subprocess.run(
         [sys.executable, str(SCRIPT), "--kb", str(kb), "--json", "--no-reject-file"],
-        capture_output=True, text=True, check=True,
+        capture_output=True,
+        text=True,
+        check=True,
     )
     gen.collect(kb)
     assert _snapshot(kb) == before  # identical file set + contents
@@ -190,7 +194,8 @@ def test_generator_never_writes_to_the_kb(tmp_path):
 def test_missing_kb_dir_exits_nonzero(tmp_path):
     r = subprocess.run(
         [sys.executable, str(SCRIPT), "--kb", str(tmp_path / "nope"), "--no-reject-file"],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert r.returncode == 2
 
@@ -199,8 +204,10 @@ def test_missing_kb_dir_exits_nonzero(tmp_path):
 
 
 def test_generator_wired_as_cat1_file():
-    assert (_CAT1_FILES_FROM_PLUGIN["scripts/generate-enrichment-questions.py"]
-            == "templates/scripts/generate-enrichment-questions.py")
+    assert (
+        _CAT1_FILES_FROM_PLUGIN["scripts/generate-enrichment-questions.py"]
+        == "templates/scripts/generate-enrichment-questions.py"
+    )
 
 
 def test_state_files_seeded_install_only():

--- a/phases/modes/feedback-processing.md
+++ b/phases/modes/feedback-processing.md
@@ -136,14 +136,43 @@ For each improvement that targets `SKILL.md` (from Step 1d):
 
 ***
 
-### Step 1f: Commit
+### Step 1f: Proactive Enrichment Recall — the "🧠 Help me remember" loop
 
-If Phase 1 made any changes (mistake audit updates, KB fixes, dreaming improvements, applied proposals, new proposals):
+This is the *pull*-capture half of the feedback loop: {{INSTANCE_NAME}} proactively asks {{USER_NAME}} a small, rotating set of questions about facts **no connector can see** — in-person events, decisions, relationships, head-knowledge — and later feeds the answers back into the KB, enriching the graph faster than passive scanning can. It lives in this phase because this phase already harvests in-thread replies (Step 1a) and is the natural place to record a dismissal.
+
+**1. Handle answers & dismissals to the *previous* run's questions** (from the thread replies harvested in Step 1a):
+- **Answered** → capture the fact into the appropriate KB file (cite: "per {{USER_NAME}} enrichment reply on [date]"), and log the round to `knowledge-base/enrichment-qa-log.md`.
+- **Dismissed** ("I don't care" / "you should already know this" / a ❌ on the question) → append the question's distinguishing keyword (a short substring, one per line) to `scripts/enrichment-stoplist.txt` so it can never resurface. Log the round as dismissed.
+
+**2. Generate this run's candidates.** Run the read-only generator (it never writes to the KB):
+
+```bash
+python3 {{SCOUT_DIR}}/scripts/generate-enrichment-questions.py --limit 3 \
+  --exclude "<prior run's surfaced fingerprint>" [--exclude "<another>" ...]
+```
+
+- The persistent stoplist (`scripts/enrichment-stoplist.txt`) is loaded automatically on every run.
+- Pass one `--exclude` per question surfaced in the **previous** run (its topic / source / keyword). This is the **rotation** rule — a question never repeats two runs in a row — made mechanical by the script; do not re-derive it by hand.
+
+**3. Apply the quality rules** (the valuable kernel — the generator enforces most of this, but you are the last gate):
+- **User-only-answerable, not connector-answerable.** Drop any question a connector or research session could resolve (customer/contract status, "who introduced X", SDK/API facts). The bar is "is this a head-fact only {{USER_NAME}} holds?"
+- **No over-suppression to zero.** A constant trickle is the goal. If the generator returns nothing, do **not** ask nothing — hand-mine the day's deltas for one judgment question rather than staying silent.
+- **Self-containment.** A question referencing a specific artifact must carry a link/locator **and** a one-line gist, and keep the artifact title visually distinct from the ask — including on re-surface (never "the question from earlier").
+
+**4. Compose the "🧠 Help me remember" block** into the dreaming wrap DM — the picked questions (typically 1–3), each self-contained per the rule above. This is the only user-facing output of this step; everything else is state.
+
+**Record what was surfaced** to `knowledge-base/enrichment-qa-log.md` so the *next* run can rotate it out (pass it back via `--exclude`) and match answers/dismissals in Step 1a.
+
+***
+
+### Step 1g: Commit
+
+If Phase 1 made any changes (mistake audit updates, KB fixes, dreaming improvements, applied proposals, new proposals, enrichment stoplist/Q&A-log updates):
 
 ```bash
 git -C {{SCOUT_DIR}} add -A && git -C {{SCOUT_DIR}} commit -m "dreaming [HH:MM]: feedback processing — <summary of changes>"
 ```
 
-The summary should mention what was processed: e.g., "3 feedback signals, 1 new mistake pattern, 2 KB fixes" or "applied 1 approved proposal, added 2 new proposals."
+The summary should mention what was processed: e.g., "3 feedback signals, 1 new mistake pattern, 2 KB fixes" or "applied 1 approved proposal, added 2 new proposals, 1 enrichment answer captured."
 
-If Phase 1 found no actionable feedback (no reactions, no thread replies in the time window), skip the commit and proceed to Phase 2. Log "No feedback signals found in time window" in the session entry.
+If Phase 1 found no actionable feedback (no reactions, no thread replies in the time window) **and** surfaced no enrichment questions, skip the commit and proceed to Phase 2. Log "No feedback signals found in time window" in the session entry.

--- a/templates/enrichment-qa-log.md.tmpl
+++ b/templates/enrichment-qa-log.md.tmpl
@@ -1,0 +1,16 @@
+# Enrichment Q&A Log
+
+History of the "🧠 Help me remember" pull-capture loop: what {{INSTANCE_NAME}} asked
+{{USER_NAME}}, what was answered, and what it enriched in the KB. One round per entry,
+newest first. Vault-owned — seeded once on install, never overwritten on upgrade.
+
+**Parent:** [[knowledge-base]]
+
+<!--
+Entry format (a dreaming run appends one block per surfaced round):
+
+## <YYYY-MM-DD HH:MM> — <short topic>
+- **Asked:** <the question, self-contained, with its source locator>
+- **Answered:** <the user's reply, or "no reply" / "dismissed">
+- **Enriched:** <what changed in the KB — file(s) + one-line gist, or "none">
+-->

--- a/templates/enrichment-stoplist.txt.tmpl
+++ b/templates/enrichment-stoplist.txt.tmpl
@@ -1,0 +1,15 @@
+# enrichment-stoplist.txt — persistent suppression list for the "🧠 Help me remember" loop.
+#
+# One suppression substring per line (case-insensitive). Any candidate enrichment
+# question whose topic / question / source contains a line here is suppressed on
+# EVERY run — permanently, unlike the one-run --exclude rotation.
+#
+# Two classes of never-ask topics belong here:
+#   (a) capabilities {{INSTANCE_NAME}} already instruments — asking about them reads as
+#       "the assistant doesn't know its own system".
+#   (b) questions {{USER_NAME}} has explicitly dismissed in-thread ("I don't care" /
+#       "you should already know this"). The dreaming run appends the keyword here.
+#
+# Blank lines and `#` comments are ignored. This file is vault-owned: it is seeded
+# once on install and never overwritten on upgrade, so it accumulates your own
+# suppressions over time. Shipped empty on purpose — a fresh install starts clean.

--- a/templates/scripts/generate-enrichment-questions.py
+++ b/templates/scripts/generate-enrichment-questions.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""generate-enrichment-questions.py — proactive KB-enrichment question generator.
+
+The *pull*-capture half of the capture-surface family (the inverse of a *push*-capture
+notepad): instead of waiting for the user to dump notes, the system proactively asks a
+small, ranked set of questions about gaps that NO connector can fill — facts that live
+only in the user's head or in in-person / verbal events the system never sees.
+
+Sources scanned, in priority order (all things only the user can resolve):
+  0. Explicit `[needs: …]` inline gap-flags                          — rank 0. A deliberately
+     placed connector-blind marker ("ask me this"), so it outranks every heuristic source.
+  1. review-queue.md "Question for the user:" / "Ask the user:" lines — rank 1. Explicitly
+     user-directed by a prior run.
+  2. Entity / KB "Open Question(s)" sections                         — rank 2. An open thread
+     that names a head-fact (personal-scoped only; see ENRICHMENT_EXCLUDED_DIRS).
+  3. [single-source] / [unverified] tagged claims                   — rank 3. The second
+     source is often the user.
+  4. Thin / stub entity files (frontmatter present, body near-empty) — rank 4. A connector can
+     create the node, but only the user knows the substance.
+
+Output: a short ranked list (default 5) that a dreaming/briefing run can paste into a
+DM, or `--json` for tooling. This is a read-only scanner — it never writes to the KB.
+
+Usage:
+    python3 scripts/generate-enrichment-questions.py [--limit N] [--json] [--kb DIR]
+                                                     [--thin-threshold CHARS]
+                                                     [--exclude SUBSTR ...]
+                                                     [--reject-file PATH | --no-reject-file]
+
+`--exclude` (repeatable) suppresses any question whose topic/question/source contains the
+substring (case-insensitive). The dreaming run passes the prior run's surfaced fingerprints
+so the "🧠 Help me remember" block never repeats a question two runs in a row — making the
+recall step's rotation rule mechanical rather than compose-time discipline.
+
+`--reject-file` is a *persistent* stoplist (default: scripts/enrichment-stoplist.txt) loaded
+on every run. Unlike --exclude (a one-run rotation), its substrings suppress questions forever.
+It carries two classes of never-ask topics:
+  (a) capabilities the system already instruments — asking reads as "the assistant doesn't
+      know its own system", and
+  (b) questions the user has explicitly dismissed as irrelevant — an in-thread "I don't care"
+      / "you should already know this" is a permanent suppression.
+When the user rejects a question in-thread, the dreaming run appends its keyword to that file so
+the same dead question can never resurface. Pass --no-reject-file to disable for debugging.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_KB = Path(__file__).resolve().parent.parent / "knowledge-base"
+DEFAULT_REJECT_FILE = Path(__file__).resolve().parent / "enrichment-stoplist.txt"
+
+# Files that only *discuss* markers in prose (narrative), never carry live ones to ask about.
+NARRATIVE_SKIP = {"scout-mistake-audit.md", "review-queue.md"}  # review-queue handled separately
+
+# Open-questions phrased as *research/connector* actions are answerable WITHOUT the user — they
+# belong to the research session, not the "🧠 Help me remember" enrichment block, which exists
+# only for facts no connector can see. Conservative phrasing match — only drops questions that
+# explicitly point at a non-user source. The classes below are the generic, tenant-agnostic
+# kernel of "a connector/research pass can resolve this":
+#   · research/investigation actions (web search, contact form, case study, "should confirm")
+#   · attribution ("who introduced / routed / brought in X") — discoverable from connector
+#     history (who created the issue / opened the thread), not a user-held fact
+#   · customer / contract / account status — CRM- or project-lookup facts, not head-facts
+#   · an answer attributed to a *named non-user person* ("X should know / may have / likely has")
+#   · connector- or profile-answerable identity facts (title, handle, direct contact)
+# NOTE (the subtle part — flag for review): this guard was generalized from an employer-specific
+# alternation to employer-agnostic phrasing. It must keep the connector-answerable-vs-head-fact
+# discrimination without hardcoding any org/product vocabulary.
+RESEARCH_ANSWERABLE = re.compile(
+    r"research pass|contact form|\bping\b|\bweb search\b|should confirm|records? should|"
+    r"public confirmation|case study|audit first|next .{0,20}research|"
+    # attribution — who did/connected/introduced something (connector-history-answerable)
+    r"who routed|who introduced|who brought|who connected|who referred|how was .{0,30}introduced|"
+    # customer / contract / account status — CRM- or project-lookup, not a head-fact
+    r"current paying|paying .{0,15}customer|customer status|customer vs|customer or a|"
+    r"stalled prospect|contract scope|\baccount id\b|crm record|deal stage|renewal date|"
+    # an answer attributed to a named non-user person ("X should know / may have / likely has")
+    r"should know|may have|likely has|"
+    # connector- / profile-answerable identity facts
+    r"exact title|title at|slack handle|direct contact",
+    re.I,
+)
+
+# Entity files under ontology/entities/ are ORGANIZATION + TECHNOLOGY research artifacts, and
+# project files are workstream-investigation logs. Their "Open Question" sections are
+# overwhelmingly research/connector-answerable — confirm an external fact, a customer/product
+# status, a product capability, or a design/decision backlog item — i.e. research-session work,
+# not the connector-blind head-facts the "🧠 Help me remember" block exists for. So both dirs are
+# scoped OUT of the enrichment surface here (they still drive the *research* session via the
+# research queue, which this generator does not feed). people/ + personal/ open-questions stay:
+# relationship and family facts skew genuinely user-only. Deliberate project decisions still reach
+# enrichment via rank-0 [needs:] markers and rank-1 review-queue asks.
+ENRICHMENT_EXCLUDED_DIRS = ("ontology/entities/", "projects/")
+
+
+def _clean(text: str) -> str:
+    """Strip markdown emphasis / wikilink brackets for a readable question."""
+    text = re.sub(r"\*\*?|__?|`", "", text)
+    text = re.sub(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]", r"\1", text)
+    return text.strip()
+
+
+# Explicit inline gap-flag convention: `[needs: <what user-only fact is missing>]`.
+# Deliberately placed (by the user or a run that identified a connector-blind gap) to mean
+# "ask me this" — so it outranks every heuristic source. The body after the colon becomes the
+# question verbatim. Lives anywhere in the KB; NARRATIVE_SKIP files are excluded (they discuss
+# the convention in prose). A resolved flag is removed, not marked — its absence is the close.
+NEEDS_MARKER = re.compile(r"\[needs:\s*(.+?)\]", re.I)
+
+
+def scan_needs_markers(kb: Path) -> list[dict]:
+    """Explicit `[needs: …]` inline flags — the highest-intent enrichment signal (rank 0)."""
+    out = []
+    for path in sorted(kb.rglob("*.md")):
+        if path.name in NARRATIVE_SKIP:
+            continue
+        rel = path.relative_to(kb).as_posix()
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        for m in NEEDS_MARKER.finditer(text):
+            want = _clean(m.group(1)).rstrip(". ")
+            if len(want) < 3:
+                continue
+            out.append({
+                "rank": 0,
+                "source": rel,
+                "topic": rel.rsplit("/", 1)[-1].replace(".md", ""),
+                "question": f"{want}?" if "?" not in want else want,
+            })
+    return out
+
+
+def scan_review_queue(kb: Path) -> list[dict]:
+    """Pending-review items with an explicit question for the user — highest heuristic priority."""
+    out = []
+    rq = kb / "review-queue.md"
+    if not rq.exists():
+        return out
+    lines = rq.read_text(encoding="utf-8").splitlines()
+    # Only items under "## Pending Review" (stop at "## Recently Processed" / "## Reviewed").
+    in_pending = False
+    current_title = None
+    for line in lines:
+        if line.startswith("## "):
+            in_pending = line.strip().lower().startswith("## pending")
+            continue
+        if not in_pending:
+            continue
+        if line.startswith("### "):
+            current_title = _clean(line[4:])
+            continue
+        m = re.match(r"\s*\*\*(?:Question for the user|Ask the user)[:：]\*\*\s*(.+)", line, re.I)
+        if m and current_title:
+            out.append({
+                "rank": 1,
+                "source": "review-queue.md",
+                "topic": current_title,
+                "question": _clean(m.group(1)),
+            })
+    return out
+
+
+def scan_open_questions(kb: Path) -> list[dict]:
+    """'Open Question' headers / lines across KB files (entity & project open threads)."""
+    out = []
+    for path in sorted(kb.rglob("*.md")):
+        if path.name in NARRATIVE_SKIP:
+            continue
+        rel = path.relative_to(kb).as_posix()
+        # org/tech entity + project open-questions are research-session work, not head-facts —
+        # scoped out of the enrichment surface (see ENRICHMENT_EXCLUDED_DIRS).
+        if any(rel.startswith(d) for d in ENRICHMENT_EXCLUDED_DIRS):
+            continue
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except (UnicodeDecodeError, OSError):
+            continue
+        for i, line in enumerate(lines):
+            # Headed open-question lines: "Open Question #N — ..." or "### Open Questions"
+            m = re.match(r"\s*#{2,5}\s*Open Question[s]?\s*(?:#\d+)?\s*[—\-:]?\s*(.*)", line, re.I)
+            if not m:
+                continue
+            # Strip a trailing parenthetical scope-note ("(for the user to resolve …)") off the header.
+            text = re.sub(r"^\(.*?\)\s*", "", m.group(1).strip()).strip("() ")
+            # A real question contains "?"; otherwise the header is just a section label —
+            # fall through to the first substantive bullet under it.
+            if "?" not in text:
+                for nxt in lines[i + 1:i + 8]:
+                    if re.match(r"\s*#{1,5}\s", nxt):  # next header ⇒ stop
+                        break
+                    b = re.match(r"\s*[-*\d.]+\s+(.+)", nxt)
+                    if b and (("?" in b.group(1)) or len(b.group(1).strip()) > 40):
+                        text = b.group(1)
+                        break
+            # Skip questions already answered in-place: a resolution sentinel (✅ / RESOLVED /
+            # MOOT / DONE) or a struck-through (~~…~~) line is a closed gap, not something to
+            # re-ask the user.
+            if re.search(r"✅|~~|\bRESOLVED\b|\bMOOT\b|\bDONE\b", text, re.I):
+                continue
+            # Research/connector-answerable → not a user-only enrichment gap.
+            if RESEARCH_ANSWERABLE.search(text):
+                continue
+            # A line carrying an explicit [needs: …] flag is already surfaced at rank 0 by
+            # scan_needs_markers — don't also emit the raw-marker text as a rank-2 question.
+            if NEEDS_MARKER.search(text):
+                continue
+            if text and len(text.strip()) > 8:
+                out.append({
+                    "rank": 2,
+                    "source": rel,
+                    "topic": rel.rsplit("/", 1)[-1].replace(".md", ""),
+                    "question": _clean(text)[:240],
+                })
+    return out
+
+
+def scan_unverified(kb: Path) -> list[dict]:
+    """[single-source] / [unverified] claims — a second source is often only the user."""
+    out = []
+    pat = re.compile(r"\[(single-source|unverified)\]", re.I)
+    for path in sorted(kb.rglob("*.md")):
+        if path.name in NARRATIVE_SKIP:
+            continue
+        rel = path.relative_to(kb).as_posix()
+        # Same scoping as the open-question scan: projects/ + ontology/entities/ single-source
+        # claims are research/connector-answerable (confirm against docs/code/connector history),
+        # not connector-blind head-facts.
+        if any(rel.startswith(d) for d in ENRICHMENT_EXCLUDED_DIRS):
+            continue
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except (UnicodeDecodeError, OSError):
+            continue
+        for line in lines:
+            stripped = line.strip()
+            # Skip table rows: a [single-source]/[unverified] marker inside a `|`-delimited row
+            # tags the row's data, and slicing the cell text yields an unreadable fragment
+            # ("| Vendor — direct API (admin) | …") — not an askable claim.
+            if stripped.startswith("|"):
+                continue
+            # Skip resolved-in-place claims + research/connector-answerable phrasing, mirroring
+            # the rank-2 open-question guards so rank-3 holds the same user-only bar.
+            if re.search(r"✅|~~|\bRESOLVED\b|\bMOOT\b|\bDONE\b", line, re.I):
+                continue
+            if RESEARCH_ANSWERABLE.search(line):
+                continue
+            if pat.search(line) and len(stripped) > 25:
+                claim = _clean(pat.sub("", line))[:200]
+                out.append({
+                    "rank": 3,
+                    "source": rel,
+                    "topic": rel.rsplit("/", 1)[-1].replace(".md", ""),
+                    "question": f"Can you confirm or correct this single-sourced claim? — {claim}",
+                })
+    return out
+
+
+def scan_thin_entities(kb: Path, threshold: int = 200) -> list[dict]:
+    """Entity files (YAML frontmatter with a `type:`) whose body is near-empty — stubs that
+    exist as a graph node but were never enriched. The body-text floor (non-whitespace chars
+    after the closing frontmatter fence, excluding the Relations block) is the 'never enriched'
+    signal: a connector can create the node but only the user knows the substance.
+    Scoped to the entity folders (ontology/entities, people, personal) so prose KB files and
+    long-form project notes are never mistaken for stubs."""
+    out = []
+    entity_dirs = ("ontology/entities", "people", "personal")
+    for path in sorted(kb.rglob("*.md")):
+        rel = path.relative_to(kb).as_posix()
+        if not any(rel.startswith(d + "/") for d in entity_dirs):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        # Require YAML frontmatter delimited by leading '---'.
+        if not text.startswith("---"):
+            continue
+        parts = text.split("---", 2)
+        if len(parts) < 3:
+            continue
+        front, body = parts[1], parts[2]
+        mtype = re.search(r"^\s*type:\s*(.+)$", front, re.M)
+        name = re.search(r"^\s*name:\s*(.+)$", front, re.M)
+        if not mtype:
+            continue
+        etype = mtype.group(1).strip().strip("\"'")
+        ename = _clean(name.group(1)) if name else rel.rsplit("/", 1)[-1].replace(".md", "")
+        # Body length excluding a Relations/relationships block and whitespace — that's
+        # graph plumbing, not human-readable substance.
+        body_wo_rels = re.split(r"(?im)^#{1,4}\s*relation", body)[0]
+        substance = re.sub(r"\s+", "", body_wo_rels)
+        if len(substance) < threshold:
+            out.append({
+                "rank": 4,
+                "source": rel,
+                "topic": ename,
+                "question": (f"The {ename} ({etype}) entity is a stub "
+                             f"({len(substance)} chars of body) — what's the substance here? "
+                             f"(role, why it matters to you, key facts)"),
+            })
+    return out
+
+
+def load_reject_file(path: Path) -> list[str]:
+    """Read a persistent stoplist file — one suppression substring per line, `#` comments
+    and blank lines ignored. Returns [] if the file is missing (default-on but optional)."""
+    if not path or not path.exists():
+        return []
+    out = []
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            s = line.split("#", 1)[0].strip()
+            if s:
+                out.append(s)
+    except OSError:
+        return []
+    return out
+
+
+def collect(kb: Path, thin_threshold: int = 200,
+            exclude: list[str] | None = None) -> list[dict]:
+    items = (scan_needs_markers(kb) + scan_review_queue(kb) + scan_open_questions(kb)
+             + scan_unverified(kb) + scan_thin_entities(kb, thin_threshold))
+    # Dedupe on (source, question), keep best (lowest) rank.
+    seen: dict[tuple, dict] = {}
+    for it in items:
+        key = (it["source"], it["question"][:80])
+        if key not in seen or it["rank"] < seen[key]["rank"]:
+            seen[key] = it
+    ranked = sorted(seen.values(), key=lambda x: (x["rank"], x["source"]))
+    # Rotation guard: drop any item whose topic/question/source contains an
+    # excluded substring (case-insensitive). The dreaming run passes the prior
+    # run's surfaced fingerprints here so the "🧠 Help me remember" block never
+    # repeats a question two runs in a row — the recall step's rotate rule made
+    # mechanical rather than compose-time discipline.
+    if exclude:
+        needles = [s.lower() for s in exclude if s and s.strip()]
+        if needles:
+            ranked = [
+                it for it in ranked
+                if not any(
+                    n in (it["topic"] + " " + it["question"] + " " + it["source"]).lower()
+                    for n in needles
+                )
+            ]
+    return ranked
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Generate KB-enrichment questions (facts only the user can answer).")
+    ap.add_argument("--limit", type=int, default=5, help="Max questions to emit (default 5).")
+    ap.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+    ap.add_argument("--kb", type=Path, default=DEFAULT_KB, help="knowledge-base directory.")
+    ap.add_argument("--thin-threshold", type=int, default=200,
+                    help="Body-char floor below which an entity file counts as a thin stub (default 200).")
+    ap.add_argument("--exclude", action="append", default=[], metavar="SUBSTR",
+                    help="Suppress questions whose topic/question/source contains SUBSTR "
+                         "(case-insensitive, repeatable). Used by the dreaming run to pass the "
+                         "prior run's surfaced questions so the recall block never repeats two runs "
+                         "in a row.")
+    ap.add_argument("--reject-file", type=Path, default=DEFAULT_REJECT_FILE, metavar="PATH",
+                    help="Persistent stoplist file (default: scripts/enrichment-stoplist.txt) — its "
+                         "substrings suppress questions on EVERY run (known-answer / instrumented "
+                         "topics + user-rejected questions). One substring per line, # comments OK.")
+    ap.add_argument("--no-reject-file", action="store_true",
+                    help="Ignore the persistent stoplist (debugging — surfaces suppressed questions).")
+    args = ap.parse_args()
+
+    if not args.kb.exists():
+        print(f"error: KB directory not found: {args.kb}", file=sys.stderr)
+        return 2
+
+    rejects = [] if args.no_reject_file else load_reject_file(args.reject_file)
+    ranked = collect(args.kb, args.thin_threshold, args.exclude + rejects)
+    picked = ranked[: args.limit] if args.limit and args.limit > 0 else ranked
+
+    if args.json:
+        print(json.dumps({"count": len(picked), "total_available": len(ranked),
+                          "questions": picked}, indent=2, ensure_ascii=False))
+        return 0
+
+    if not picked:
+        print("No enrichment questions found — the KB has no open gaps to ask about.")
+        return 0
+
+    tier = {0: "explicit [needs:] flag", 1: "explicit review-queue ask", 2: "open question",
+            3: "single-source claim", 4: "thin/stub entity"}
+    print(f"🧠 {len(picked)} enrichment questions "
+          f"({len(ranked)} available; user-only-answerable gaps):\n")
+    for n, it in enumerate(picked, 1):
+        print(f"{n}. [{tier[it['rank']]} · {it['source']}]")
+        print(f"   {it['question']}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements the design spec merged in #150 (`docs/superpowers/specs/2026-06-21-enrichment-recall-subsystem-design.md`) — the **pull-capture** half of the feedback loop. At the end of a dreaming run the system appends a small ranked set of "🧠 Help me remember …" questions to its wrap DM, asking about facts **no connector can see** (in-person events, decisions, head-knowledge), and later feeds the answers back into the KB.

## What's here (matches the spec's 4-part plan)

1. **Generator** → `templates/scripts/generate-enrichment-questions.py`, wired into `_CAT1_FILES_FROM_PLUGIN` exactly like `recurring-task-status.py` (raw `.py`, copied verbatim, no template rendering). A pure-stdlib, **read-only** KB scanner that ranks connector-blind candidates (rank 0 explicit `[needs:]` flags → rank 4 thin stubs), with one-run `--exclude` **rotation** and a persistent `--reject-file` **stoplist**.
2. **State seeds** (install-only, never clobbered on upgrade) → `scripts/enrichment-stoplist.txt` + `knowledge-base/enrichment-qa-log.md`, added to `_INSTALL_ONLY_TEMPLATES`. Shipped as empty headers.
3. **Recall section** → `phases/modes/feedback-processing.md` (dreaming-scoped): generate → quality-gate → compose the "🧠 Help me remember" block → record dismissals to the stoplist and rounds to the Q&A log. New `Step 1f`; old commit step renumbered to `1g`.
4. **Tests** → `engine/tests/unit/test_enrichment_questions.py`.

## De-personalization (this is the public engine)

The generator was ported from a running instance and scrubbed: stripped dated user-feedback quotes, real names, employer references, and `Pattern #NN` citations; genericized the argparse/header string literals.

⚠️ **Please scrutinize the regex generalization** (the spec called this out as the subtlest change): the connector-answerable guard `RESEARCH_ANSWERABLE` previously hardcoded the employer name in an alternation (`…|<employer> customer|…`) plus product-specific jargon. It's now employer-agnostic (`customer status`, `account id`, `crm record`, `deal stage`, `renewal date`, attribution phrasing, named-non-user-person phrasing, connector/profile identity facts) — aiming to keep the connector-answerable-vs-head-fact discrimination without baking in any org/product vocabulary. A scrub check confirms no leaked identifiers.

## Verification

- `883 passed` (full engine unit suite) — incl. bootstrap install/upgrade wiring.
- `ruff check` clean on the new/changed files.
- New tests cover: ranking/dedupe, persistent stoplist, `--exclude` rotation, the guards (research-answerable dropped, `projects/` + `ontology/entities/` scoped out, resolved gaps skipped), the **read-only contract** (asserts the KB is byte-identical after a run), bootstrap wiring, and assembly scoping (recall lands in DREAMING, not SKILL/RESEARCH).

## Open questions carried from the spec

- The engine has no dedicated dreaming **notification-composition** phase; the recall attaches to `feedback-processing.md` (the closest existing home). A future consolidation would be a cleaner home — out of scope here.
- `enrichment-qa-log.md` growth is unbounded today; a retention policy is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)