### PR TITLE
feat: add Asana (CLI-first), Jira, and Google Chat connectors

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "scout",
       "source": "./",
-      "description": "Autonomous knowledge management and daily briefing system for Claude Code",
+      "description": "Autonomous knowledge management and daily briefing system for Claude Code. Monitors Slack, Gmail, Google Calendar, Google Chat, Linear, Jira, Asana, GitHub, Granola, and Google Drive; synthesizes findings into a persistent knowledge base and delivers scheduled daily action items.",
       "version": "0.7.3",
       "author": {
         "name": "Jordan Burger"
@@ -20,7 +20,18 @@
         "briefing",
         "automation",
         "scheduling",
-        "obsidian"
+        "obsidian",
+        "connectors",
+        "slack",
+        "gmail",
+        "google-calendar",
+        "google-chat",
+        "linear",
+        "jira",
+        "asana",
+        "github",
+        "granola",
+        "google-drive"
       ]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -190,9 +190,12 @@ The `.scout-cache/` directory is gitignored — everything in it is recomputed o
 | Connector | What it provides | Required? |
 |-----------|-----------------|-----------|
 | Slack | Message monitoring, outbound tracking, feedback loop | No (enables dreaming feedback) |
+| Google Chat (`gws` CLI) | Space/DM monitoring, outbound tracking, notifications | No |
 | Google Calendar | Meeting context, scheduling verification | No |
 | Gmail | Email tracking, sent mail verification | No |
 | Linear | Issue tracking, status sync | No |
+| Jira (`jtk` CLI) | Issue tracking, JQL search, sprint snapshot, status sync | No |
+| Asana (`asana-api` CLI) | Task tracking, project sections, due-date triage, status sync, comments incl. @mentions | No |
 | GitHub (`gh` CLI) | PR tracking, commit monitoring, review requests | No |
 | Granola | Meeting transcripts | No |
 | Google Drive | Documents, meeting notes | No |

--- a/commands/scout-setup.md
+++ b/commands/scout-setup.md
@@ -79,6 +79,84 @@ Read the merged probe registry (shipped probes unioned with the user's
 `~/Scout/connector-probes.local.yaml` overlay, if present). Use the
 `$SCOUTCTL` resolved in Step 0:
 
+For each connector below, attempt the probe. Wrap each probe in error handling — if a tool call fails or returns an error, mark that connector as not connected and move on. Never let a failed probe crash the wizard.
+
+### Slack
+
+Try calling the Slack MCP tool `slack_read_user_profile` (or `mcp__plugin_slack_slack__slack_read_user_profile` if using the full tool name). If the call succeeds and returns profile data, Slack is connected.
+
+- Set `SLACK_ENABLED=true`
+- If connected, ask: "Slack is connected! What's your Slack member ID? (In Slack, click your profile photo, then the three dots menu, then 'Copy member ID')"
+- Store the response as `USER_SLACK_ID`
+- If not connected: set `SLACK_ENABLED=false`, `USER_SLACK_ID=""`
+
+### Google Chat
+
+Run via Bash:
+```bash
+gws chat spaces list --format json --params '{"pageSize":1}' >/dev/null 2>&1 && echo OK || echo FAIL
+```
+If the output is `OK`, Google Chat (via the `gws` Google Workspace CLI) is connected. If `gws` is not on PATH, the command fails — treat as not connected and tell the user where to install it (`https://github.com/googleworkspace/cli`, or `engine/scout/docs/connectors/google-chat-setup.md` once scaffolded).
+
+- Set `GOOGLE_CHAT_ENABLED=true` or `false`
+- If connected, ask: "Google Chat is connected! What's your Google Chat user ID? (The numeric ID after `users/` in your profile resource name. Run `gws chat users get --params '{\"name\":\"users/me\"}'` to retrieve it — copy the digits from the `name` field.)"
+- Store the response as `USER_GOOGLE_CHAT_ID` (digits only — Scout will format as `users/<id>` where needed)
+- If not connected: set `GOOGLE_CHAT_ENABLED=false`, `USER_GOOGLE_CHAT_ID=""`
+
+### Google Calendar
+
+Try calling `gcal_list_calendars` (or `mcp__claude_ai_Google_Calendar__gcal_list_calendars`). If it returns calendar data, Calendar is connected.
+
+- Set `CALENDAR_ENABLED=true` or `false`
+
+### Gmail
+
+Try calling `gmail_get_profile` (or `mcp__claude_ai_Gmail__gmail_get_profile`). If it returns profile data, Gmail is connected.
+
+- Set `EMAIL_ENABLED=true` or `false`
+
+### Linear
+
+Try calling `list_teams` (or `mcp__plugin_linear_linear__list_teams`). If it returns team data, Linear is connected.
+
+- Set `LINEAR_ENABLED=true` or `false`
+
+### Jira
+
+Run via Bash:
+```bash
+jtk config test 2>&1
+```
+If the exit code is 0 and the output reports a successful connection, Jira (via the `jtk` Atlassian CLI — https://github.com/open-cli-collective/atlassian-cli) is connected. If `jtk` is not on PATH, treat as not connected and tell the user where to install it (`engine/scout/docs/connectors/jira-setup.md` once scaffolded).
+
+- Set `JIRA_ENABLED=true` or `false`
+- If connected, capture the user's Jira account ID:
+  ```bash
+  jtk me --id
+  ```
+  Store the printed account ID as `USER_JIRA_ACCOUNT_ID`.
+- If connected, ask: "Jira is connected! Which Jira projects should Scout monitor? (Comma-separated project keys, e.g. `PROJ, PLAT, OPS`. The first one is treated as your primary project for sprint queries. Press enter to skip — you can add these later in scout-config.yaml.)"
+- Store the response as `JIRA_PROJECTS` (raw comma-separated string — the queries quote each value as needed)
+- The first key in `JIRA_PROJECTS` is `JIRA_PRIMARY_PROJECT` (use the empty string if `JIRA_PROJECTS` is empty)
+- If not connected: set `JIRA_ENABLED=false`, `USER_JIRA_ACCOUNT_ID=""`, `JIRA_PROJECTS=""`, `JIRA_PRIMARY_PROJECT=""`
+
+### Asana
+
+Scout drives Asana through the bundled **asana-api CLI** (a PAT-based REST wrapper staged into the vault at `scripts/asana_api.py`); the claude.ai Asana MCP server is the runtime fallback.
+
+Detect by running `python3 ~/Scout/scripts/asana_api.py whoami` (the script reads the PAT from `~/.agent-skills/asana/asana_pat` or `$ASANA_ACCESS_TOKEN`). If it returns user data with a `gid`, Asana is connected. If the script isn't staged yet, run the equivalent MCP `get_me` instead.
+
+- If neither the CLI nor MCP returns a `gid`, the PAT isn't set. Point the user to `engine/scout/docs/connectors/asana-setup.md`: generate a PAT at https://app.asana.com/0/my-apps and store it at `~/.agent-skills/asana/asana_pat` (chmod 600). Then re-run `whoami`.
+- Set `ASANA_ENABLED=true`
+- Capture the user's Asana GID directly from the `whoami` response (the `data.gid` field — no separate prompt needed). Store as `USER_ASANA_GID`.
+- Ask: "Asana is connected! Which Asana projects should Scout monitor? (Comma-separated project GIDs. You can find a project's GID in its URL: `app.asana.com/0/<GID>/...`. Press enter to skip — you can add these later in scout-config.yaml.)"
+- Store the response as `ASANA_PROJECTS` (raw comma-separated GID list — the queries quote each value as needed)
+- Capture the workspace GID from the `whoami` response (`data.workspaces[0].gid`); if multiple, ask which one. Store as `ASANA_WORKSPACE_GID`. (`asana_api.py whoami` returns the workspace list, so no separate prompt is usually needed.)
+- If not connected: set `ASANA_ENABLED=false`, `USER_ASANA_GID=""`, `ASANA_PROJECTS=""`, `ASANA_WORKSPACE_GID=""`
+
+### GitHub
+
+Run via Bash:
 ```bash
 "$SCOUTCTL" connectors probe-registry --json
 ```
@@ -111,9 +189,17 @@ After all probes complete, present the checklist as a tidy summary:
 
 ```
 Connected tools:
-  [✓] Slack          [✓] Calendar          [✗] Gmail
-  [✓] Linear         [✓] GitHub             [✗] Granola
-  [✗] Drive          [✓] Claude Sessions
+  [✓] Slack
+  [✓] Google Chat (gws CLI)
+  [✓] Google Calendar
+  [✓] Gmail
+  [✓] Linear
+  [✓] Jira (jtk CLI)
+  [✓] Asana
+  [✓] GitHub (gh CLI)
+  [✓] Granola
+  [✓] Google Drive
+  [✓] Claude Code session history
 ```
 
 Confirm with the user: "Proceed with these connectors? Or pause to enable more first?"
@@ -141,7 +227,110 @@ Build the comma-separated connector list (only enabled), then run (use the `$SCO
 
 The plist + cron block installed by this step automatically reference `$SCOUTCTL` — `resolve_scoutctl_bin()` derives the path from the running engine's plugin root, so the scheduler is always pinned to the venv the wizard just used.
 
-Capture exit code and stdout. The command emits one line per concern: `installed: <path>`, `doctor: green`, plus warnings for sidecar files or missing snapshots.
+### 3b. Process template files
+
+The plugin's template files are in `${CLAUDE_PLUGIN_ROOT}/templates/`. Read each template file, replace all `{{TEMPLATE_VARIABLES}}` with the collected values, and write the result to the corresponding location in SCOUT_DIR.
+
+**Variable reference for template replacement:**
+
+| Variable | Value |
+|----------|-------|
+| `{{INSTANCE_NAME}}` | The instance name (e.g., "Scout") |
+| `{{INSTANCE_NAME_LOWER}}` | Lowercased, hyphenated instance name (e.g., "scout") |
+| `{{USER_NAME}}` | The user's name |
+| `{{USER_EMAIL}}` | The user's email |
+| `{{USER_SLACK_ID}}` | Slack member ID (or empty string if not connected) |
+| `{{USER_GOOGLE_CHAT_ID}}` | Google Chat user ID — digits only (or empty string if not connected) |
+| `{{USER_JIRA_ACCOUNT_ID}}` | Jira account ID from `jtk me --id` (or empty string if not connected) |
+| `{{JIRA_PROJECTS}}` | Comma-separated Jira project keys (or empty string) |
+| `{{JIRA_PRIMARY_PROJECT}}` | First key from `JIRA_PROJECTS` (or empty string) — used for sprint queries |
+| `{{USER_ASANA_GID}}` | Asana user GID from `asana_api.py whoami` `data.gid` (or empty string if not connected) |
+| `{{ASANA_PROJECTS}}` | Comma-separated Asana project GIDs (or empty string) |
+| `{{ASANA_WORKSPACE_GID}}` | Asana workspace GID from `whoami` `data.workspaces[].gid` (or empty string) |
+| `{{GITHUB_USERNAME}}` | GitHub username (or empty string if not connected) |
+| `{{GITHUB_REPOS}}` | Comma-separated repo list (or empty string) |
+| `{{SCOUT_DIR}}` | Absolute path to the Scout directory |
+| `{{TODAY_DATE}}` | Today's date in YYYY-MM-DD format |
+| `{{SLACK_ENABLED}}` | "true" or "false" |
+| `{{GOOGLE_CHAT_ENABLED}}` | "true" or "false" |
+| `{{CALENDAR_ENABLED}}` | "true" or "false" |
+| `{{EMAIL_ENABLED}}` | "true" or "false" |
+| `{{LINEAR_ENABLED}}` | "true" or "false" |
+| `{{JIRA_ENABLED}}` | "true" or "false" |
+| `{{ASANA_ENABLED}}` | "true" or "false" |
+| `{{GITHUB_ENABLED}}` | "true" or "false" |
+| `{{GRANOLA_ENABLED}}` | "true" or "false" |
+| `{{DRIVE_ENABLED}}` | "true" or "false" |
+| `{{CLAUDE_SESSIONS_ENABLED}}` | "true" or "false" |
+| `{{MAX_BUDGET}}` | e.g., "10" |
+| `{{TIMEZONE}}` | e.g., "America/New_York" |
+| `{{PLATFORM}}` | "macos" or "linux" |
+| `{{BRIEFING_TIME}}` | e.g., "8:03" |
+| `{{CONSOLIDATION_TIMES}}` | e.g., "11:03, 13:07, 17:03" |
+| `{{DREAMING_TIMES}}` | e.g., "18:33, 20:33" |
+| `{{WEEKDAYS_ONLY}}` | "true" or "false" |
+
+**Template file mapping:**
+
+1. Read `${CLAUDE_PLUGIN_ROOT}/templates/knowledge-base/knowledge-base.md.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/knowledge-base/knowledge-base.md`
+2. Read `${CLAUDE_PLUGIN_ROOT}/templates/knowledge-base/people.md.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/knowledge-base/people.md`
+3. Read `${CLAUDE_PLUGIN_ROOT}/templates/knowledge-base/channels.md.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/knowledge-base/channels.md`
+4. Read `${CLAUDE_PLUGIN_ROOT}/templates/knowledge-base/projects/projects.md.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/knowledge-base/projects/projects.md`
+5. Read `${CLAUDE_PLUGIN_ROOT}/templates/docs/Wishlist.md.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/docs/Wishlist.md`
+5a. Read `${CLAUDE_PLUGIN_ROOT}/templates/docs/Wishlist-in-progress.md.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/docs/Wishlist-in-progress.md`
+5b. Read `${CLAUDE_PLUGIN_ROOT}/templates/docs/Wishlist-done.md.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/docs/Wishlist-done.md`
+6. Read `${CLAUDE_PLUGIN_ROOT}/templates/scout-config.yaml.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/scout-config.yaml`
+7. Read `${CLAUDE_PLUGIN_ROOT}/templates/knowledge-base/research-queue.md.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/knowledge-base/research-queue.md`
+8. Read `${CLAUDE_PLUGIN_ROOT}/templates/knowledge-base/ontology/schema.yaml.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/knowledge-base/ontology/schema.yaml`
+9. Copy `${CLAUDE_PLUGIN_ROOT}/templates/knowledge-base/ontology/parser.py` -> write to `{{SCOUT_DIR}}/knowledge-base/ontology/parser.py` (no variable replacement needed — this is Python code)
+10. Copy `${CLAUDE_PLUGIN_ROOT}/templates/knowledge-base/ontology/__init__.py` -> write to `{{SCOUT_DIR}}/knowledge-base/ontology/__init__.py`
+
+**Script templates (after template processing):**
+
+11. Read `${CLAUDE_PLUGIN_ROOT}/templates/scripts/budget-check.sh.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/scripts/budget-check.sh` -> `chmod +x`
+12. Read `${CLAUDE_PLUGIN_ROOT}/templates/scripts/write-session-cost.sh.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/scripts/write-session-cost.sh` -> `chmod +x`
+13. Read `${CLAUDE_PLUGIN_ROOT}/templates/scripts/rate-limit-detect.sh.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/scripts/rate-limit-detect.sh` -> `chmod +x`
+14. Read `${CLAUDE_PLUGIN_ROOT}/templates/scripts/heartbeat.sh.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/scripts/heartbeat.sh` -> `chmod +x`
+
+**Pre-session hook templates (new in v0.3.0):**
+
+15. Read `${CLAUDE_PLUGIN_ROOT}/templates/hooks/kb-pre-filter.sh.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/hooks/kb-pre-filter.sh` -> `chmod +x`
+16. Read `${CLAUDE_PLUGIN_ROOT}/templates/scripts/pre-session-data.sh.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/scripts/pre-session-data.sh` -> `chmod +x`
+17. Read `${CLAUDE_PLUGIN_ROOT}/templates/scripts/cc-session-cache.sh.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/scripts/cc-session-cache.sh` -> `chmod +x`
+
+**Action-items dashboard templates (optional GUI, new in v0.3.0):**
+
+18. Copy `${CLAUDE_PLUGIN_ROOT}/templates/action-items/render.py` -> write to `{{SCOUT_DIR}}/action-items/render.py` (no variable replacement — standalone Python script). After copying, `chmod +x` is not required; the script is invoked via `python3`.
+19. Read `${CLAUDE_PLUGIN_ROOT}/templates/action-items/watch.sh.tmpl` -> replace variables -> write to `{{SCOUT_DIR}}/action-items/watch.sh` -> `chmod +x`
+
+For each template: read the file content, perform a global find-and-replace for every `{{VARIABLE}}` in the table above, and write the result. If a variable has no value (e.g., `USER_SLACK_ID` when Slack is not connected), replace it with an empty string.
+
+### 3c. Create additional files
+
+**`.gitignore`** at `{{SCOUT_DIR}}/.gitignore`:
+
+```
+.scout-logs/
+.scout-cache/
+.obsidian/
+.DS_Store
+__pycache__/
+*.pyc
+```
+
+**`dreaming-proposals.md`** at `{{SCOUT_DIR}}/dreaming-proposals.md`:
+
+```markdown
+# Dreaming Proposals
+
+Proposals for changes to SKILL.md, generated by dreaming feedback processing runs. {{USER_NAME}} reviews and approves proposals; the next dreaming run applies approved ones.
+
+## How It Works
+
+1. Dreaming Phase 1 identifies improvements from feedback signals
+2. Changes targeting SKILL.md are written here as proposals (never edited directly)
+3. {{USER_NAME}} reviews and changes status to `Approved` for items to apply
+4. The next dreaming run applies approved proposals and marks them `Applied`
 
 ---
 
@@ -191,7 +380,135 @@ Otherwise: "First scheduled run will fire at the next slot in `~/Scout/.scout-st
 
 ## Manual Reset
 
-If you need to wipe Scout entirely and start over:
+Tell the user: "Assembling your personalized skill files based on your connected tools. This is the core step — I'm reading the phase files and composing them into complete, self-contained skill files."
+
+### How Assembly Works
+
+The plugin ships phase files in `${CLAUDE_PLUGIN_ROOT}/phases/` organized into three directories:
+- `phases/core/` — Always included (git setup, KB management, action items)
+- `phases/connectors/` — Included only if the corresponding connector is enabled
+- `phases/modes/` — Dreaming-specific phases
+
+Each phase file has YAML frontmatter with fields: `phase`, `name`, `slot`, `mode`, `requires`. Files with multiple sections separated by `---` have multiple frontmatter blocks — each section is independent.
+
+**Filtering rule:** A section is included if `requires` is `null` (always include) OR the connector named in `requires` is enabled in the user's config. If `requires` names a connector that is not enabled, skip that section entirely.
+
+### Assemble SKILL.md
+
+Read all phase files from `${CLAUDE_PLUGIN_ROOT}/phases/core/` and `${CLAUDE_PLUGIN_ROOT}/phases/connectors/`. Parse each file's frontmatter sections. Filter based on enabled connectors.
+
+Write `{{SCOUT_DIR}}/SKILL.md` with the following structure. Replace all `{{VARIABLES}}` with collected values. For each `[INSERT: ...]` marker below, paste the FULL content from the corresponding phase section (everything after the frontmatter, with template variables replaced). Do not summarize or abbreviate — include the complete text of each phase section.
+
+```markdown
+---
+name: {{INSTANCE_NAME_LOWER}}
+description: Morning briefing and knowledge base consolidation — manages action items, queries connectors, and maintains the persistent knowledge base
+---
+
+You are running the **{{INSTANCE_NAME}}** autonomous knowledge management and daily briefing system. This task runs at scheduled times on weekdays and operates in two modes depending on the current hour.
+
+**BASE_DIR:** `{{SCOUT_DIR}}`
+
+All file paths in this document are relative to BASE_DIR unless otherwise noted.
+
+<!-- Assembled by scout-setup from phase files. Re-run /scout-setup to regenerate. -->
+
+## Determine Your Mode
+
+Check the current time:
+```bash
+date '+%H %Z'
+```
+
+- **If the hour is {{BRIEFING_HOUR}} ({{BRIEFING_DISPLAY}}) AND it's a weekday (Mon-Fri)** -> run in **MORNING BRIEFING** mode (full cold-start)
+- **If the hour is {{BRIEFING_HOUR}} ({{BRIEFING_DISPLAY}}) AND it's a weekend (Sat/Sun)** -> run in **WEEKEND BRIEFING** mode (lighter version)
+- **If the hour is {{CONSOLIDATION_HOURS_DISPLAY}}** -> run in **CONSOLIDATION** mode (lightweight delta)
+- **If any other hour** (manual trigger) -> check day of week: if weekend, use **WEEKEND BRIEFING**; if weekday, use **CONSOLIDATION** if today's action items exist, otherwise **MORNING BRIEFING**
+
+---
+
+[INSERT: Full content of phases/core/git-setup.md — the "Step 0: Git Setup" and "Using Git History" sections, with variables replaced]
+
+[INSERT: Full content of phases/core/kb-management.md — the "Knowledge Base Management Guidelines", "Source Equality Principle", and all subsections, with variables replaced]
+
+---
+
+# MORNING BRIEFING MODE
+
+[INSERT: Full content of phases/core/action-items.md — the "Archive Old Action Items", "Action Item Categories", "Action Items File Format", "Mandatory Cross-Check", "Source Equality for Action Items" sections, with variables replaced. Exclude the "Per-Item Reconciliation" section — that is consolidation-only.]
+
+## Query All Connectors
+
+Gather data from all connected services. For each connector below, run the query to build a complete picture before writing any action items.
+
+[For each enabled connector that has a `slot: query` section, INSERT the full query section content here as a subsection. Only include connectors where the corresponding ENABLED flag is true. Each gets its own subsection header.]
+
+[If Slack is enabled, INSERT: slack query section]
+[If Google Chat is enabled, INSERT: google-chat query section]
+[If Calendar is enabled, INSERT: calendar query section]
+[If Gmail is enabled, INSERT: email query section]
+[If Linear is enabled, INSERT: linear query section]
+[If Jira is enabled, INSERT: jira query section]
+[If Asana is enabled, INSERT: asana query section]
+[If GitHub is enabled, INSERT: github query section]
+[If Granola is enabled, INSERT: granola query section]
+[If Drive is enabled, INSERT: drive query section]
+
+## Cross-Check and Build Action Items
+
+**Before ANY item becomes a To Do, it must pass ALL available cross-checks.** Run every cross-check from every connected service.
+
+[INSERT: The "Mandatory Cross-Check" rules from action-items.md if not already included above]
+
+[For each enabled connector that has a `slot: cross-check` section, INSERT the full cross-check content. Only include connectors where the corresponding ENABLED flag is true.]
+
+[If Slack is enabled, INSERT: slack cross-check section]
+[If Google Chat is enabled, INSERT: google-chat cross-check section]
+[If Calendar is enabled, INSERT: calendar cross-check section]
+[If Linear is enabled, INSERT: linear cross-check section]
+[If Jira is enabled, INSERT: jira cross-check section]
+[If Asana is enabled, INSERT: asana cross-check section]
+[If GitHub is enabled, INSERT: github cross-check section]
+
+## Write Today's Action Items
+
+Create `action-items/action-items-YYYY-MM-DD.md` using today's date. Follow the Action Items File Format specified above. Every item must have survived the cross-check gauntlet before being written.
+
+Include:
+- All urgent items first
+- To Do items with full context and source citations
+- Watching items for things being tracked
+- Done items with evidence of completion
+- Carryover items from previous days that are still open (read yesterday's action items file if it exists)
+
+All action items files must include `[[wikilinks]]` to any KB files referenced by action items.
+
+## Update Knowledge Base
+
+After building action items, update the KB with everything learned during the query phase.
+
+[For each enabled connector that has a `slot: update` section, INSERT the full update content. Only include connectors where the corresponding ENABLED flag is true.]
+
+[If Slack is enabled, INSERT: slack update section]
+[If Google Chat is enabled, INSERT: google-chat update section]
+[If Calendar is enabled, INSERT: calendar update section]
+[If Linear is enabled, INSERT: linear update section]
+[If Jira is enabled, INSERT: jira update section]
+[If Asana is enabled, INSERT: asana update section]
+[If GitHub is enabled, INSERT: github update section]
+
+### General KB Updates (all runs)
+
+- Update `knowledge-base.md` with a session entry in the Recent Sessions table
+- Update any project files that received new information from any connector
+- Add new people to `people.md` if discovered during queries
+- Update cross-references and `[[wikilinks]]` across all modified files
+- Route any uncertain claims to `knowledge-base/review-queue.md`
+- Update "Last verified" dates on files that were checked against live sources
+
+## Git Commit
+
+Commit all changes with a descriptive message:
 
 ```bash
 # macOS
@@ -205,4 +522,526 @@ crontab -l | sed '/# >>> scout-managed >>>/,/# <<< scout-managed <<</d' | cronta
 rm -rf ~/Scout
 ```
 
-Then re-run `/scout-setup`.
+The summary should mention: number of action items by category, which connectors were queried, and what KB files were updated. Keep it to one line.
+
+---
+
+# CONSOLIDATION MODE
+
+Consolidation is a lighter, delta-focused run. It looks at what changed since the last run, reconciles action items, and does a KB audit pass.
+
+## PHASE 1: What Did {{USER_NAME}} Do?
+
+Search for evidence of {{USER_NAME}}'s own actions since the last run. This is the most important phase — outbound activity is the strongest signal for what has been handled.
+
+[For each enabled connector that has a `slot: outbound-scan` section, INSERT the full outbound-scan content. Only include connectors where the corresponding ENABLED flag is true.]
+
+[If Slack is enabled, INSERT: slack outbound-scan section]
+[If Google Chat is enabled, INSERT: google-chat outbound-scan section]
+[If Calendar is enabled, INSERT: calendar outbound-scan section]
+[If Gmail is enabled, INSERT: email outbound-scan section]
+[If GitHub is enabled, INSERT: github outbound-scan section]
+[If Claude Sessions is enabled, INSERT: claude-sessions outbound-scan section]
+
+## PHASE 2: What Happened?
+
+Check for inbound activity — things directed at {{USER_NAME}} or relevant to {{USER_NAME}}'s projects since the last run.
+
+[For each enabled connector that has a `slot: inbound-scan` section, INSERT the full inbound-scan content. Only include connectors where the corresponding ENABLED flag is true.]
+
+[If Slack is enabled, INSERT: slack inbound-scan section]
+[If Google Chat is enabled, INSERT: google-chat inbound-scan section]
+[If Calendar is enabled, INSERT: calendar inbound-scan section]
+[If Gmail is enabled, INSERT: email inbound-scan section]
+[If Linear is enabled, INSERT: linear inbound-scan section]
+[If Jira is enabled, INSERT: jira inbound-scan section]
+[If Asana is enabled, INSERT: asana inbound-scan section]
+[If GitHub is enabled, INSERT: github inbound-scan section]
+[If Granola is enabled, INSERT: granola inbound-scan section]
+[If Drive is enabled, INSERT: drive inbound-scan section]
+
+## PHASE 3: Per-Item Reconciliation
+
+This is the most important step of consolidation. Every action item being written or updated must go through individual reconciliation. Do not batch or shortcut this.
+
+[INSERT: Full "Per-Item Reconciliation (Consolidation Mode)" section from phases/core/action-items.md, with variables replaced — includes steps 1-5: Check if handled, Targeted topic search, Enrich with specifics, Apply cross-check, Write with full context]
+
+Run every available cross-check from connected services:
+
+[For each enabled connector that has a `slot: cross-check` section, INSERT the full cross-check content. Only include connectors where the corresponding ENABLED flag is true.]
+
+[If Slack is enabled, INSERT: slack cross-check section]
+[If Google Chat is enabled, INSERT: google-chat cross-check section]
+[If Calendar is enabled, INSERT: calendar cross-check section]
+[If Linear is enabled, INSERT: linear cross-check section]
+[If Jira is enabled, INSERT: jira cross-check section]
+[If Asana is enabled, INSERT: asana cross-check section]
+[If GitHub is enabled, INSERT: github cross-check section]
+
+Update the "Last consolidated" timestamp in the action items file after reconciliation is complete.
+
+## PHASE 4: Knowledge Base Audit and Improvement
+
+Every consolidation run must audit at minimum 2 KB files — one deep pass and one quick pass.
+
+### Deep Pass (1 file)
+
+Pick the stalest high-priority project file (or `people.md`/issue tracker if those are staler). For this file:
+- Re-query the relevant connectors for current data
+- Verify every factual claim against live sources
+- Update statuses, people, decisions, and open questions
+- Apply verification levels to any claims you cannot confirm
+- Fix broken `[[wikilinks]]` and add missing cross-references
+- Update "Last verified" date with today's date and which sources were checked
+
+### Quick Pass (1+ files)
+
+Pick 1-2 additional files and do a lighter check:
+- Verify the most important claims (statuses, assignments)
+- Check that the file's structure matches expectations for its type
+- Update "Last verified" if you confirmed data against a live source
+- Flag anything that needs a deep pass in a future run
+
+### KB Update from Consolidation Findings
+
+[For each enabled connector that has a `slot: update` section, INSERT the full update content if not already included. Only include connectors where the corresponding ENABLED flag is true.]
+
+Update `knowledge-base.md` with a session entry. Route uncertain claims to `review-queue.md`.
+
+## PHASE 5: Git Commit
+
+```bash
+cd "{{SCOUT_DIR}}" && git add -A && git commit -m "consolidation [$(date +%H:%M)]: <summary>"
+```
+
+The summary should mention: action items reconciled (new/updated/completed), KB files audited, and notable findings. Keep it to one line.
+
+## PHASE 6: Notification
+
+[If Slack is enabled, INSERT: Full notification section from slack.md — both consolidation and briefing notification formats, notification rules]
+
+[If Google Chat is enabled, INSERT: Full notification section from google-chat.md — DM-space resolution, both consolidation and briefing notification formats, notification rules]
+
+[If neither Slack nor Google Chat is enabled:]
+The git commit message serves as the run record. No external notification is sent. If you want notifications, connect Slack or Google Chat and re-run `/scout-setup`.
+
+---
+
+## Your Details
+
+- **Instance:** {{INSTANCE_NAME}}
+- **User:** {{USER_NAME}}
+- **Email:** {{USER_EMAIL}}
+[If Slack is enabled:] - **Slack ID:** {{USER_SLACK_ID}}
+[If Google Chat is enabled:] - **Google Chat user:** users/{{USER_GOOGLE_CHAT_ID}}
+[If GitHub is enabled:] - **GitHub:** {{GITHUB_USERNAME}}
+[If GitHub repos are configured:] - **Monitored repos:** {{GITHUB_REPOS}}
+```
+
+**IMPORTANT:** When writing SKILL.md, you must paste the FULL text of each phase section — do not use `[INSERT: ...]` placeholders in the output file. The markers above are instructions to you about what to include. The final SKILL.md must be completely self-contained with no references to phase files.
+
+### Assemble DREAMING.md
+
+Read phase files from `${CLAUDE_PLUGIN_ROOT}/phases/modes/` and the core setup/KB phases. Filter based on enabled connectors.
+
+Write `{{SCOUT_DIR}}/DREAMING.md` with the following structure:
+
+```markdown
+---
+name: {{INSTANCE_NAME_LOWER}}-dreaming
+description: Evening self-improvement and KB deep work — processes feedback, proposes skill improvements, and does knowledge base deep work
+---
+
+You are running **{{INSTANCE_NAME}}** in **DREAMING** mode — the evening self-improvement and knowledge base deep work session. This is distinct from the morning briefing and daytime consolidation runs.
+
+**BASE_DIR:** `{{SCOUT_DIR}}`
+
+All file paths in this document are relative to BASE_DIR unless otherwise noted.
+
+<!-- Assembled by scout-setup from phase files. Re-run /scout-setup to regenerate. -->
+
+## What Dreaming Does
+
+Three phases, every run:
+
+1. **Feedback Processing** — Read {{USER_NAME}}'s reactions and replies on {{INSTANCE_NAME}}'s messages, classify feedback, update the mistake audit, apply direct improvements to KB files, and write proposals for SKILL.md changes through a gated workflow.
+2. **KB Deep Work** — Score every KB file on staleness, gaps, structural integrity, and feedback signals. Dynamically pick the highest-value improvement work.
+3. **Wishlist** — Check `docs/Wishlist.md` for feature requests. Pick one actionable item per run and implement it.
+
+## What Dreaming Does NOT Do
+
+- No action items work (no reading, updating, or creating action-items files)
+- No "what happened today" delta scanning
+- No morning briefing mode
+- No Calendar/Gmail scanning for activities
+- No status reports or external artifacts
+
+---
+
+## Time Check
+
+Check the current time:
+```bash
+date '+%H %Z'
+```
+
+- **If the hour is {{DREAMING_HOUR_1}} ({{DREAMING_DISPLAY_1}})** -> first evening run (full day's feedback)
+- **If the hour is {{DREAMING_HOUR_2}} ({{DREAMING_DISPLAY_2}})** -> second evening run (new feedback + more KB work)
+- **If any other hour** (manual trigger) -> run normally
+
+Both runs execute the same phases. The difference is natural: the first run processes the full day's feedback; the second picks up reactions to the first run's notification and does a fresh round of KB work on different files.
+
+---
+
+[INSERT: Full content of phases/core/git-setup.md — with variables replaced]
+
+[INSERT: Full content of phases/core/kb-management.md — with variables replaced]
+
+---
+
+# PHASE 1: FEEDBACK PROCESSING
+
+[If Slack is enabled, INSERT: Full content of phases/modes/feedback-processing.md — all steps 1a through 1f, with variables replaced]
+
+[If Slack is NOT enabled, write instead:]
+Phase 1 is skipped — Slack is not connected. The shipped feedback-processing pass is Slack-specific (reactions and replies on {{INSTANCE_NAME}}'s DM notifications). If Google Chat is connected, basic feedback can still be inferred from replies in the self-DM space (`gws chat spaces messages list --params '{"parent":"<DM_SPACE>","filter":"create_time > \"<since>\""}'` with `sender.name != users/{{USER_GOOGLE_CHAT_ID}}`), but the full classification flow requires Slack today. Connect Slack and re-run `/scout-setup` to enable the full phase.
+
+Proceed directly to Phase 2.
+
+---
+
+# PHASE 2: KB DEEP WORK
+
+[INSERT: Full content of phases/modes/kb-deep-work.md — all steps 2a through 2g, with variables replaced. This is always included regardless of connectors.]
+
+---
+
+# PHASE 3: WISHLIST
+
+[INSERT: Full content of phases/modes/wishlist.md — all steps 3a through 3e, with variables replaced. This is always included regardless of connectors.]
+
+---
+
+# NOTIFICATION
+
+[If Slack is enabled:]
+Send a Slack DM to {{USER_NAME}} (Slack ID: `{{USER_SLACK_ID}}`) summarizing the dreaming run:
+
+```
+{{INSTANCE_NAME}} dreaming run complete.
+- Feedback: [X signals processed, Y mistakes logged, Z proposals written]
+- KB deep work: [mode chosen], [files worked on]
+- Wishlist: [item completed/in-progress/skipped, or "no actionable items"]
+```
+
+[If Google Chat is enabled:]
+Send a Google Chat DM to {{USER_NAME}} (Google Chat user: `users/{{USER_GOOGLE_CHAT_ID}}`) summarizing the dreaming run. Resolve the self-DM space once via `gws chat spaces findDirectMessage --params '{"name":"users/{{USER_GOOGLE_CHAT_ID}}"}'` (or read it from `.scout-cache/google-chat-self-dm` if previously cached), then post with `gws chat +send --space "$DM_SPACE" --text "..."`:
+
+```
+{{INSTANCE_NAME}} dreaming run complete.
+- Feedback: [X signals processed, Y mistakes logged, Z proposals written]
+- KB deep work: [mode chosen], [files worked on]
+- Wishlist: [item completed/in-progress/skipped, or "no actionable items"]
+```
+
+[If neither Slack nor Google Chat is enabled:]
+The git commit message serves as the run record. No external notification is sent.
+
+---
+
+## Your Details
+
+- **Instance:** {{INSTANCE_NAME}}
+- **User:** {{USER_NAME}}
+- **Email:** {{USER_EMAIL}}
+[If Slack is enabled:] - **Slack ID:** {{USER_SLACK_ID}}
+[If Google Chat is enabled:] - **Google Chat user:** users/{{USER_GOOGLE_CHAT_ID}}
+[If GitHub is enabled:] - **GitHub:** {{GITHUB_USERNAME}}
+```
+
+**IMPORTANT:** Same rule as SKILL.md — paste the FULL text of each phase section. The `[INSERT: ...]` markers are instructions to you. The final DREAMING.md must be completely self-contained.
+
+### Assemble RESEARCH.md
+
+Read phase files from `${CLAUDE_PLUGIN_ROOT}/phases/research/`. These are always included regardless of connectors (research uses web tools and `gh` CLI, not MCP connectors).
+
+Write `{{SCOUT_DIR}}/RESEARCH.md` with the following structure:
+
+```markdown
+---
+name: {{INSTANCE_NAME_LOWER}}-research
+description: Outward-facing knowledge expansion — enriches KB entities with real-world information from web, docs, and APIs
+---
+
+You are running **{{INSTANCE_NAME}}** in **RESEARCH** mode — the knowledge expansion session. Unlike dreaming (which audits existing KB quality) or consolidation (which captures what happened today), Research goes **outward** — discovering new information about entities, technologies, and trends, then integrating it into the knowledge base.
+
+**Related files:** [[knowledge-base]] | [[DREAMING]] | [[research-queue]] | [[ontology/schema.yaml]]
+
+**BASE_DIR:** `{{SCOUT_DIR}}`
+
+## What Research Does
+
+1. **Select research targets** — Pick entities or topics that would benefit most from external knowledge enrichment.
+2. **Deep research** — Web search, documentation reading, API queries, changelog scanning.
+3. **Knowledge integration** — Update entity files, add new entities, extend relationships.
+4. **Insight synthesis** — Summarize findings, flag actionable items.
+
+## What Research Does NOT Do
+
+- No action items work
+- No "what happened today" scanning (that's consolidation)
+- No KB quality auditing (that's dreaming)
+- No feedback processing (that's dreaming Phase 1)
+- No wishlist work (that's dreaming Phase 3)
+
+---
+
+[INSERT: Full content of phases/core/git-setup.md — with variables replaced]
+
+[INSERT: Full content of phases/research/research-targets.md — Phase 1]
+
+[INSERT: Full content of phases/research/deep-research.md — Phase 2]
+
+[INSERT: Full content of phases/research/knowledge-integration.md — Phase 3]
+
+[INSERT: Full content of phases/research/commit-notify.md — Phase 4]
+
+---
+
+## KB Management Rules
+
+Same rules as dreaming and consolidation:
+- Use `[[wikilinks]]` for all internal references
+- Never use `index.md` — name files after their folder
+- Never reorganize the folder structure
+- Follow verification levels: no marker = 2+ sources, [single-source], [unverified], [stale]
+- Send uncertain claims to `knowledge-base/review-queue.md`
+- Use `gh` CLI for all GitHub operations
+
+## {{USER_NAME}}'s Details
+
+- **Email:** {{USER_EMAIL}}
+[If Slack is enabled:] - **Slack ID:** {{USER_SLACK_ID}}
+[If Google Chat is enabled:] - **Google Chat user:** users/{{USER_GOOGLE_CHAT_ID}}
+[If GitHub is enabled:] - **GitHub:** {{GITHUB_USERNAME}}
+```
+
+**IMPORTANT:** Same assembly rules — paste the FULL text of each phase section. The final RESEARCH.md must be completely self-contained.
+
+### Commit Skill Files
+
+After writing all three files:
+
+```bash
+cd "{{SCOUT_DIR}}" && git add SKILL.md DREAMING.md RESEARCH.md && git commit -m "Add assembled skill files"
+```
+
+Tell the user: "Skill files assembled. SKILL.md covers morning briefings, weekend briefings, and consolidation. DREAMING.md covers evening self-improvement. RESEARCH.md covers knowledge expansion. All are tailored to your connected tools."
+
+---
+
+## Step 5: Scheduling
+
+Tell the user: "Now let's set up automated scheduling. Here are sensible defaults for your runs:"
+
+Present the default schedule:
+
+```
+Morning briefing:   8:03 AM (weekdays)
+Consolidation:      11:03 AM, 1:07 PM, 5:03 PM (weekdays)
+Dreaming:           6:33 PM, 8:33 PM (weekdays)
+```
+
+Ask: "Press enter to accept these defaults, or tell me your preferred times."
+
+Store the schedule values. Defaults:
+- `BRIEFING_TIME` = "8:03"
+- `BRIEFING_HOUR` = "08" (two-digit hour for the mode check)
+- `CONSOLIDATION_TIMES` = "11:03, 13:07, 17:03"
+- `DREAMING_TIMES` = "18:33, 20:33"
+- `WEEKDAYS_ONLY` = "true"
+
+If the user provides custom times, parse them and update all schedule variables accordingly. Extract hours for the mode-check logic in the skill files.
+
+Compute derived variables for runner scripts:
+- `BRIEFING_HOUR` — the hour portion of the briefing time (zero-padded, e.g., "08")
+- `CONSOLIDATION_HOURS_CASE` — bash case pattern for consolidation hours (e.g., `11|13|17) MODE="consolidation" ;;`)
+- `CONSOLIDATION_HOURS_DISPLAY` — human-readable for SKILL.md mode check (e.g., "11, 13, or 17 (11 AM, 1 PM, or 5 PM)")
+- `DREAMING_HOUR_1`, `DREAMING_HOUR_2` — hours for the two dreaming slots
+- `DREAMING_DISPLAY_1`, `DREAMING_DISPLAY_2` — human-readable (e.g., "6:33 PM")
+- `DREAMING_HOURS_CASE` — bash case pattern for dreaming hours (e.g., `18|20) MODE="dreaming" ;;`)
+
+### Detect Platform
+
+```bash
+uname -s
+```
+
+- "Darwin" = macOS (use launchd)
+- "Linux" = Linux (use cron)
+
+Store as `PLATFORM` ("macos" or "linux").
+
+### Detect Claude Binary
+
+```bash
+which claude 2>/dev/null || echo "NOT_FOUND"
+```
+
+Store the path as `CLAUDE_BIN`. If not found, ask the user: "I couldn't find the `claude` binary. What's the full path to your Claude Code CLI?" Store whatever they provide.
+
+### Set Budget
+
+Ask: "What's the maximum budget per run in USD? (default: 5.00)"
+
+Store as `MAX_BUDGET`. Default: "5.00".
+
+### macOS Scheduling (launchd)
+
+If `PLATFORM` is "macos":
+
+**1. Write runner scripts**
+
+Read `${CLAUDE_PLUGIN_ROOT}/templates/run-scout.sh.tmpl`. Replace all `{{VARIABLES}}` with collected values. Write to `{{SCOUT_DIR}}/run-scout.sh`. Make executable with `chmod +x`.
+
+Read `${CLAUDE_PLUGIN_ROOT}/templates/run-dreaming.sh.tmpl`. Replace all `{{VARIABLES}}`. Write to `{{SCOUT_DIR}}/run-dreaming.sh`. Make executable with `chmod +x`.
+
+Read `${CLAUDE_PLUGIN_ROOT}/templates/run-research.sh.tmpl`. Replace all `{{VARIABLES}}`. Write to `{{SCOUT_DIR}}/run-research.sh`. Make executable with `chmod +x`.
+
+**2. Generate plist files**
+
+Read `${CLAUDE_PLUGIN_ROOT}/templates/launchd-plist.tmpl`.
+
+Generate TWO plist files from this template:
+
+**Briefing + Consolidation plist** (`com.{{INSTANCE_NAME_LOWER}}.briefing.plist`):
+- `PLIST_TYPE` = "briefing"
+- `RUN_SCRIPT_PATH` = "{{SCOUT_DIR}}/run-scout.sh"
+- `SCHEDULE_ENTRIES` = Generate one `<dict>` block per time slot per weekday. For each time in the briefing + consolidation schedule, and for each weekday (Monday=1 through Friday=5), create:
+  ```xml
+          <dict>
+              <key>Hour</key>
+              <integer>HOUR</integer>
+              <key>Minute</key>
+              <integer>MINUTE</integer>
+              <key>Weekday</key>
+              <integer>WEEKDAY</integer>
+          </dict>
+  ```
+- `PATH_ENV` = Output of `echo $PATH`
+- `HOME_ENV` = Output of `echo $HOME`
+
+**Dreaming plist** (`com.{{INSTANCE_NAME_LOWER}}.dreaming.plist`):
+- `PLIST_TYPE` = "dreaming"
+- `RUN_SCRIPT_PATH` = "{{SCOUT_DIR}}/run-dreaming.sh"
+- `SCHEDULE_ENTRIES` = Same pattern but for dreaming times only
+
+Write both plists to `~/Library/LaunchAgents/`.
+
+**3. Ask to load**
+
+Ask: "Schedule files written. Load them now? This will start the automated runs at the configured times. (yes/no)"
+
+If yes:
+```bash
+launchctl load ~/Library/LaunchAgents/com.{{INSTANCE_NAME_LOWER}}.briefing.plist
+launchctl load ~/Library/LaunchAgents/com.{{INSTANCE_NAME_LOWER}}.dreaming.plist
+```
+
+Verify:
+```bash
+launchctl list | grep {{INSTANCE_NAME_LOWER}}
+```
+
+If the grep returns results, tell the user the schedule is active. If not, tell the user the load may have failed and suggest checking with `launchctl list`.
+
+### Linux Scheduling (cron)
+
+If `PLATFORM` is "linux":
+
+**1. Write runner scripts** (same as macOS — write run-scout.sh, run-dreaming.sh, and run-research.sh to SCOUT_DIR, chmod +x)
+
+**2. Generate cron entries**
+
+Read `${CLAUDE_PLUGIN_ROOT}/templates/cron-entry.tmpl` for the header format.
+
+Generate cron lines. For each briefing + consolidation time, create:
+```
+MINUTE HOUR * * 1-5 {{SCOUT_DIR}}/run-scout.sh >> {{SCOUT_DIR}}/.scout-logs/cron.log 2>&1
+```
+
+For each dreaming time:
+```
+MINUTE HOUR * * 1-5 {{SCOUT_DIR}}/run-dreaming.sh >> {{SCOUT_DIR}}/.scout-logs/cron.log 2>&1
+```
+
+(If `WEEKDAYS_ONLY` is false, use `*` instead of `1-5` for the day-of-week field.)
+
+**3. Present and ask**
+
+Show the user the complete cron entries and ask: "Install these cron entries? (yes/no)"
+
+If yes, append to crontab:
+```bash
+(crontab -l 2>/dev/null; echo ""; echo "# {{INSTANCE_NAME}} scheduled runs"; cat <<'CRON'
+<generated cron entries>
+CRON
+) | crontab -
+```
+
+### Update Config and Commit
+
+Update `{{SCOUT_DIR}}/scout-config.yaml` with the final schedule values (re-process the template or edit in place).
+
+Update SKILL.md and DREAMING.md if the schedule times differ from the defaults initially used during assembly (the mode-check hours need to match the actual schedule).
+
+Commit runner scripts and any config updates:
+```bash
+cd "{{SCOUT_DIR}}" && git add -A && git commit -m "Add runner scripts and configure scheduling"
+```
+
+---
+
+## Step 6: First Run
+
+Tell the user:
+
+"Setup complete! Your **{{INSTANCE_NAME}}** is ready."
+
+"Your knowledge base is at `{{SCOUT_DIR}}/knowledge-base/`. For the best reading experience, open the entire `{{SCOUT_DIR}}` directory as an Obsidian vault — the `[[wikilink]]` structure creates a navigable knowledge graph."
+
+"Summary of what was set up:"
+- Instance: **{{INSTANCE_NAME}}**
+- Directory: `{{SCOUT_DIR}}`
+- Connected tools: [list only the enabled ones]
+- Schedule: [briefing time, consolidation times, dreaming times]
+- Platform: [macOS launchd / Linux cron]
+
+"Would you like to run your first morning briefing now? This will query your connected tools, build today's action items, and populate the knowledge base. It typically takes 3-5 minutes."
+
+If the user says yes, run the briefing:
+
+```bash
+cd "{{SCOUT_DIR}}" && bash run-scout.sh
+```
+
+Or, if the runner script is not yet tested and they prefer a direct invocation:
+
+```bash
+cd "{{SCOUT_DIR}}" && claude --permission-mode auto --model opus -p "You are {{INSTANCE_NAME}}, an autonomous knowledge management system. Your working directory is {{SCOUT_DIR}}. Read {{SCOUT_DIR}}/SKILL.md in full, determine your mode (use MORNING BRIEFING for this first run), and execute all steps completely."
+```
+
+If the user says no, tell them: "No problem! Your first run will happen automatically at the next scheduled briefing time. You can also trigger a manual run anytime with: `cd {{SCOUT_DIR}} && bash run-scout.sh`"
+
+---
+
+## Error Handling Notes
+
+Throughout this wizard, follow these principles:
+
+- **Connector probes must not crash the wizard.** If any tool call fails (timeout, auth error, tool not found), catch the error, mark that connector as not connected, and continue. Tell the user which probe failed if useful.
+- **Template files must exist.** If a template file is missing from `${CLAUDE_PLUGIN_ROOT}/templates/`, tell the user which file is missing and suggest re-installing the plugin. Do not proceed with a partial setup.
+- **Phase files must exist for assembly.** If a phase file referenced during assembly is missing, warn the user and skip that section. The resulting skill file may be incomplete — note this clearly.
+- **Git failures are non-fatal.** If `git init` or `git commit` fails, warn the user but continue. The setup is still usable without git history.
+- **Path expansion.** Always expand `~` to the full home directory path when writing to config files and scripts. Use `$HOME` in bash or the expanded path in file writes.
+- **Idempotent file writes.** If a file already exists at the target path (e.g., during Reconfigure), overwrite it. The git history preserves the old version.

--- a/commands/scout-status.md
+++ b/commands/scout-status.md
@@ -219,8 +219,11 @@ List every connector from the config. Use ✅ for `true` and ❌ for `false`:
 
 ```
   ✅ Slack
+  ❌ Google Chat
   ❌ Google Calendar
   ✅ Gmail
+  ❌ Jira
+  ❌ Asana
   ...
 ```
 
@@ -383,25 +386,45 @@ If an update is available, add: "Run `/scout-update` to apply it."
 
 ### Knowledge Graph Health
 
-Run the ontology parser to check the knowledge graph:
+Run the ontology parser to check the knowledge graph. Prefer the project venv if present (`SCOUT_DIR/.venv/bin/python`) — falls back to system `python3` then `python`:
 
 ```bash
-cd "SCOUT_DIR" && python knowledge-base/ontology/parser.py stats 2>/dev/null
-cd "SCOUT_DIR" && python knowledge-base/ontology/parser.py validate 2>/dev/null
+PY="$SCOUT_DIR/.venv/bin/python"
+[ -x "$PY" ] || PY=$(command -v python3 || command -v python || echo "")
+[ -n "$PY" ] && cd "$SCOUT_DIR" && "$PY" knowledge-base/ontology/parser.py stats 2>/dev/null
+[ -n "$PY" ] && cd "$SCOUT_DIR" && "$PY" knowledge-base/ontology/parser.py validate 2>/dev/null
 ```
 
-If the parser is available and succeeds, show:
+If the parser succeeds, show **all four** facets — counts by type, total relationships, validation status, and an orphan summary (counted separately from errors):
 
 ```
-  Entities:       X (Y person, Z project, ...)
+  Entities:       N (X person, Y project, Z organization, W technology, ...)
   Relationships:  N
-  Validation:     X errors / No errors
+  Validation:     0 errors / N errors
+  Orphans:        N entities with no relationships
 ```
 
-If the parser isn't set up (file doesn't exist or Python error), show:
+Compute the orphan count by re-running `validate` and counting lines that match `Orphaned entity` — these are warnings, not validation errors. List up to 5 most recently modified orphan entity files (use `find SCOUT_DIR/knowledge-base/ontology/entities -name '*.md' -newer ...` or `ls -t`) when the count is non-zero, so the user can see what's drifting:
+
+```
+  ⚠️  Orphans (top 5 by recency):
+    - knowledge-base/ontology/entities/people/<name>.md  — <YYYY-MM-DD>
+    ...
+```
+
+If `Entities: 0` even though the parser ran, surface the gap:
+
+```
+  ⚠️  Parser runs but graph is empty. Likely cause: KB markdown files lack YAML frontmatter
+  with `name:` and `type:` keys. Run a dreaming session to auto-seed entities from prose,
+  or re-run scripts/seed-entities-from-people.py manually.
+```
+
+If the parser isn't set up (file doesn't exist) OR the runtime is unavailable (no python3 / yaml module missing), show:
 
 ```
   Knowledge graph not configured. Run /scout-setup to set up the ontology.
+  (Tip: if python3 is present but yaml is missing — `pip3 install pyyaml` or use a venv.)
 ```
 
 ---

--- a/engine/scout/connectors.snapshot.json
+++ b/engine/scout/connectors.snapshot.json
@@ -38,8 +38,23 @@
       "tier": "official"
     },
     {
+      "key": "asana:cli",
+      "display_name": "Asana (asana-api CLI)",
+      "tier": "official"
+    },
+    {
+      "key": "jtk:jira",
+      "display_name": "Jira (jtk CLI)",
+      "tier": "official"
+    },
+    {
       "key": "github",
       "display_name": "GitHub (gh CLI)",
+      "tier": "official"
+    },
+    {
+      "key": "gws:chat",
+      "display_name": "Google Chat (gws CLI)",
       "tier": "official"
     },
     {

--- a/engine/scout/connectors.yaml
+++ b/engine/scout/connectors.yaml
@@ -126,6 +126,54 @@ connectors:
       first_fix: "Reconnect Google Drive at https://claude.ai/settings/connectors."
       detail: "Google Drive connector — same reconnect flow as Gmail at https://claude.ai/settings/connectors."
 
+  asana:cli:
+    display_name: Asana (asana-api CLI)
+    tier: official
+    capabilities: [inbound]
+    required_in: []   # opt-in — only critical for users who choose Asana as their task tracker
+    remediation:
+      first_fix: "Verify the asana-api CLI: `python3 ~/Scout/scripts/asana_api.py whoami` should return your user gid."
+      detail: |
+        Asana is driven by the bundled asana-api CLI (PAT-based REST wrapper) at
+        `~/Scout/scripts/asana_api.py`. The claude.ai Asana MCP server is the
+        runtime fallback when the CLI is unavailable.
+
+        Common failure modes:
+          1. PAT missing/expired — regenerate at https://app.asana.com/0/my-apps and
+             store at `~/.agent-skills/asana/asana_pat` (chmod 600) or export
+             `ASANA_ACCESS_TOKEN`. Verify with `asana_api.py whoami`.
+          2. Workspace switched — update `asana_workspace_gid` in scout-config.yaml.
+          3. Project GID renamed/archived — update `asana_projects` in
+             scout-config.yaml so the task-search calls don't return empty.
+          4. Script not staged — re-run `/scout-update` to re-copy
+             scripts/asana_api.py into the vault.
+
+        Fallback (CLI down): reconnect the Asana MCP at
+        https://claude.ai/settings/connectors.
+
+        Setup walkthrough: engine/scout/docs/connectors/asana-setup.md
+
+  jtk:jira:
+    display_name: Jira (jtk CLI)
+    tier: official
+    capabilities: [inbound]
+    required_in: []   # opt-in — only critical for users who choose Jira as their issue tracker
+    remediation:
+      first_fix: "Run `jtk config test`; if it errors, re-run `jtk init` to refresh API token + base URL."
+      detail: |
+        Jira access is via the local `jtk` CLI (https://github.com/open-cli-collective/atlassian-cli),
+        not an MCP. `jtk` stores Jira Cloud credentials (base URL + email + API token) per the
+        `jtk init` guided flow.
+
+        Common failure modes:
+          1. API token rotated or revoked — re-run `jtk init` and paste a fresh token from
+             https://id.atlassian.com/manage-profile/security/api-tokens.
+          2. `jtk` not on PATH — install via Homebrew/Go per the setup doc.
+          3. Project key in `jira_projects` was renamed in Jira — update scout-config.yaml
+             so the JQL queries don't 400.
+
+        Setup walkthrough: engine/scout/docs/connectors/jira-setup.md
+
   github:
     display_name: GitHub (gh CLI)
     tier: official
@@ -139,6 +187,28 @@ connectors:
         GitHub access is via the local `gh` CLI (not an MCP). Token expiry is the usual
         cause. `gh auth status` shows current state; `gh auth login` refreshes it. After an
         SSO/SAML re-auth, the personal token may need a separate refresh.
+
+  gws:chat:
+    display_name: Google Chat (gws CLI)
+    tier: official
+    capabilities: [inbound, outbound]
+    required_in: []   # opt-in — only critical for users who pick it as their notification channel
+    remediation:
+      first_fix: "Run `gws chat spaces list --params '{\"pageSize\":1}'`; if it errors with auth, run `gws auth login` to refresh scopes."
+      detail: |
+        Google Chat access is via the local `gws` Google Workspace CLI
+        (https://github.com/googleworkspace/cli). The connector reads spaces, DMs,
+        threads, and reactions; the notification phase posts run summaries into the
+        user's self-DM space.
+
+        Common failure modes:
+          1. OAuth token expired — `gws auth login` and re-grant `chat.spaces.readonly`,
+             `chat.messages.readonly`, `chat.messages.create` scopes.
+          2. `gws` not on PATH — reinstall via npm/Homebrew per the setup doc.
+          3. `findDirectMessage` returns 404 — no self-DM exists yet; send a manual
+             message to yourself in Google Chat once, then re-run.
+
+        Setup walkthrough: engine/scout/docs/connectors/google-chat-setup.md
 
   mcp:claude-in-chrome:
     display_name: Chrome (Google Messages)

--- a/engine/scout/docs/connectors/asana-setup.md
+++ b/engine/scout/docs/connectors/asana-setup.md
@@ -1,0 +1,101 @@
+# Asana Connector — Setup
+
+Scout's Asana connector reads tasks, sections, projects, comments, and stories — and can post comments (including `@`-mentions) — through the bundled **asana-api CLI** (`scripts/asana_api.py`), a PAT-based REST wrapper. The claude.ai Asana MCP server (`mcp__claude_ai_Asana__*`) is the runtime fallback when the CLI is unavailable.
+
+The CLI is token-efficient (returns only the fields you ask for, keeps raw JSON out of context) and works on any Asana tier without OAuth round-trips.
+
+## 1. Generate a Personal Access Token (PAT)
+
+1. Open https://app.asana.com/0/my-apps
+2. **Create new token** → name it (e.g. `scout`) → copy the token (shown once).
+3. Store it where the CLI looks for it:
+
+   ```bash
+   mkdir -p ~/.agent-skills/asana
+   printf '%s' "<YOUR_PAT>" > ~/.agent-skills/asana/asana_pat
+   chmod 600 ~/.agent-skills/asana/asana_pat
+   ```
+
+   Or export `ASANA_ACCESS_TOKEN=<YOUR_PAT>` in your shell profile. The CLI reads the file (or env var) internally, so the secret never appears on a command line.
+
+The script itself is staged into the vault at `~/Scout/scripts/asana_api.py` by `/scout-setup` / `/scout-update` (source of truth: `skills/asana-api/`).
+
+## 2. Verify
+
+```bash
+python3 ~/Scout/scripts/asana_api.py whoami
+```
+
+A successful response returns `data.gid`, `data.name`, `data.email`, and `data.workspaces[]`. That means Scout will detect the connector during `/scout-setup`.
+
+If it errors with an auth message, the PAT is missing/expired — regenerate (step 1). If the script isn't staged yet, run the MCP `get_me` as a fallback and re-run `/scout-update` to stage the script.
+
+## 3. Capture Your Asana GID + Workspace
+
+`/scout-setup` pulls both directly from the `whoami` response — no manual copy needed:
+
+- `user.asana_gid` ← `data.gid`
+- `asana_workspace_gid` ← `data.workspaces[0].gid` (if you belong to more than one workspace, the wizard asks which)
+
+To look them up later, just re-run `whoami`.
+
+## 4. Pick the Projects Scout Should Monitor
+
+Scout queries are scoped to a comma-separated project GID list (`asana_projects` in `scout-config.yaml`). Asana has no project keys — only numeric GIDs.
+
+Find a GID from the project URL `https://app.asana.com/0/<PROJECT_GID>/...`, or list them:
+
+```bash
+python3 ~/Scout/scripts/asana_api.py projects --team <TEAM_GID>
+# or, across the workspace:
+python3 ~/Scout/scripts/asana_api.py request GET /workspaces/<WORKSPACE_GID>/projects --data 'limit=200&opt_fields=name,gid' | jq '.data'
+```
+
+Pick the projects you actually work in. Avoid org-wide noisy projects — they slow the daily sweep without adding signal.
+
+## 5. Priority Sections / Tasks (optional but recommended)
+
+For recurring rosters (e.g. a weekly-status section that grows as people onboard), configure `asana_priority_sections` in `scout-config.yaml` rather than hardcoding task GIDs. Each entry references a section by GID and a cadence; Scout sweeps the whole section on schedule via `section-tasks`. See the comments in `templates/scout-config.yaml.tmpl` for the schema.
+
+## 6. Posting Comments + @mentions
+
+Scout can reply on a task when a slot calls for it (e.g. a weekly-status nudge):
+
+```bash
+# plain text
+python3 ~/Scout/scripts/asana_api.py comment-task <task_gid> --text "Status synced."
+
+# with an @mention — Asana rich-text markup carrying the person's Asana GID
+python3 ~/Scout/scripts/asana_api.py comment-task <task_gid> \
+  --html-text '<body><a data-asana-gid="<PERSON_ASANA_GID>"/> please refresh before Friday.</body>'
+```
+
+Resolve a person's GID from `people.md` (`asana_gid:` field) or `users --workspace <WORKSPACE_GID>`. Scheduled runs never post without an approval gate; interactive `/scout-work` asks per item.
+
+## 7. Premium vs Non-Premium Workspaces
+
+The workspace task-search endpoint (`/workspaces/<gid>/tasks/search`, used for date-bounded assignee sweeps and keyword cross-checks) requires a **Premium / Business** workspace. On non-premium workspaces those calls return a 402/forbidden; the phases fall back to `project-assigned-tasks <project_gid>` (works on any tier) and filter locally. No config change needed.
+
+## 8. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `whoami` returns auth error | PAT missing/expired/revoked | Regenerate at https://app.asana.com/0/my-apps, re-store at `~/.agent-skills/asana/asana_pat` |
+| `asana_api.py: No such file` | Script not staged into the vault | Re-run `/scout-update` (stages `scripts/asana_api.py`) |
+| `tasks/search` returns "premium required" | Non-premium workspace | Phases auto-fall back to `project-assigned-tasks` — no action |
+| Project GIDs return empty results | Project archived/renamed | Re-list projects and refresh `asana_projects` |
+| Wrong workspace's tasks appear | Multi-workspace account | Set `asana_workspace_gid` in scout-config.yaml |
+| `@`-mention doesn't notify | Wrong/omitted `data-asana-gid` | Use the person's numeric Asana GID; confirm via `users --workspace <gid>` |
+| Everything fails, MCP works | CLI/PAT broken | Connector falls back to `mcp__claude_ai_Asana__*` automatically; fix the PAT when convenient |
+
+## 9. What Scout Reads / Writes
+
+**Reads** (per scheduled run):
+
+- `project-assigned-tasks <project_gid> --workspace <ws>` / `request … /tasks/search` for the assigned-work snapshot
+- `section-tasks` + `task` + `task-comments` for priority-section sweeps
+- `task` / `task-stories` for individual cross-checks
+- `search-tasks --text` for keyword cross-checks
+- `whoami` once at setup to capture the user GID + workspace list
+
+**Writes:** None automatically. Scout never creates, completes, comments on, or deletes tasks during scheduled runs. Write actions (closing a task, posting a comment / `@`-mention via `comment-task`) happen only through the interactive `/scout-work` flow with explicit per-item approval. The CLI exposes the write commands (`create-task`, `update-task`, `comment-task`, …) but they are intentionally not invoked by scheduled runs.

--- a/engine/scout/docs/connectors/google-chat-setup.md
+++ b/engine/scout/docs/connectors/google-chat-setup.md
@@ -1,0 +1,97 @@
+# Google Chat Connector — Setup
+
+Scout's Google Chat connector reads spaces, DMs, threads, and reactions through the `gws` Google Workspace CLI (https://github.com/googleworkspace/cli) and posts run-summary notifications back into a self-DM.
+
+## 1. Install `gws`
+
+The `gws` binary is distributed via npm and Homebrew. Verify what you have:
+
+```bash
+gws --version
+```
+
+If missing, install it (one of):
+
+```bash
+# npm
+npm install -g @googleworkspace/cli
+
+# Homebrew (macOS / Linux)
+brew install googleworkspace/tap/gws
+```
+
+The exact install command may evolve — consult the upstream README at https://github.com/googleworkspace/cli for the current path.
+
+## 2. Authenticate
+
+`gws` reads credentials from one of the following, in priority order:
+
+| Variable | Purpose |
+|----------|---------|
+| `GOOGLE_WORKSPACE_CLI_TOKEN` | Pre-obtained OAuth2 access token (highest priority — useful for short-lived runs) |
+| `GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE` | Path to OAuth credentials JSON file |
+| `GOOGLE_WORKSPACE_CLI_CLIENT_ID` + `GOOGLE_WORKSPACE_CLI_CLIENT_SECRET` | Client credentials used by `gws auth login` |
+
+For a personal install, run the interactive login once:
+
+```bash
+gws auth login
+```
+
+Confirm Scout's required scopes are granted. At minimum:
+
+- `https://www.googleapis.com/auth/chat.spaces.readonly` (list spaces, find DM)
+- `https://www.googleapis.com/auth/chat.messages.readonly` (read messages, threads, reactions)
+- `https://www.googleapis.com/auth/chat.messages.create` (post run-summary DMs)
+
+Verify the install:
+
+```bash
+gws chat spaces list --format json --params '{"pageSize":1}'
+```
+
+A 200 response with a `spaces` array (possibly empty) means Scout will detect the connector during `/scout-setup`. A 401/403 means re-run `gws auth login` and ensure the scopes above are checked.
+
+## 3. Find Your Google Chat User ID
+
+Scout stores a numeric user ID (no `users/` prefix) in `scout-config.yaml` as `user.google_chat_id`. To retrieve it:
+
+```bash
+gws chat users get --params '{"name":"users/me"}' --format json
+```
+
+Copy the digits from the `name` field (e.g. `users/123456789012345678901` -> `123456789012345678901`). The setup wizard will prompt for this value when it detects Google Chat is connected.
+
+## 4. Optional — Cache the Self-DM Space
+
+The first run resolves your self-DM space via:
+
+```bash
+gws chat spaces findDirectMessage --params '{"name":"users/<YOUR_ID>"}'
+```
+
+The notification phase writes the resulting space resource name into `.scout-cache/google-chat-self-dm` so subsequent runs skip the lookup. This file is gitignored and auto-recreated.
+
+## 5. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `gws: command not found` | Binary not on PATH | Reinstall, or add the npm/brew bin dir to `PATH` |
+| `error: Auth — credentials missing or invalid` (exit 2) | OAuth token expired or scopes missing | `gws auth login` and re-grant scopes |
+| `findDirectMessage` returns 404 | No DM space exists yet | Send any manual message to yourself in Google Chat once, then re-run |
+| Empty `spaces.list` response | New account / no spaces joined yet | Join at least one space or wait for the first DM, then re-run |
+
+## 6. What Scout Reads / Writes
+
+**Reads** (per scheduled run):
+
+- `gws chat spaces list` (cached for the run)
+- `gws chat spaces messages list` per space, scoped by `create_time` since the last run
+- `gws chat spaces messages get` for individual message details when cross-checking
+- `gws chat users get` to resolve unknown sender IDs into names
+
+**Writes** (notification phase only):
+
+- `gws chat +send --space <self-DM> --text "<run summary>"` (or the equivalent `gws chat spaces messages create` for richer payloads)
+
+No external Google Chat data is written outside the self-DM. Scout never posts into shared spaces on your behalf.

--- a/engine/scout/docs/connectors/jira-setup.md
+++ b/engine/scout/docs/connectors/jira-setup.md
@@ -1,0 +1,98 @@
+# Jira Connector — Setup
+
+Scout's Jira connector reads issues, comments, transitions, and sprints through the `jtk` Atlassian CLI (https://github.com/open-cli-collective/atlassian-cli).
+
+## 1. Install `jtk`
+
+Verify what you have:
+
+```bash
+jtk --version
+```
+
+If missing, install (one of):
+
+```bash
+# Homebrew (macOS / Linux)
+brew install open-cli-collective/tap/jtk
+
+# Go
+go install github.com/open-cli-collective/atlassian-cli/cmd/jtk@latest
+```
+
+Consult the upstream README for the current install path: https://github.com/open-cli-collective/atlassian-cli
+
+## 2. Authenticate
+
+`jtk` needs your Jira Cloud base URL, email, and an API token.
+
+1. Generate an API token at https://id.atlassian.com/manage-profile/security/api-tokens (label it `jtk` so you can revoke it later).
+2. Run the guided init:
+
+```bash
+jtk init
+```
+
+Provide the base URL (e.g. `https://your-org.atlassian.net`), your email, and the token. The credentials are stored in the OS keyring where supported.
+
+Verify the connection:
+
+```bash
+jtk config test
+```
+
+A success message means Scout will detect the connector during `/scout-setup`. If the test fails, re-run `jtk init` with a fresh token.
+
+## 3. Capture Your Account ID
+
+Scout stores your Jira account ID in `scout-config.yaml` as `user.jira_account_id`. The setup wizard asks for it, but you can fetch it manually:
+
+```bash
+jtk me --id
+```
+
+Copy the printed account ID (e.g. `5b10ac8d82e05b22cc7d4ef5`).
+
+## 4. Pick the Projects Scout Should Monitor
+
+Scout queries are scoped to a comma-separated project list (`jira_projects` in `scout-config.yaml`). The first key is treated as the primary project for sprint queries.
+
+List project keys you have access to:
+
+```bash
+jtk projects list --max 200
+```
+
+Pick the keys you actually work in (e.g. `PROJ, PLAT, OPS`). Avoid adding org-wide noisy projects — they make the daily JQL queries slower and noisier without adding signal.
+
+## 5. Optional — Confirm a Sample JQL Returns
+
+Scout's queries lean on JQL. Confirm at least one returns a non-empty result:
+
+```bash
+jtk issues search --jql "assignee = currentUser() AND statusCategory != Done" --max 5
+```
+
+If the response is `No issues found` and you do have open assigned issues, double-check the base URL / account in `jtk config show` — you may be authed against the wrong Atlassian site.
+
+## 6. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `jtk: command not found` | Binary not on PATH | Reinstall, or add the brew/go bin dir to `PATH` |
+| `jtk config test` fails with 401 | API token rotated, expired, or revoked | Generate a new token and re-run `jtk init` |
+| JQL returns 400 / `Field "X" does not exist` | Custom field renamed or absent in your instance | Edit the JQL in `phases/connectors/jira.md` (or the assembled `SKILL.md`) to match your field names |
+| Empty results despite open issues | Wrong Atlassian site auth | `jtk config show` and re-init against the right base URL |
+| Sprint queries fail | Project isn't scrum-mode (no sprints) | Drop sprint queries by leaving `jira_primary_project` empty |
+
+## 7. What Scout Reads / Writes
+
+**Reads** (per scheduled run):
+
+- `jtk issues search` with JQL filters scoped to {{USER_NAME}} or `${JIRA_PROJECTS}`
+- `jtk issues get <KEY>` for individual issue cross-checks
+- `jtk comments list <KEY>` for thread context and "did {{USER_NAME}} already act on this?" detection
+- `jtk issues list --sprint current` for the active-sprint snapshot in briefings
+- `jtk me --id` once at setup to capture the account ID
+
+**Writes:** None. Scout never transitions tickets, files comments, or assigns issues automatically. Any write actions ({{USER_NAME}} commenting, transitioning, etc.) happen through the interactive `/scout-work` flow with explicit approval per item.

--- a/engine/scout/scripts/bootstrap.py
+++ b/engine/scout/scripts/bootstrap.py
@@ -99,6 +99,11 @@ _CAT1_FILES_FROM_PLUGIN = {
     "knowledge-base/ontology/__init__.py": "templates/knowledge-base/ontology/__init__.py",
     "action-items/render.py": "templates/action-items/render.py",
     "scripts/recurring-task-status.py": "templates/scripts/recurring-task-status.py",
+    # asana-api CLI wrapper — primary path for the Asana connector (MCP is the
+    # runtime fallback). Staged verbatim into the vault so connector phases can
+    # call `python3 scripts/asana_api.py ...`. Staged straight from the bundled
+    # skill (single source of truth — no templates/ duplicate).
+    "scripts/asana_api.py": "skills/asana-api/scripts/asana_api.py",
 }
 
 # Cat-1 files that are BOTH engine-owned AND user-editable in the vault, so they

--- a/engine/tests/unit/test_bootstrap_install.py
+++ b/engine/tests/unit/test_bootstrap_install.py
@@ -44,6 +44,22 @@ def test_install_creates_directory_tree(tmp_path):
     assert (vault / "hooks").is_dir()
 
 
+def test_install_stages_asana_api_cli(tmp_path):
+    """The Asana connector calls `python3 scripts/asana_api.py` vault-relative,
+    so bootstrap MUST stage the CLI into <vault>/scripts/ from the bundled
+    skill (skills/asana-api/scripts/asana_api.py). Regression guard: a missing
+    stage entry would leave every Asana connector call failing with
+    'No such file or directory' at runtime."""
+    plugin = Path(__file__).parent.parent.parent.parent
+    vault = tmp_path / "Scout"
+    install(_config(vault, plugin_root=plugin))
+    staged = vault / "scripts" / "asana_api.py"
+    assert staged.is_file()
+    # Verbatim copy of the source of truth, not a placeholder stub.
+    source = plugin / "skills" / "asana-api" / "scripts" / "asana_api.py"
+    assert staged.read_text(encoding="utf-8") == source.read_text(encoding="utf-8")
+
+
 def test_install_writes_scout_config(tmp_path):
     plugin = Path(__file__).parent.parent.parent.parent
     vault = tmp_path / "Scout"

--- a/engine/tests/unit/test_scripts_connectors_snapshot.py
+++ b/engine/tests/unit/test_scripts_connectors_snapshot.py
@@ -61,8 +61,9 @@ def test_build_snapshot_filters_to_official_tier_only():
 def test_build_snapshot_contains_expected_canonical_keys():
     """Lock in the exact roster that scout-app must reflect.
 
-    The YAML defines 11 official-tier connectors (Slack, Linear, Gmail,
-    Calendar, Granola, Fathom, Drive, github, chrome, whatsapp, telegram).
+    The YAML defines 14 official-tier connectors (Slack, Linear, Gmail,
+    Calendar, Granola, Fathom, Drive, asana:cli, jtk:jira, github,
+    gws:chat, chrome, whatsapp, telegram).
     """
     s = snap.build_snapshot()
     keys = {c["key"] for c in s["connectors"]}
@@ -74,12 +75,15 @@ def test_build_snapshot_contains_expected_canonical_keys():
         "mcp:claude_ai_Granola",
         "mcp:fathom",
         "mcp:claude_ai_Google_Drive",
+        "asana:cli",
+        "jtk:jira",
         "github",
+        "gws:chat",
         "mcp:claude-in-chrome",
         "mcp:whatsapp-mcp",
         "notify:telegram",
     }
-    assert len(s["connectors"]) == 11
+    assert len(s["connectors"]) == 14
 
 
 def test_build_snapshot_preserves_yaml_insertion_order():

--- a/phases/connectors/asana.md
+++ b/phases/connectors/asana.md
@@ -1,0 +1,314 @@
+---
+phase: connector
+name: asana
+slot: inbound-scan
+mode: [consolidation, briefing]
+requires: asana
+---
+
+## Asana Inbound Scan — Task Activity
+
+Check for changes to {{USER_NAME}}'s assigned Asana tasks and any newly created or assigned tasks.
+
+**Primary path: the `asana-api` CLI** — a PAT-based wrapper. Run every Asana call as `python3 scripts/asana_api.py <subcommand>`; it reads the token from `~/.agent-skills/asana/asana_pat` (or `$ASANA_ACCESS_TOKEN`) so the secret never appears on the command line. It returns only the requested fields as JSON — pipe through `jq` and keep raw output in the sandbox.
+
+> **Script path.** Every `scripts/asana_api.py` reference in this phase is **vault-relative**: at runtime the session cwd is `{{SCOUT_DIR}}` (every runner `cd`s there), and `/scout-setup` + `/scout-update` stage the script into `{{SCOUT_DIR}}/scripts/asana_api.py`. It is **not** the plugin repo's root `scripts/` dir — the source of truth lives in the plugin at `skills/asana-api/scripts/asana_api.py` and is copied into the vault by bootstrap. For raw/unsupported endpoints, use the CLI's own `request` subcommand (e.g. `asana_api.py request GET /path --query k=v`); there is no separate curl wrapper.
+
+**Fallback:** if the CLI is unavailable (script missing, PAT not configured), use the Asana MCP server (`mcp__claude_ai_Asana__*`) with the equivalent parameters.
+
+**Response shapes** (so the `jq` filters below are right): raw-passthrough commands — `request`, `section-tasks`, `search-tasks`, `project-assigned-tasks` — return `{"data": [...]}`; lookup commands — `task`, `task-comments`, `task-stories` — return `{"command", "count", "items": [...]}`; `board` returns `{"project_gid", "sections": [...]}`. Note `search-tasks` requires `--text` and `project-assigned-tasks` requires `--workspace {{ASANA_WORKSPACE_GID}}`.
+
+Compute the lower bound once and reuse it across all Asana calls:
+
+```
+SINCE_DAYS = 1   # consolidation = 1d, briefing = 1d, weekend briefing = 3d
+```
+
+Convert to ISO-8601 (`modified_at.after`, `created_at.after`, `completed_at.after`).
+
+### Status / Completion Changes
+
+`search-tasks` requires `--text`, so for date-bounded assignee sweeps (no keyword) use the raw `request` passthrough to the workspace search endpoint:
+
+```bash
+# Recently completed (candidate Done items for reconciliation)
+python3 scripts/asana_api.py request GET /workspaces/{{ASANA_WORKSPACE_GID}}/tasks/search \
+  --query 'assignee.any=me' --query 'completed=true' --query 'completed_at.after=<SINCE>' \
+  --opt-fields 'gid,name,completed_at,memberships.section.name' | jq '.data'
+
+# Recently modified open (section move, due-date shift, custom-field update)
+python3 scripts/asana_api.py request GET /workspaces/{{ASANA_WORKSPACE_GID}}/tasks/search \
+  --query 'assignee.any=me' --query 'completed=false' --query 'modified_at.after=<SINCE>' --query 'sort_by=modified_at' \
+  --opt-fields 'gid,name,due_on,modified_at,memberships.section.name' | jq '.data'
+```
+
+If the workspace is non-premium (search endpoint returns a 402/forbidden), fall back to `project-assigned-tasks <project_gid> --workspace {{ASANA_WORKSPACE_GID}} --completed false --include-comments` per configured project, and filter `modified_at >= <SINCE>` locally. (MCP fallback: `search_tasks(assignee_any="me", ...)` / `get_my_tasks`.)
+
+Status transitions to watch for (Asana has no named statuses — section membership is the equivalent):
+- **Backlog → In Progress section**: work started
+- **In Progress → In Review / Awaiting QA**: work delivered
+- **Any → Done section / completed=true**: task resolved
+- **Backlog → a current-cycle section**: task was prioritized
+
+For each change, update the KB task tracker and note implications for action items.
+
+### Newly Created / Newly Assigned Tasks
+
+```bash
+# Newly created assigned to me
+python3 scripts/asana_api.py request GET /workspaces/{{ASANA_WORKSPACE_GID}}/tasks/search \
+  --query 'assignee.any=me' --query 'created_at.after=<SINCE>' --query 'completed=false' \
+  --opt-fields 'gid,name,due_on,projects,assignee,created_at' | jq '.data'
+
+# New work in configured projects (may affect {{USER_NAME}} even when not assigned)
+python3 scripts/asana_api.py request GET /workspaces/{{ASANA_WORKSPACE_GID}}/tasks/search \
+  --query 'projects.any={{ASANA_PROJECTS}}' --query 'created_at.after=<SINCE>' --query 'completed=false' \
+  --opt-fields 'gid,name,assignee,due_on' | jq '.data'
+```
+
+Asana exposes no "assignee changed" filter — treat any assigned task whose `created_at` predates the previous run as a likely re-assignment.
+
+### Comments / Stories Updates
+
+For each changed task, fetch only the comment stories (text + html_text) with the dedicated command:
+
+```bash
+python3 scripts/asana_api.py task-comments <GID> | jq '.items'
+```
+
+Recent comments may carry questions needing {{USER_NAME}}'s response, status notes / blockers, or reviewer feedback. Use `task-stories <GID>` when you also need system stories (section moves, completions, assignee changes).
+
+### Mentions / Followers
+
+```bash
+python3 scripts/asana_api.py request GET /workspaces/{{ASANA_WORKSPACE_GID}}/tasks/search \
+  --query 'followers.any=me' --query 'modified_at.after=<SINCE>' --query 'completed=false' \
+  --opt-fields 'gid,name,assignee,due_on' | jq '.data'
+```
+
+Tasks where {{USER_NAME}} is a follower (often via `@`-mention in a description or comment) but not the assignee — high-signal context, often relevant even if not directly actionable.
+
+---
+phase: connector
+name: asana
+slot: query
+mode: [briefing]
+requires: asana
+---
+
+## Asana Query — Briefing Data Gathering
+
+All commands run via the `asana-api` CLI (`python3 scripts/asana_api.py …`); MCP `asana_*` tools are the fallback when the CLI is unavailable.
+
+### Priority Sections (always sweep) — Dynamic Roster
+
+If `scout-config.yaml` defines `asana_priority_sections`, Scout enumerates every task in each referenced project section on the configured cadence. Prefer this over hardcoded task lists when the roster is fluid — e.g. a recurring weekly-status section in a leads project that grows as new team leads onboard.
+
+Each config entry:
+```yaml
+asana_priority_sections:
+  - section_gid: '<asana_section_gid>'
+    name: '<display name>'
+    cadence: monday | daily | weekly_friday | ...
+    expected_cadence: weekly_friday   # optional — each task should have a new dated subtask this often
+    self_assignee_gid: '<user_asana_gid>'   # entries assigned to this gid are role=self; others are role=direct_report
+    why: <one-line reason>
+```
+
+**Sweep procedure (when cadence matches today):**
+
+```bash
+# 1. List section tasks  (section-tasks returns {"data": [...]})
+python3 scripts/asana_api.py section-tasks <section_gid> \
+  --opt-fields 'name,gid,assignee.name,assignee.gid,completed,modified_at' | jq '.data'
+
+# 2a. Fetch a task with its subtasks
+python3 scripts/asana_api.py task <task_gid> \
+  --opt-fields 'name,notes,subtasks.gid,subtasks.name,subtasks.assignee.name,subtasks.completed,subtasks.due_on,subtasks.modified_at' | jq '.items[0]'
+
+# 2e. Fetch the subtask's comments
+python3 scripts/asana_api.py task-comments <subtask_gid> | jq '.items'
+```
+
+For single-task planning, `task-bundle <task_gid> --project-gid <project_gid>` pulls fields + comments + subtasks + project workflow context in one call.
+
+1. **List section tasks** (above).
+2. **For each task:**
+   a. Fetch the task with subtasks.
+   b. If the task uses a dated-subtask pattern (e.g. `Weekly Update - <Name> - YYYY-MM-DD`), identify the **latest dated subtask** by parsing the date suffix and sorting descending.
+   c. Determine role: parent task's `assignee.gid == self_assignee_gid` → `role: self`; else → `role: direct_report`.
+   d. Fetch that subtask.
+   e. Fetch comments since previous run (`task-comments`; they are already comment-only).
+   f. Classify write state: **Written** (notes extend meaningfully beyond template prompts) / **WIP/empty** (only template prompts) / **Missing** (no subtask for expected period).
+
+**Integrity check (`expected_cadence: weekly_friday`):** the latest *complete* (non-WIP, non-empty) dated subtask per task should correspond to the most recent Friday. If older, flag as overdue.
+
+**Action item rules:**
+- **`role: self` + own subtask WIP/empty/missing by cadence day** → 🔴 urgent: write/finish before dependent meeting.
+- **`role: direct_report` + subtask older than expected_cadence OR WIP/empty by cadence day** → 🟡 to-do: nudge that person.
+- **Inbound comment from manager on `role: self` subtask not replied to** → 🔴 urgent.
+
+### Priority Tasks (one-off) — User-Pinned Cadences
+
+For pinned individual tasks outside any section sweep:
+```yaml
+asana_priority_tasks:
+  - gid: '<asana_task_gid>'
+    name: '<display name>'
+    cadence: monday_afternoon | daily | weekly_friday | ...
+    role: self | direct_report | peer
+    why: <one-line reason>
+```
+
+Same per-entry procedure as section entries (step 2a–f above).
+
+### All Open Assigned Tasks
+
+```bash
+python3 scripts/asana_api.py project-assigned-tasks <PROJECT_GID> --workspace {{ASANA_WORKSPACE_GID}} \
+  --completed false --include-task-position --include-comments --comment-limit 3 \
+  --opt-fields 'gid,name,due_on,due_at,assignee,completed,projects.name,memberships.section.name,custom_fields' | jq '.data'
+```
+
+`project-assigned-tasks` searches the workspace by project + assignee and includes matching subtasks with parent-section context — it catches assigned subtasks that a bare project listing misses. For each task note: name + GID, project/section, due date (`due_on` date-only, `due_at` datetime), the `Priority` custom field if present, and recent comments.
+
+### Tasks Due This Week
+
+```bash
+python3 scripts/asana_api.py request GET /workspaces/{{ASANA_WORKSPACE_GID}}/tasks/search \
+  --query 'assignee.any=me' --query 'completed=false' \
+  --query 'due_on.before=<TODAY+6d>' --query 'due_on.after=<TODAY-1d>' \
+  --query 'sort_by=due_date' --query 'sort_ascending=true' \
+  --opt-fields 'gid,name,due_on,memberships.section.name' | jq '.data'
+```
+
+Surface anything overdue (`due_on < today`) at the top of the briefing.
+
+### Active Project Snapshot
+
+For each project in `{{ASANA_PROJECTS}}`, pull active sections + tasks:
+
+```bash
+python3 scripts/asana_api.py board <PROJECT_GID> --context | jq '.'
+```
+
+`board` returns sections and their tasks in order; `--context` adds per-section stats for workflow analysis. Look for: assignments without progress, blockers, items at risk for the cycle.
+
+### Priority Check
+
+Flag tasks that are:
+- **Overdue** (`due_on < today` and `completed=false`) — top priority, surface every run
+- **High priority custom field** and not yet in an "In Progress" section
+- **Stuck** — same section / same assignee for more than 2 days (compare `modified_at`)
+- **Blocked** — has a `blocked` tag, a comment containing "blocked", or a "Blocked by" relation in `dependencies`
+
+---
+phase: connector
+name: asana
+slot: cross-check
+mode: [consolidation, briefing]
+requires: asana
+---
+
+## Asana Cross-Check
+
+Before promoting any candidate action item to To Do, verify against Asana via the CLI (MCP fallback in brackets).
+
+**Does a task already exist for this?** Search by keyword:
+
+```bash
+python3 scripts/asana_api.py search-tasks --workspace {{ASANA_WORKSPACE_GID}} \
+  --text "<keywords>" --project {{ASANA_PROJECTS}} --completed false \
+  --opt-fields 'gid,name,completed,memberships.section.name' | jq '.data'
+```
+
+(MCP fallback: `search_tasks(text=..., projects_any=...)`; non-premium fallback: `search_objects`.) If a matching task exists:
+- Link the action item to the task (include the GID and permalink — `https://app.asana.com/0/0/<GID>`).
+- Use the task's section / completed state as the source of truth for progress.
+- Don't create a duplicate.
+
+**Has it already been resolved?** Check recently completed matches:
+
+```bash
+python3 scripts/asana_api.py search-tasks --workspace {{ASANA_WORKSPACE_GID}} \
+  --text "<keywords>" --completed true \
+  --opt-fields 'gid,name,completed_at' | jq '.data'
+```
+
+Common pattern: a meeting generates "we need to fix X" but X was already completed yesterday by someone else.
+
+**Is the status current?** If the action item references a known GID:
+
+```bash
+python3 scripts/asana_api.py task <GID> \
+  --opt-fields 'completed,completed_at,assignee.name,due_on,memberships.section.name,custom_fields' | jq '.items[0]'
+```
+
+If the KB says "In Progress" but Asana says `completed=true`, update the action item to Done and cite `completed_at` as evidence.
+
+**Did {{USER_NAME}} already act on this task?** Inspect recent stories:
+
+```bash
+python3 scripts/asana_api.py task-stories <GID> | jq '.items'
+```
+
+A recent story authored by {{USER_NAME}} (comment, section move, completion, assignee change) signals "already handled" — use the story `created_at` and `text` as evidence.
+
+---
+phase: connector
+name: asana
+slot: update
+mode: [consolidation, briefing]
+requires: asana
+---
+
+## Asana-Sourced KB Updates
+
+After scanning Asana, update the knowledge base with current task data. **Task status staleness is the most common form of KB rot** — treat this update step as critical.
+
+### Task Tracker Sync
+
+For every Asana task referenced in the KB:
+1. **Verify the state matches Asana.** `python3 scripts/asana_api.py task <GID> --opt-fields 'completed,assignee.name,memberships.section.name,due_on,custom_fields'` and reconcile.
+2. **Update section / completion** if it changed.
+3. **Update due date or priority** if either shifted.
+4. **Add new comments or context.** Pull `task-comments <GID>` for the most recent updates and quote pertinent snippets in the KB.
+5. **Move completed tasks** to a "Completed" section in the KB — don't delete; cite `completed_at` and `completed_by.name`.
+
+### Spot-Check Requirement
+
+Every run must spot-check at least 2-3 task states against Asana as the source of truth. Pick tasks that are high priority, haven't been verified recently, or are referenced by current action items.
+
+### Posting Comments (incl. @mentions)
+
+When a slot calls for {{INSTANCE_NAME}} to reply on a task (e.g. a weekly-status nudge or a manager-summary follow-up), post via `comment-task`. Plain text:
+
+```bash
+python3 scripts/asana_api.py comment-task <task_gid> --text "Status synced — see KB for details."
+```
+
+To **@mention** a person, use `--html-text` with Asana's rich-text mention markup — a self-closing anchor carrying the user's Asana GID. Asana renders it as `@Name` and notifies them:
+
+```bash
+python3 scripts/asana_api.py comment-task <task_gid> \
+  --html-text '<body><a data-asana-gid="{{ASANA_GID_OF_PERSON}}"/> please refresh this before Friday.</body>'
+```
+
+Resolve the GID from `people.md` (the `asana_gid` field) or `users --workspace {{ASANA_WORKSPACE_GID}}`. For multi-line or longer comments, use `--html-text-file`. Never post an externally-visible comment without {{USER_NAME}}'s approval during interactive sessions.
+
+### New Tasks
+
+Add newly discovered tasks to the tracker with: GID + name, project(s)/section, assignee, due date, priority custom field if present, permalink (`https://app.asana.com/0/0/<GID>`), and a one-line context on why it matters.
+
+### Project File Updates
+
+If task changes affect active projects, update `knowledge-base/projects/`: changed task states, new tasks, completed milestones (`resource_subtype="milestone"`), section progress for the active cycle.
+
+### People Updates
+
+If new assignees, followers, or commenters appeared who are not in `people.md`, add them:
+- Name (resolve via `python3 scripts/asana_api.py users --workspace {{ASANA_WORKSPACE_GID}}` or `user <GID>` if only a GID is known)
+- Asana user GID (as `asana_gid:` — needed for @mention markup above)
+- Email if visible
+- Context: "Assignee on <task name> in <project>" or "Commented on <task name>"
+- Role `[single-source]` based on observed activity

--- a/phases/connectors/google-chat.md
+++ b/phases/connectors/google-chat.md
@@ -1,0 +1,315 @@
+---
+phase: connector
+name: google-chat
+slot: outbound-scan
+mode: [consolidation]
+requires: google_chat
+---
+
+## Google Chat Outbound Scan — What {{USER_NAME}} Did
+
+Search for messages FROM {{USER_NAME}} since the last run using the `gws` CLI (Google Workspace CLI). Outbound activity in Google Chat is the strongest signal for what {{USER_NAME}} has already handled.
+
+### List Spaces {{USER_NAME}} Is In
+
+```bash
+gws chat spaces list --format json --page-all 2>/dev/null
+```
+
+This returns all spaces (DMs, group chats, named rooms) {{USER_NAME}} is a member of. Cache the space list for the rest of the run — it changes rarely. Note each space's `name` (e.g. `spaces/AAAA...`), `displayName`, and `spaceType` (`DIRECT_MESSAGE`, `GROUP_CHAT`, or `SPACE`).
+
+### DMs Sent
+
+For each `DIRECT_MESSAGE` space in the list, fetch recent messages and keep only those where `sender.name == "users/{{USER_GOOGLE_CHAT_ID}}"`:
+
+```bash
+gws chat spaces messages list \
+  --params '{"parent":"spaces/AAAA...","filter":"create_time > \"<ISO-8601 since-last-run>\"","orderBy":"create_time DESC","pageSize":50}' \
+  --format json 2>/dev/null
+```
+
+Each outbound DM is a strong signal:
+- A reply to someone = that request/question is likely handled
+- A proactive message = {{USER_NAME}} initiated something (delegation, follow-up)
+- A message containing a link or attachment ID = possible deliverable completed
+
+### Space Posts
+
+For each project space listed in `channels.md` (or every `SPACE` / `GROUP_CHAT` in the cached list, scoped to high-priority ones), list messages since the last run and filter by `sender.name`:
+
+```bash
+gws chat spaces messages list \
+  --params '{"parent":"spaces/BBBB...","filter":"create_time > \"<ISO-8601>\"","pageSize":50}' \
+  --format json 2>/dev/null
+```
+
+Space posts indicate:
+- Status updates given (the underlying work is done or in progress)
+- Questions asked ({{USER_NAME}} is blocked or exploring)
+- Answers provided ({{USER_NAME}} helped someone — may indicate context/expertise)
+
+### Thread Replies
+
+Google Chat threads are first-class. Each message has a `thread.name` (e.g. `spaces/AAA/threads/BBB`). After listing space messages, group by `thread.name` to find threads {{USER_NAME}} replied in. Thread replies are easy to miss but often indicate handled items — someone asked a question in a thread, {{USER_NAME}} replied, and the item is resolved.
+
+To pull a full thread once a candidate thread is identified:
+
+```bash
+gws chat spaces messages list \
+  --params '{"parent":"spaces/AAA","filter":"thread.name = spaces/AAA/threads/BBB"}' \
+  --format json 2>/dev/null
+```
+
+### What to Record
+
+For each outbound message found, note:
+- **Who** it was sent to (DM peer, space `displayName`, or thread)
+- **Topic** (brief summary of what was discussed)
+- **Implications** for action items:
+  - Did this complete something? (mark it Done)
+  - Did this delegate something? (track the delegation)
+  - Did this respond to a request? (the request is handled)
+  - Did this create a new commitment? (new action item for {{USER_NAME}})
+
+---
+phase: connector
+name: google-chat
+slot: inbound-scan
+mode: [consolidation, briefing]
+requires: google_chat
+---
+
+## Google Chat Inbound Scan — What Happened to {{USER_NAME}}
+
+Search for messages TO or MENTIONING {{USER_NAME}} since the last run. These are potential new action items or context updates.
+
+### Direct Mentions
+
+Google Chat's API has no global mention search. Iterate the space list (cached from the outbound scan if available) and, for each `SPACE` / `GROUP_CHAT`, list messages since the last run, then keep messages whose text contains `<users/{{USER_GOOGLE_CHAT_ID}}>` or whose `annotations[].userMention.user.name == "users/{{USER_GOOGLE_CHAT_ID}}"`:
+
+```bash
+gws chat spaces messages list \
+  --params '{"parent":"spaces/BBBB...","filter":"create_time > \"<ISO-8601>\"","pageSize":50}' \
+  --format json 2>/dev/null
+```
+
+Direct mentions are high-signal — someone specifically wanted {{USER_NAME}}'s attention.
+
+### DMs Received
+
+For each `DIRECT_MESSAGE` space, list messages since the last run and keep messages where `sender.name != "users/{{USER_GOOGLE_CHAT_ID}}"`. Inbound DMs often contain:
+- Requests for help or input
+- Questions needing answers
+- Updates on shared work
+- FYIs that may affect priorities
+
+### Key Space Activity
+
+Check spaces listed in `channels.md` for recent activity, even if {{USER_NAME}} wasn't mentioned. Important space activity includes:
+- Decisions made that affect {{USER_NAME}}'s work
+- New issues or blockers raised
+- Status updates from collaborators
+- Announcements that change priorities
+
+### Priority Spaces (always sweep)
+
+If `scout-config.yaml` defines a `google_chat_priority_spaces` list, sweep every entry on every run regardless of dynamic discovery. These are pinned strategic spaces (e.g. CTO direct-reports broadcast, org-wide engineering channels, weekly tech meetings) where missing a message has high cost. For each entry:
+
+```bash
+gws chat spaces messages list \
+  --params '{"parent":"spaces/<id>","filter":"create_time > \"'$SINCE'\""}' \
+  --format json
+```
+
+Record matched items with the same fields as Key Space Activity even when {{USER_NAME}} wasn't tagged.
+
+### What to Record
+
+For each inbound message found, note:
+- **From** whom (resolve `sender.name` -> display name via cached `people.md` or `gws chat users get --params '{"name":"users/<id>"}'`)
+- **Space/thread** where it appeared
+- **What's being asked or communicated**
+- **Urgency level** — is this time-sensitive?
+- **Whether {{USER_NAME}} already responded** (cross-reference with outbound scan)
+
+Remember: every inbound item is a *candidate* action item, not a confirmed one. It must pass the cross-check before becoming a To Do.
+
+---
+phase: connector
+name: google-chat
+slot: query
+mode: [briefing]
+requires: google_chat
+---
+
+## Google Chat Query — Briefing Data Gathering
+
+Gather Google Chat context for the briefing. Check the past 24 hours of activity. Compute the lower bound once and reuse it across all `gws` calls:
+
+```bash
+SINCE=$(date -u -v-24H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+```
+
+### Inbound — What Needs Attention
+
+1. **Space inventory**: `gws chat spaces list --format json --page-all` (cache the result for the rest of the run).
+2. **DMs to {{USER_NAME}}**: For each `DIRECT_MESSAGE` space, `gws chat spaces messages list --params '{"parent":"<space>","filter":"create_time > \"'$SINCE'\""}' --format json`. Keep messages whose `sender.name != "users/{{USER_GOOGLE_CHAT_ID}}"`. Prioritize peers in `people.md`.
+3. **Mentions**: For each `SPACE` / `GROUP_CHAT`, list messages since `$SINCE` and keep messages where `annotations[].userMention.user.name == "users/{{USER_GOOGLE_CHAT_ID}}"` or whose `text` contains `<users/{{USER_GOOGLE_CHAT_ID}}>`.
+4. **Key spaces**: Read recent messages in spaces listed in `channels.md` that are marked as high-priority. Look for anything actionable even if {{USER_NAME}} wasn't tagged.
+4a. **Priority spaces (always sweep)**: If `scout-config.yaml` defines `google_chat_priority_spaces`, sweep every entry on every run regardless of dynamic discovery — `gws chat spaces messages list --params '{"parent":"spaces/<id>","filter":"create_time > \"'$SINCE'\""}' --format json` for each. These are pinned strategic spaces (e.g. CTO direct-reports broadcast, org-wide engineering channels, weekly tech meetings) where missing a message has high cost. Surface key updates even when {{USER_NAME}} wasn't tagged.
+
+### Outbound — What's Already Handled
+
+5. **Messages FROM {{USER_NAME}}**: For each space (DMs first, then high-priority spaces), filter the same listing by `sender.name == "users/{{USER_GOOGLE_CHAT_ID}}"`. This reveals what's already been dealt with — critical for avoiding stale action items.
+6. **Thread participation**: Group {{USER_NAME}}'s outbound messages by `thread.name`. If {{USER_NAME}} replied in a thread about a topic, that topic is likely in-progress or handled.
+
+### Synthesis
+
+For each finding, note whether it's:
+- A new request needing action
+- An update on an existing project/issue (link to KB file)
+- Something {{USER_NAME}} already handled (evidence from outbound search)
+- FYI/context only (no action needed)
+
+---
+phase: connector
+name: google-chat
+slot: cross-check
+mode: [consolidation, briefing]
+requires: google_chat
+---
+
+## Google Chat Cross-Check
+
+Before promoting any candidate action item to To Do, verify against Google Chat:
+
+**Did {{USER_NAME}} already handle this?** Search outbound messages — DMs, space posts, and thread replies — about this topic. Google Chat has no full-text search across spaces, so:
+
+1. Identify candidate spaces (DM with the requester, the space where the topic was raised, or any space tagged with the relevant project in `channels.md`).
+2. For each candidate space, list messages with a `create_time` filter wide enough to cover the topic's lifetime, then locally grep `text` for topic-specific keywords AND filter by `sender.name == "users/{{USER_GOOGLE_CHAT_ID}}"`.
+
+```bash
+gws chat spaces messages list \
+  --params '{"parent":"spaces/AAA","filter":"create_time > \"<ISO-8601>\"","pageSize":200}' \
+  --format json 2>/dev/null \
+  | jq '.messages[] | select(.sender.name == "users/{{USER_GOOGLE_CHAT_ID}}") | select(.text | test("<keyword>"; "i"))'
+```
+
+- If {{USER_NAME}} sent a message about the topic, the item is likely **handled or in progress**. Read the message content to determine if it's fully resolved or still pending.
+- If {{USER_NAME}} replied in a thread discussing this topic, pull the full thread (`filter=thread.name = spaces/AAA/threads/BBB`) to understand the current state.
+- If {{USER_NAME}} posted a status update or shared a deliverable related to this item, mark it Done and cite the message resource name (`spaces/AAA/messages/BBB`) as evidence.
+
+**Was this already discussed and resolved?** Sometimes a topic was raised, discussed, and resolved — all in a thread {{USER_NAME}} may not have participated in. List recent messages in the relevant project space, group by `thread.name`, and read full threads where the topic appears.
+
+---
+phase: connector
+name: google-chat
+slot: update
+mode: [consolidation, briefing]
+requires: google_chat
+---
+
+## Google Chat-Sourced KB Updates
+
+After scanning Google Chat, update the knowledge base with any new information discovered:
+
+### People Updates
+
+- If new people appeared in threads, DMs, or space conversations who are not in `people.md`, add them with:
+  - Name (resolve via `gws chat users get --params '{"name":"users/<id>"}'` if not already known)
+  - Context (how they appeared — "mentioned in <space displayName> discussing project-x")
+  - Google Chat user resource name (`users/<id>`) and email if visible
+  - Role if determinable from context `[single-source]`
+- If existing people showed new context (e.g., someone listed as "Engineering" is now clearly leading a specific project), update their entry with the new information and source citation.
+
+### Space (Channel) Updates
+
+- If new spaces were discovered that are relevant to {{USER_NAME}}'s work, add them to `channels.md` with:
+  - Space `displayName` and resource name (`spaces/AAAA...`)
+  - `spaceType` (`SPACE`, `GROUP_CHAT`, `DIRECT_MESSAGE`)
+  - Purpose/context (what the space is used for based on observed messages)
+  - Which project(s) it relates to
+- If existing spaces have changed in relevance (e.g., a project space went quiet or a new one became active), note the change.
+
+### Project Updates
+
+- If Google Chat conversations revealed new decisions, status changes, or context for active projects, update the relevant project files in `knowledge-base/projects/`.
+- Always cite the Google Chat source: "Per discussion in <space displayName> on [date]" or "Per DM from [person] on [date]." Include the message resource name (`spaces/AAA/messages/BBB`) so the source can be re-fetched with `gws chat spaces messages get`.
+
+---
+phase: connector
+name: google-chat
+slot: notification
+mode: [consolidation, briefing]
+requires: google_chat
+---
+
+## Google Chat Notification
+
+Send a Google Chat DM to {{USER_NAME}} (Google Chat user ID: `{{USER_GOOGLE_CHAT_ID}}`) summarizing the run results. Resolve the DM space once per run, then post into it.
+
+### Resolve the Self-DM Space
+
+```bash
+DM_SPACE=$(gws chat spaces findDirectMessage \
+  --params '{"name":"users/{{USER_GOOGLE_CHAT_ID}}"}' \
+  --format json 2>/dev/null \
+  | jq -r '.name')
+```
+
+If `findDirectMessage` returns 404 (no DM exists yet), fall back to `users/{{USER_EMAIL}}` as the user alias. Cache `DM_SPACE` in `.scout-cache/google-chat-self-dm` so subsequent runs skip the lookup.
+
+### Send the Notification
+
+Use the `+send` helper for plain-text notifications:
+
+```bash
+gws chat +send --space "$DM_SPACE" --text "$(cat <<'EOF'
+Scout consolidation complete.
+- Action items: X new, Y completed, Z carried forward
+- KB audited: <list of files checked/updated>
+- Urgent: <any urgent items, or "none">
+EOF
+)"
+```
+
+For threaded replies or rich cards, call the raw API instead:
+
+```bash
+gws chat spaces messages create \
+  --params '{"parent":"'"$DM_SPACE"'"}' \
+  --json '{"text":"<message body>"}' \
+  --format json 2>/dev/null
+```
+
+### Consolidation Notification (3-5 lines)
+
+Keep it tight. Example format:
+
+```
+Scout consolidation complete.
+- Action items: X new, Y completed, Z carried forward
+- KB audited: [list of files checked/updated]
+- Urgent: [any urgent items, or "none"]
+```
+
+### Briefing Notification (5-8 lines)
+
+Slightly more detail. Example format:
+
+```
+Scout morning briefing ready.
+- Today's meetings: [count] ([first meeting time])
+- Action items: X urgent, Y to-do, Z watching
+- New since yesterday: [brief summary of new items]
+- KB areas updated: [list]
+- Review queue: [count] items pending your review
+```
+
+### Notification Rules
+
+- Never include sensitive details in the notification — just summaries and counts.
+- If there are urgent items, mention them by name (briefly) so {{USER_NAME}} knows to check.
+- Always include where to find the full details: "Full report in {{SCOUT_DIR}}/action-items/"
+- If the run encountered errors or couldn't access a connector, mention it briefly so {{USER_NAME}} knows the run was partial.
+- Google Chat plain-text messages cap at 32,000 bytes. Scout notifications are short by design — splitting is not required, but if a body exceeds the cap, truncate with a "(truncated — see {{SCOUT_DIR}}/...)" suffix rather than fanning out multiple messages.

--- a/phases/connectors/jira.md
+++ b/phases/connectors/jira.md
@@ -1,0 +1,253 @@
+---
+phase: connector
+name: jira
+slot: inbound-scan
+mode: [consolidation, briefing]
+requires: jira
+---
+
+## Jira Inbound Scan — Issue Activity
+
+Check for changes to {{USER_NAME}}'s assigned Jira issues and any newly created or assigned issues. All queries run via the local `jtk` CLI (https://github.com/open-cli-collective/atlassian-cli).
+
+Compute the lower bound once and reuse it across all `jtk` calls:
+
+```bash
+SINCE_DAYS=1   # consolidation = 1d, briefing = 1d, weekend briefing = 3d
+```
+
+### Status Changes
+
+Use `jtk issues search` with JQL filtered to {{USER_NAME}} (`assignee = currentUser()`) and updated since the last run:
+
+```bash
+jtk issues search \
+  --jql "assignee = currentUser() AND updated >= -${SINCE_DAYS}d" \
+  --fields "Key,Summary,Status,Priority,Updated" \
+  --max 100
+```
+
+Status transitions to watch for:
+- **To Do -> In Progress**: Someone (or {{USER_NAME}}) started working on it
+- **In Progress -> In Review / Code Review**: Work is done, awaiting review
+- **In Review -> Done / Resolved / Closed**: Issue resolved
+- **Any -> Cancelled / Won't Do / Duplicate**: Issue no longer relevant
+- **Backlog -> Selected for Development / To Do**: Issue was prioritized — new commitment
+
+For each status change, update the KB issue tracker file and note implications for action items.
+
+### Newly Created Issues
+
+```bash
+jtk issues search \
+  --jql "(assignee = currentUser() OR reporter = currentUser()) AND created >= -${SINCE_DAYS}d" \
+  --fields "Key,Summary,Status,Priority,Reporter,Assignee" \
+  --max 100
+```
+
+Also scan key projects from `{{JIRA_PROJECTS}}` (configured at setup) for newly filed issues that may affect {{USER_NAME}}'s work even when not directly assigned:
+
+```bash
+jtk issues search \
+  --jql "project in (${JIRA_PROJECTS}) AND created >= -${SINCE_DAYS}d" \
+  --fields "Key,Summary,Status,Priority,Reporter" \
+  --max 50
+```
+
+New issues may represent: new work assignments, bug reports needing triage, or feature requests needing evaluation.
+
+### Newly Assigned Issues
+
+```bash
+jtk issues search \
+  --jql "assignee = currentUser() AND assignee changed AFTER -${SINCE_DAYS}d" \
+  --fields "Key,Summary,Status,Priority,Updated" \
+  --max 100
+```
+
+Issues whose `assignee` changed to {{USER_NAME}} during the window are direct new action items.
+
+### Comments and Updates
+
+For each updated issue from the status-changes query, list new comments:
+
+```bash
+jtk comments list <ISSUE-KEY> --fulltext --max 20
+```
+
+Comments may contain:
+- Questions needing {{USER_NAME}}'s response
+- Status updates from collaborators
+- Blockers or dependency changes
+- Review feedback
+
+### Mentions
+
+```bash
+jtk issues search \
+  --jql "text ~ \"\\\"@${USER_JIRA_ACCOUNT_ID}\\\"\" AND updated >= -${SINCE_DAYS}d" \
+  --fields "Key,Summary,Status,Updated" \
+  --max 50
+```
+
+`@`-mentions in descriptions or comments are high-signal — someone wanted {{USER_NAME}}'s attention even if not assigned.
+
+---
+phase: connector
+name: jira
+slot: query
+mode: [briefing]
+requires: jira
+---
+
+## Jira Query — Briefing Data Gathering
+
+### All Assigned Issues
+
+```bash
+jtk issues search \
+  --jql "assignee = currentUser() AND statusCategory != Done" \
+  --fields "Key,Summary,Status,Priority,Updated,Sprint,Issue Type" \
+  --max 200
+```
+
+For each issue, note:
+- **Key and summary** (e.g. `PROJ-123 — Fix auth race`)
+- **Current status** (Backlog, To Do, In Progress, In Review, Done — exact names vary per Jira workflow)
+- **Priority** (Highest, High, Medium, Low, Lowest)
+- **Sprint / fix version** if applicable
+- **Issue type** (Bug, Story, Task, Epic, Sub-task)
+- **Recent updates** — fetch comments for issues updated in the last 24h
+
+### New Issues Since Yesterday
+
+```bash
+jtk issues search \
+  --jql "project in (${JIRA_PROJECTS}) AND created >= -1d" \
+  --fields "Key,Summary,Status,Priority,Reporter" \
+  --max 100
+```
+
+Even issues not assigned to {{USER_NAME}} may be relevant context (e.g. a teammate's bug report that affects {{USER_NAME}}'s project).
+
+### Active Sprint Snapshot
+
+If {{USER_NAME}} works in scrum-mode projects, pull the current sprint:
+
+```bash
+jtk issues list \
+  --project "${JIRA_PRIMARY_PROJECT}" \
+  --sprint current \
+  --fields "Key,Summary,Status,Assignee,Priority" \
+  --max 200
+```
+
+Look for: assignments without progress, blockers, items at risk for the sprint goal.
+
+### Priority Check
+
+Flag any issues that are:
+- **Highest / High priority** and not yet In Progress
+- **High priority** and stuck in the same status for more than 2 days (compare `Updated` to status duration)
+- **Blocked** — has a `blocker`/`blocked` label, a comment containing "blocked", or an inbound `is blocked by` link (use `jtk links` if a candidate is found)
+
+---
+phase: connector
+name: jira
+slot: cross-check
+mode: [consolidation, briefing]
+requires: jira
+---
+
+## Jira Cross-Check
+
+Before promoting any candidate action item to To Do, verify against Jira:
+
+**Does a ticket already exist for this?** Search Jira issues by keyword to see if this action item is already tracked as a formal issue:
+
+```bash
+jtk issues search \
+  --jql "text ~ \"<keywords>\" AND project in (${JIRA_PROJECTS})" \
+  --fields "Key,Summary,Status,Assignee" \
+  --max 20
+```
+
+If a ticket exists:
+- Link the action item to the ticket (include the issue key, e.g. `PROJ-123`)
+- Use the ticket's status as the source of truth for progress
+- Don't create a duplicate action item if the ticket is already being tracked
+
+**Has it already been resolved?** Check if a related issue was recently moved to Done / Resolved / Won't Do:
+
+```bash
+jtk issues search \
+  --jql "text ~ \"<keywords>\" AND statusCategory = Done AND resolved >= -7d" \
+  --fields "Key,Summary,Status,Resolution,Resolved" \
+  --max 20
+```
+
+Common pattern: a meeting generates "we need to fix X" but X was already closed yesterday.
+
+**Is the status current?** If the action item references a known issue key, verify the issue's current status:
+
+```bash
+jtk issues get <ISSUE-KEY> --fields "Status,Assignee,Priority,Resolution,Updated"
+```
+
+If the KB says "In Progress" but Jira says "Done," update the action item to Done and cite the issue's `Resolved` timestamp as evidence.
+
+**Did {{USER_NAME}} already act on this ticket?** Check comments authored by {{USER_NAME}}:
+
+```bash
+jtk comments list <ISSUE-KEY> --fulltext --max 50
+```
+
+Filter the output for comments where the author matches {{USER_NAME}}. A recent comment, a transition `jtk transitions do <ISSUE-KEY> ...`, or an assignee change by {{USER_NAME}} all signal "already handled".
+
+---
+phase: connector
+name: jira
+slot: update
+mode: [consolidation, briefing]
+requires: jira
+---
+
+## Jira-Sourced KB Updates
+
+After scanning Jira, update the knowledge base with current issue data. **Issue status staleness is the most common form of KB rot** — treat this update step as critical.
+
+### Issue Tracker Sync
+
+For every issue in the KB's issue tracker file:
+1. **Verify the status matches Jira.** Run `jtk issues get <KEY> --fields Status,Priority,Assignee,Resolution` and reconcile.
+2. **Update priority** if it changed.
+3. **Add any new comments or context** that are relevant. Use `jtk comments list <KEY> --fulltext` and quote pertinent snippets.
+4. **Move resolved issues** (statusCategory == Done) to a "Completed" section — don't delete; the history is useful. Cite the resolution and resolved-date.
+
+### Spot-Check Requirement
+
+Every run must spot-check at least 2-3 issue statuses against Jira as the source of truth. Pick issues that:
+- Are Highest/High priority (most impactful if stale)
+- Haven't been verified recently (check the "Last verified" note)
+- Are referenced by current action items (most likely to cause errors if stale)
+
+### New Issues
+
+Add any newly discovered issues to the issue tracker file with:
+- Issue key and summary (e.g. `PROJ-123 — Fix auth race`)
+- Status, priority, assignee, reporter
+- Issue type (Bug, Story, Task, Epic)
+- Sprint / fix version if applicable
+- Link to Jira (the URL is `${JIRA_BASE_URL}/browse/<KEY>` — base URL stored in `jtk` config; reference by key only in the KB and let the renderer resolve)
+
+### Project File Updates
+
+If issue changes affect active projects, update the relevant project files in `knowledge-base/projects/`:
+- Changed issue statuses in the project's issues section
+- New issues added to the project
+- Completed milestones or resolved blockers
+- Sprint progress notes if scrum is in use
+
+### Epic / Parent Tracking
+
+When issues belong to an epic (Jira's `Parent` or `Epic Link` field), record the epic key alongside each child issue. Group child issues under their epic in the project file so the KB shows the work's structural context, not just a flat list.

--- a/skills/asana-api/SKILL.md
+++ b/skills/asana-api/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: asana-api
+description: Read or update Asana data via REST API using scripts/asana_api.py — token-efficient alternative to Asana MCP. Use for tasks, projects, sections, stories/comments, teams, users, tags, attachments, custom fields, workspace metadata. Higher-level workflows supported: daily-briefing command center, inbox-cleanup (AI-gated My Tasks triage), close-out-sections cleanup, project-assigned-tasks working-set triage, manager summary rollups, follow-up summaries. Triggers on requests like "get task <gid>", "list project <gid>", "search Asana for X", "comment on task Y", "Asana board for Z", "triage my Asana inbox", "morning Asana briefing", or any reference to Asana entities by GID. Skip when user explicitly invokes MCP (mcp__claude_ai_Asana__*).
+---
+
+# Asana API Skill
+
+Local Python wrapper over Asana REST API. Saves tokens vs MCP — only requested fields returned, no chat-rendering overhead. Bulk read, batch write, JSON pipeline through `jq`.
+
+## Setup (one-time)
+
+1. Generate PAT: https://app.asana.com/0/my-apps
+2. Store:
+   ```bash
+   mkdir -p ~/.agent-skills/asana
+   echo "<PAT>" > ~/.agent-skills/asana/asana_pat
+   chmod 600 ~/.agent-skills/asana/asana_pat
+   ```
+   Or export `ASANA_ACCESS_TOKEN=<PAT>`.
+3. Optional context defaults at `~/.agent-skills/asana/asana-context.json`:
+   ```json
+   {"default_workspace_gid": "<your-workspace-gid>", "default_team_gid": "<your-team-gid>"}
+   ```
+4. Verify: `python3 scripts/asana_api.py whoami`.
+
+Overrides: `ASANA_TOKEN_FILE`, `ASANA_CONTEXT_FILE`, `ASANA_CACHE_FILE`. Local entity cache for workspaces/teams/projects/users/tags auto-refreshes on `whoami`, `workspaces`, `teams`, `projects`, `users`, `tags`, `project-assigned-tasks`.
+
+## Workflow
+
+1. For single-task planning: prefer `task-bundle` — pulls fields + comments + attachments + project workflow context in one call.
+2. For project working sets: prefer `project-assigned-tasks` over `project-tasks`. It searches workspace by project + assignee, includes matching subtasks, enriches with parent section context. `project-tasks` alone misses assigned subtasks.
+3. Lookup-style read commands (`task`, `story`, `project`, `section`, etc.) accept one or many gids (space or comma separated). Response wraps in `command`, `count`, `items`.
+4. Before writes: inspect current object first unless user gave exact target GID + mutation.
+5. After writes that create or update a task/story: surface returned `review_url` (and `target_review_url` for story writes) so user can click into the updated object.
+6. For batch operations: build JSON action array, run `batch` (up to 10 ops per HTTP round-trip).
+7. Run via `ctx_execute` shell so raw JSON stays in sandbox; pipe through `jq` to print only summary.
+
+## Common Subcommands
+
+| Subcommand | Purpose |
+|---|---|
+| `whoami` | Verify auth + first-run advertising |
+| `workspaces` / `teams --workspace <gid>` / `users --workspace <gid>` | Org metadata |
+| `projects --team <gid>` | List projects in team |
+| `project <gid>` | Inspect project(s), bulk OK |
+| `project-tasks <gid>` | List tasks in project |
+| `project-assigned-tasks <gid> --completed false --include-task-position --include-comments --comment-limit 3 --include-attachments` | Enriched assigned working set (preferred) |
+| `board <gid> [--context]` | Sections + tasks in order; `--context` adds stats for workflow analysis |
+| `sections <gid>` / `section <gid>` / `section-tasks <gid>` | Section ops |
+| `create-section` / `update-section` / `close-out-sections` | Section mgmt |
+| `task <gid> [<gid>...]` | Inspect tasks (bulk OK) |
+| `task-bundle <gid> --project-gid <pgid>` | Task + stories + subtasks + projects + attachments + workflow context (one call) |
+| `task-status <gid>` | Completion + board column |
+| `task-stories <gid>` | All stories (system + comments) |
+| `task-comments <gid>` | Comment stories only (text + html_text) |
+| `task-projects <gid>` | Projects a task belongs to |
+| `task-custom-fields <gid>` | Custom fields on task |
+| `task-tags <gid>` | Tags on task |
+| `search-tasks --workspace <gid> --text "X"` | Workspace text search |
+| `create-task --workspace <gid> --name "X" --assignee me --project <pgid>` | Create |
+| `update-task <gid> --name "Y" --completed true` | Update |
+| `comment-task <gid> --text "msg"` or `--html-text "<body>...</body>"` | Add comment |
+| `update-story <gid>` | Edit existing comment |
+| `add-task-project` / `remove-task-project` / `add-task-followers` / `remove-task-followers` | Membership |
+| `add-task-tag` / `remove-task-tag` / `add-task-dependencies` / `remove-task-dependencies` | Relations |
+| `workspace-custom-fields` / `team-custom-fields` / `project-custom-fields` / `create-custom-field` | Custom field schema |
+| `batch --actions actions.json` | ≤10 ops per HTTP call |
+| `request GET /tasks/<gid> --query opt_fields=name` | Generic call (JSON body wrapped in `{"data": ...}` unless `--no-wrap-data`) |
+| `inbox-cleanup` / `daily-briefing` | AI-gated higher-level workflows (see below) |
+| `close-out-sections <pgid> --section "Old" --move-to "Done" --completed-mode completed [--apply]` | Bulk section cleanup |
+| `trigger-rule <id> --task <gid> --action-data k=v` | Fire Asana rule with "Incoming web request" trigger |
+| `show-context` / `show-cache` | Local state |
+
+Full surface: `python3 scripts/asana_api.py --help` then `<sub> --help`.
+
+## Token-Saving Patterns
+
+1. **Always restrict fields**: `--opt-fields name,assignee.name,completed,due_on` (default returns 30+ fields per record).
+2. **Bulk inspect**: `task <gid1> <gid2> <gid3>` instead of three calls.
+3. **`task-bundle`** replaces task + task-stories + task-projects (3 calls → 1).
+4. **`board`** replaces sections + per-section section-tasks loop.
+5. **Batch writes**: build `actions.json` array, run `batch` (10 ops per HTTP round-trip).
+6. **Pipe through `jq`**: `... | jq '.data[] | {gid, name}'` — shrink before printing.
+7. **Run via `ctx_execute` shell** so raw JSON stays in sandbox; only print summary.
+8. **Use cache**: `--assignee` accepts cached user names/emails after first `users` call — no extra lookup needed.
+
+## Inbox Cleanup (My Tasks triage)
+
+AI-gated workflow. Default source section: `Recently assigned`. Wider sweeps need explicit `--all-open` or extra `--source-section`.
+
+```bash
+# 1. Generate snapshot + plan template (no writes)
+python3 scripts/asana_api.py inbox-cleanup \
+  --snapshot-file /tmp/asana-inbox-snapshot.json \
+  --plan-template-file /tmp/asana-inbox-plan.json
+
+# 2. AI defines high-level categories first (not Python heuristics).
+#    Edit plan: category definitions, per-task bucket, ask_user questions
+#    for ambiguous, concrete section targets for high-confidence.
+
+# 3. Apply
+python3 scripts/asana_api.py inbox-cleanup --plan-file /tmp/asana-inbox-plan.json --apply
+# add --include-low-confidence to also move ambiguous tasks
+```
+
+## Daily Briefing (command center)
+
+```bash
+python3 scripts/asana_api.py daily-briefing \
+  --snapshot-file /tmp/asana-daily-briefing-snapshot.json \
+  --plan-template-file /tmp/asana-daily-briefing-plan.json
+# Edit plan, then:
+python3 scripts/asana_api.py daily-briefing --plan-file /tmp/asana-daily-briefing-plan.json
+# Or render markdown:
+python3 scripts/asana_api.py daily-briefing --plan-file /tmp/asana-daily-briefing-plan.json --markdown
+```
+
+## Workflow Analysis
+
+User asks about bottlenecks, project health, automation rules:
+
+1. `board <pgid> --context` → enriched board snapshot with stats.
+2. Inspect `context` key for: section pile-ups, stale tasks, low custom field coverage, unassigned tasks, missing due dates.
+3. Asana **does not** expose rule creation via API — recommend rules with step-by-step UI instructions.
+4. Existing rules with "Incoming web request" trigger can be fired via `trigger-rule`.
+
+## Comment Formatting Rules
+
+- **Plain `--text`**: no Markdown bullets, no escaped `\n`. Newlines literal.
+- **Rich `--html-text`**: use proper HTML structure. Supported safe tags: `<body>`, `<strong>`, `<em>`, `<u>`, `<s>`, `<code>`, `<ol>`, `<ul>`, `<li>`, `<a>`, `<blockquote>`, `<pre>`.
+- Use `<strong>` for labels, `<ul><li>` only for actual lists (not narrative). Block-style sections for status/narrative.
+- `@mentions`: wrapper has no explicit flag. Test mention token in `html_text` first; if rejected, fall back to raw stories endpoint.
+- After AI-authored writes: surface returned `review_url` in user-facing reply.
+
+## Guardrails
+
+- Never print the PAT in output.
+- File uploads and external URL attachments: explicit only, do not guess URLs.
+- Membership changes (followers, tags, dependencies, project membership): prefer dedicated endpoints over full-object replacement.
+- `request` subcommand JSON bodies auto-wrap in `{"data": ...}` unless `--no-wrap-data`.
+- `completed` = canonical completion flag. Section/column names are reporting context, not status mapping.
+- Don't present raw `project-assigned-tasks` output as final answer. Interpret + split into: done/QA-only, active code-now, needs repro/screenshots, backlog/no-code.
+
+## Examples
+
+List incomplete tasks in a project, terse:
+```bash
+python3 scripts/asana_api.py project-tasks 1208668767580814 \
+  --opt-fields name,assignee.name,due_on,completed \
+  | jq '[.data[] | select(.completed == false) | {gid, name, who: .assignee.name, due: .due_on}]'
+```
+
+Comment on a task:
+```bash
+python3 scripts/asana_api.py comment-task 1234567890 --text "Reviewed, LGTM"
+```
+
+Batch get 3 users in one HTTP call:
+```bash
+python3 scripts/asana_api.py batch --actions \
+  '[{"method":"get","relative_path":"/users/123"},
+    {"method":"get","relative_path":"/users/456"},
+    {"method":"get","relative_path":"/users/789"}]'
+```
+
+## When NOT to use
+
+- User explicitly invokes Asana MCP (`mcp__claude_ai_Asana__*`)
+- Need rich card UI rendering in Claude.ai web (MCP renders cards; API returns JSON)
+- One-shot trivial lookup where MCP `get_task` is faster to type
+
+## Attribution
+
+Derived from [elibosley/asana-ai-skill](https://github.com/elibosley/asana-ai-skill).

--- a/skills/asana-api/scripts/asana_api.py
+++ b/skills/asana-api/scripts/asana_api.py
@@ -1,0 +1,6585 @@
+#!/usr/bin/env python3
+"""
+Thin Asana API helper for local AI agent skills.
+
+Features:
+- Reads PAT from ASANA_ACCESS_TOKEN or a local token file
+- Reads default workspace/team IDs from a local context file when present
+- Supports generic GET/POST/PUT/DELETE requests
+- Supports JSON and multipart/form-data requests
+- Includes convenience subcommands for common Asana flows
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import fcntl
+import html
+import json
+import mimetypes
+import os
+import re
+import socket
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any
+from urllib import error, parse, request
+
+
+BASE_URL = "https://app.asana.com/api/1.0"
+BATCH_ACTION_LIMIT = 10
+SKILL_DIR = Path(__file__).resolve().parent.parent
+LOCAL_STATE_DIR = Path.home() / ".agent-skills" / "asana"
+LEGACY_LOCAL_STATE_DIR = Path.home() / ".codex" / "skills-data" / "asana"
+DEFAULT_TOKEN_FILE = LOCAL_STATE_DIR / "asana_pat"
+LEGACY_SHARED_TOKEN_FILE = LEGACY_LOCAL_STATE_DIR / "asana_pat"
+LEGACY_TOKEN_FILE = SKILL_DIR / ".secrets" / "asana_pat"
+DEFAULT_CONTEXT_FILE = LOCAL_STATE_DIR / "asana-context.json"
+LEGACY_SHARED_CONTEXT_FILE = LEGACY_LOCAL_STATE_DIR / "asana-context.json"
+LEGACY_CONTEXT_FILE = SKILL_DIR / "asana-context.json"
+DEFAULT_CACHE_FILE = LOCAL_STATE_DIR / "asana-cache.json"
+LEGACY_SHARED_CACHE_FILE = LEGACY_LOCAL_STATE_DIR / "asana-cache.json"
+LEGACY_CACHE_FILE = SKILL_DIR / ".cache" / "asana-cache.json"
+API_TIMEOUT_SECONDS = 30
+API_NETWORK_RETRY_ATTEMPTS = 3
+API_NETWORK_RETRY_DELAY_SECONDS = 1.0
+DEFAULT_SORTING_TAG_LABELS = (
+    "Quick Win",
+    "Delegate",
+    "Close Out",
+    "Deep Work",
+    "Waiting",
+    "Needs Clarity",
+)
+
+INBOX_CLEANUP_REVIEW_SECTIONS = {
+    "ready_to_close": "Review: Likely Ready To Close",
+    "needs_verification": "Review: Needs Verification",
+    "waiting_on_others": "Review: Waiting On Others",
+    "needs_next_action": "Review: Needs Next Action",
+    "backlog_cleanup": "Review: Backlog Cleanup",
+}
+INBOX_CLEANUP_SNAPSHOT_WORKFLOW = "asana_inbox_cleanup_snapshot"
+INBOX_CLEANUP_PLAN_WORKFLOW = "asana_inbox_cleanup_plan"
+INBOX_CLEANUP_PLAN_VERSION = 1
+INBOX_CLEANUP_CATEGORY_SEEDS = [
+    {
+        "slug": "execute_now",
+        "name": "Execute Now",
+        "description": "Tasks that should actively drive work today or this week.",
+        "suggested_section_name": "WIP",
+    },
+    {
+        "slug": "needs_verification",
+        "name": "Needs Verification",
+        "description": "Tasks that look implemented and need QA, close-out, or release tracking.",
+        "suggested_section_name": "Review: Needs Verification",
+    },
+    {
+        "slug": "waiting_on_others",
+        "name": "Waiting On Others",
+        "description": "Tasks blocked on another person, team, or external dependency.",
+        "suggested_section_name": "Review: Waiting On Others",
+    },
+    {
+        "slug": "likely_ready_to_close",
+        "name": "Likely Ready To Close",
+        "description": "Tasks that likely only need a final confirmation and close-out.",
+        "suggested_section_name": "Review: Likely Ready To Close",
+    },
+    {
+        "slug": "backlog_or_not_now",
+        "name": "Backlog / Not Now",
+        "description": "Tasks that should stay visible but should not drive the current work cycle.",
+        "suggested_section_name": "Review: Backlog Cleanup",
+    },
+    {
+        "slug": "needs_user_input",
+        "name": "Needs User Input",
+        "description": "Tasks the AI should not auto-bucket until the user answers a specific question.",
+        "suggested_section_name": "",
+    },
+]
+DEFAULT_INBOX_CLEANUP_SOURCE_SECTIONS = ("Recently assigned",)
+DAILY_BRIEFING_SNAPSHOT_WORKFLOW = "asana_daily_briefing_snapshot"
+DAILY_BRIEFING_PLAN_WORKFLOW = "asana_daily_briefing_plan"
+DAILY_BRIEFING_PLAN_VERSION = 1
+DAILY_BRIEFING_BUCKET_SEEDS = [
+    {
+        "slug": "execute-now",
+        "name": "Execute Now",
+        "description": "Tasks the AI believes are the best candidates for active work today.",
+        "display_order": 1,
+    },
+    {
+        "slug": "release-watch",
+        "name": "Release / Ship Watch",
+        "description": "Tasks that need rollout watching, shipping awareness, or post-implementation monitoring.",
+        "display_order": 2,
+    },
+    {
+        "slug": "needs-verification",
+        "name": "Needs Verification",
+        "description": "Tasks where the next move is checking, QA, or validating output.",
+        "display_order": 3,
+    },
+    {
+        "slug": "needs-follow-up",
+        "name": "Needs Follow-Up",
+        "description": "Tasks that need a response, unblock, or external coordination step.",
+        "display_order": 4,
+    },
+    {
+        "slug": "ready-to-close",
+        "name": "Likely Ready To Close",
+        "description": "Tasks that appear effectively done and need final confirmation or close-out.",
+        "display_order": 5,
+    },
+    {
+        "slug": "background",
+        "name": "Background / Not Today",
+        "description": "Tasks that should stay visible but should not drive today's work.",
+        "display_order": 6,
+    },
+]
+DAILY_BRIEFING_DONE_LIKE_PATTERN = re.compile(
+    r"\b(done|test|testing|staging|qa|production|complete|completed|released|shipped)\b",
+    re.IGNORECASE,
+)
+DAILY_BRIEFING_ADMIN_NOISE_PATTERN = re.compile(
+    r"\b(goal|goals|trainual|1:1|one on one|travel|reminder|birthday|shopping)\b",
+    re.IGNORECASE,
+)
+DAILY_BRIEFING_URGENT_PATTERN = re.compile(
+    r"\b(urgent|today|asap|overdue|priority)\b",
+    re.IGNORECASE,
+)
+
+
+def token_file() -> Path:
+    configured = os.environ.get("ASANA_TOKEN_FILE")
+    if configured:
+        return Path(configured).expanduser()
+    if DEFAULT_TOKEN_FILE.exists():
+        return DEFAULT_TOKEN_FILE
+    if LEGACY_SHARED_TOKEN_FILE.exists():
+        return LEGACY_SHARED_TOKEN_FILE
+    return LEGACY_TOKEN_FILE
+
+
+def context_file() -> Path:
+    configured = os.environ.get("ASANA_CONTEXT_FILE")
+    if configured:
+        return Path(configured).expanduser()
+    if DEFAULT_CONTEXT_FILE.exists():
+        return DEFAULT_CONTEXT_FILE
+    if LEGACY_SHARED_CONTEXT_FILE.exists():
+        return LEGACY_SHARED_CONTEXT_FILE
+    return LEGACY_CONTEXT_FILE
+
+
+def cache_file() -> Path:
+    configured = os.environ.get("ASANA_CACHE_FILE")
+    if configured:
+        return Path(configured).expanduser()
+    if DEFAULT_CACHE_FILE.exists():
+        return DEFAULT_CACHE_FILE
+    if LEGACY_SHARED_CACHE_FILE.exists():
+        return LEGACY_SHARED_CACHE_FILE
+    if LEGACY_CACHE_FILE.exists():
+        return LEGACY_CACHE_FILE
+    return DEFAULT_CACHE_FILE
+
+
+def load_context() -> dict[str, Any]:
+    file_path = context_file()
+    if not file_path.exists():
+        return {}
+    return json.loads(file_path.read_text())
+
+
+def empty_cache() -> dict[str, Any]:
+    return {
+        "metadata": {"updated_at": None},
+        "workspaces": {"by_gid": {}},
+        "teams": {"by_gid": {}},
+        "projects": {"by_gid": {}},
+        "users": {"by_gid": {}},
+        "tags": {"by_gid": {}},
+    }
+
+
+def ensure_cache_shape(cache: dict[str, Any]) -> dict[str, Any]:
+    cache.setdefault("metadata", {})
+    for bucket_name in ("workspaces", "teams", "projects", "users", "tags"):
+        bucket = cache.setdefault(bucket_name, {})
+        if not isinstance(bucket, dict):
+            cache[bucket_name] = {"by_gid": {}}
+            continue
+        bucket.setdefault("by_gid", {})
+        if not isinstance(bucket["by_gid"], dict):
+            bucket["by_gid"] = {}
+    return cache
+
+
+def merge_nested_dicts(base: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    for key, value in incoming.items():
+        existing = merged.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            merged[key] = merge_nested_dicts(existing, value)
+        elif value is not None:
+            merged[key] = value
+    return merged
+
+
+def load_cache() -> dict[str, Any]:
+    file_path = cache_file()
+    if not file_path.exists():
+        return empty_cache()
+    return ensure_cache_shape(json.loads(file_path.read_text()))
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def metadata_bucket(cache: dict[str, Any], key: str) -> dict[str, Any]:
+    metadata = ensure_cache_shape(cache).setdefault("metadata", {})
+    bucket = metadata.setdefault(key, {})
+    if not isinstance(bucket, dict):
+        metadata[key] = {}
+    return metadata[key]
+
+
+def parse_iso_timestamp(value: str | None) -> datetime:
+    token = str(value or "").strip()
+    if not token:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if token.endswith("Z"):
+        token = f"{token[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(token)
+    except ValueError:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def merge_cache_records(existing: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(existing)
+    for key, value in incoming.items():
+        if value is not None:
+            merged[key] = value
+
+    existing_cached_at = parse_iso_timestamp(existing.get("cached_at"))
+    incoming_cached_at = parse_iso_timestamp(incoming.get("cached_at"))
+    merged["cached_at"] = (
+        incoming.get("cached_at")
+        if incoming_cached_at >= existing_cached_at
+        else existing.get("cached_at")
+    )
+    return merged
+
+
+def merge_cache_data(base: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    merged = ensure_cache_shape(dict(base))
+    incoming_normalized = ensure_cache_shape(dict(incoming))
+
+    for bucket_name in ("workspaces", "teams", "projects", "users", "tags"):
+        merged_bucket = cache_bucket(merged, bucket_name)
+        incoming_bucket = cache_bucket(incoming_normalized, bucket_name)
+        for gid, record in incoming_bucket["by_gid"].items():
+            if not isinstance(record, dict):
+                continue
+            existing_record = merged_bucket["by_gid"].get(gid, {})
+            if isinstance(existing_record, dict):
+                merged_bucket["by_gid"][gid] = merge_cache_records(existing_record, record)
+            else:
+                merged_bucket["by_gid"][gid] = dict(record)
+
+    merged_metadata = merged.setdefault("metadata", {})
+    incoming_metadata = incoming_normalized.get("metadata", {})
+    merged["metadata"] = merge_nested_dicts(merged_metadata, incoming_metadata)
+    return merged
+
+
+@contextlib.contextmanager
+def cache_lock(file_path: Path):
+    lock_path = file_path.with_name(f"{file_path.name}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def save_cache(cache: dict[str, Any]) -> Path:
+    file_path = cache_file()
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with cache_lock(file_path):
+        on_disk = empty_cache()
+        if file_path.exists():
+            on_disk = ensure_cache_shape(json.loads(file_path.read_text()))
+
+        normalized = merge_cache_data(on_disk, cache)
+        normalized["metadata"]["updated_at"] = now_iso()
+
+        with NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=file_path.parent,
+            prefix=f"{file_path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp_file:
+            tmp_file.write(f"{json.dumps(normalized, indent=2, sort_keys=True)}\n")
+            temp_path = Path(tmp_file.name)
+
+        os.replace(temp_path, file_path)
+    return file_path
+
+
+def cache_bucket(cache: dict[str, Any], bucket_name: str) -> dict[str, Any]:
+    return ensure_cache_shape(cache).setdefault(bucket_name, {"by_gid": {}})
+
+
+def cache_record(cache: dict[str, Any], bucket_name: str, record: dict[str, Any]) -> None:
+    gid = str(record.get("gid") or "").strip()
+    if not gid:
+        return
+    bucket = cache_bucket(cache, bucket_name)
+    existing = bucket["by_gid"].get(gid, {})
+    merged = dict(existing)
+    merged.update({key: value for key, value in record.items() if value is not None})
+    merged["cached_at"] = now_iso()
+    bucket["by_gid"][gid] = merged
+
+
+def cache_records(cache: dict[str, Any], bucket_name: str, records: list[dict[str, Any]]) -> None:
+    for record in records:
+        if isinstance(record, dict):
+            cache_record(cache, bucket_name, record)
+
+
+def normalize_match_key(value: str | None) -> str:
+    return str(value or "").strip().casefold()
+
+
+def is_gid_like(value: str | None) -> bool:
+    token = str(value or "").strip()
+    return bool(token) and token.isdigit()
+
+
+def find_cached_record(
+    cache: dict[str, Any],
+    bucket_name: str,
+    identifier: str | None,
+    *,
+    fields: tuple[str, ...],
+) -> dict[str, Any] | None:
+    token = str(identifier or "").strip()
+    if not token:
+        return None
+    if is_gid_like(token):
+        return cache_bucket(cache, bucket_name)["by_gid"].get(token)
+
+    lowered = normalize_match_key(token)
+    matches: list[dict[str, Any]] = []
+    for record in cache_bucket(cache, bucket_name)["by_gid"].values():
+        if not isinstance(record, dict):
+            continue
+        if any(normalize_match_key(record.get(field)) == lowered for field in fields):
+            matches.append(record)
+
+    if not matches:
+        return None
+    unique_matches: dict[str, dict[str, Any]] = {}
+    for record in matches:
+        gid = str(record.get("gid") or "").strip()
+        if gid:
+            unique_matches[gid] = record
+    if len(unique_matches) == 1:
+        return next(iter(unique_matches.values()))
+    match_list = ", ".join(
+        f"{record.get('name', record.get('gid'))} ({record.get('gid')})"
+        for record in unique_matches.values()
+    )
+    raise SystemExit(f"Ambiguous cached {bucket_name[:-1]} identifier '{token}': {match_list}")
+
+
+def find_section_record(
+    sections: list[dict[str, Any]],
+    identifier: str | None,
+) -> dict[str, Any]:
+    token = str(identifier or "").strip()
+    if not token:
+        raise SystemExit("Missing section identifier.")
+
+    if is_gid_like(token):
+        for section in sections:
+            if str(section.get("gid") or "").strip() == token:
+                return dict(section)
+        raise SystemExit(f"No section with gid '{token}' exists in this project.")
+
+    lowered = normalize_match_key(token)
+    matches = [
+        dict(section)
+        for section in sections
+        if normalize_match_key(section.get("name")) == lowered
+    ]
+    if not matches:
+        raise SystemExit(f"No section named '{token}' exists in this project.")
+    if len(matches) == 1:
+        return matches[0]
+
+    match_list = ", ".join(
+        f"{section.get('name', section.get('gid'))} ({section.get('gid')})"
+        for section in matches
+    )
+    raise SystemExit(f"Ambiguous section identifier '{token}': {match_list}")
+
+
+def user_cache_record(user: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "gid": user.get("gid"),
+        "name": user.get("name"),
+        "email": user.get("email"),
+    }
+
+
+def workspace_cache_record(workspace: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "gid": workspace.get("gid"),
+        "name": workspace.get("name"),
+    }
+
+
+def team_cache_record(team: dict[str, Any], *, workspace_gid: str | None = None) -> dict[str, Any]:
+    return {
+        "gid": team.get("gid"),
+        "name": team.get("name"),
+        "workspace_gid": workspace_gid,
+    }
+
+
+def project_cache_record(project: dict[str, Any], *, team_gid: str | None = None) -> dict[str, Any]:
+    team = project.get("team") if isinstance(project.get("team"), dict) else {}
+    owner = project.get("owner") if isinstance(project.get("owner"), dict) else {}
+    return {
+        "gid": project.get("gid"),
+        "name": project.get("name"),
+        "team_gid": team.get("gid") or team_gid,
+        "team_name": team.get("name"),
+        "owner_gid": owner.get("gid"),
+        "owner_name": owner.get("name"),
+    }
+
+
+def tag_cache_record(tag: dict[str, Any], *, workspace_gid: str | None = None) -> dict[str, Any]:
+    return {
+        "gid": tag.get("gid"),
+        "name": tag.get("name"),
+        "color": tag.get("color"),
+        "workspace_gid": workspace_gid,
+    }
+
+
+def find_cached_tag_record(
+    cache: dict[str, Any],
+    identifier: str | None,
+    *,
+    workspace_gid: str | None = None,
+) -> dict[str, Any] | None:
+    token = str(identifier or "").strip()
+    if not token:
+        return None
+    if is_gid_like(token):
+        return cache_bucket(cache, "tags")["by_gid"].get(token)
+
+    lowered = normalize_match_key(token)
+    matches: list[dict[str, Any]] = []
+    for record in cache_bucket(cache, "tags")["by_gid"].values():
+        if not isinstance(record, dict):
+            continue
+        if normalize_match_key(record.get("name")) != lowered:
+            continue
+        record_workspace_gid = str(record.get("workspace_gid") or "").strip()
+        if workspace_gid and record_workspace_gid and record_workspace_gid != workspace_gid:
+            continue
+        matches.append(record)
+
+    if not matches:
+        return None
+
+    unique_matches: dict[str, dict[str, Any]] = {}
+    for record in matches:
+        gid = str(record.get("gid") or "").strip()
+        if gid:
+            unique_matches[gid] = record
+    if len(unique_matches) == 1:
+        return next(iter(unique_matches.values()))
+
+    match_list = ", ".join(
+        f"{record.get('name', record.get('gid'))} ({record.get('gid')})"
+        for record in unique_matches.values()
+    )
+    raise SystemExit(f"Ambiguous cached tag identifier '{token}': {match_list}")
+
+
+def get_token(args: argparse.Namespace) -> str:
+    file_path = token_file()
+
+    token = (
+        os.environ.get("ASANA_ACCESS_TOKEN")
+        or (file_path.read_text().strip() if file_path.exists() else "")
+    )
+    if not token:
+        raise SystemExit(
+            "Missing Asana token. Set ASANA_ACCESS_TOKEN or write the PAT to "
+            f"{file_path}."
+        )
+    return token
+
+
+def parse_bool(value: str) -> bool:
+    lowered = value.strip().lower()
+    if lowered in {"1", "true", "yes", "y"}:
+        return True
+    if lowered in {"0", "false", "no", "n"}:
+        return False
+    raise argparse.ArgumentTypeError(f"Expected a boolean value, got: {value}")
+
+
+def parse_kv(items: list[str] | None) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for item in items or []:
+        if "=" not in item:
+            raise SystemExit(f"Expected KEY=VALUE, got: {item}")
+        key, value = item.split("=", 1)
+        result[key] = value
+    return result
+
+
+def parse_many_gid(items: list[str] | None) -> list[str]:
+    values: list[str] = []
+    for item in items or []:
+        for part in item.split(","):
+            cleaned = part.strip()
+            if cleaned:
+                values.append(cleaned)
+    return values
+
+
+def parse_gid_args(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return parse_many_gid([value])
+    if isinstance(value, (list, tuple)):
+        return parse_many_gid([str(item) for item in value if item is not None])
+    raise SystemExit(f"Expected a gid or list of gids, got: {type(value).__name__}")
+
+
+def nullable_arg(value: str | None) -> str | None:
+    if value is None:
+        return None
+    if value.strip().lower() == "null":
+        return None
+    return value
+
+
+def task_position_args(args: argparse.Namespace) -> tuple[str | None, str | None]:
+    insert_before = getattr(args, "insert_before", None)
+    insert_after = getattr(args, "insert_after", None)
+    if insert_before is not None and insert_after is not None:
+        raise SystemExit("Pass only one of --insert-before or --insert-after.")
+    return insert_before, insert_after
+
+
+def load_inline_or_file_value(
+    inline_value: str | None,
+    file_path: str | None,
+    *,
+    field_name: str,
+) -> str | None:
+    if inline_value is not None and file_path is not None:
+        raise SystemExit(f"Pass only one of --{field_name} or --{field_name}-file")
+    if file_path is None:
+        return inline_value
+    return Path(file_path).read_text()
+
+
+AI_MESSAGE_HEADER_RE = re.compile(
+    r"(?P<header><strong>\s*AI MESSAGE DISCLAIMER\s*</strong>)(?P<rest>.*)",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+AI_MESSAGE_LABEL_RE = re.compile(
+    r"(<strong>\s*(?!AI MESSAGE DISCLAIMER\b)[^<]+?:\s*</strong>)(.*?)(?=(<strong>\s*(?!AI MESSAGE DISCLAIMER\b)[^<]+?:\s*</strong>)|$)",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+AI_MESSAGE_LABEL_ONLY_RE = re.compile(
+    r"^(<strong>\s*(?!AI MESSAGE DISCLAIMER\b)[^<]+?:\s*</strong>)$",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+AI_MESSAGE_LABEL_WITH_CONTENT_RE = re.compile(
+    r"^(<strong>\s*(?!AI MESSAGE DISCLAIMER\b)[^<]+?:\s*</strong>)(.+)$",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+AI_MESSAGE_FOOTNOTE_RE = re.compile(
+    r"^\s*<blockquote>\s*<strong>\s*AI MESSAGE DISCLAIMER\s*</strong>\s*(?P<text>.*?)</blockquote>\s*$",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+
+
+def collapse_html_whitespace(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def render_ai_message_footnote(disclaimer_text: str) -> str:
+    scalar = collapse_html_whitespace(disclaimer_text)
+    if not scalar:
+        return ""
+    return f"<blockquote><strong>AI MESSAGE DISCLAIMER</strong> {scalar}</blockquote>"
+
+
+def render_ai_message_sections(
+    sections: list[tuple[str | None, str, str | list[str]]],
+) -> str | None:
+    if not sections:
+        return None
+
+    parts = ["<body>"]
+    disclaimer_text: str | None = None
+    for label_html, kind, content in sections:
+        if label_html is None and kind == "scalar" and disclaimer_text is None:
+            scalar = collapse_html_whitespace(str(content))
+            if scalar:
+                disclaimer_text = scalar
+                continue
+
+        if label_html is None:
+            scalar = collapse_html_whitespace(str(content))
+            if scalar:
+                parts.append(f"<blockquote>{scalar}</blockquote>")
+            continue
+
+        parts.append(label_html)
+        if kind == "list":
+            items = [
+                f"<li>{collapse_html_whitespace(item)}</li>"
+                for item in content
+                if collapse_html_whitespace(item)
+            ]
+            if items:
+                parts.append(f"<ul>{''.join(items)}</ul>")
+            continue
+
+        scalar = collapse_html_whitespace(str(content))
+        if scalar:
+            parts.append(f"<blockquote>{scalar}</blockquote>")
+
+    if disclaimer_text:
+        parts.append(render_ai_message_footnote(disclaimer_text))
+
+    parts.append("</body>")
+    return "".join(parts)
+
+
+def canonicalize_ai_authored_markup(value: str) -> str:
+    compact = re.sub(r">\s+<", "><", value.strip(), flags=re.DOTALL)
+
+    def _trim_tag_content(tag: str, text: str) -> str:
+        pattern = re.compile(
+            rf"<{tag}\b(?P<attrs>[^>]*)>(?P<content>.*?)</{tag}>",
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+
+        def _replace(match: re.Match[str]) -> str:
+            attrs = match.group("attrs")
+            content = collapse_html_whitespace(match.group("content"))
+            return f"<{tag}{attrs}>{content}</{tag}>"
+
+        return pattern.sub(_replace, text)
+
+    for tag_name in ("blockquote", "li", "strong"):
+        compact = _trim_tag_content(tag_name, compact)
+    return compact
+
+
+def normalize_structured_ai_message(inner: str) -> str | None:
+    disclaimer_match = AI_MESSAGE_HEADER_RE.match(inner)
+    if not disclaimer_match:
+        if AI_MESSAGE_FOOTNOTE_RE.search(inner):
+            return canonicalize_ai_authored_markup(f"<body>{inner}</body>")
+        return None
+
+    rest = disclaimer_match.group("rest").strip()
+    if not rest:
+        return canonicalize_ai_authored_markup(
+            f"<body>{render_ai_message_footnote('This message was generated by AI.')}</body>"
+        )
+
+    leading_blockquote_match = re.match(
+        r"^<blockquote\b[^>]*>(?P<text>.*?)</blockquote>(?P<rest>.*)$",
+        rest,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    if leading_blockquote_match:
+        disclaimer_text = collapse_html_whitespace(leading_blockquote_match.group("text"))
+        body_rest = leading_blockquote_match.group("rest").strip()
+        parts = ["<body>"]
+        if body_rest:
+            parts.append(body_rest)
+        if disclaimer_text:
+            parts.append(render_ai_message_footnote(disclaimer_text))
+        parts.append("</body>")
+        return canonicalize_ai_authored_markup("".join(parts))
+
+    return None
+
+
+def normalize_legacy_ai_message_list(inner: str) -> str | None:
+    disclaimer_match = AI_MESSAGE_HEADER_RE.match(inner)
+    if not disclaimer_match:
+        return None
+
+    rest = disclaimer_match.group("rest").strip()
+    if re.search(r"<(ol|blockquote|pre)\b", rest, flags=re.IGNORECASE):
+        return None
+
+    ul_match = re.fullmatch(r"<ul\b[^>]*>(?P<items>.*)</ul>", rest, flags=re.IGNORECASE | re.DOTALL)
+    if not ul_match:
+        return None
+
+    item_matches = re.findall(
+        r"<li\b[^>]*>(.*?)</li>",
+        ul_match.group("items"),
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    if not item_matches:
+        return None
+
+    sections: list[tuple[str | None, str, str | list[str]]] = []
+    pending_list_label: str | None = None
+    pending_list_items: list[str] = []
+
+    def flush_pending_list() -> None:
+        nonlocal pending_list_label, pending_list_items
+        if pending_list_label is None:
+            return
+        if pending_list_items:
+            sections.append((pending_list_label, "list", pending_list_items[:]))
+        else:
+            sections.append((pending_list_label, "scalar", ""))
+        pending_list_label = None
+        pending_list_items = []
+
+    for raw_item in item_matches:
+        item = collapse_html_whitespace(raw_item)
+        if not item:
+            continue
+
+        label_only_match = AI_MESSAGE_LABEL_ONLY_RE.fullmatch(item)
+        if label_only_match:
+            flush_pending_list()
+            pending_list_label = label_only_match.group(1).strip()
+            pending_list_items = []
+            continue
+
+        label_with_content_match = AI_MESSAGE_LABEL_WITH_CONTENT_RE.fullmatch(item)
+        if label_with_content_match:
+            flush_pending_list()
+            sections.append(
+                (
+                    label_with_content_match.group(1).strip(),
+                    "scalar",
+                    label_with_content_match.group(2).strip(),
+                )
+            )
+            continue
+
+        if pending_list_label is not None:
+            pending_list_items.append(item)
+        else:
+            sections.append((None, "scalar", item))
+
+    flush_pending_list()
+    return render_ai_message_sections(sections)
+
+
+def normalize_ai_authored_rich_text(value: str | None) -> str | None:
+    raw = str(value or "").strip()
+    if not raw or "AI MESSAGE DISCLAIMER" not in raw:
+        return value
+
+    body_match = re.search(r"<body\b[^>]*>(.*)</body>", raw, flags=re.IGNORECASE | re.DOTALL)
+    inner = body_match.group(1) if body_match else raw
+    inner = collapse_html_whitespace(inner)
+
+    legacy_list_normalized = normalize_legacy_ai_message_list(inner)
+    if legacy_list_normalized is not None:
+        return canonicalize_ai_authored_markup(legacy_list_normalized)
+
+    structured_normalized = normalize_structured_ai_message(inner)
+    if structured_normalized is not None:
+        return structured_normalized
+
+    if re.search(r"<(ul|ol|blockquote|pre)\b", raw, flags=re.IGNORECASE):
+        return canonicalize_ai_authored_markup(raw)
+
+    disclaimer_match = AI_MESSAGE_HEADER_RE.match(inner)
+    if not disclaimer_match:
+        return value
+
+    rest = disclaimer_match.group("rest").strip()
+    sections: list[tuple[str | None, str, str | list[str]]] = []
+    first_label = AI_MESSAGE_LABEL_RE.search(rest)
+    intro = rest[: first_label.start()].strip() if first_label else rest
+    if intro:
+        sections.append((None, "scalar", intro))
+
+    for match in AI_MESSAGE_LABEL_RE.finditer(rest[first_label.start() :] if first_label else ""):
+        label_html = match.group(1).strip()
+        content_html = match.group(2).strip()
+        sections.append((label_html, "scalar", content_html))
+
+    normalized = render_ai_message_sections(sections)
+    if normalized is None:
+        return value
+    return canonicalize_ai_authored_markup(normalized)
+
+
+def comment_payload_from_args(args: argparse.Namespace) -> dict[str, str]:
+    text_value = load_inline_or_file_value(args.text, args.text_file, field_name="text")
+    html_text_value = load_inline_or_file_value(
+        args.html_text,
+        args.html_text_file,
+        field_name="html-text",
+    )
+
+    provided_count = sum(value is not None for value in (text_value, html_text_value))
+    if provided_count != 1:
+        raise SystemExit(
+            "Pass exactly one of --text/--text-file or --html-text/--html-text-file"
+        )
+
+    if html_text_value is not None:
+        return {"html_text": normalize_ai_authored_rich_text(html_text_value) or ""}
+    return {"text": text_value or ""}
+
+
+def maybe_wrap_data(payload: Any, no_wrap_data: bool) -> Any:
+    if no_wrap_data:
+        return payload
+    if isinstance(payload, dict) and "data" in payload:
+        return payload
+    return {"data": payload}
+
+
+def build_multipart(form_fields: dict[str, str], file_fields: dict[str, str]) -> tuple[bytes, str]:
+    boundary = f"----codex-asana-{uuid.uuid4().hex}"
+    body = bytearray()
+
+    for name, value in form_fields.items():
+        body.extend(f"--{boundary}\r\n".encode("utf-8"))
+        body.extend(
+            f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode("utf-8")
+        )
+        body.extend(value.encode("utf-8"))
+        body.extend(b"\r\n")
+
+    for field, path_str in file_fields.items():
+        path = Path(path_str).expanduser().resolve()
+        content = path.read_bytes()
+        mime = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+        body.extend(f"--{boundary}\r\n".encode("utf-8"))
+        body.extend(
+            (
+                f'Content-Disposition: form-data; name="{field}"; '
+                f'filename="{path.name}"\r\n'
+            ).encode("utf-8")
+        )
+        body.extend(f"Content-Type: {mime}\r\n\r\n".encode("utf-8"))
+        body.extend(content)
+        body.extend(b"\r\n")
+
+    body.extend(f"--{boundary}--\r\n".encode("utf-8"))
+    return bytes(body), f"multipart/form-data; boundary={boundary}"
+
+
+def build_url(path_or_url: str, query: dict[str, str]) -> str:
+    if path_or_url.startswith("http://") or path_or_url.startswith("https://"):
+        base = path_or_url
+    else:
+        path = path_or_url if path_or_url.startswith("/") else f"/{path_or_url}"
+        base = f"{BASE_URL}{path}"
+    if not query:
+        return base
+    separator = "&" if "?" in base else "?"
+    return f"{base}{separator}{parse.urlencode(query, doseq=True)}"
+
+
+def network_error_detail(exc: BaseException) -> str:
+    if isinstance(exc, error.URLError):
+        reason = getattr(exc, "reason", exc)
+        return str(reason)
+    return str(exc)
+
+
+def is_retryable_network_error(exc: BaseException) -> bool:
+    if isinstance(exc, socket.gaierror | TimeoutError):
+        return True
+    if not isinstance(exc, error.URLError):
+        return False
+    reason = getattr(exc, "reason", None)
+    if isinstance(reason, socket.gaierror | TimeoutError):
+        return True
+    reason_text = str(reason or "").casefold()
+    return any(
+        fragment in reason_text
+        for fragment in (
+            "temporary failure in name resolution",
+            "nodename nor servname provided",
+            "name or service not known",
+            "timed out",
+            "timeout",
+        )
+    )
+
+
+def api_request(
+    *,
+    token: str,
+    method: str,
+    path_or_url: str,
+    query: dict[str, str] | None = None,
+    json_body: Any | None = None,
+    multipart_form: dict[str, str] | None = None,
+    multipart_files: dict[str, str] | None = None,
+) -> Any:
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    data = None
+
+    if multipart_form or multipart_files:
+        data, content_type = build_multipart(multipart_form or {}, multipart_files or {})
+        headers["Content-Type"] = content_type
+    elif json_body is not None:
+        data = json.dumps(json_body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    req = request.Request(
+        build_url(path_or_url, query or {}),
+        data=data,
+        headers=headers,
+        method=method.upper(),
+    )
+
+    payload = ""
+    for attempt in range(1, API_NETWORK_RETRY_ATTEMPTS + 1):
+        try:
+            with request.urlopen(req, timeout=API_TIMEOUT_SECONDS) as response:
+                payload = response.read().decode("utf-8")
+            break
+        except error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise SystemExit(f"HTTP {exc.code} {exc.reason}\n{detail}") from exc
+        except (error.URLError, TimeoutError, socket.gaierror) as exc:
+            if attempt < API_NETWORK_RETRY_ATTEMPTS and is_retryable_network_error(exc):
+                time.sleep(API_NETWORK_RETRY_DELAY_SECONDS * attempt)
+                continue
+            raise SystemExit(f"Network error while calling Asana: {network_error_detail(exc)}") from exc
+
+    if not payload:
+        return {}
+    return json.loads(payload)
+
+
+def maybe_paginate(token: str, first_response: Any, enabled: bool, limit_pages: int) -> Any:
+    if not enabled:
+        return first_response
+
+    data = first_response.get("data")
+    if not isinstance(data, list):
+        return first_response
+
+    merged = list(data)
+    response = first_response
+    pages = 1
+
+    while response.get("next_page") and response["next_page"].get("uri"):
+        if limit_pages and pages >= limit_pages:
+            break
+        response = api_request(
+            token=token,
+            method="GET",
+            path_or_url=response["next_page"]["uri"],
+        )
+        page_data = response.get("data", [])
+        if not isinstance(page_data, list):
+            break
+        merged.extend(page_data)
+        pages += 1
+
+    final_response = dict(first_response)
+    final_response["data"] = merged
+    final_response["pagination_pages"] = pages
+    return final_response
+
+
+def print_json(payload: Any, compact: bool) -> None:
+    if compact:
+        print(json.dumps(payload, separators=(",", ":")))
+        return
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def task_write_opt_fields() -> str:
+    return (
+        "gid,name,completed,completed_at,permalink_url,assignee.gid,assignee.name,"
+        "due_on,due_at,parent.gid,parent.name"
+    )
+
+
+def story_write_opt_fields() -> str:
+    return (
+        "gid,created_at,resource_subtype,permalink_url,target.gid,target.name,"
+        "target.permalink_url"
+    )
+
+
+def response_with_review_links(response: Any) -> Any:
+    if not isinstance(response, dict):
+        return response
+
+    data = response.get("data")
+    if not isinstance(data, dict):
+        return response
+
+    enriched = dict(response)
+    review_url = str(data.get("permalink_url") or "").strip()
+    if review_url:
+        enriched["review_url"] = review_url
+
+    target = data.get("target")
+    if isinstance(target, dict):
+        target_review_url = str(target.get("permalink_url") or "").strip()
+        if target_review_url:
+            enriched["target_review_url"] = target_review_url
+
+    return enriched
+
+
+def batch_actions_request(token: str, actions: list[dict[str, Any]]) -> Any:
+    return api_request(
+        token=token,
+        method="POST",
+        path_or_url="/batch",
+        json_body={"data": {"actions": actions}},
+    )
+
+
+def chunked(items: list[Any], size: int) -> list[list[Any]]:
+    if size <= 0:
+        raise ValueError("Chunk size must be positive")
+    return [items[index : index + size] for index in range(0, len(items), size)]
+
+
+def batch_actions_request_chunked(token: str, actions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    aggregated: list[dict[str, Any]] = []
+    for action_group in chunked(actions, BATCH_ACTION_LIMIT):
+        response = batch_actions_request(token, action_group)
+        data = response.get("data", [])
+        if not isinstance(data, list):
+            raise SystemExit("Batch response did not contain a data array")
+        aggregated.extend(item for item in data if isinstance(item, dict))
+    return aggregated
+
+
+def batch_body_at(response: Any, index: int) -> Any:
+    data = response.get("data", [])
+    if index >= len(data):
+        return {}
+    item = data[index]
+    if item.get("status_code", 200) >= 400:
+        return {"error": item}
+    return item.get("body", {})
+
+
+def section_order_from_sections(sections: list[dict[str, Any]]) -> dict[str, int]:
+    order_map: dict[str, int] = {}
+    for index, section in enumerate(sections, start=1):
+        section_gid = section.get("gid")
+        if section_gid:
+            order_map[section_gid] = index
+    return order_map
+
+
+def render_many_results(command_name: str, entries: list[dict[str, Any]], compact: bool) -> dict[str, Any]:
+    payload = {
+        "command": command_name,
+        "count": len(entries),
+        "items": entries,
+    }
+    print_json(payload, compact)
+    return payload
+
+
+def extract_image_urls_from_html(html: str | None) -> list[str]:
+    if not html:
+        return []
+    return re.findall(r'<img[^>]+src="([^"]+)"', html)
+
+
+def comment_stories_only(stories: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        story
+        for story in stories
+        if story.get("type") == "comment" or story.get("resource_subtype") == "comment_added"
+    ]
+
+
+def strip_html_to_text(value: str | None) -> str:
+    if not value:
+        return ""
+    text = re.sub(r"<br\s*/?>", "\n", value, flags=re.IGNORECASE)
+    text = re.sub(r"</(li|blockquote|div|p|ul|ol|body)>", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"<li\b[^>]*>", "- ", text, flags=re.IGNORECASE)
+    text = re.sub(r"<[^>]+>", "", text)
+    text = html.unescape(text)
+    return re.sub(r"\n{2,}", "\n", text).strip()
+
+
+def chunked(items: list[Any], size: int) -> list[list[Any]]:
+    if size <= 0:
+        return [items[:]]
+    return [items[index : index + size] for index in range(0, len(items), size)]
+
+
+def user_task_list_opt_fields(default: str | None = None) -> str:
+    return default or (
+        "gid,name,completed,created_at,modified_at,due_on,due_at,permalink_url,"
+        "resource_subtype,parent.gid,parent.name,projects.gid,projects.name,"
+        "memberships.project.gid,memberships.project.name,memberships.section.gid,"
+        "memberships.section.name,assignee_status,assignee_section.gid,assignee_section.name"
+    )
+
+
+def my_tasks_task_detail_fields(default: str | None = None) -> str:
+    return default or (
+        "gid,name,notes,html_notes,resource_subtype,completed,completed_at,created_at,"
+        "modified_at,due_on,due_at,permalink_url,parent.gid,parent.name,"
+        "assignee_status,assignee_section.gid,assignee_section.name,"
+        "assignee.gid,assignee.name,followers.gid,followers.name,"
+        "collaborators.gid,collaborators.name,"
+        "projects.gid,projects.name,memberships.project.gid,memberships.project.name,"
+        "memberships.section.gid,memberships.section.name,custom_fields.gid,"
+        "custom_fields.name,custom_fields.resource_subtype,custom_fields.display_value,"
+        "custom_fields.enum_value.name,tags.gid,tags.name,tags.color"
+    )
+
+
+def my_tasks_project(token: str, workspace_gid: str) -> dict[str, Any]:
+    response = api_request(
+        token=token,
+        method="GET",
+        path_or_url="/users/me/user_task_list",
+        query={
+            "workspace": workspace_gid,
+            "opt_fields": "gid,name,owner.gid,owner.name,workspace.gid,workspace.name",
+        },
+    )
+    return response.get("data", {})
+
+
+def my_tasks_sections(token: str, user_task_list_gid: str) -> list[dict[str, Any]]:
+    response = api_request(
+        token=token,
+        method="GET",
+        path_or_url=f"/projects/{user_task_list_gid}/sections",
+        query={"opt_fields": section_opt_fields()},
+    )
+    return response.get("data", [])
+
+
+def my_tasks_tasks(
+    token: str,
+    user_task_list_gid: str,
+    *,
+    paginate: bool,
+    limit_pages: int,
+) -> list[dict[str, Any]]:
+    response = api_request(
+        token=token,
+        method="GET",
+        path_or_url=f"/user_task_lists/{user_task_list_gid}/tasks",
+        query={
+            "completed_since": "now",
+            "limit": "100",
+            "opt_fields": user_task_list_opt_fields(),
+        },
+    )
+    response = maybe_paginate(token, response, paginate, limit_pages)
+    data = response.get("data", [])
+    return data if isinstance(data, list) else []
+
+
+def get_task_tags(
+    token: str,
+    task_gid: str,
+    *,
+    opt_fields: str | None = None,
+) -> list[dict[str, Any]]:
+    response = api_request(
+        token=token,
+        method="GET",
+        path_or_url=f"/tasks/{task_gid}/tags",
+        query={"opt_fields": opt_fields or tag_opt_fields("gid,name,color")},
+    )
+    data = response.get("data", [])
+    return data if isinstance(data, list) else []
+
+
+def fetch_task_review_context(
+    token: str,
+    task_gids: list[str],
+) -> dict[str, dict[str, Any]]:
+    context_by_gid: dict[str, dict[str, Any]] = {}
+    for gid_chunk in chunked(task_gids, 5):
+        if not gid_chunk:
+            continue
+        actions: list[dict[str, Any]] = []
+        for task_gid in gid_chunk:
+            actions.append(
+                {
+                    "method": "get",
+                    "relative_path": f"/tasks/{task_gid}",
+                    "options": {"fields": field_list(my_tasks_task_detail_fields())},
+                }
+            )
+            actions.append(
+                {
+                    "method": "get",
+                    "relative_path": f"/tasks/{task_gid}/stories",
+                    "options": {"fields": field_list(story_opt_fields())},
+                }
+            )
+        batch_response = batch_actions_request(token, actions)
+        for index, task_gid in enumerate(gid_chunk):
+            task_body = batch_body_at(batch_response, index * 2).get("data", {})
+            story_body = batch_body_at(batch_response, index * 2 + 1).get("data", [])
+            context_by_gid[task_gid] = {
+                "task": task_body if isinstance(task_body, dict) else {},
+                "stories": story_body if isinstance(story_body, list) else [],
+            }
+    return context_by_gid
+
+
+def task_membership_labels(task: dict[str, Any]) -> list[str]:
+    labels: list[str] = []
+    for membership in task.get("memberships", []) or []:
+        if not isinstance(membership, dict):
+            continue
+        project = membership.get("project") or {}
+        section = membership.get("section") or {}
+        project_name = project.get("name") or "No project"
+        section_name = section.get("name") or "No section"
+        labels.append(f"{project_name} :: {section_name}")
+    return labels
+
+
+def task_project_names(task: dict[str, Any]) -> list[str]:
+    names: list[str] = []
+    for project in task.get("projects", []) or []:
+        if isinstance(project, dict) and project.get("name"):
+            names.append(str(project["name"]))
+    return names
+
+
+def story_author_gids(stories: list[dict[str, Any]]) -> set[str]:
+    author_gids: set[str] = set()
+    for story in comment_stories_only(stories):
+        created_by = story.get("created_by") or {}
+        author_gid = str(created_by.get("gid") or "").strip()
+        if author_gid:
+            author_gids.add(author_gid)
+    return author_gids
+
+
+def task_participant_gids(task: dict[str, Any], field_name: str) -> set[str]:
+    gids: set[str] = set()
+    for participant in task.get(field_name, []) or []:
+        if not isinstance(participant, dict):
+            continue
+        participant_gid = str(participant.get("gid") or "").strip()
+        if participant_gid:
+            gids.add(participant_gid)
+    return gids
+
+
+def task_is_shared_for_manager_comments(
+    task: dict[str, Any],
+    stories: list[dict[str, Any]],
+) -> tuple[bool, str | None]:
+    owner_gid = str(((task.get("assignee") or {}).get("gid")) or "").strip()
+    project_names = task_project_names(task)
+    membership_labels = task_membership_labels(task)
+    parent = task.get("parent") or {}
+    if project_names or membership_labels:
+        return True, "Task belongs to a project/section that is likely shared with others."
+    if isinstance(parent, dict) and parent.get("gid"):
+        return True, "Task is a subtask/child task and may be visible in shared parent context."
+    if not owner_gid:
+        return True, "Task has no clear personal owner, so AI PM comments stay disabled."
+
+    follower_gids = task_participant_gids(task, "followers")
+    if follower_gids - {owner_gid}:
+        return True, "Task has followers other than the assignee, so it is treated as shared."
+
+    collaborator_gids = task_participant_gids(task, "collaborators")
+    if collaborator_gids - {owner_gid}:
+        return True, "Task has collaborators other than the assignee, so it is treated as shared."
+
+    commenter_gids = story_author_gids(stories)
+    if commenter_gids - {owner_gid}:
+        return True, "Task has comment history from other people, so it is treated as shared."
+    return False, None
+
+
+def story_text(story: dict[str, Any]) -> str:
+    return strip_html_to_text(story.get("html_text") or story.get("text"))
+
+
+def recent_comments(task_context: dict[str, Any], limit: int = 3) -> list[dict[str, Any]]:
+    comments = comment_stories_only(task_context.get("stories", []))
+    comments.sort(key=lambda story: parse_iso_timestamp(story.get("created_at")), reverse=True)
+    return comments[:limit]
+
+
+def short_date(value: str | None) -> str | None:
+    token = str(value or "").strip()
+    if not token:
+        return None
+    return token.split("T", 1)[0]
+
+
+def inbox_cleanup_comment_html(
+    *,
+    category_label: str,
+    evidence_lines: list[str],
+) -> str:
+    sections: list[tuple[str | None, str, str | list[str]]] = [
+        (
+            None,
+            "scalar",
+            "This message was generated by AI to summarize My Tasks cleanup review state.",
+        ),
+        ("<strong>Review state:</strong>", "scalar", category_label),
+        ("<strong>Why this looks done:</strong>", "list", evidence_lines),
+        (
+            "<strong>Requested action:</strong>",
+            "scalar",
+            "Please verify and mark complete if this matches reality.",
+        ),
+    ]
+    return render_ai_message_sections(sections) or ""
+
+
+def manager_plan_comment_html(
+    *,
+    category_label: str,
+    work_type: str,
+    task_read: str,
+    classification_basis: str,
+    next_action: str,
+    todo_label: str,
+    todo_items: list[str],
+    ask_user: str,
+    ai_help_summary: str,
+    execution_prompt: str | None,
+) -> str:
+    sections: list[tuple[str | None, str, str | list[str]]] = [
+        (
+            None,
+            "scalar",
+            "This message was generated by AI to propose a personal project-manager next step for this task.",
+        ),
+        ("<strong>Review state:</strong>", "scalar", category_label),
+        ("<strong>Work type:</strong>", "scalar", work_type),
+        ("<strong>Task read:</strong>", "scalar", task_read),
+        ("<strong>Why this bucket:</strong>", "scalar", classification_basis),
+        ("<strong>Suggested next action:</strong>", "scalar", next_action),
+        (f"<strong>{html.escape(todo_label)}:</strong>", "list", todo_items),
+        ("<strong>Ask before acting:</strong>", "scalar", ask_user),
+        ("<strong>How AI can help:</strong>", "scalar", ai_help_summary),
+    ]
+    if execution_prompt:
+        sections.append(("<strong>Execution option:</strong>", "scalar", execution_prompt))
+    return render_ai_message_sections(sections) or ""
+
+
+def comment_already_mentions_inbox_cleanup(stories: list[dict[str, Any]], category_label: str) -> bool:
+    category_token = category_label.casefold()
+    for story in comment_stories_only(stories):
+        text = story_text(story).casefold()
+        if "my tasks cleanup review state" in text and category_token in text:
+            return True
+    return False
+
+
+def comment_already_mentions_manager_plan(stories: list[dict[str, Any]], category_label: str) -> bool:
+    category_token = category_label.casefold()
+    for story in comment_stories_only(stories):
+        text = story_text(story).casefold()
+        if "personal project-manager next step" in text and category_token in text:
+            return True
+    return False
+
+
+def looks_like_person_name_only(name: str) -> bool:
+    token = re.sub(r"\s+", " ", str(name or "").strip())
+    if not token:
+        return False
+    if re.search(r"[:/@#\-\(\)\[\]\d]", token):
+        return False
+    parts = token.split(" ")
+    if not 1 < len(parts) <= 3:
+        return False
+    return all(part[:1].isupper() and part[1:].islower() for part in parts if part)
+
+
+def infer_task_work_type(combined_text: str, name: str) -> str:
+    if looks_like_person_name_only(name):
+        return "admin"
+    if re.search(r"\b(research|investigate|audit|analyze|analysis|r&d|information gathering|review|discuss|spec|plan)\b", combined_text):
+        return "research"
+    if re.search(r"\b(meeting|follow up|follow-up|email|coordinate|contact|waiting|partner|vendor|ops dashboard|details needed)\b", combined_text):
+        return "coordination"
+    if re.search(r"\b(bug|broken|issue|error|not working|regression|fix)\b", combined_text):
+        return "bug"
+    if re.search(r"\b(build|implement|create|add|remove|update|move|streamline|deploy|release|ship|endpoint|automation|hookup)\b", combined_text):
+        return "implementation"
+    if re.search(r"\b(check in|check-in|birthday|shopping|travel|comp time|p&l|scope of work)\b", combined_text) or "eli -" in name.casefold():
+        return "admin"
+    return "implementation"
+
+
+def has_substantive_manager_context(
+    *,
+    task: dict[str, Any],
+    recent_comment_lines: list[str],
+) -> bool:
+    notes = strip_html_to_text(task.get("html_notes") or task.get("notes"))
+    if len(notes) >= 80:
+        return True
+    if any(len(line) >= 80 for line in recent_comment_lines):
+        return True
+    if task.get("due_on") and (notes or recent_comment_lines):
+        return True
+    return False
+
+
+def extract_urls(text: str) -> list[str]:
+    return re.findall(r"https?://[^\s<>\"]+", text)
+
+
+def extract_github_pr_links(text: str) -> list[dict[str, str]]:
+    links: list[dict[str, str]] = []
+    pattern = re.compile(r"https://github\.com/([^/\s]+)/([^/\s]+)/pull/(\d+)")
+    for match in pattern.finditer(text):
+        owner, repo, pr_number = match.groups()
+        links.append(
+            {
+                "url": match.group(0),
+                "owner": owner,
+                "repo": repo,
+                "pr_number": pr_number,
+            }
+        )
+    seen_pr_numbers = {str(link.get("pr_number") or "").strip() for link in links}
+    for match in re.finditer(r"\bPR\s*#(\d+)\b", text, flags=re.IGNORECASE):
+        pr_number = match.group(1)
+        if pr_number in seen_pr_numbers:
+            continue
+        links.append(
+            {
+                "url": "",
+                "owner": "",
+                "repo": "",
+                "pr_number": pr_number,
+            }
+        )
+        seen_pr_numbers.add(pr_number)
+    return links
+
+
+def normalize_whitespace(value: str | None) -> str:
+    return re.sub(r"\s+", " ", str(value or "")).strip()
+
+
+def shorten_text(value: str | None, *, limit: int = 180) -> str:
+    token = normalize_whitespace(value)
+    if len(token) <= limit:
+        return token
+    return f"{token[: max(0, limit - 3)].rstrip()}..."
+
+
+def primary_pr_label(linked_prs: list[dict[str, str]]) -> str | None:
+    if not linked_prs:
+        return None
+    pr_number = str((linked_prs[0] or {}).get("pr_number") or "").strip()
+    if not pr_number:
+        return None
+    return f"PR #{pr_number}"
+
+
+def task_title_kind(name: str, combined_text: str) -> str:
+    source = f"{name} {combined_text}".casefold()
+    if re.search(r"\b(decide|decision|clarify|validate|scope|define|recommend)\b", source):
+        return "decision"
+    if re.search(r"\b(draft|memo|write[\s-]?up|writeup)\b", source):
+        return "writing"
+    if re.search(r"\b(wireframe|mockup|design)\b", source):
+        return "design"
+    if re.search(r"\b(follow up|follow-up|intro|call|meeting|contact|email)\b", source):
+        return "follow_up"
+    return "general"
+
+
+def active_ai_action_for_task(
+    *,
+    category_key: str,
+    work_type: str,
+    ready_signal: bool,
+    verify_signal: bool,
+    waiting_signal: bool,
+    negative_signal: bool,
+    linked_prs: list[dict[str, str]],
+) -> dict[str, Any]:
+    if ready_signal and category_key == "ready_to_close":
+        return {
+            "action": "ask_to_close",
+            "reason": "Recent comments indicate this is likely fixed and ready for manual close-out.",
+        }
+    if verify_signal and category_key == "needs_verification" and not negative_signal:
+        return {
+            "action": "ask_to_verify",
+            "reason": "This looks like verification/QA follow-up rather than net-new work.",
+        }
+    if linked_prs and work_type in {"implementation", "bug", "research"}:
+        return {
+            "action": "ask_to_execute_now",
+            "reason": "This task references a PR/code path and looks like a good candidate for immediate AI execution after confirmation.",
+        }
+    if verify_signal and not negative_signal:
+        return {
+            "action": "ask_to_verify",
+            "reason": "This looks like verification/QA follow-up rather than net-new work.",
+        }
+    if waiting_signal:
+        return {
+            "action": "ask_to_follow_up",
+            "reason": "This looks blocked on another person or team and needs a targeted follow-up.",
+        }
+    if category_key == "needs_next_action" and work_type in {"research", "implementation", "bug"}:
+        return {
+            "action": "ask_to_execute_now",
+            "reason": "This still looks open-ended, but it is concrete enough for the AI to take a first pass after confirmation.",
+        }
+    return {
+        "action": "no_ai_action",
+        "reason": "No immediate AI action is recommended from current task context.",
+    }
+
+
+def infer_execution_candidate(
+    *,
+    category_key: str,
+    work_type: str,
+    combined_text: str,
+) -> tuple[bool, str | None]:
+    if category_key in {"waiting_on_others", "backlog_cleanup"}:
+        return False, None
+    if work_type in {"implementation", "bug", "research"} and re.search(
+        r"\b(pr\b|github|preview|branch|webgui|api|plugin|repo|account app|automation|endpoint|beta|test|memo|draft|clarify|validate|decide|scope|recommendation|doc|document|spec)\b",
+        combined_text,
+    ):
+        return True, "Ask whether I should investigate or execute this task now, and I can try to solve it end-to-end."
+    return False, None
+
+
+def manager_plan_for_task(
+    *,
+    name: str,
+    work_type: str,
+    category_key: str,
+    task: dict[str, Any],
+    combined_text: str,
+    reasons: list[str],
+    recent_comment_lines: list[str],
+    linked_prs: list[dict[str, str]],
+    ready_signal: bool,
+    verify_signal: bool,
+    waiting_signal: bool,
+    negative_signal: bool,
+) -> dict[str, Any]:
+    name = str(name or task.get("name") or "")
+    due_on = task.get("due_on")
+    pr_label = primary_pr_label(linked_prs)
+    kind = task_title_kind(name, combined_text)
+    project_state = ""
+    if reasons:
+        first_reason = str(reasons[0])
+        if first_reason.startswith("Project state: "):
+            project_state = first_reason.removeprefix("Project state: ").strip()
+    comment_excerpt = shorten_text(recent_comment_lines[0] if recent_comment_lines else "", limit=160)
+    task_read = ""
+    classification_basis = ""
+    todo_label = "Suggested TODO"
+    next_action = "Review the task and decide the concrete next owner/action."
+    ask_user = "Should this stay active right now, or should it be parked until there is a concrete next step?"
+    ai_help_summary = "This needs your prioritization more than immediate AI action."
+    todo_items: list[str] = []
+
+    if category_key == "ready_to_close":
+        task_read = "This looks substantially done already and is behaving more like close-out than active execution work."
+        if project_state:
+            task_read = f"{task_read} Project state already reads as `{project_state}`."
+        if comment_excerpt:
+            task_read = f"{task_read} Latest signal: {comment_excerpt}"
+        classification_basis = "Recent comments plus project-state context both point toward close-out."
+        next_action = "Do one final verification pass, then close it or reopen it with the exact remaining issue."
+        todo_label = "Close-Out TODO"
+        todo_items = [
+            "Check the latest build, preview, or shipped state one more time.",
+            "Capture one clear pass/fail note so the task does not stay in limbo.",
+            "If it passes, post the close-out note and mark it complete.",
+            "If it fails, reopen it with the exact remaining repro or gap.",
+        ]
+        ask_user = "Do you want me to draft the close-out note after a quick verification read?"
+        ai_help_summary = "I can review the latest context and draft the close-out note or the reopen summary."
+    elif category_key == "needs_verification":
+        verification_target = pr_label or "the latest claimed fix"
+        if project_state:
+            task_read = f"This no longer looks like fresh implementation work. It looks like verification against `{project_state}`"
+        else:
+            task_read = "This no longer looks like fresh implementation work. It looks like verification against the latest claimed fix"
+        if pr_label:
+            task_read = f"{task_read} and {pr_label}."
+        else:
+            task_read = f"{task_read}."
+        if comment_excerpt:
+            task_read = f"{task_read} Latest signal: {comment_excerpt}"
+        classification_basis = "Verification language or done-like workflow state outweighed net-new implementation signals."
+        next_action = f"Verify {verification_target} on the latest relevant environment and decide between close-out and a new implementation step."
+        todo_label = "Verification TODO"
+        todo_items = [
+            "Collect the exact build, branch, or environment you should test against.",
+            f"Verify {verification_target} and record what passed or failed.",
+            "If it passes, move it toward close-out with evidence.",
+            "If it fails, write the smallest remaining gap as the new implementation step.",
+        ]
+        ask_user = "Do you want me to run the verification pass now, or just leave this staged in verification?"
+        ai_help_summary = "I can verify the latest change, summarize pass/fail evidence, and recommend close-out versus reopen."
+    elif category_key == "waiting_on_others" or waiting_signal:
+        task_read = "This looks blocked on another person, team, or external dependency rather than blocked on your own implementation work."
+        if comment_excerpt:
+            task_read = f"{task_read} Latest signal: {comment_excerpt}"
+        classification_basis = "The strongest signal here is dependency-follow-up, not independent execution."
+        todo_label = "Coordination TODO"
+        next_action = "Send one concrete unblock message, make the ask explicit, and record the expected reply or handoff date."
+        todo_items = [
+            "Identify the exact person or team who needs to respond.",
+            "State the concrete ask, not just a status nudge.",
+            "Record the expected reply date or next checkpoint in the task.",
+            "Move it back to execution only after the dependency clears.",
+        ]
+        ask_user = "Who should be nudged here, and do you want me to draft the exact follow-up message?"
+        ai_help_summary = "I can draft the unblock message or task comment for you."
+    elif work_type == "research":
+        todo_label = "Research TODO"
+        if kind == "writing":
+            task_read = "This is a writing/recommendation task, not a vague research placeholder. The real missing artifact is the first draft."
+            next_action = "Write the first draft now, then call out the recommendation, open questions, and owner."
+            todo_items = [
+                "Write the exact question this memo or write-up needs to answer.",
+                "Draft the recommendation or narrative directly in the task or linked doc.",
+                "Call out what is still unknown or needs sign-off.",
+                "Name the next reviewer or owner so it does not stall after drafting.",
+            ]
+            ask_user = "Do you want me to draft the first version now, or should this remain a placeholder?"
+            ai_help_summary = "I can draft the memo or recommendation from the current task context."
+        else:
+            task_read = "This is a decision/research task. The missing deliverable is a short recommendation that turns the open question into a call to action."
+            next_action = "Turn this into a short written recommendation with a clear decision owner and follow-up."
+            todo_items = [
+                "Read the task description, linked docs, PRs, and the latest comments.",
+                "Write a 3-5 bullet summary of the current state and what is still unknown.",
+                "List the specific decision this research should unblock.",
+                "Recommend one next action, one owner, and one target date.",
+            ]
+            ask_user = "Do you want me to turn this into a recommendation now, or is this waiting on human discussion first?"
+            ai_help_summary = "I can synthesize the current context into a recommendation and next-step note."
+        classification_basis = "Research-style language points to a recommendation artifact, not just another round of vague investigation."
+        if re.search(r"\b(spreadsheet|sheet|docs.google.com|document|spec)\b", combined_text):
+            todo_items.insert(1, "Review the linked document/spreadsheet and capture the key takeaways in the task.")
+    elif work_type == "bug":
+        todo_label = "Bug TODO"
+        task_read = "This is still a bug triage task. The useful outcome is not more discussion; it is either a confirmed repro or a confirmed fix."
+        if pr_label:
+            task_read = f"{task_read} There is already a concrete code signal via {pr_label}."
+        if negative_signal:
+            task_read = f"{task_read} Recent context also suggests the issue may still be failing."
+        classification_basis = "Bug language is the dominant signal, so the task should drive toward repro-versus-fixed, not vague planning."
+        next_action = "Confirm whether this is still reproducible, then either close it as fixed or create the smallest remaining implementation step."
+        todo_items = [
+            "Collect the latest repro details, version, and any screenshots or logs.",
+            "Verify whether the issue still reproduces on the latest relevant build.",
+            "If fixed, comment with evidence and ask for close-out.",
+            "If not fixed, define the smallest next engineering step and owner.",
+        ]
+        ask_user = "Do you want me to investigate this now and come back with either a narrowed repro or the smallest next fix?"
+        ai_help_summary = "I can narrow the repro path or draft the concrete remaining fix step."
+    elif work_type == "implementation":
+        todo_label = "Implementation TODO"
+        if kind == "decision":
+            task_read = "This is not really implementation yet. It is a scoping or decision task that still needs a concrete recommendation before code can move cleanly."
+            next_action = "Write the scoped recommendation, name the owner, and define the first testable milestone that would follow from that decision."
+            todo_items = [
+                "Write the exact decision or scope question in one sentence.",
+                "List the constraints or options that matter.",
+                "Recommend one direction instead of leaving it open-ended.",
+                "Define the first milestone that would start once the decision is accepted.",
+            ]
+            ask_user = "Do you want me to draft the recommendation now, or is this waiting on discussion first?"
+            ai_help_summary = "I can draft the recommendation and reduce this to a shippable first milestone."
+        elif kind == "writing":
+            task_read = "This is really a writing/output task hiding inside implementation. The missing artifact is a concrete document, not another placeholder."
+            next_action = "Draft the output, then move the task into review or verification once the first pass exists."
+            todo_items = [
+                "Define the output artifact this task is supposed to produce.",
+                "Draft the first pass instead of keeping the task broad.",
+                "Link the draft or working area back into the task.",
+                "Move it to review once there is something testable or reviewable.",
+            ]
+            ask_user = "Do you want me to produce the first draft now?"
+            ai_help_summary = "I can create the first pass so this stops being a placeholder."
+        else:
+            task_read = "This is an implementation task, but it is still too broad to drive execution cleanly from the task as written."
+            if pr_label:
+                task_read = f"{task_read} There is already a code signal via {pr_label}, so the best next move is to define the next testable milestone."
+            classification_basis = "Implementation signals are present, but the task still needs a smaller, more testable milestone."
+            next_action = "Reduce this to one concrete shipping step instead of leaving it as a broad open task."
+            todo_items = [
+                "Confirm the exact deliverable for this task.",
+                "Link the active PR, branch, or code area if one exists.",
+                "Define the next testable milestone.",
+                "Move it to verification once that milestone is shipped.",
+            ]
+            ask_user = "Do you want me to turn this into a concrete first milestone now?"
+            ai_help_summary = "I can define the first milestone and, if there is code context, push it forward."
+        if not classification_basis:
+            classification_basis = "The title and recent context still read as open implementation work, but not yet as a crisp milestone."
+    elif work_type == "coordination":
+        todo_label = "Coordination TODO"
+        task_read = "This is primarily a coordination task. The value comes from creating movement with one clear ask, not from doing more solo work."
+        classification_basis = "The strongest signal is handoff/follow-up language instead of implementation details."
+        next_action = "Push the external dependency forward with one specific follow-up."
+        todo_items = [
+            "Identify the external person or team currently blocking progress.",
+            "Post a follow-up comment or send a ping with the concrete ask.",
+            "Record the expected reply date or handoff date in the task.",
+            "Move back to execution once the dependency clears.",
+        ]
+        ask_user = "Who should receive the follow-up, and do you want me to draft it?"
+        ai_help_summary = "I can draft the follow-up or summarize the current ask."
+    else:
+        todo_label = "Admin TODO"
+        task_read = "This reads more like a reminder or admin placeholder than meaningful engineering work."
+        classification_basis = "The task does not currently contain enough execution substance to justify active focus."
+        next_action = "Either schedule the work or move it out of active My Tasks if it is not actionable this cycle."
+        todo_items = [
+            "Decide whether this belongs in active My Tasks right now.",
+            "If yes, assign a date or next checkpoint.",
+            "If no, move it to backlog or an appropriate holding section.",
+        ]
+        ask_user = "Should this stay in your active queue, or should it be parked in a holding section?"
+        ai_help_summary = "I can help re-scope or re-file it, but it does not look like a good execution target."
+
+    if not task_read:
+        task_read = "This task needs a clearer definition before it can drive execution."
+    if not classification_basis:
+        classification_basis = "The current signals are mixed, so the safest move is to define the next concrete owner/action."
+
+    if due_on:
+        todo_items.append(f"Check whether the due date `{due_on}` still makes sense.")
+    if reasons:
+        todo_items.append(f"Use this context when updating the task: {reasons[0]}")
+    if recent_comment_lines:
+        todo_items.append("Incorporate the latest comment context before changing scope or status.")
+
+    execution_candidate, execution_prompt = infer_execution_candidate(
+        category_key=category_key,
+        work_type=work_type,
+        combined_text=combined_text,
+    )
+
+    return {
+        "work_type": work_type,
+        "task_read": task_read,
+        "classification_basis": classification_basis,
+        "next_action": next_action,
+        "todo_label": todo_label,
+        "todo_items": todo_items[:6],
+        "ask_user": ask_user,
+        "ai_help_now": category_key != "backlog_cleanup",
+        "ai_help_summary": ai_help_summary,
+        "execution_candidate": execution_candidate,
+        "execution_prompt": execution_prompt,
+    }
+
+
+def classify_inbox_cleanup_task(task_context: dict[str, Any], now: datetime) -> dict[str, Any]:
+    task = task_context.get("task", {})
+    stories = task_context.get("stories", [])
+    name = str(task.get("name") or "")
+    notes = strip_html_to_text(task.get("html_notes") or task.get("notes"))
+    membership_labels = task_membership_labels(task)
+    project_names = task_project_names(task)
+    current_my_tasks_section = ((task.get("assignee_section") or {}).get("name") or "").strip()
+    recent = recent_comments(task_context, limit=3)
+    recent_comment_lines = [
+        f"{comment.get('created_by', {}).get('name') or 'Unknown'} on {short_date(comment.get('created_at'))}: {story_text(comment)}"
+        for comment in recent
+        if story_text(comment)
+    ]
+
+    combined_text = " ".join(
+        [
+            name,
+            notes,
+            " ".join(membership_labels),
+            " ".join(project_names),
+            " ".join(recent_comment_lines),
+        ]
+    ).casefold()
+    modified_at = parse_iso_timestamp(task.get("modified_at"))
+    created_at = parse_iso_timestamp(task.get("created_at"))
+    stale_days = max(0, int((now - modified_at).total_seconds() // 86400))
+    age_days = max(0, int((now - created_at).total_seconds() // 86400))
+    linked_prs = extract_github_pr_links(combined_text)
+    linked_urls = extract_urls(combined_text)
+
+    ready_signal = bool(
+        re.search(
+            r"\b(confirmed fixed|confirmed both working|fully resolved|most likely fully resolved|working for beta|works on|working for|shows correctly|looks ok to me|looks done|shipped)\b",
+            combined_text,
+        )
+    )
+    verify_signal = bool(
+        re.search(
+            r"\b(pr\b|preview|staging|test|beta|rc|should be out now|should be fixed|please test|confirmed)\b",
+            combined_text,
+        )
+    )
+    waiting_signal = bool(
+        re.search(
+            r"\b(blocked|waiting|emailed|email|cc'd|contact|confirm with|needs info|details needed|partner|vendor|external)\b",
+            combined_text,
+        )
+    ) or "[blocked]" in name.casefold()
+    negative_signal = bool(
+        re.search(
+            r"\b(still happening|still broken|not working|another fix|needs another fix|difficult to be 100% confident)\b",
+            combined_text,
+        )
+    )
+    backlog_signal = stale_days >= 30 or bool(
+        re.search(r"\b(backlog|nice to have|initiatives|feature backlog)\b", combined_text)
+    )
+    done_like_signal = bool(
+        re.search(r"\b(production|done|qa|completed|staging|test)\b", " ".join(membership_labels).casefold())
+    )
+
+    reasons: list[str] = []
+    if membership_labels:
+        reasons.append(f"Project state: {membership_labels[0]}")
+    if task.get("due_on"):
+        reasons.append(f"Due date: {task['due_on']}")
+    reasons.append(f"Last updated {stale_days} day(s) ago")
+    if recent_comment_lines:
+        reasons.extend(recent_comment_lines[:2])
+
+    work_type = infer_task_work_type(combined_text, name)
+    shared_for_manager_comments, shared_reason = task_is_shared_for_manager_comments(task, stories)
+    substantive_manager_context = has_substantive_manager_context(
+        task=task,
+        recent_comment_lines=recent_comment_lines,
+    )
+
+    category_key = "needs_next_action"
+    if ready_signal and done_like_signal and not negative_signal:
+        category_key = "ready_to_close"
+    elif verify_signal and not negative_signal:
+        category_key = "needs_verification"
+    elif waiting_signal:
+        category_key = "waiting_on_others"
+    elif backlog_signal and stale_days >= 14:
+        category_key = "backlog_cleanup"
+
+    # Fresh tasks with little context should stay in the action bucket instead of backlog.
+    if category_key == "backlog_cleanup" and age_days < 14:
+        category_key = "needs_next_action"
+
+    manager_plan = manager_plan_for_task(
+        name=name,
+        work_type=work_type,
+        category_key=category_key,
+        task=task,
+        combined_text=combined_text,
+        reasons=reasons,
+        recent_comment_lines=recent_comment_lines,
+        linked_prs=linked_prs,
+        ready_signal=ready_signal,
+        verify_signal=verify_signal,
+        waiting_signal=waiting_signal,
+        negative_signal=negative_signal,
+    )
+    manager_comment_allowed = (
+        not shared_for_manager_comments
+        and bool(substantive_manager_context)
+        and work_type != "admin"
+    )
+    active_ai_action = active_ai_action_for_task(
+        category_key=category_key,
+        work_type=work_type,
+        ready_signal=ready_signal,
+        verify_signal=verify_signal,
+        waiting_signal=waiting_signal,
+        negative_signal=negative_signal,
+        linked_prs=linked_prs,
+    )
+
+    return {
+        "category_key": category_key,
+        "category_label": INBOX_CLEANUP_REVIEW_SECTIONS[category_key],
+        "current_my_tasks_section": current_my_tasks_section,
+        "reasons": reasons,
+        "stale_days": stale_days,
+        "age_days": age_days,
+        "work_type": work_type,
+        "manager_plan": manager_plan,
+        "shared_for_manager_comments": shared_for_manager_comments,
+        "shared_for_manager_comments_reason": shared_reason,
+        "substantive_manager_context": substantive_manager_context,
+        "manager_comment_allowed": manager_comment_allowed,
+        "linked_prs": linked_prs,
+        "linked_urls": linked_urls[:10],
+        "active_ai_action": active_ai_action,
+    }
+
+
+def ensure_review_sections(
+    token: str,
+    *,
+    user_task_list_gid: str,
+    existing_sections: list[dict[str, Any]],
+    apply: bool,
+) -> dict[str, dict[str, Any]]:
+    sections_by_name: dict[str, dict[str, Any]] = {
+        str(section.get("name")): dict(section)
+        for section in existing_sections
+        if isinstance(section, dict) and section.get("name")
+    }
+    for section_name in INBOX_CLEANUP_REVIEW_SECTIONS.values():
+        if section_name in sections_by_name or not apply:
+            continue
+        created = api_request(
+            token=token,
+            method="POST",
+            path_or_url=f"/projects/{user_task_list_gid}/sections",
+            json_body={"data": {"name": section_name}},
+        ).get("data", {})
+        if isinstance(created, dict) and created.get("name"):
+            sections_by_name[str(created["name"])] = created
+    return sections_by_name
+
+
+def infer_workspace_gid_from_payload(payload: dict[str, Any], cache: dict[str, Any]) -> str | None:
+    data = payload.get("data")
+    if isinstance(data, dict):
+        workspace = data.get("workspace")
+        if isinstance(workspace, dict) and workspace.get("gid"):
+            return str(workspace["gid"])
+        workspaces = data.get("workspaces")
+        if isinstance(workspaces, list) and workspaces:
+            first = workspaces[0]
+            if isinstance(first, dict) and first.get("gid"):
+                return str(first["gid"])
+    workspaces = cache_bucket(cache, "workspaces").get("by_gid", {})
+    if len(workspaces) == 1:
+        return next(iter(workspaces.keys()))
+    return None
+
+
+def my_tasks_summary(
+    token: str,
+    *,
+    workspace_gid: str,
+    cache: dict[str, Any],
+    refresh: bool = False,
+    max_age_hours: int = 6,
+) -> dict[str, Any]:
+    summaries = metadata_bucket(cache, "my_tasks_summary_by_workspace")
+    existing = summaries.get(workspace_gid)
+    if isinstance(existing, dict) and not refresh:
+        captured_at = parse_iso_timestamp(existing.get("captured_at"))
+        age_seconds = (datetime.now(timezone.utc) - captured_at).total_seconds()
+        if age_seconds <= max_age_hours * 3600:
+            return existing
+
+    user_task_list = my_tasks_project(token, workspace_gid)
+    user_task_list_gid = str(user_task_list.get("gid") or "").strip()
+    tasks = my_tasks_tasks(token, user_task_list_gid, paginate=True, limit_pages=0) if user_task_list_gid else []
+    section_counts: dict[str, int] = {}
+    for task in tasks:
+        if not isinstance(task, dict):
+            continue
+        section_name = str(((task.get("assignee_section") or {}).get("name")) or "Unsectioned")
+        section_counts[section_name] = section_counts.get(section_name, 0) + 1
+
+    summary = {
+        "captured_at": now_iso(),
+        "user_task_list_gid": user_task_list_gid,
+        "user_task_list_name": user_task_list.get("name"),
+        "open_task_count": len(tasks),
+        "recently_assigned_count": section_counts.get("Recently assigned", 0),
+        "review_task_count": sum(
+            count
+            for section_name, count in section_counts.items()
+            if section_name in INBOX_CLEANUP_REVIEW_SECTIONS.values()
+        ),
+        "section_counts": section_counts,
+    }
+    summaries[workspace_gid] = summary
+    save_cache(cache)
+    return summary
+
+
+def advertising_message_for_my_tasks(summary: dict[str, Any]) -> dict[str, Any]:
+    open_count = int(summary.get("open_task_count") or 0)
+    recently_assigned = int(summary.get("recently_assigned_count") or 0)
+    review_count = int(summary.get("review_task_count") or 0)
+
+    recommendation = {
+        "priority": "low",
+        "message": "My Tasks looks manageable. Use inbox cleanup when you want an AI-gated category plan for your tasks.",
+        "command": "python3 scripts/asana_api.py inbox-cleanup",
+    }
+    if recently_assigned >= 50:
+        recommendation = {
+            "priority": "high",
+            "message": f"My Tasks intake is large: {recently_assigned} tasks in Recently assigned and {open_count} open overall.",
+            "command": "python3 scripts/asana_api.py inbox-cleanup",
+        }
+    elif recently_assigned >= 15:
+        recommendation = {
+            "priority": "medium",
+            "message": f"My Tasks intake is building up: {recently_assigned} tasks in Recently assigned.",
+            "command": "python3 scripts/asana_api.py inbox-cleanup",
+        }
+    elif review_count > 0:
+        recommendation = {
+            "priority": "low",
+            "message": f"My Tasks already has {review_count} tasks in Review sections. Start with a morning command center before doing another cleanup pass.",
+            "command": "python3 scripts/asana_api.py daily-briefing",
+        }
+    return recommendation
+
+
+def skill_feature_highlights() -> list[dict[str, str]]:
+    return [
+        {
+            "command": "python3 scripts/asana_api.py inbox-cleanup",
+            "use_when": "Generate an AI-gated cleanup snapshot and plan scaffold for My Tasks before any bucket moves happen.",
+        },
+        {
+            "command": "python3 scripts/asana_api.py inbox-cleanup --plan-file /tmp/asana-inbox-plan.json --apply",
+            "use_when": "Apply an AI-authored cleanup plan after categories and bucket decisions have been reviewed.",
+        },
+        {
+            "command": "python3 scripts/asana_api.py daily-briefing",
+            "use_when": "Run the AI-gated daily briefing workflow: generate the snapshot internally, auto-author the briefing plan, and only ask the user about truly ambiguous tasks.",
+        },
+        {
+            "command": "python3 scripts/asana_api.py daily-briefing --plan-file /tmp/asana-daily-briefing-plan.json --markdown",
+            "use_when": "Render an AI-authored morning command center after the briefing plan has been reviewed.",
+        },
+        {
+            "command": "python3 scripts/asana_api.py task-bundle <task_gid> --project-gid <project_gid>",
+            "use_when": "Pull one task with notes, comments, attachments, and project workflow context.",
+        },
+        {
+            "command": "python3 scripts/asana_api.py project-assigned-tasks <project_gid> --completed false --include-task-position --include-comments --comment-limit 3 --include-attachments",
+            "use_when": "Get your actual assigned work in one project with triage context.",
+        },
+        {
+            "command": "python3 scripts/asana_api.py close-out-sections <project_gid> --section \"Old Section\" --move-to \"Work Completed\" --completed-mode completed --apply",
+            "use_when": "Relocate tasks out of stale personal sections, then delete the section once it is empty.",
+        },
+        {
+            "command": "python3 scripts/asana_api.py search-tasks --text \"<query>\" --assignee me",
+            "use_when": "Find tasks quickly across the workspace without clicking around.",
+        },
+    ]
+
+
+def attach_skill_advertising(
+    *,
+    args: argparse.Namespace,
+    payload: Any,
+    token: str | None = None,
+    workspace_gid: str | None = None,
+    cache: dict[str, Any] | None = None,
+    include_first_run: bool = True,
+    refresh_summary: bool = False,
+) -> Any:
+    if not isinstance(payload, dict):
+        return payload
+
+    cache = cache or load_cache()
+    metadata = ensure_cache_shape(cache).setdefault("metadata", {})
+    current_user_gid = str(metadata.get("current_user_gid") or "").strip()
+    if not current_user_gid:
+        current_user_gid = str((((payload.get("data") or {}) if isinstance(payload.get("data"), dict) else {}).get("gid")) or "").strip()
+
+    resolved_workspace_gid = workspace_gid or infer_workspace_gid_from_payload(payload, cache)
+    my_tasks_info = None
+    recommendation = None
+    if token and resolved_workspace_gid:
+        my_tasks_info = my_tasks_summary(
+            token,
+            workspace_gid=resolved_workspace_gid,
+            cache=cache,
+            refresh=refresh_summary,
+        )
+        recommendation = advertising_message_for_my_tasks(my_tasks_info)
+
+    onboarding_bucket = metadata_bucket(cache, "feature_onboarding")
+    onboarding_key = f"{current_user_gid}:{resolved_workspace_gid or 'unknown'}"
+    first_run = include_first_run and current_user_gid and onboarding_key not in onboarding_bucket
+
+    advertising: dict[str, Any] = {
+        "my_tasks": my_tasks_info,
+        "recommended_next_step": recommendation,
+    }
+    if first_run:
+        advertising["first_run"] = True
+        advertising["message"] = (
+            "This Asana integration can triage My Tasks, inspect single tickets with full context, "
+            "and pull your assigned work inside projects."
+        )
+        advertising["feature_highlights"] = skill_feature_highlights()
+        onboarding_bucket[onboarding_key] = {
+            "shown_at": now_iso(),
+            "command": getattr(args, "command", None),
+        }
+        save_cache(cache)
+    else:
+        advertising["first_run"] = False
+
+    enriched = dict(payload)
+    enriched["skill_advertising"] = advertising
+    return enriched
+
+
+def recent_comment_stories(
+    stories: list[dict[str, Any]],
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    comments = sorted(
+        comment_stories_only(stories),
+        key=lambda story: parse_iso_timestamp(story.get("created_at")),
+    )
+    if limit is None or limit <= 0:
+        return comments
+    return comments[-limit:]
+
+
+def field_list(csv_fields: str) -> list[str]:
+    return [field.strip() for field in csv_fields.split(",") if field.strip()]
+
+
+def workspace_default(
+    args: argparse.Namespace,
+    context: dict[str, Any],
+    cache: dict[str, Any] | None = None,
+) -> str | None:
+    value = getattr(args, "workspace", None) or context.get("workspace_gid")
+    if not value:
+        return None
+    if value == context.get("workspace_name"):
+        return context.get("workspace_gid")
+    if cache:
+        record = find_cached_record(cache, "workspaces", value, fields=("name",))
+        if record:
+            return str(record.get("gid"))
+    return value
+
+
+def team_default(
+    args: argparse.Namespace,
+    context: dict[str, Any],
+    cache: dict[str, Any] | None = None,
+) -> str | None:
+    value = getattr(args, "team", None) or context.get("team_gid")
+    if not value:
+        return None
+    teams = context.get("teams", {})
+    if value in teams:
+        return value
+    lowered = value.casefold()
+    for gid, name in teams.items():
+        if str(name).casefold() == lowered:
+            return gid
+    if cache:
+        record = find_cached_record(cache, "teams", value, fields=("name",))
+        if record:
+            return str(record.get("gid"))
+    return value
+
+
+def resolve_user_identifier(
+    value: str | None,
+    context: dict[str, Any],
+    cache: dict[str, Any] | None = None,
+) -> str | None:
+    token = str(value or "").strip()
+    if not token:
+        return None
+    if token == "me":
+        return context.get("user_gid") or "me"
+    if token == context.get("user_name") or token == context.get("user_gid"):
+        return context.get("user_gid") or token
+    if is_gid_like(token):
+        return token
+    if cache:
+        record = find_cached_record(cache, "users", token, fields=("name", "email"))
+        if record:
+            return str(record.get("gid"))
+    return token
+
+
+def resolve_many_user_identifiers(
+    values: list[str] | None,
+    context: dict[str, Any],
+    cache: dict[str, Any] | None = None,
+) -> list[str]:
+    resolved: list[str] = []
+    for item in parse_many_gid(values):
+        user_gid = resolve_user_identifier(item, context, cache)
+        if user_gid:
+            resolved.append(user_gid)
+    return resolved
+
+
+def refresh_workspace_tags(
+    token: str,
+    workspace_gid: str,
+    cache: dict[str, Any],
+) -> list[dict[str, Any]]:
+    response = api_request(
+        token=token,
+        method="GET",
+        path_or_url=f"/workspaces/{workspace_gid}/tags",
+        query={"opt_fields": tag_opt_fields("gid,name,color")},
+    )
+    tags = response.get("data", [])
+    if isinstance(tags, list):
+        cache_records(
+            cache,
+            "tags",
+            [tag_cache_record(item, workspace_gid=workspace_gid) for item in tags if isinstance(item, dict)],
+        )
+        save_cache(cache)
+        return tags
+    return []
+
+
+def resolve_tag_identifier(
+    value: str | None,
+    *,
+    token: str,
+    cache: dict[str, Any],
+    workspace_gid: str | None = None,
+) -> dict[str, Any]:
+    token_value = str(value or "").strip()
+    if not token_value:
+        raise SystemExit("Missing tag identifier.")
+
+    record = find_cached_tag_record(cache, token_value, workspace_gid=workspace_gid)
+    if record:
+        return record
+
+    if workspace_gid:
+        refresh_workspace_tags(token, workspace_gid, cache)
+        record = find_cached_tag_record(cache, token_value, workspace_gid=workspace_gid)
+        if record:
+            return record
+
+    workspace_note = f" in workspace {workspace_gid}" if workspace_gid else ""
+    raise SystemExit(f"No tag matching '{token_value}' was found{workspace_note}.")
+
+
+def normalize_sorting_tag_labels(values: list[str] | None) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw_value in values or list(DEFAULT_SORTING_TAG_LABELS):
+        label = str(raw_value or "").strip()
+        if not label:
+            continue
+        key = label.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(label)
+    return normalized
+
+
+def add_common_output_flags(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--compact", action="store_true", help="Print compact JSON")
+
+
+def task_opt_fields(default: str | None = None) -> str:
+    return default or (
+        "gid,name,completed,assignee.name,due_on,due_at,projects.name,"
+        "memberships.section.name,parent.name,permalink_url"
+    )
+
+
+def section_close_out_task_opt_fields(default: str | None = None) -> str:
+    return default or "gid,name,completed,completed_at,permalink_url"
+
+
+def project_assigned_task_opt_fields(default: str | None = None) -> str:
+    return default or (
+        "gid,name,completed,assignee.gid,assignee.name,due_on,due_at,permalink_url,"
+        "parent.gid,parent.name,projects.gid,projects.name,memberships.project.gid,"
+        "memberships.project.name,memberships.section.gid,memberships.section.name"
+    )
+
+
+def parent_task_context_opt_fields(default: str | None = None) -> str:
+    return default or (
+        "gid,name,permalink_url,memberships.project.gid,memberships.project.name,"
+        "memberships.section.gid,memberships.section.name"
+    )
+
+
+def section_opt_fields(default: str | None = None) -> str:
+    return default or "gid,name,project.name,created_at"
+
+
+def tag_opt_fields(default: str | None = None) -> str:
+    return default or "gid,name,color,notes,followers.name,permalink_url"
+
+
+def story_opt_fields(default: str | None = None) -> str:
+    return default or "gid,created_at,created_by.gid,created_by.name,text,html_text,type,resource_subtype"
+
+
+def story_detail_opt_fields(default: str | None = None) -> str:
+    return default or (
+        "gid,created_at,created_by.gid,created_by.name,text,html_text,type,"
+        "resource_subtype,permalink_url,target.gid,target.name,target.resource_type,"
+        "target.permalink_url"
+    )
+
+
+def custom_field_setting_opt_fields(default: str | None = None) -> str:
+    return default or (
+        "gid,is_important,custom_field.gid,custom_field.name,"
+        "custom_field.resource_subtype,custom_field.display_value,"
+        "custom_field.enum_options.name"
+    )
+
+
+def attachment_opt_fields(default: str | None = None) -> str:
+    return default or "gid,name,resource_subtype,download_url,permanent_url,view_url,host,parent_type,parent.name"
+
+
+def task_status_fields(default: str | None = None) -> str:
+    return default or (
+        "gid,name,completed,completed_at,permalink_url,assignee.name,due_on,due_at,"
+        "memberships.project.gid,memberships.project.name,memberships.section.gid,"
+        "memberships.section.name,custom_fields.gid,custom_fields.name,"
+        "custom_fields.resource_subtype,custom_fields.display_value"
+    )
+
+
+def build_task_list_query(args: argparse.Namespace, default_fields: str | None = None) -> dict[str, str]:
+    return {"opt_fields": args.opt_fields or task_opt_fields(default_fields)}
+
+
+def post_task_relationship(
+    args: argparse.Namespace,
+    path: str,
+    payload: dict[str, Any],
+) -> Any:
+    token = get_token(args)
+    response = api_request(
+        token=token,
+        method="POST",
+        path_or_url=path,
+        json_body={"data": payload},
+    )
+    print_json(response, args.compact)
+    return response
+
+
+def section_order_map(token: str, project_gid: str) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    response = api_request(
+        token=token,
+        method="GET",
+        path_or_url=f"/projects/{project_gid}/sections",
+        query={"opt_fields": section_opt_fields()},
+    )
+    sections = response.get("data", [])
+    order_map: dict[str, int] = {}
+    for index, section in enumerate(sections, start=1):
+        section_gid = section.get("gid")
+        if section_gid:
+            order_map[section_gid] = index
+    return sections, order_map
+
+
+def section_task_positions_map(
+    token: str,
+    section_gids: list[str],
+) -> dict[str, dict[str, int]]:
+    unique_section_gids: list[str] = []
+    seen: set[str] = set()
+    for section_gid in section_gids:
+        if section_gid and section_gid not in seen:
+            seen.add(section_gid)
+            unique_section_gids.append(section_gid)
+
+    positions_by_section: dict[str, dict[str, int]] = {}
+    for section_gid in unique_section_gids:
+        section_tasks = api_request(
+            token=token,
+            method="GET",
+            path_or_url=f"/sections/{section_gid}/tasks",
+            query={"opt_fields": "gid"},
+        ).get("data", [])
+        positions_by_section[section_gid] = {
+            str(section_task.get("gid")): index
+            for index, section_task in enumerate(section_tasks, start=1)
+            if isinstance(section_task, dict) and section_task.get("gid")
+        }
+    return positions_by_section
+
+
+def fetch_all_section_tasks(
+    token: str,
+    section_gid: str,
+    *,
+    opt_fields: str | None = None,
+    limit_pages: int = 0,
+) -> list[dict[str, Any]]:
+    response = api_request(
+        token=token,
+        method="GET",
+        path_or_url=f"/sections/{section_gid}/tasks",
+        query={
+            "opt_fields": opt_fields or section_close_out_task_opt_fields(),
+            "limit": "100",
+        },
+    )
+    response = maybe_paginate(token, response, True, limit_pages)
+    data = response.get("data", [])
+    if not isinstance(data, list):
+        return []
+    return [task for task in data if isinstance(task, dict)]
+
+
+def select_section_tasks(
+    tasks: list[dict[str, Any]],
+    completed_mode: str,
+) -> list[dict[str, Any]]:
+    if completed_mode == "all":
+        return list(tasks)
+    if completed_mode == "completed":
+        return [task for task in tasks if bool(task.get("completed"))]
+    if completed_mode == "incomplete":
+        return [task for task in tasks if not bool(task.get("completed"))]
+    raise SystemExit(f"Unsupported completed mode: {completed_mode}")
+
+
+def command_request(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    query = parse_kv(args.query)
+    if args.opt_fields:
+        query["opt_fields"] = args.opt_fields
+    if args.opt_expand:
+        query["opt_expand"] = args.opt_expand
+
+    json_body = None
+    form_body = parse_kv(args.form)
+    file_body = parse_kv(args.file)
+
+    if args.data and args.data_file:
+        raise SystemExit("Pass only one of --data or --data-file")
+
+    if args.data:
+        json_body = maybe_wrap_data(json.loads(args.data), args.no_wrap_data)
+    elif args.data_file:
+        json_body = maybe_wrap_data(json.loads(Path(args.data_file).read_text()), args.no_wrap_data)
+
+    response = api_request(
+        token=token,
+        method=args.method,
+        path_or_url=args.path,
+        query=query,
+        json_body=json_body,
+        multipart_form=form_body,
+        multipart_files=file_body,
+    )
+    response = maybe_paginate(token, response, args.paginate, args.limit_pages)
+    print_json(response, args.compact)
+    return response
+
+
+def command_whoami(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    response = api_request(
+        token=token,
+        method="GET",
+        path_or_url="/users/me",
+        query={"opt_fields": "gid,name,email,workspaces.name"},
+    )
+    cache = load_cache()
+    user = response.get("data", {})
+    if isinstance(user, dict):
+        cache_record(cache, "users", user_cache_record(user))
+        workspaces = user.get("workspaces", [])
+        if isinstance(workspaces, list):
+            cache_records(cache, "workspaces", [workspace_cache_record(item) for item in workspaces if isinstance(item, dict)])
+        cache["metadata"]["current_user_gid"] = user.get("gid")
+        cache["metadata"]["current_user_name"] = user.get("name")
+        save_cache(cache)
+    enriched = attach_skill_advertising(
+        args=args,
+        payload=response,
+        token=token,
+        cache=cache,
+        refresh_summary=True,
+    )
+    print_json(enriched, args.compact)
+    return enriched
+
+
+def command_workspaces(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    response = api_request(
+        token=token,
+        method="GET",
+        path_or_url="/users/me/workspaces",
+    )
+    cache = load_cache()
+    workspaces = response.get("data", [])
+    if isinstance(workspaces, list):
+        cache_records(cache, "workspaces", [workspace_cache_record(item) for item in workspaces if isinstance(item, dict)])
+        save_cache(cache)
+    enriched = attach_skill_advertising(
+        args=args,
+        payload=response,
+        token=token,
+        cache=cache,
+    )
+    print_json(enriched, args.compact)
+    return enriched
+
+
+def command_teams(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    context = load_context()
+    cache = load_cache()
+    workspace = workspace_default(args, context, cache)
+    if not workspace:
+        raise SystemExit("No workspace GID provided and no default workspace in asana-context.json")
+    response = api_request(
+        token=token,
+        method="GET",
+        path_or_url=f"/workspaces/{workspace}/teams",
+    )
+    teams = response.get("data", [])
+    if isinstance(teams, list):
+        cache_records(
+            cache,
+            "teams",
+            [team_cache_record(item, workspace_gid=workspace) for item in teams if isinstance(item, dict)],
+        )
+        save_cache(cache)
+    enriched = attach_skill_advertising(
+        args=args,
+        payload=response,
+        token=token,
+        workspace_gid=workspace,
+        cache=cache,
+    )
+    print_json(enriched, args.compact)
+    return enriched
+
+
+def command_projects(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    context = load_context()
+    cache = load_cache()
+    team = team_default(args, context, cache)
+    if not team:
+        raise SystemExit("No team GID provided and no default team in asana-context.json")
+    response = api_request(
+        token=token,
+        method="GET",
+        path_or_url=f"/teams/{team}/projects",
+    )
+    projects = response.get("data", [])
+    if isinstance(projects, list):
+        cache_records(
+            cache,
+            "projects",
+            [project_cache_record(item, team_gid=team) for item in projects if isinstance(item, dict)],
+        )
+        save_cache(cache)
+    workspace_gid = None
+    team_record = find_cached_record(cache, "teams", team, fields=("workspace_gid",))
+    if isinstance(team_record, dict) and team_record.get("workspace_gid"):
+        workspace_gid = str(team_record["workspace_gid"])
+    enriched = attach_skill_advertising(
+        args=args,
+        payload=response,
+        token=token,
+        workspace_gid=workspace_gid,
+        cache=cache,
+    )
+    print_json(enriched, args.compact)
+    return enriched
+
+
+def command_users(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    context = load_context()
+    cache = load_cache()
+    workspace = workspace_default(args, context, cache)
+    if not workspace:
+        raise SystemExit("No workspace GID provided and no default workspace in asana-context.json")
+    response = api_request(
+        token=token,
+        method="GET",
+        path_or_url=f"/workspaces/{workspace}/users",
+        query={"opt_fields": args.opt_fields or "gid,name,email"},
+    )
+    response = maybe_paginate(token, response, args.paginate, args.limit_pages)
+    users = response.get("data", [])
+    if isinstance(users, list):
+        cache_records(cache, "users", [user_cache_record(item) for item in users if isinstance(item, dict)])
+        save_cache(cache)
+    enriched = attach_skill_advertising(
+        args=args,
+        payload=response,
+        token=token,
+        workspace_gid=workspace,
+        cache=cache,
+    )
+    print_json(enriched, args.compact)
+    return enriched
+
+
+def command_task(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    task_gids = parse_gid_args(getattr(args, "task_gids", None) or getattr(args, "task_gid", None))
+    opt_fields = (
+        args.opt_fields
+        or "gid,name,resource_subtype,completed,assignee.name,due_on,due_at,"
+        "projects.name,memberships.section.name,parent.name,permalink_url,notes"
+    )
+    actions = [
+        {
+            "method": "get",
+            "relative_path": f"/tasks/{task_gid}",
+            "options": {"fields": field_list(opt_fields)},
+        }
+        for task_gid in task_gids
+    ]
+    items = batch_actions_request_chunked(token, actions)
+    return render_many_results(
+        "task",
+        [
+            {
+                "requested_gid": task_gid,
+                "status_code": item.get("status_code", 200),
+                "result": item.get("body", {}),
+            }
+            for task_gid, item in zip(task_gids, items)
+        ],
+        args.compact,
+    )
+
+
+def command_story(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    story_gids = parse_gid_args(getattr(args, "story_gids", None) or getattr(args, "story_gid", None))
+    opt_fields = args.opt_fields or story_detail_opt_fields()
+    actions = [
+        {
+            "method": "get",
+            "relative_path": f"/stories/{story_gid}",
+            "options": {"fields": field_list(opt_fields)},
+        }
+        for story_gid in story_gids
+    ]
+    items = batch_actions_request_chunked(token, actions)
+    return render_many_results(
+        "story",
+        [
+            {
+                "requested_gid": story_gid,
+                "status_code": item.get("status_code", 200),
+                "result": response_with_review_links(item.get("body", {})),
+            }
+            for story_gid, item in zip(story_gids, items)
+        ],
+        args.compact,
+    )
+
+
+def command_project(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    project_gids = parse_gid_args(getattr(args, "project_gids", None) or getattr(args, "project_gid", None))
+    opt_fields = (
+        args.opt_fields
+        or "gid,name,team.name,owner.name,public,archived,current_status,"
+        "default_view,created_at,permalink_url,notes"
+    )
+    cache = load_cache()
+    actions = [
+        {
+            "method": "get",
+            "relative_path": f"/projects/{project_gid}",
+            "options": {"fields": field_list(opt_fields)},
+        }
+        for project_gid in project_gids
+    ]
+    items = batch_actions_request_chunked(token, actions)
+    for item in items:
+        project = (item.get("body") or {}).get("data", {})
+        if isinstance(project, dict):
+            cache_record(cache, "projects", project_cache_record(project))
+    save_cache(cache)
+    return render_many_results(
+        "project",
+        [
+            {
+                "requested_gid": project_gid,
+                "status_code": item.get("status_code", 200),
+                "result": item.get("body", {}),
+            }
+            for project_gid, item in zip(project_gids, items)
+        ],
+        args.compact,
+    )
+
+
+def command_project_tasks(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    response = api_request(
+        token=token,
+        method="GET",
+        path_or_url=f"/projects/{args.project_gid}/tasks",
+        query=build_task_list_query(args),
+    )
+    response = maybe_paginate(token, response, args.paginate, args.limit_pages)
+    print_json(response, args.compact)
+    return response
+
+
+def command_sections(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    response = api_request(
+        token=token,
+        method="GET",
+        path_or_url=f"/projects/{args.project_gid}/sections",
+        query={"opt_fields": args.opt_fields or section_opt_fields()},
+    )
+    print_json(response, args.compact)
+    return response
+
+
+def command_section(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    section_gids = parse_gid_args(getattr(args, "section_gids", None) or getattr(args, "section_gid", None))
+    opt_fields = args.opt_fields or section_opt_fields("gid,name,project.name")
+    actions = [
+        {
+            "method": "get",
+            "relative_path": f"/sections/{section_gid}",
+            "options": {"fields": field_list(opt_fields)},
+        }
+        for section_gid in section_gids
+    ]
+    items = batch_actions_request_chunked(token, actions)
+    return render_many_results(
+        "section",
+        [
+            {
+                "requested_gid": section_gid,
+                "status_code": item.get("status_code", 200),
+                "result": item.get("body", {}),
+            }
+            for section_gid, item in zip(section_gids, items)
+        ],
+        args.compact,
+    )
+
+
+def command_section_tasks(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    response = api_request(
+        token=token,
+        method="GET",
+        path_or_url=f"/sections/{args.section_gid}/tasks",
+        query=build_task_list_query(args),
+    )
+    response = maybe_paginate(token, response, args.paginate, args.limit_pages)
+    print_json(response, args.compact)
+    return response
+
+
+def command_create_section(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    response = api_request(
+        token=token,
+        method="POST",
+        path_or_url=f"/projects/{args.project_gid}/sections",
+        json_body={"data": {"name": args.name}},
+    )
+    print_json(response, args.compact)
+    return response
+
+
+def command_update_section(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    response = api_request(
+        token=token,
+        method="PUT",
+        path_or_url=f"/sections/{args.section_gid}",
+        json_body={"data": {"name": args.name}},
+    )
+    print_json(response, args.compact)
+    return response
+
+
+def command_close_out_sections(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    sections_response = api_request(
+        token=token,
+        method="GET",
+        path_or_url=f"/projects/{args.project_gid}/sections",
+        query={"opt_fields": section_opt_fields("gid,name,project.gid,project.name")},
+    )
+    project_sections = sections_response.get("data", [])
+    if not isinstance(project_sections, list):
+        raise SystemExit("Failed to load project sections.")
+
+    source_sections: list[dict[str, Any]] = []
+    seen_source_gids: set[str] = set()
+    for identifier in args.section:
+        section = find_section_record(project_sections, identifier)
+        section_gid = str(section.get("gid") or "").strip()
+        if not section_gid or section_gid in seen_source_gids:
+            continue
+        source_sections.append(section)
+        seen_source_gids.add(section_gid)
+
+    destination_section = None
+    if args.move_to:
+        destination_section = find_section_record(project_sections, args.move_to)
+        destination_gid = str(destination_section.get("gid") or "").strip()
+        if destination_gid in seen_source_gids:
+            raise SystemExit("Destination section must be different from every source section.")
+
+    project_name = ""
+    if source_sections:
+        project_name = str(((source_sections[0].get("project") or {}).get("name")) or "")
+
+    section_results: list[dict[str, Any]] = []
+    total_moved = 0
+    total_deleted = 0
+    for source_section in source_sections:
+        source_gid = str(source_section.get("gid") or "").strip()
+        source_name = str(source_section.get("name") or source_gid)
+        tasks = fetch_all_section_tasks(
+            token,
+            source_gid,
+            opt_fields=section_close_out_task_opt_fields(),
+            limit_pages=args.limit_pages,
+        )
+        selected_tasks = select_section_tasks(tasks, args.completed_mode)
+        selected_task_gids = {
+            str(task.get("gid") or "").strip()
+            for task in selected_tasks
+            if str(task.get("gid") or "").strip()
+        }
+        remaining_tasks = [
+            task
+            for task in tasks
+            if str(task.get("gid") or "").strip() not in selected_task_gids
+        ]
+        completed_count = sum(1 for task in tasks if bool(task.get("completed")))
+        incomplete_count = len(tasks) - completed_count
+
+        result: dict[str, Any] = {
+            "source_section": {
+                "gid": source_gid,
+                "name": source_name,
+            },
+            "destination_section": (
+                {
+                    "gid": str(destination_section.get("gid") or ""),
+                    "name": str(destination_section.get("name") or ""),
+                }
+                if destination_section
+                else None
+            ),
+            "task_count": len(tasks),
+            "completed_count": completed_count,
+            "incomplete_count": incomplete_count,
+            "selected_task_count": len(selected_tasks),
+            "remaining_task_count_after_selected_moves": len(remaining_tasks),
+            "completed_mode": args.completed_mode,
+            "apply": bool(args.apply),
+            "sample_tasks": [
+                {
+                    "gid": str(task.get("gid") or ""),
+                    "name": task.get("name"),
+                    "completed": bool(task.get("completed")),
+                }
+                for task in tasks[:5]
+            ],
+            "selected_sample_tasks": [
+                {
+                    "gid": str(task.get("gid") or ""),
+                    "name": task.get("name"),
+                    "completed": bool(task.get("completed")),
+                }
+                for task in selected_tasks[:5]
+            ],
+            "planned_actions": {
+                "move_selected_tasks": bool(destination_section and selected_tasks),
+                "delete_after_move": len(remaining_tasks) == 0,
+            },
+        }
+
+        moved_tasks: list[dict[str, Any]] = []
+        delete_attempted = False
+        deleted = False
+        blocked_reason = None
+
+        if args.apply:
+            if destination_section:
+                destination_gid = str(destination_section.get("gid") or "").strip()
+                for task in selected_tasks:
+                    task_gid = str(task.get("gid") or "").strip()
+                    if not task_gid:
+                        continue
+                    api_request(
+                        token=token,
+                        method="POST",
+                        path_or_url=f"/tasks/{task_gid}/addProject",
+                        json_body={
+                            "data": {
+                                "project": args.project_gid,
+                                "section": destination_gid,
+                            }
+                        },
+                    )
+                    moved_tasks.append(
+                        {
+                            "gid": task_gid,
+                            "name": task.get("name"),
+                            "completed": bool(task.get("completed")),
+                            "permalink_url": task.get("permalink_url"),
+                        }
+                    )
+                total_moved += len(moved_tasks)
+
+            remaining_probe = api_request(
+                token=token,
+                method="GET",
+                path_or_url=f"/sections/{source_gid}/tasks",
+                query={"opt_fields": "gid,name,completed", "limit": "1"},
+            )
+            remaining_data = remaining_probe.get("data", [])
+            has_remaining_tasks = isinstance(remaining_data, list) and bool(remaining_data)
+            delete_attempted = True
+            if has_remaining_tasks:
+                if not destination_section and tasks:
+                    blocked_reason = (
+                        "Section still has tasks and no destination section was provided."
+                    )
+                elif remaining_tasks:
+                    blocked_reason = (
+                        "Section still has tasks after moving the selected subset."
+                    )
+                else:
+                    blocked_reason = "Section still has tasks after the move request."
+            else:
+                api_request(
+                    token=token,
+                    method="DELETE",
+                    path_or_url=f"/sections/{source_gid}",
+                )
+                deleted = True
+                total_deleted += 1
+
+        result["applied_actions"] = {
+            "moved_task_count": len(moved_tasks),
+            "moved_tasks": moved_tasks,
+            "delete_attempted": delete_attempted,
+            "deleted": deleted,
+            "blocked_reason": blocked_reason,
+        }
+        section_results.append(result)
+
+    payload = {
+        "project_gid": args.project_gid,
+        "project_name": project_name,
+        "section_count": len(section_results),
+        "completed_mode": args.completed_mode,
+        "apply": bool(args.apply),
+        "moved_task_count": total_moved,
+        "deleted_section_count": total_deleted,
+        "sections": section_results,
+    }
+    print_json(payload, args.compact)
+    return payload
+
+
+def command_task_stories(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    task_gids = parse_gid_args(getattr(args, "task_gids", None) or getattr(args, "task_gid", None))
+    opt_fields = args.opt_fields or story_opt_fields()
+    if args.paginate:
+        entries = []
+        for task_gid in task_gids:
+            response = api_request(
+                token=token,
+                method="GET",
+                path_or_url=f"/tasks/{task_gid}/stories",
+                query={"opt_fields": opt_fields},
+            )
+            response = maybe_paginate(token, response, True, args.limit_pages)
+            entries.append({"requested_gid": task_gid, "status_code": 200, "result": response})
+        return render_many_results("task-stories", entries, args.compact)
+
+    actions = [
+        {
+            "method": "get",
+            "relative_path": f"/tasks/{task_gid}/stories",
+            "options": {"fields": field_list(opt_fields)},
+        }
+        for task_gid in task_gids
+    ]
+    items = batch_actions_request_chunked(token, actions)
+    return render_many_results(
+        "task-stories",
+        [
+            {
+                "requested_gid": task_gid,
+                "status_code": item.get("status_code", 200),
+                "result": item.get("body", {}),
+            }
+            for task_gid, item in zip(task_gids, items)
+        ],
+        args.compact,
+    )
+
+
+def command_task_comments(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    task_gids = parse_gid_args(getattr(args, "task_gids", None) or getattr(args, "task_gid", None))
+    opt_fields = args.opt_fields or story_opt_fields()
+    entries = []
+    if args.paginate:
+        story_responses = []
+        for task_gid in task_gids:
+            response = api_request(
+                token=token,
+                method="GET",
+                path_or_url=f"/tasks/{task_gid}/stories",
+                query={"opt_fields": opt_fields},
+            )
+            story_responses.append(maybe_paginate(token, response, True, args.limit_pages))
+    else:
+        actions = [
+            {
+                "method": "get",
+                "relative_path": f"/tasks/{task_gid}/stories",
+                "options": {"fields": field_list(opt_fields)},
+            }
+            for task_gid in task_gids
+        ]
+        story_responses = [item.get("body", {}) for item in batch_actions_request_chunked(token, actions)]
+
+    for task_gid, response in zip(task_gids, story_responses):
+        comments = [
+            story
+            for story in response.get("data", [])
+            if story.get("type") == "comment" or story.get("resource_subtype") == "comment_added"
+        ]
+        entries.append(
+            {
+                "requested_gid": task_gid,
+                "status_code": 200,
+                "result": {
+                    "data": comments,
+                    "comment_count": len(comments),
+                    "task_gid": task_gid,
+                },
+            }
+        )
+    return render_many_results("task-comments", entries, args.compact)
+
+
+def command_task_projects(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    task_gids = parse_gid_args(getattr(args, "task_gids", None) or getattr(args, "task_gid", None))
+    opt_fields = args.opt_fields or "gid,name"
+    actions = [
+        {
+            "method": "get",
+            "relative_path": f"/tasks/{task_gid}/projects",
+            "options": {"fields": field_list(opt_fields)},
+        }
+        for task_gid in task_gids
+    ]
+    items = batch_actions_request_chunked(token, actions)
+    return render_many_results(
+        "task-projects",
+        [
+            {
+                "requested_gid": task_gid,
+                "status_code": item.get("status_code", 200),
+                "result": item.get("body", {}),
+            }
+            for task_gid, item in zip(task_gids, items)
+        ],
+        args.compact,
+    )
+
+
+def build_task_status_payload(
+    task: dict[str, Any],
+    *,
+    project_filter: str | None,
+    include_task_position: bool,
+    section_cache: dict[str, tuple[list[dict[str, Any]], dict[str, int]]],
+    task_positions_by_section: dict[str, dict[str, int]],
+) -> dict[str, Any]:
+    memberships = task.get("memberships") or []
+    membership_summaries: list[dict[str, Any]] = []
+
+    for membership in memberships:
+        project = membership.get("project") or {}
+        section = membership.get("section") or {}
+        project_gid = project.get("gid")
+        if project_filter and project_gid != project_filter:
+            continue
+
+        sections, order_map = section_cache.get(project_gid, ([], {})) if project_gid else ([], {})
+        section_gid = section.get("gid")
+        task_position = None
+        if include_task_position and section_gid:
+            task_position = (task_positions_by_section.get(section_gid) or {}).get(str(task.get("gid") or ""))
+
+        membership_summaries.append(
+            {
+                "project_gid": project_gid,
+                "project_name": project.get("name"),
+                "section_gid": section_gid,
+                "section_name": section.get("name"),
+                "section_position": order_map.get(section_gid),
+                "section_count": len(sections),
+                "task_position_in_section": task_position,
+            }
+        )
+
+    return {
+        "task_gid": task.get("gid"),
+        "name": task.get("name"),
+        "completed": task.get("completed"),
+        "completed_at": task.get("completed_at"),
+        "permalink_url": task.get("permalink_url"),
+        "assignee": task.get("assignee"),
+        "due_on": task.get("due_on"),
+        "due_at": task.get("due_at"),
+        "custom_fields": task.get("custom_fields", []),
+        "memberships": membership_summaries,
+    }
+
+
+def command_task_status(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    task_gids = parse_gid_args(getattr(args, "task_gids", None) or getattr(args, "task_gid", None))
+    opt_fields = args.opt_fields or task_status_fields()
+    project_filter = args.project
+
+    actions = [
+        {
+            "method": "get",
+            "relative_path": f"/tasks/{task_gid}",
+            "options": {"fields": field_list(opt_fields)},
+        }
+        for task_gid in task_gids
+    ]
+    items = batch_actions_request_chunked(token, actions)
+    tasks = [(item.get("body") or {}).get("data", {}) for item in items]
+
+    project_gids: list[str] = []
+    for task in tasks:
+        for membership in task.get("memberships") or []:
+            project = membership.get("project") or {}
+            project_gid = str(project.get("gid") or "").strip()
+            if not project_gid or (project_filter and project_gid != project_filter) or project_gid in project_gids:
+                continue
+            project_gids.append(project_gid)
+
+    section_cache = {project_gid: section_order_map(token, project_gid) for project_gid in project_gids}
+
+    task_positions_by_section: dict[str, dict[str, int]] = {}
+    if args.include_task_position:
+        section_gids: list[str] = []
+        for task in tasks:
+            for membership in task.get("memberships") or []:
+                project = membership.get("project") or {}
+                if project_filter and project.get("gid") != project_filter:
+                    continue
+                section_gid = str(((membership.get("section") or {}).get("gid")) or "").strip()
+                if section_gid and section_gid not in section_gids:
+                    section_gids.append(section_gid)
+        task_positions_by_section = section_task_positions_map(token, section_gids)
+
+    return render_many_results(
+        "task-status",
+        [
+            {
+                "requested_gid": task_gid,
+                "status_code": item.get("status_code", 200),
+                "result": build_task_status_payload(
+                    task,
+                    project_filter=project_filter,
+                    include_task_position=bool(args.include_task_position),
+                    section_cache=section_cache,
+                    task_positions_by_section=task_positions_by_section,
+                ),
+            }
+            for task_gid, item, task in zip(task_gids, items, tasks)
+        ],
+        args.compact,
+    )
+
+
+def compute_board_context(
+    section_payloads: list[dict[str, Any]], now: datetime
+) -> dict[str, Any]:
+    """Compute workflow-relevant stats from board section/task data.
+
+    Pure function: takes already-fetched section payloads (each with a
+    ``tasks`` list) and returns aggregated stats the AI layer uses to
+    recommend workflow optimisations.
+    """
+
+    all_tasks: list[dict[str, Any]] = []
+    section_summaries: list[dict[str, Any]] = []
+    for sp in section_payloads:
+        tasks = sp.get("tasks", [])
+        all_tasks.extend(tasks)
+        completed = sum(1 for t in tasks if t.get("completed"))
+        section_summaries.append({
+            "name": sp.get("name"),
+            "gid": sp.get("gid"),
+            "total": len(tasks),
+            "completed": completed,
+            "incomplete": len(tasks) - completed,
+        })
+
+    total = len(all_tasks)
+    completed_total = sum(1 for t in all_tasks if t.get("completed"))
+
+    # Compute pct_of_project for each section
+    for ss in section_summaries:
+        ss["pct_of_project"] = round(ss["total"] / total * 100, 1) if total else 0.0
+
+    # Custom field coverage
+    field_counts: dict[str, dict[str, Any]] = {}
+    for task in all_tasks:
+        for cf in task.get("custom_fields", []):
+            gid = cf.get("gid", "")
+            if gid not in field_counts:
+                field_counts[gid] = {
+                    "name": cf.get("name"),
+                    "gid": gid,
+                    "type": cf.get("resource_subtype", cf.get("type", "")),
+                    "filled_count": 0,
+                    "total_applicable": 0,
+                }
+            field_counts[gid]["total_applicable"] += 1
+            if cf.get("display_value"):
+                field_counts[gid]["filled_count"] += 1
+
+    field_coverage = []
+    for fc in field_counts.values():
+        ta = fc["total_applicable"]
+        fc["coverage_pct"] = round(fc["filled_count"] / ta * 100, 1) if ta else 0.0
+        field_coverage.append(fc)
+
+    # Date coverage
+    with_due = sum(1 for t in all_tasks if t.get("due_on") or t.get("due_at"))
+    overdue = 0
+    for t in all_tasks:
+        if t.get("completed"):
+            continue
+        due = t.get("due_on") or (t.get("due_at") or "")[:10]
+        if due:
+            try:
+                if datetime.strptime(due, "%Y-%m-%d").replace(tzinfo=timezone.utc) < now:
+                    overdue += 1
+            except ValueError:
+                pass
+
+    # Assignee distribution
+    assigned = 0
+    unassigned = 0
+    by_assignee: dict[str, dict[str, Any]] = {}
+    for t in all_tasks:
+        assignee = t.get("assignee")
+        if assignee and assignee.get("name"):
+            assigned += 1
+            key = assignee.get("gid", assignee["name"])
+            if key not in by_assignee:
+                by_assignee[key] = {"name": assignee["name"], "gid": assignee.get("gid", ""), "count": 0}
+            by_assignee[key]["count"] += 1
+        else:
+            unassigned += 1
+
+    # Staleness
+    buckets = {"within_7d": 0, "8_to_14d": 0, "15_to_30d": 0, "over_30d": 0}
+    oldest_stale: dict[str, Any] | None = None
+    for t in all_tasks:
+        mod = t.get("modified_at")
+        if not mod:
+            continue
+        try:
+            mod_dt = datetime.fromisoformat(mod.replace("Z", "+00:00"))
+            days = (now - mod_dt).days
+        except (ValueError, TypeError):
+            continue
+        if days <= 7:
+            buckets["within_7d"] += 1
+        elif days <= 14:
+            buckets["8_to_14d"] += 1
+        elif days <= 30:
+            buckets["15_to_30d"] += 1
+        else:
+            buckets["over_30d"] += 1
+            if oldest_stale is None or days > oldest_stale["days_stale"]:
+                oldest_stale = {"name": t.get("name", ""), "gid": t.get("gid", ""), "days_stale": days}
+
+    return {
+        "project_summary": {
+            "total_tasks": total,
+            "completed_tasks": completed_total,
+            "incomplete_tasks": total - completed_total,
+            "sections": section_summaries,
+        },
+        "custom_field_coverage": {"fields": field_coverage},
+        "date_coverage": {
+            "with_due_date": with_due,
+            "without_due_date": total - with_due,
+            "coverage_pct": round(with_due / total * 100, 1) if total else 0.0,
+            "overdue": overdue,
+        },
+        "assignee_distribution": {
+            "assigned": assigned,
+            "unassigned": unassigned,
+            "by_assignee": sorted(by_assignee.values(), key=lambda x: x["count"], reverse=True),
+        },
+        "staleness": {
+            "modified_within_7d": buckets["within_7d"],
+            "modified_8_to_14d": buckets["8_to_14d"],
+            "modified_15_to_30d": buckets["15_to_30d"],
+            "modified_over_30d": buckets["over_30d"],
+            "oldest_stale_task": oldest_stale,
+        },
+    }
+
+
+def command_project_board(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    sections, order_map = section_order_map(token, args.project_gid)
+    section_payloads: list[dict[str, Any]] = []
+
+    context_mode = getattr(args, "context", False)
+    default_fields = (
+        "gid,name,completed,completed_at,assignee.gid,assignee.name,due_on,due_at,"
+        "modified_at,custom_fields.gid,custom_fields.name,custom_fields.resource_subtype,"
+        "custom_fields.display_value"
+        if context_mode
+        else "gid,name,completed,completed_at,assignee.name,due_on,due_at,"
+        "custom_fields.name,custom_fields.display_value"
+    )
+
+    for section in sections:
+        section_gid = section.get("gid")
+        tasks_response = api_request(
+            token=token,
+            method="GET",
+            path_or_url=f"/sections/{section_gid}/tasks",
+            query={
+                "opt_fields": args.opt_fields or default_fields
+            },
+        )
+        tasks = []
+        for index, task in enumerate(tasks_response.get("data", []), start=1):
+            task_copy = dict(task)
+            task_copy["task_position_in_section"] = index
+            tasks.append(task_copy)
+
+        section_name = section.get("name")
+        section_payloads.append(
+            {
+                "gid": section_gid,
+                "name": section_name,
+                "section_position": order_map.get(section_gid),
+                "task_count": len(tasks),
+                "tasks": tasks,
+            }
+        )
+
+    payload: dict[str, Any] = {
+        "project_gid": args.project_gid,
+        "sections": section_payloads,
+    }
+
+    if context_mode:
+        now = datetime.now(timezone.utc)
+        payload["context"] = compute_board_context(section_payloads, now)
+
+    print_json(payload, args.compact)
+    return payload
+
+
+def command_trigger_rule(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    action_data: dict[str, str] = {}
+    for pair in getattr(args, "action_data", None) or []:
+        if "=" not in pair:
+            raise SystemExit(f"Invalid --action-data format: {pair!r}  (expected key=value)")
+        key, value = pair.split("=", 1)
+        action_data[key] = value
+
+    body: dict[str, Any] = {"data": {"resource": args.task_gid}}
+    if action_data:
+        body["data"]["action_data"] = action_data
+
+    result = api_request(
+        token=token,
+        method="POST",
+        path_or_url=f"/rule_triggers/{args.trigger_identifier}/run",
+        json_body=body,
+    )
+    print_json(result, args.compact)
+    return result
+
+
+def build_task_bundle_payload(
+    token: str,
+    *,
+    task_gid: str,
+    project_gid: str | None,
+    task_opt_fields: str | None,
+    story_opt_fields_value: str | None,
+    attachment_opt_fields: str | None,
+) -> dict[str, Any]:
+    actions = [
+        {
+            "method": "get",
+            "relative_path": f"/tasks/{task_gid}",
+            "options": {
+                "fields": field_list(
+                    task_opt_fields
+                    or "gid,name,notes,html_notes,resource_subtype,completed,completed_at,assignee.gid,assignee.name,"
+                    "due_on,due_at,permalink_url,parent.gid,parent.name,memberships.project.gid,memberships.project.name,"
+                    "memberships.section.gid,memberships.section.name,custom_fields.gid,custom_fields.name,"
+                    "custom_fields.resource_subtype,custom_fields.display_value,custom_fields.enum_value.name,"
+                    "tags.gid,tags.name,tags.color"
+                )
+            },
+        },
+        {
+            "method": "get",
+            "relative_path": f"/tasks/{task_gid}/stories",
+            "options": {"fields": field_list(story_opt_fields_value or story_opt_fields())},
+        },
+        {
+            "method": "get",
+            "relative_path": f"/tasks/{task_gid}/attachments",
+            "options": {
+                "fields": field_list(
+                    attachment_opt_fields
+                    or "gid,name,resource_subtype,download_url,permanent_url,view_url,host,parent_type,parent.name"
+                )
+            },
+        },
+    ]
+    if project_gid:
+        actions.append(
+            {
+                "method": "get",
+                "relative_path": f"/projects/{project_gid}/sections",
+                "options": {"fields": field_list(section_opt_fields())},
+            }
+        )
+        actions.append(
+            {
+                "method": "get",
+                "relative_path": f"/projects/{project_gid}/custom_field_settings",
+                "options": {"fields": field_list(custom_field_setting_opt_fields())},
+            }
+        )
+
+    batch_response = batch_actions_request(token, actions)
+    task = batch_body_at(batch_response, 0).get("data", {})
+    stories = batch_body_at(batch_response, 1).get("data", [])
+    attachments = batch_body_at(batch_response, 2).get("data", [])
+    sections = batch_body_at(batch_response, 3).get("data", []) if project_gid else []
+    project_custom_field_settings = batch_body_at(batch_response, 4).get("data", []) if project_gid else []
+    section_order = section_order_from_sections(sections)
+    comments = comment_stories_only(stories)
+
+    memberships = []
+    for membership in task.get("memberships", []):
+        project = membership.get("project") or {}
+        if project_gid and project.get("gid") != project_gid:
+            continue
+        section = membership.get("section") or {}
+        section_gid = section.get("gid")
+        memberships.append(
+            {
+                "project_gid": project.get("gid"),
+                "project_name": project.get("name"),
+                "section_gid": section_gid,
+                "section_name": section.get("name"),
+                "section_position": section_order.get(section_gid),
+            }
+        )
+
+    image_urls = []
+    for attachment in attachments:
+        for key in ("download_url", "view_url", "permanent_url"):
+            value = attachment.get(key)
+            if isinstance(value, str) and value not in image_urls:
+                image_urls.append(value)
+    for comment in comments:
+        for url in extract_image_urls_from_html(comment.get("html_text")):
+            if url not in image_urls:
+                image_urls.append(url)
+    if task.get("html_notes"):
+        for url in extract_image_urls_from_html(task.get("html_notes")):
+            if url not in image_urls:
+                image_urls.append(url)
+
+    payload = {
+        "task": task,
+        "workflow_context": {
+            "project_gid": project_gid,
+            "memberships": memberships,
+            "section_order": [
+                {"gid": section.get("gid"), "name": section.get("name"), "section_position": section_order.get(section.get("gid"))}
+                for section in sections
+            ],
+        },
+        "comments": {
+            "data": comments,
+            "comment_count": len(comments),
+        },
+        "attachments": attachments,
+        "project_custom_field_settings": project_custom_field_settings,
+        "image_urls": image_urls,
+        "asana_permalink": task.get("permalink_url"),
+    }
+    return payload
+
+
+def command_task_bundle(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    task_gids = parse_gid_args(getattr(args, "task_gids", None) or getattr(args, "task_gid", None))
+    return render_many_results(
+        "task-bundle",
+        [
+            {
+                "requested_gid": task_gid,
+                "status_code": 200,
+                "result": build_task_bundle_payload(
+                    token,
+                    task_gid=task_gid,
+                    project_gid=args.project_gid,
+                    task_opt_fields=args.task_opt_fields,
+                    story_opt_fields_value=args.story_opt_fields,
+                    attachment_opt_fields=args.attachment_opt_fields,
+                ),
+            }
+            for task_gid in task_gids
+        ],
+        args.compact,
+    )
+
+
+def command_add_task_project(args: argparse.Namespace) -> Any:
+    task_position_args(args)
+    payload: dict[str, Any] = {"project": args.project_gid}
+    if args.section:
+        payload["section"] = args.section
+    if args.insert_before is not None:
+        payload["insert_before"] = nullable_arg(args.insert_before)
+    if args.insert_after is not None:
+        payload["insert_after"] = nullable_arg(args.insert_after)
+    return post_task_relationship(args, f"/tasks/{args.task_gid}/addProject", payload)
+
+
+def command_remove_task_project(args: argparse.Namespace) -> Any:
+    return post_task_relationship(
+        args,
+        f"/tasks/{args.task_gid}/removeProject",
+        {"project": args.project_gid},
+    )
+
+
+def command_add_task_followers(args: argparse.Namespace) -> Any:
+    context = load_context()
+    cache = load_cache()
+    return post_task_relationship(
+        args,
+        f"/tasks/{args.task_gid}/addFollowers",
+        {"followers": resolve_many_user_identifiers(args.followers, context, cache)},
+    )
+
+
+def command_remove_task_followers(args: argparse.Namespace) -> Any:
+    context = load_context()
+    cache = load_cache()
+    return post_task_relationship(
+        args,
+        f"/tasks/{args.task_gid}/removeFollowers",
+        {"followers": resolve_many_user_identifiers(args.followers, context, cache)},
+    )
+
+
+def command_task_tags(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    cache = load_cache()
+    task_gids = parse_gid_args(getattr(args, "task_gids", None) or getattr(args, "task_gid", None))
+    opt_fields = args.opt_fields or tag_opt_fields("gid,name,color")
+    actions = [
+        {
+            "method": "get",
+            "relative_path": f"/tasks/{task_gid}/tags",
+            "options": {"fields": field_list(opt_fields)},
+        }
+        for task_gid in task_gids
+    ]
+    items = batch_actions_request_chunked(token, actions)
+    for item in items:
+        body = item.get("body", {})
+        tags = body.get("data", []) if isinstance(body, dict) else []
+        if isinstance(tags, list):
+            cache_records(cache, "tags", [tag_cache_record(tag) for tag in tags if isinstance(tag, dict)])
+    save_cache(cache)
+    return render_many_results(
+        "task-tags",
+        [
+            {
+                "requested_gid": task_gid,
+                "status_code": item.get("status_code", 200),
+                "result": item.get("body", {}),
+            }
+            for task_gid, item in zip(task_gids, items)
+        ],
+        args.compact,
+    )
+
+
+def command_tags(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    context = load_context()
+    cache = load_cache()
+    workspace = workspace_default(args, context, cache)
+    if not workspace:
+        raise SystemExit("No workspace GID provided and no default workspace in asana-context.json")
+    response = api_request(
+        token=token,
+        method="GET",
+        path_or_url=f"/workspaces/{workspace}/tags",
+        query={"opt_fields": args.opt_fields or tag_opt_fields("gid,name,color")},
+    )
+    response = maybe_paginate(token, response, args.paginate, args.limit_pages)
+    tags = response.get("data", [])
+    if isinstance(tags, list):
+        cache_records(cache, "tags", [tag_cache_record(item, workspace_gid=workspace) for item in tags if isinstance(item, dict)])
+        save_cache(cache)
+    print_json(response, args.compact)
+    return response
+
+
+def command_workspace_custom_fields(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    context = load_context()
+    cache = load_cache()
+    workspace = workspace_default(args, context, cache)
+    if not workspace:
+        raise SystemExit("No workspace GID provided and no default workspace in asana-context.json")
+    response = api_request(
+        token=token,
+        method="GET",
+        path_or_url=f"/workspaces/{workspace}/custom_fields",
+        query={"opt_fields": args.opt_fields or "gid,name,resource_subtype,enum_options.name,enabled"},
+    )
+    response = maybe_paginate(token, response, args.paginate, args.limit_pages)
+    print_json(response, args.compact)
+    return response
+
+
+def command_team_custom_fields(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    context = load_context()
+    cache = load_cache()
+    team = team_default(args, context, cache)
+    if not team:
+        raise SystemExit("No team GID provided and no default team in asana-context.json")
+    response = api_request(
+        token=token,
+        method="GET",
+        path_or_url=f"/teams/{team}/custom_field_settings",
+        query={"opt_fields": args.opt_fields or custom_field_setting_opt_fields()},
+    )
+    response = maybe_paginate(token, response, args.paginate, args.limit_pages)
+    print_json(response, args.compact)
+    return response
+
+
+def command_project_custom_fields(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    project_gids = parse_gid_args(getattr(args, "project_gids", None) or getattr(args, "project_gid", None))
+    opt_fields = args.opt_fields or custom_field_setting_opt_fields()
+    actions = [
+        {
+            "method": "get",
+            "relative_path": f"/projects/{project_gid}/custom_field_settings",
+            "options": {"fields": field_list(opt_fields)},
+        }
+        for project_gid in project_gids
+    ]
+    items = batch_actions_request_chunked(token, actions)
+    return render_many_results(
+        "project-custom-fields",
+        [
+            {
+                "requested_gid": project_gid,
+                "status_code": item.get("status_code", 200),
+                "result": item.get("body", {}),
+            }
+            for project_gid, item in zip(project_gids, items)
+        ],
+        args.compact,
+    )
+
+
+def command_task_custom_fields(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    task_gids = parse_gid_args(getattr(args, "task_gids", None) or getattr(args, "task_gid", None))
+    opt_fields = (
+        args.opt_fields
+        or "gid,name,custom_fields.gid,custom_fields.name,custom_fields.resource_subtype,"
+        "custom_fields.display_value,custom_fields.enum_value.name"
+    )
+    actions = [
+        {
+            "method": "get",
+            "relative_path": f"/tasks/{task_gid}",
+            "options": {"fields": field_list(opt_fields)},
+        }
+        for task_gid in task_gids
+    ]
+    items = batch_actions_request_chunked(token, actions)
+    entries = []
+    for task_gid, item in zip(task_gids, items):
+        task = (item.get("body") or {}).get("data", {})
+        entries.append(
+            {
+                "requested_gid": task_gid,
+                "status_code": item.get("status_code", 200),
+                "result": {
+                    "task_gid": task.get("gid"),
+                    "name": task.get("name"),
+                    "custom_fields": task.get("custom_fields", []),
+                },
+            }
+        )
+    return render_many_results("task-custom-fields", entries, args.compact)
+
+
+def command_create_custom_field(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    context = load_context()
+    cache = load_cache()
+    workspace = workspace_default(args, context, cache)
+    if not workspace:
+        raise SystemExit("No workspace GID provided and no default workspace in asana-context.json")
+    payload: dict[str, Any] = {
+        "workspace": workspace,
+        "name": args.name,
+        "resource_subtype": args.resource_subtype,
+    }
+    if args.description:
+        payload["description"] = args.description
+    if args.precision is not None:
+        payload["precision"] = args.precision
+    if args.enum_option:
+        payload["enum_options"] = [{"name": name} for name in args.enum_option]
+    response = api_request(
+        token=token,
+        method="POST",
+        path_or_url="/custom_fields",
+        json_body={"data": payload},
+    )
+    print_json(response, args.compact)
+    return response
+
+
+def command_batch(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    if bool(args.actions) == bool(args.actions_file):
+        raise SystemExit("Pass exactly one of --actions or --actions-file")
+    actions_payload = args.actions
+    if args.actions_file:
+        actions_payload = Path(args.actions_file).read_text()
+    actions = json.loads(actions_payload)
+    if not isinstance(actions, list):
+        raise SystemExit("Batch actions must be a JSON array")
+    response = api_request(
+        token=token,
+        method="POST",
+        path_or_url="/batch",
+        json_body={"data": {"actions": actions}},
+    )
+    print_json(response, args.compact)
+    return response
+
+
+def command_create_tag(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    context = load_context()
+    cache = load_cache()
+    workspace = workspace_default(args, context, cache)
+    if not workspace:
+        raise SystemExit("No workspace GID provided and no default workspace in asana-context.json")
+    payload: dict[str, Any] = {"workspace": workspace, "name": args.name}
+    if args.color:
+        payload["color"] = args.color
+    if args.notes:
+        payload["notes"] = args.notes
+    response = api_request(
+        token=token,
+        method="POST",
+        path_or_url="/tags",
+        json_body={"data": payload},
+    )
+    tag = response.get("data", {})
+    if isinstance(tag, dict):
+        cache_record(cache, "tags", tag_cache_record(tag, workspace_gid=workspace))
+        save_cache(cache)
+    print_json(response, args.compact)
+    return response
+
+
+def command_add_task_tag(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    context = load_context()
+    cache = load_cache()
+    workspace = workspace_default(args, context, cache)
+    tag = resolve_tag_identifier(
+        args.tag_gid,
+        token=token,
+        cache=cache,
+        workspace_gid=workspace,
+    )
+    return post_task_relationship(
+        args,
+        f"/tasks/{args.task_gid}/addTag",
+        {"tag": str(tag.get("gid"))},
+    )
+
+
+def command_remove_task_tag(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    context = load_context()
+    cache = load_cache()
+    workspace = workspace_default(args, context, cache)
+    tag = resolve_tag_identifier(
+        args.tag_gid,
+        token=token,
+        cache=cache,
+        workspace_gid=workspace,
+    )
+    return post_task_relationship(
+        args,
+        f"/tasks/{args.task_gid}/removeTag",
+        {"tag": str(tag.get("gid"))},
+    )
+
+
+def command_set_task_sorting_tag(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    context = load_context()
+    cache = load_cache()
+    workspace = workspace_default(args, context, cache)
+    sorting_labels = normalize_sorting_tag_labels(args.sorting_label)
+    sorter_records = [
+        resolve_tag_identifier(label, token=token, cache=cache, workspace_gid=workspace)
+        for label in sorting_labels
+    ]
+    sorter_by_gid = {
+        str(record.get("gid")): record
+        for record in sorter_records
+        if str(record.get("gid") or "").strip()
+    }
+    desired_tag = resolve_tag_identifier(
+        args.sorting_tag,
+        token=token,
+        cache=cache,
+        workspace_gid=workspace,
+    )
+    desired_tag_gid = str(desired_tag.get("gid") or "").strip()
+    if desired_tag_gid not in sorter_by_gid:
+        allowed_names = ", ".join(record.get("name", record.get("gid")) for record in sorter_by_gid.values())
+        raise SystemExit(
+            f"Sorting tag '{args.sorting_tag}' is not in the allowed sorter set: {allowed_names}"
+        )
+
+    current_tags = get_task_tags(token, args.task_gid)
+    current_by_gid = {
+        str(tag.get("gid")): tag
+        for tag in current_tags
+        if isinstance(tag, dict) and str(tag.get("gid") or "").strip()
+    }
+    current_sorter_tags = [
+        tag
+        for tag in current_tags
+        if isinstance(tag, dict) and str(tag.get("gid") or "").strip() in sorter_by_gid
+    ]
+    removed_sorting_tags = [
+        tag
+        for tag in current_sorter_tags
+        if str(tag.get("gid") or "").strip() != desired_tag_gid
+    ]
+    add_needed = desired_tag_gid not in current_by_gid
+
+    if removed_sorting_tags or add_needed:
+        for tag in removed_sorting_tags:
+            api_request(
+                token=token,
+                method="POST",
+                path_or_url=f"/tasks/{args.task_gid}/removeTag",
+                json_body={"data": {"tag": str(tag.get("gid"))}},
+            )
+        if add_needed:
+            api_request(
+                token=token,
+                method="POST",
+                path_or_url=f"/tasks/{args.task_gid}/addTag",
+                json_body={"data": {"tag": desired_tag_gid}},
+            )
+
+    resulting_tags: list[dict[str, Any]] = []
+    desired_tag_present = False
+    for tag in current_tags:
+        if not isinstance(tag, dict):
+            continue
+        tag_gid = str(tag.get("gid") or "").strip()
+        if not tag_gid:
+            continue
+        if tag_gid == desired_tag_gid:
+            desired_tag_present = True
+            resulting_tags.append(tag)
+            continue
+        if tag_gid in sorter_by_gid:
+            continue
+        resulting_tags.append(tag)
+    if not desired_tag_present:
+        resulting_tags.append(
+            current_by_gid.get(desired_tag_gid)
+            or {"gid": desired_tag_gid, "name": desired_tag.get("name"), "color": desired_tag.get("color")}
+        )
+
+    payload = {
+        "command": "set-task-sorting-tag",
+        "task_gid": args.task_gid,
+        "sorting_tag": {
+            "gid": desired_tag_gid,
+            "name": desired_tag.get("name"),
+            "color": desired_tag.get("color"),
+        },
+        "status": "updated" if removed_sorting_tags or add_needed else "unchanged",
+        "added_sorting_tag": add_needed,
+        "removed_sorting_tags": [
+            {"gid": tag.get("gid"), "name": tag.get("name"), "color": tag.get("color")}
+            for tag in removed_sorting_tags
+        ],
+        "preserved_tags": [
+            {"gid": tag.get("gid"), "name": tag.get("name"), "color": tag.get("color")}
+            for tag in current_tags
+            if isinstance(tag, dict) and str(tag.get("gid") or "").strip() not in sorter_by_gid
+        ],
+        "resulting_tags": [
+            {"gid": tag.get("gid"), "name": tag.get("name"), "color": tag.get("color")}
+            for tag in resulting_tags
+        ],
+    }
+    print_json(payload, args.compact)
+    return payload
+
+
+def command_add_task_dependencies(args: argparse.Namespace) -> Any:
+    return post_task_relationship(
+        args,
+        f"/tasks/{args.task_gid}/addDependencies",
+        {"dependencies": parse_many_gid(args.dependencies)},
+    )
+
+
+def command_remove_task_dependencies(args: argparse.Namespace) -> Any:
+    return post_task_relationship(
+        args,
+        f"/tasks/{args.task_gid}/removeDependencies",
+        {"dependencies": parse_many_gid(args.dependencies)},
+    )
+
+
+def command_search_tasks(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    context = load_context()
+    cache = load_cache()
+    workspace = workspace_default(args, context, cache)
+    if not workspace:
+        raise SystemExit("No workspace GID provided and no default workspace in asana-context.json")
+
+    query: dict[str, str] = {
+        "text": args.text,
+        "opt_fields": args.opt_fields
+        or "gid,name,completed,assignee.name,due_on,projects.name,permalink_url",
+    }
+    optional_values = {
+        "projects.any": args.project,
+        "assignee.any": resolve_user_identifier(args.assignee, context, cache),
+        "completed": str(args.completed).lower() if args.completed is not None else None,
+    }
+    for key, value in optional_values.items():
+        if value is not None:
+            query[key] = value
+
+    response = api_request(
+        token=token,
+        method="GET",
+        path_or_url=f"/workspaces/{workspace}/tasks/search",
+        query=query,
+    )
+    response = maybe_paginate(token, response, args.paginate, args.limit_pages)
+    tasks = response.get("data", [])
+    if isinstance(tasks, list):
+        assignees = [
+            user_cache_record(task["assignee"])
+            for task in tasks
+            if isinstance(task, dict) and isinstance(task.get("assignee"), dict)
+        ]
+        if assignees:
+            cache_records(cache, "users", assignees)
+            save_cache(cache)
+    print_json(response, args.compact)
+    return response
+
+
+def fetch_parent_task_context_map(token: str, parent_gids: list[str]) -> dict[str, dict[str, Any]]:
+    unique_parent_gids: list[str] = []
+    seen: set[str] = set()
+    for parent_gid in parent_gids:
+        if parent_gid and parent_gid not in seen:
+            seen.add(parent_gid)
+            unique_parent_gids.append(parent_gid)
+
+    parent_context_map: dict[str, dict[str, Any]] = {}
+    for start in range(0, len(unique_parent_gids), 10):
+        chunk = unique_parent_gids[start : start + 10]
+        actions = [
+            {
+                "method": "get",
+                "relative_path": f"/tasks/{parent_gid}",
+                "options": {"fields": field_list(parent_task_context_opt_fields())},
+            }
+            for parent_gid in chunk
+        ]
+        batch_response = batch_actions_request(token, actions)
+        for index, parent_gid in enumerate(chunk):
+            parent = batch_body_at(batch_response, index).get("data", {})
+            if parent:
+                parent_context_map[parent_gid] = parent
+    return parent_context_map
+
+
+def fetch_task_activity_context_map(
+    token: str,
+    task_gids: list[str],
+    *,
+    include_comments: bool,
+    comment_limit: int,
+    include_attachments: bool,
+) -> dict[str, dict[str, Any]]:
+    activity_map: dict[str, dict[str, Any]] = {
+        task_gid: {}
+        for task_gid in task_gids
+        if task_gid
+    }
+    if not include_comments and not include_attachments:
+        return activity_map
+
+    actions: list[tuple[str, str, dict[str, Any]]] = []
+    for task_gid in task_gids:
+        if not task_gid:
+            continue
+        if include_comments:
+            actions.append(
+                (
+                    task_gid,
+                    "comments",
+                    {
+                        "method": "get",
+                        "relative_path": f"/tasks/{task_gid}/stories",
+                        "options": {"fields": field_list(story_opt_fields())},
+                    },
+                )
+            )
+        if include_attachments:
+            actions.append(
+                (
+                    task_gid,
+                    "attachments",
+                    {
+                        "method": "get",
+                        "relative_path": f"/tasks/{task_gid}/attachments",
+                        "options": {"fields": field_list(attachment_opt_fields())},
+                    },
+                )
+            )
+
+    max_batch_actions = 10
+    for start in range(0, len(actions), max_batch_actions):
+        chunk = actions[start : start + max_batch_actions]
+        batch_response = batch_actions_request(
+            token,
+            [action for _, _, action in chunk],
+        )
+        for index, (task_gid, kind, _) in enumerate(chunk):
+            body = batch_body_at(batch_response, index).get("data", [])
+            if not isinstance(body, list):
+                continue
+            task_activity = activity_map.setdefault(task_gid, {})
+            if kind == "comments":
+                comments = recent_comment_stories(body, comment_limit)
+                task_activity["recent_comments"] = comments
+                task_activity["comment_count"] = len(comment_stories_only(body))
+                existing_image_urls = task_activity.setdefault("image_urls", [])
+                for comment in comments:
+                    for url in extract_image_urls_from_html(comment.get("html_text")):
+                        if url not in existing_image_urls:
+                            existing_image_urls.append(url)
+            elif kind == "attachments":
+                task_activity["attachments"] = body
+                task_activity["attachment_count"] = len(body)
+                existing_image_urls = task_activity.setdefault("image_urls", [])
+                for attachment in body:
+                    for key in ("download_url", "view_url", "permanent_url"):
+                        value = attachment.get(key) if isinstance(attachment, dict) else None
+                        if isinstance(value, str) and value not in existing_image_urls:
+                            existing_image_urls.append(value)
+
+    return activity_map
+
+
+def command_project_assigned_tasks(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    context = load_context()
+    cache = load_cache()
+    workspace = workspace_default(args, context, cache)
+    if not workspace:
+        raise SystemExit("No workspace GID provided and no default workspace in asana-context.json")
+
+    assignee = resolve_user_identifier(args.assignee or context.get("user_gid") or "me", context, cache)
+
+    query: dict[str, str] = {
+        "projects.any": args.project_gid,
+        "assignee.any": assignee,
+        "opt_fields": args.opt_fields or project_assigned_task_opt_fields(),
+    }
+    if args.completed is not None:
+        query["completed"] = str(args.completed).lower()
+
+    response = api_request(
+        token=token,
+        method="GET",
+        path_or_url=f"/workspaces/{workspace}/tasks/search",
+        query=query,
+    )
+    response = maybe_paginate(token, response, args.paginate, args.limit_pages)
+
+    tasks = response.get("data", [])
+    if not isinstance(tasks, list):
+        print_json(response, args.compact)
+        return response
+
+    parent_context_map = fetch_parent_task_context_map(
+        token,
+        [
+            str(task.get("parent", {}).get("gid"))
+            for task in tasks
+            if isinstance(task, dict) and isinstance(task.get("parent"), dict) and task["parent"].get("gid")
+        ],
+    )
+    sections, section_order = section_order_map(token, args.project_gid)
+    activity_context_map = fetch_task_activity_context_map(
+        token,
+        [
+            str(task.get("gid"))
+            for task in tasks
+            if isinstance(task, dict) and task.get("gid")
+        ],
+        include_comments=args.include_comments,
+        comment_limit=args.comment_limit,
+        include_attachments=args.include_attachments,
+    )
+
+    section_positions: dict[str, dict[str, int]] = {}
+    if args.include_task_position:
+        relevant_section_gids: list[str] = []
+        for task in tasks:
+            if not isinstance(task, dict):
+                continue
+            parent = task.get("parent")
+            parent_gid = parent.get("gid") if isinstance(parent, dict) else None
+            parent_context = parent_context_map.get(str(parent_gid)) if parent_gid else None
+            memberships = task.get("memberships")
+            effective_memberships = memberships if memberships else parent_context.get("memberships", []) if parent_context else []
+            for membership in effective_memberships:
+                if not isinstance(membership, dict):
+                    continue
+                section = membership.get("section") or {}
+                section_gid = section.get("gid")
+                if section_gid:
+                    relevant_section_gids.append(str(section_gid))
+        section_positions = section_task_positions_map(token, relevant_section_gids)
+
+    enriched_tasks: list[dict[str, Any]] = []
+    for task in tasks:
+        if not isinstance(task, dict):
+            enriched_tasks.append(task)
+            continue
+
+        task_payload = dict(task)
+        parent = task_payload.get("parent")
+        parent_gid = parent.get("gid") if isinstance(parent, dict) else None
+        parent_context = parent_context_map.get(str(parent_gid)) if parent_gid else None
+        memberships = task_payload.get("memberships")
+        effective_memberships = memberships if memberships else parent_context.get("memberships", []) if parent_context else []
+        effective_membership_summaries: list[dict[str, Any]] = []
+        task_gid = str(task_payload.get("gid") or "")
+        for membership in effective_memberships:
+            if not isinstance(membership, dict):
+                continue
+            project = membership.get("project") or {}
+            section = membership.get("section") or {}
+            section_gid = str(section.get("gid") or "")
+            effective_membership_summaries.append(
+                {
+                    "project_gid": project.get("gid"),
+                    "project_name": project.get("name"),
+                    "section_gid": section.get("gid"),
+                    "section_name": section.get("name"),
+                    "section_position": section_order.get(section_gid) if section_gid else None,
+                    "task_position_in_section": section_positions.get(section_gid, {}).get(task_gid)
+                    if section_gid
+                    else None,
+                }
+            )
+
+        task_payload["is_subtask"] = bool(parent_gid)
+        task_payload["effective_memberships"] = effective_memberships
+        task_payload["effective_membership_summaries"] = effective_membership_summaries
+        if parent_context:
+            task_payload["parent_context"] = parent_context
+        activity_context = activity_context_map.get(task_gid)
+        if activity_context:
+            task_payload.update(activity_context)
+
+        enriched_tasks.append(task_payload)
+
+    payload = dict(response)
+    payload["data"] = enriched_tasks
+    payload["project_gid"] = args.project_gid
+    payload["workspace_gid"] = workspace
+    payload["assignee"] = assignee
+    payload["includes_subtasks"] = True
+    payload["workflow_context"] = {
+        "section_order": [
+            {
+                "gid": section.get("gid"),
+                "name": section.get("name"),
+                "section_position": section_order.get(section.get("gid")),
+            }
+            for section in sections
+        ],
+    }
+    payload["context_includes"] = {
+        "section_order": True,
+        "task_position_in_section": bool(args.include_task_position),
+        "recent_comments": bool(args.include_comments),
+        "attachments": bool(args.include_attachments),
+    }
+    payload["subtask_count"] = sum(1 for task in enriched_tasks if isinstance(task, dict) and task.get("is_subtask"))
+    assignees = [
+        user_cache_record(task["assignee"])
+        for task in enriched_tasks
+        if isinstance(task, dict) and isinstance(task.get("assignee"), dict)
+    ]
+    if assignees:
+        cache_records(cache, "users", assignees)
+        save_cache(cache)
+    print_json(payload, args.compact)
+    return payload
+
+
+def build_task_payload(
+    args: argparse.Namespace,
+    context: dict[str, Any],
+    cache: dict[str, Any],
+    is_create: bool,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    for attr in ("name", "notes", "due_on", "due_at"):
+        value = getattr(args, attr, None)
+        if value:
+            payload[attr] = value
+
+    html_notes = getattr(args, "html_notes", None)
+    if html_notes:
+        payload["html_notes"] = normalize_ai_authored_rich_text(html_notes) or ""
+
+    assignee = resolve_user_identifier(getattr(args, "assignee", None), context, cache)
+    if assignee:
+        payload["assignee"] = assignee
+
+    if getattr(args, "completed", None) is not None:
+        payload["completed"] = args.completed
+
+    project = getattr(args, "project", None)
+    workspace = workspace_default(args, context, cache)
+    parent = getattr(args, "parent", None)
+
+    if is_create and project:
+        payload["projects"] = [project]
+    elif is_create and workspace:
+        payload["workspace"] = workspace
+
+    if parent:
+        payload["parent"] = parent
+
+    if args.custom_field:
+        payload["custom_fields"] = parse_custom_fields(args.custom_field)
+
+    return payload
+
+
+def task_placement_requested(args: argparse.Namespace, *, project_only: bool) -> bool:
+    insert_before, insert_after = task_position_args(args)
+    return bool(
+        getattr(args, "section", None)
+        or insert_before is not None
+        or insert_after is not None
+        or (project_only and getattr(args, "project", None))
+    )
+
+
+def validate_position_anchor(
+    token: str,
+    *,
+    project_gid: str | None,
+    section_gid: str | None,
+    anchor_gid: str | None,
+) -> None:
+    if anchor_gid is None:
+        return
+
+    sentinel_gids = {gid for gid in (project_gid, section_gid) if gid}
+    if anchor_gid in sentinel_gids:
+        return
+
+    if section_gid:
+        path = f"/sections/{section_gid}/tasks"
+        scope_label = f"section {section_gid}"
+    elif project_gid:
+        path = f"/projects/{project_gid}/tasks"
+        scope_label = f"project {project_gid}"
+    else:
+        raise SystemExit("Pass --project or --section when using --insert-before or --insert-after.")
+
+    response = api_request(
+        token=token,
+        method="GET",
+        path_or_url=path,
+        query={"limit": "100", "opt_fields": "gid"},
+    )
+    response = maybe_paginate(token, response, True, 0)
+    tasks = response.get("data", [])
+    if not any(isinstance(task, dict) and task.get("gid") == anchor_gid for task in tasks):
+        raise SystemExit(f"Position anchor task {anchor_gid} is not in {scope_label}.")
+
+
+def apply_task_placement(
+    token: str,
+    args: argparse.Namespace,
+    *,
+    task_gid: str,
+    project_only: bool,
+) -> Any | None:
+    insert_before_arg, insert_after_arg = task_position_args(args)
+    project_gid = getattr(args, "project", None)
+    section_gid = getattr(args, "section", None)
+    if not task_placement_requested(args, project_only=project_only):
+        return None
+
+    insert_before = nullable_arg(insert_before_arg) if insert_before_arg is not None else None
+    insert_after = nullable_arg(insert_after_arg) if insert_after_arg is not None else None
+    anchor_gid = insert_before if insert_before_arg is not None else insert_after
+    validate_position_anchor(token, project_gid=project_gid, section_gid=section_gid, anchor_gid=anchor_gid)
+
+    if section_gid:
+        path = f"/sections/{section_gid}/addTask"
+        payload: dict[str, Any] = {"task": task_gid}
+    elif project_gid:
+        path = f"/tasks/{task_gid}/addProject"
+        payload = {"project": project_gid}
+    else:
+        raise SystemExit("Pass --project or --section when using task placement options.")
+
+    if insert_before_arg is not None:
+        payload["insert_before"] = insert_before
+    if insert_after_arg is not None:
+        payload["insert_after"] = insert_after
+
+    return api_request(
+        token=token,
+        method="POST",
+        path_or_url=path,
+        json_body={"data": payload},
+    )
+
+
+def parse_custom_fields(items: list[str]) -> dict[str, Any]:
+    parsed: dict[str, Any] = {}
+    for item in items:
+        if "=" not in item:
+            raise SystemExit(f"Expected custom field assignment <gid>=<value>, got: {item}")
+        gid, value = item.split("=", 1)
+        parsed[gid] = value
+    return parsed
+
+
+def command_create_task(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    context = load_context()
+    cache = load_cache()
+    task_position_args(args)
+    payload = build_task_payload(args, context, cache, is_create=True)
+    response = api_request(
+        token=token,
+        method="POST",
+        path_or_url="/tasks",
+        query={"opt_fields": task_write_opt_fields()},
+        json_body={"data": payload},
+    )
+    task = response.get("data", {})
+    if isinstance(task, dict) and isinstance(task.get("assignee"), dict):
+        cache_record(cache, "users", user_cache_record(task["assignee"]))
+        save_cache(cache)
+    if isinstance(task, dict) and task.get("gid"):
+        placement_response = apply_task_placement(token, args, task_gid=str(task["gid"]), project_only=False)
+    else:
+        placement_response = None
+    enriched = response_with_review_links(response)
+    if placement_response is not None and isinstance(enriched, dict):
+        enriched["placement"] = placement_response
+    print_json(enriched, args.compact)
+    return enriched
+
+
+def command_update_task(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    context = load_context()
+    cache = load_cache()
+    task_position_args(args)
+    payload = build_task_payload(args, context, cache, is_create=False)
+    placement_requested = task_placement_requested(args, project_only=True)
+    if payload:
+        response = api_request(
+            token=token,
+            method="PUT",
+            path_or_url=f"/tasks/{args.task_gid}",
+            query={"opt_fields": task_write_opt_fields()},
+            json_body={"data": payload},
+        )
+    elif placement_requested:
+        response = api_request(
+            token=token,
+            method="GET",
+            path_or_url=f"/tasks/{args.task_gid}",
+            query={"opt_fields": task_write_opt_fields()},
+        )
+    else:
+        response = api_request(
+            token=token,
+            method="PUT",
+            path_or_url=f"/tasks/{args.task_gid}",
+            query={"opt_fields": task_write_opt_fields()},
+            json_body={"data": payload},
+        )
+    task = response.get("data", {})
+    if isinstance(task, dict) and isinstance(task.get("assignee"), dict):
+        cache_record(cache, "users", user_cache_record(task["assignee"]))
+        save_cache(cache)
+    placement_response = (
+        apply_task_placement(token, args, task_gid=args.task_gid, project_only=True) if placement_requested else None
+    )
+    enriched = response_with_review_links(response)
+    if placement_response is not None and isinstance(enriched, dict):
+        enriched["placement"] = placement_response
+    print_json(enriched, args.compact)
+    return enriched
+
+
+def command_comment_task(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    payload = comment_payload_from_args(args)
+    response = api_request(
+        token=token,
+        method="POST",
+        path_or_url=f"/tasks/{args.task_gid}/stories",
+        query={"opt_fields": story_write_opt_fields()},
+        json_body={"data": payload},
+    )
+    enriched = response_with_review_links(response)
+    print_json(enriched, args.compact)
+    return enriched
+
+
+def command_update_story(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    payload = comment_payload_from_args(args)
+    response = api_request(
+        token=token,
+        method="PUT",
+        path_or_url=f"/stories/{args.story_gid}",
+        query={"opt_fields": story_write_opt_fields()},
+        json_body={"data": payload},
+    )
+    enriched = response_with_review_links(response)
+    print_json(enriched, args.compact)
+    return enriched
+
+
+def command_create_project(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    context = load_context()
+    cache = load_cache()
+    team = team_default(args, context, cache)
+    payload = {"name": args.name}
+    if team:
+        payload["team"] = team
+    elif workspace_default(args, context, cache):
+        payload["workspace"] = workspace_default(args, context, cache)
+    if args.notes:
+        payload["notes"] = args.notes
+
+    response = api_request(
+        token=token,
+        method="POST",
+        path_or_url="/projects",
+        json_body={"data": payload},
+    )
+    project = response.get("data", {})
+    if isinstance(project, dict):
+        cache_record(cache, "projects", project_cache_record(project, team_gid=team))
+        save_cache(cache)
+    print_json(response, args.compact)
+    return response
+
+
+def command_update_project(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    cache = load_cache()
+    payload = {"name": args.name} if args.name else {}
+    if args.notes:
+        payload["notes"] = args.notes
+    if args.archived is not None:
+        payload["archived"] = args.archived
+    response = api_request(
+        token=token,
+        method="PUT",
+        path_or_url=f"/projects/{args.project_gid}",
+        json_body={"data": payload},
+    )
+    project = response.get("data", {})
+    if isinstance(project, dict):
+        cache_record(cache, "projects", project_cache_record(project))
+        save_cache(cache)
+    print_json(response, args.compact)
+    return response
+
+
+def command_show_context(args: argparse.Namespace) -> Any:
+    response = load_context()
+    token = get_token(args)
+    cache = load_cache()
+    workspace_gid = str(response.get("workspace_gid") or "") or infer_workspace_gid_from_payload({"data": response}, cache)
+    enriched = attach_skill_advertising(
+        args=args,
+        payload=response if isinstance(response, dict) else {"data": response},
+        token=token,
+        workspace_gid=workspace_gid or None,
+        cache=cache,
+    )
+    print_json(enriched, args.compact)
+    return enriched
+
+
+def command_show_cache(args: argparse.Namespace) -> Any:
+    response = load_cache()
+    token = get_token(args)
+    workspace_gid = infer_workspace_gid_from_payload(response, response)
+    enriched = attach_skill_advertising(
+        args=args,
+        payload=response,
+        token=token,
+        workspace_gid=workspace_gid,
+        cache=response,
+    )
+    print_json(enriched, args.compact)
+    return enriched
+
+
+def build_inbox_cleanup_review_payload(args: argparse.Namespace) -> Any:
+    token = get_token(args)
+    context = load_context()
+    cache = load_cache()
+    workspace = workspace_default(args, context, cache)
+    if not workspace:
+        raise SystemExit("No workspace GID provided and no default workspace in asana-context.json")
+
+    user_task_list = my_tasks_project(token, workspace)
+    user_task_list_gid = str(user_task_list.get("gid") or "").strip()
+    if not user_task_list_gid:
+        raise SystemExit("Unable to resolve My Tasks for the selected workspace")
+
+    all_tasks = my_tasks_tasks(
+        token,
+        user_task_list_gid,
+        paginate=not args.no_paginate,
+        limit_pages=args.limit_pages,
+    )
+    source_section_names = [name.strip() for name in args.source_section if name.strip()]
+    review_section_names = set(INBOX_CLEANUP_REVIEW_SECTIONS.values())
+
+    filtered_tasks: list[dict[str, Any]] = []
+    skipped_tasks: list[dict[str, Any]] = []
+    for task in all_tasks:
+        if not isinstance(task, dict):
+            continue
+        assignee_section = task.get("assignee_section") or {}
+        current_section_name = str(assignee_section.get("name") or "").strip()
+        if current_section_name in review_section_names and not args.all_open:
+            skipped_tasks.append(
+                {
+                    "task_gid": task.get("gid"),
+                    "name": task.get("name"),
+                    "current_section": current_section_name,
+                    "reason": "already_in_review_section",
+                }
+            )
+            continue
+
+        if not args.all_open and current_section_name not in source_section_names:
+            skipped_tasks.append(
+                {
+                    "task_gid": task.get("gid"),
+                    "name": task.get("name"),
+                    "current_section": current_section_name,
+                    "reason": "outside_source_sections",
+                }
+            )
+            continue
+        filtered_tasks.append(task)
+
+    if args.max_tasks > 0:
+        filtered_tasks = filtered_tasks[: args.max_tasks]
+
+    task_contexts = fetch_task_review_context(
+        token,
+        [str(task.get("gid")) for task in filtered_tasks if task.get("gid")],
+    )
+    existing_sections = my_tasks_sections(token, user_task_list_gid)
+    sections_by_name = ensure_review_sections(
+        token,
+        user_task_list_gid=user_task_list_gid,
+        existing_sections=existing_sections,
+        apply=args.apply,
+    )
+    created_section_names = [
+        name
+        for name in INBOX_CLEANUP_REVIEW_SECTIONS.values()
+        if name not in {str(section.get("name")) for section in existing_sections if isinstance(section, dict)}
+        and name in sections_by_name
+    ]
+
+    task_results: list[dict[str, Any]] = []
+    category_counts: dict[str, int] = {
+        key: 0 for key in INBOX_CLEANUP_REVIEW_SECTIONS
+    }
+    now = datetime.now(timezone.utc)
+
+    for task in filtered_tasks:
+        task_gid = str(task.get("gid") or "").strip()
+        if not task_gid:
+            continue
+        task_context = task_contexts.get(task_gid) or {"task": task, "stories": []}
+        classification = classify_inbox_cleanup_task(task_context, now)
+        category_key = classification["category_key"]
+        category_counts[category_key] += 1
+        target_section_name = classification["category_label"]
+        target_section = sections_by_name.get(target_section_name) or {}
+        target_section_gid = str(target_section.get("gid") or "").strip()
+        current_section_name = classification["current_my_tasks_section"]
+
+        move_result: dict[str, Any] | None = None
+        comment_result: dict[str, Any] | None = None
+        comment_was_posted = False
+
+        if args.apply and target_section_gid and current_section_name != target_section_name:
+            move_response = api_request(
+                token=token,
+                method="PUT",
+                path_or_url=f"/tasks/{task_gid}",
+                query={"opt_fields": "gid,name,assignee_section.gid,assignee_section.name"},
+                json_body={"data": {"assignee_section": target_section_gid}},
+            )
+            move_result = move_response.get("data", {})
+
+        if (
+            args.apply
+            and not args.skip_ready_comments
+            and category_key == "ready_to_close"
+            and not comment_already_mentions_inbox_cleanup(task_context.get("stories", []), target_section_name)
+        ):
+            comment_response = api_request(
+                token=token,
+                method="POST",
+                path_or_url=f"/tasks/{task_gid}/stories",
+                query={"opt_fields": story_write_opt_fields()},
+                json_body={
+                    "data": {
+                        "html_text": inbox_cleanup_comment_html(
+                            category_label=target_section_name,
+                            evidence_lines=classification["reasons"][:4],
+                        )
+                    }
+                },
+            )
+            comment_result = response_with_review_links(comment_response)
+            comment_was_posted = True
+
+        manager_comment_result: dict[str, Any] | None = None
+        manager_comment_posted = False
+        manager_plan = classification["manager_plan"]
+        manager_comment_allowed = bool(classification["manager_comment_allowed"])
+        manager_comment_block_reason = classification["shared_for_manager_comments_reason"]
+        if not manager_comment_block_reason and not classification["substantive_manager_context"]:
+            manager_comment_block_reason = "Task does not have enough context yet for a useful AI PM comment."
+        if not manager_comment_block_reason and classification["work_type"] == "admin":
+            manager_comment_block_reason = "Admin/personal reminder tasks are excluded from AI PM comments by default."
+        should_post_manager_comment = False
+        if args.apply and args.comment_research_todos and classification["work_type"] == "research":
+            should_post_manager_comment = True
+        elif args.apply and args.manager_comments and category_key in {
+            "needs_next_action",
+            "needs_verification",
+            "waiting_on_others",
+        }:
+            should_post_manager_comment = True
+
+        if (
+            should_post_manager_comment
+            and manager_comment_allowed
+            and not comment_already_mentions_manager_plan(task_context.get("stories", []), target_section_name)
+        ):
+            manager_comment_response = api_request(
+                token=token,
+                method="POST",
+                path_or_url=f"/tasks/{task_gid}/stories",
+                query={"opt_fields": story_write_opt_fields()},
+                json_body={
+                    "data": {
+                        "html_text": manager_plan_comment_html(
+                            category_label=target_section_name,
+                            work_type=classification["work_type"],
+                            task_read=manager_plan["task_read"],
+                            classification_basis=manager_plan["classification_basis"],
+                            next_action=manager_plan["next_action"],
+                            todo_label=manager_plan["todo_label"],
+                            todo_items=manager_plan["todo_items"],
+                            ask_user=manager_plan["ask_user"],
+                            ai_help_summary=manager_plan["ai_help_summary"],
+                            execution_prompt=manager_plan.get("execution_prompt"),
+                        )
+                    }
+                },
+            )
+            manager_comment_result = response_with_review_links(manager_comment_response)
+            manager_comment_posted = True
+
+        task_results.append(
+            {
+                "task_gid": task_gid,
+                "name": (task_context.get("task") or {}).get("name") or task.get("name"),
+                "permalink_url": (task_context.get("task") or {}).get("permalink_url") or task.get("permalink_url"),
+                "current_section": current_section_name,
+                "target_section": target_section_name,
+                "category_key": category_key,
+                "work_type": classification["work_type"],
+                "reasons": classification["reasons"],
+                "linked_prs": classification["linked_prs"],
+                "active_ai_action": classification["active_ai_action"],
+                "manager_plan": manager_plan,
+                "task_read": manager_plan["task_read"],
+                "classification_basis": manager_plan["classification_basis"],
+                "ask_user": manager_plan["ask_user"],
+                "ai_help_now": manager_plan["ai_help_now"],
+                "ai_help_summary": manager_plan["ai_help_summary"],
+                "manager_comment_allowed": manager_comment_allowed,
+                "manager_comment_block_reason": manager_comment_block_reason,
+                "move_applied": bool(move_result),
+                "comment_posted": comment_was_posted,
+                "comment_review_url": comment_result.get("review_url") if isinstance(comment_result, dict) else None,
+                "manager_comment_posted": manager_comment_posted,
+                "manager_comment_review_url": manager_comment_result.get("review_url") if isinstance(manager_comment_result, dict) else None,
+            }
+        )
+
+    payload = {
+        "mode": "apply" if args.apply else "dry_run",
+        "workspace_gid": workspace,
+        "my_tasks": {
+            "gid": user_task_list_gid,
+            "name": user_task_list.get("name"),
+        },
+        "source_sections": source_section_names,
+        "all_open": bool(args.all_open),
+        "created_review_sections": created_section_names,
+        "review_sections": sections_by_name,
+        "counts": {
+            "all_open_tasks_in_my_tasks": len(all_tasks),
+            "tasks_considered": len(filtered_tasks),
+            "tasks_skipped": len(skipped_tasks),
+            "by_category": category_counts,
+            "by_work_type": {},
+        },
+        "tasks": task_results,
+        "skipped_tasks": skipped_tasks,
+    }
+    work_type_counts: dict[str, int] = {}
+    execution_candidates = 0
+    active_ai_action_counts: dict[str, int] = {}
+    for task_result in task_results:
+        work_type = str(task_result.get("work_type") or "unknown")
+        work_type_counts[work_type] = work_type_counts.get(work_type, 0) + 1
+        manager_plan = task_result.get("manager_plan") or {}
+        if isinstance(manager_plan, dict) and manager_plan.get("execution_candidate"):
+            execution_candidates += 1
+        active_ai = task_result.get("active_ai_action") or {}
+        if isinstance(active_ai, dict):
+            action_name = str(active_ai.get("action") or "unknown")
+            active_ai_action_counts[action_name] = active_ai_action_counts.get(action_name, 0) + 1
+    payload["counts"]["by_work_type"] = work_type_counts
+    payload["counts"]["execution_candidates"] = execution_candidates
+    payload["counts"]["by_active_ai_action"] = active_ai_action_counts
+    enriched = attach_skill_advertising(
+        args=args,
+        payload=payload,
+        token=token,
+        workspace_gid=workspace,
+        cache=cache,
+        include_first_run=True,
+        refresh_summary=True,
+    )
+    return enriched
+
+
+def slugify_category(value: str) -> str:
+    token = re.sub(r"[^a-z0-9]+", "-", str(value or "").casefold()).strip("-")
+    return token or "category"
+
+
+def write_json_file(path_value: str | None, payload: Any) -> str | None:
+    target = str(path_value or "").strip()
+    if not target:
+        return None
+    path = Path(target).expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+    return str(path)
+
+
+def inbox_cleanup_seed_categories() -> list[dict[str, str]]:
+    return [dict(seed) for seed in INBOX_CLEANUP_CATEGORY_SEEDS]
+
+
+def inbox_cleanup_snapshot_task(task_result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "task_gid": task_result.get("task_gid"),
+        "name": task_result.get("name"),
+        "permalink_url": task_result.get("permalink_url"),
+        "current_section": task_result.get("current_section"),
+        "project_state": daily_briefing_project_state(task_result),
+        "due_date": daily_briefing_due_date(task_result),
+        "reasons": task_result.get("reasons", []) or [],
+        "linked_prs": task_result.get("linked_prs", []) or [],
+        "task_read_hint": task_result.get("task_read"),
+        "classification_basis_hint": task_result.get("classification_basis"),
+        "suggested_next_action_hint": ((task_result.get("manager_plan") or {}).get("next_action")),
+        "ask_user_hint": task_result.get("ask_user"),
+        "ai_help_summary_hint": task_result.get("ai_help_summary"),
+        "active_ai_action_hint": ((task_result.get("active_ai_action") or {}).get("action")),
+        "legacy_category_hint": task_result.get("category_key"),
+        "legacy_target_section_hint": task_result.get("target_section"),
+    }
+
+
+def build_inbox_cleanup_plan_template(snapshot_payload: dict[str, Any]) -> dict[str, Any]:
+    task_templates = []
+    for task in snapshot_payload.get("tasks", []) or []:
+        if not isinstance(task, dict):
+            continue
+        task_templates.append(
+            {
+                "task_gid": task.get("task_gid"),
+                "name": task.get("name"),
+                "decision": "ask_user",
+                "category_slug": "",
+                "target_section_name": "",
+                "confidence": "low",
+                "why": "",
+                "question": task.get("ask_user_hint") or "",
+                "notes": "",
+            }
+        )
+    return {
+        "workflow": INBOX_CLEANUP_PLAN_WORKFLOW,
+        "version": INBOX_CLEANUP_PLAN_VERSION,
+        "generated_at": now_iso(),
+        "my_tasks_gid": ((snapshot_payload.get("my_tasks") or {}).get("gid")),
+        "source": {
+            "workflow": INBOX_CLEANUP_SNAPSHOT_WORKFLOW,
+            "generated_at": snapshot_payload.get("generated_at"),
+            "all_open": snapshot_payload.get("all_open"),
+        },
+        "categories": [],
+        "category_seed_suggestions": inbox_cleanup_seed_categories(),
+        "tasks": task_templates,
+    }
+
+
+def build_inbox_cleanup_snapshot_payload(args: argparse.Namespace) -> dict[str, Any]:
+    review_args = argparse.Namespace(
+        workspace=getattr(args, "workspace", None),
+        source_section=list(getattr(args, "source_section", list(DEFAULT_INBOX_CLEANUP_SOURCE_SECTIONS))),
+        all_open=bool(getattr(args, "all_open", False)),
+        apply=False,
+        skip_ready_comments=True,
+        manager_comments=False,
+        comment_research_todos=False,
+        max_tasks=getattr(args, "max_tasks", 0),
+        no_paginate=getattr(args, "no_paginate", False),
+        limit_pages=getattr(args, "limit_pages", 0),
+        compact=True,
+        token=getattr(args, "token", None),
+        command="inbox-cleanup",
+    )
+    review_payload = build_inbox_cleanup_review_payload(review_args)
+    snapshot_payload = {
+        "workflow": INBOX_CLEANUP_SNAPSHOT_WORKFLOW,
+        "version": INBOX_CLEANUP_PLAN_VERSION,
+        "generated_at": now_iso(),
+        "workspace_gid": review_payload.get("workspace_gid"),
+        "my_tasks": review_payload.get("my_tasks"),
+        "source_sections": review_payload.get("source_sections"),
+        "all_open": review_payload.get("all_open"),
+        "current_section_counts": (((review_payload.get("skill_advertising") or {}).get("my_tasks") or {}).get("section_counts") or {}),
+        "existing_sections": sorted(
+            name
+            for name in ((review_payload.get("review_sections") or {}).keys())
+            if isinstance(name, str)
+        ),
+        "starter_category_seeds": inbox_cleanup_seed_categories(),
+        "tasks": [
+            inbox_cleanup_snapshot_task(task_result)
+            for task_result in (review_payload.get("tasks") or [])
+            if isinstance(task_result, dict)
+        ],
+        "legacy_review_hints": {
+            "counts": review_payload.get("counts", {}) or {},
+        },
+        "instructions": {
+            "summary": "Use this snapshot to create an AI-gated cleanup plan. The AI should define categories first, then assign tasks, and mark ambiguous items as ask_user instead of auto-bucketing them.",
+            "required_task_fields": [
+                "decision",
+                "category_slug",
+                "target_section_name",
+                "confidence",
+                "why",
+                "question",
+            ],
+            "decision_values": [
+                "bucket",
+                "ask_user",
+                "leave_as_is",
+            ],
+        },
+    }
+    snapshot_payload["plan_template"] = build_inbox_cleanup_plan_template(snapshot_payload)
+    snapshot_path = write_json_file(getattr(args, "snapshot_file", None), snapshot_payload)
+    plan_template_path = write_json_file(getattr(args, "plan_template_file", None), snapshot_payload["plan_template"])
+    if snapshot_path:
+        snapshot_payload["snapshot_file"] = snapshot_path
+    if plan_template_path:
+        snapshot_payload["plan_template_file"] = plan_template_path
+    return snapshot_payload
+
+
+def load_json_file(path_value: str) -> dict[str, Any]:
+    path = Path(str(path_value)).expanduser()
+    try:
+        payload = json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise SystemExit(f"Plan file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Plan file is not valid JSON: {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise SystemExit(f"Expected a JSON object in {path}")
+    return payload
+
+
+def resolve_inbox_cleanup_plan_categories(plan: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    categories_by_slug: dict[str, dict[str, Any]] = {}
+    for category in plan.get("categories", []) or []:
+        if not isinstance(category, dict):
+            continue
+        slug = slugify_category(category.get("slug") or category.get("name"))
+        categories_by_slug[slug] = dict(category)
+    return categories_by_slug
+
+
+def build_inbox_cleanup_payload(args: argparse.Namespace) -> dict[str, Any]:
+    if getattr(args, "legacy_auto", False):
+        return build_inbox_cleanup_review_payload(args)
+    if getattr(args, "manager_comments", False) or getattr(args, "comment_research_todos", False) or getattr(args, "skip_ready_comments", False):
+        raise SystemExit(
+            "The AI-gated inbox-cleanup workflow no longer supports Python-authored cleanup comments. Generate a plan first, then let the AI decide whether comments are needed."
+        )
+    if getattr(args, "apply", False):
+        if not getattr(args, "plan_file", None):
+            raise SystemExit(
+                "inbox-cleanup --apply now requires --plan-file. First run inbox-cleanup to emit a snapshot, let the AI write a plan JSON, then apply that plan."
+            )
+        return build_inbox_cleanup_plan_payload(args)
+    if getattr(args, "plan_file", None):
+        return build_inbox_cleanup_plan_payload(args)
+    return build_inbox_cleanup_snapshot_payload(args)
+
+
+def build_inbox_cleanup_plan_payload(args: argparse.Namespace) -> dict[str, Any]:
+    token = get_token(args)
+    context = load_context()
+    cache = load_cache()
+    workspace = workspace_default(args, context, cache)
+    if not workspace:
+        raise SystemExit("No workspace GID provided and no default workspace in asana-context.json")
+
+    plan = load_json_file(args.plan_file)
+    if str(plan.get("workflow") or "") != INBOX_CLEANUP_PLAN_WORKFLOW:
+        raise SystemExit(
+            f"Unsupported plan workflow in {args.plan_file}. Expected `{INBOX_CLEANUP_PLAN_WORKFLOW}`."
+        )
+    categories_by_slug = resolve_inbox_cleanup_plan_categories(plan)
+
+    user_task_list = my_tasks_project(token, workspace)
+    user_task_list_gid = str(user_task_list.get("gid") or "").strip()
+    if not user_task_list_gid:
+        raise SystemExit("Unable to resolve My Tasks for the selected workspace")
+
+    all_tasks = my_tasks_tasks(
+        token,
+        user_task_list_gid,
+        paginate=not args.no_paginate,
+        limit_pages=args.limit_pages,
+    )
+    tasks_by_gid = {
+        str(task.get("gid")): task
+        for task in all_tasks
+        if isinstance(task, dict) and task.get("gid")
+    }
+    existing_sections = my_tasks_sections(token, user_task_list_gid)
+    sections_by_name = {
+        str(section.get("name")): dict(section)
+        for section in existing_sections
+        if isinstance(section, dict) and section.get("name")
+    }
+
+    created_sections: list[str] = []
+    results: list[dict[str, Any]] = []
+    user_questions: list[dict[str, Any]] = []
+
+    for entry in plan.get("tasks", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        task_gid = str(entry.get("task_gid") or "").strip()
+        if not task_gid:
+            continue
+        task = tasks_by_gid.get(task_gid)
+        if not task:
+            results.append(
+                {
+                    "task_gid": task_gid,
+                    "status": "missing_task",
+                    "name": entry.get("name"),
+                    "why": "Task is not currently open in My Tasks.",
+                }
+            )
+            continue
+
+        decision = str(entry.get("decision") or "ask_user").strip().casefold()
+        confidence = str(entry.get("confidence") or "").strip().casefold()
+        current_section = str(((task.get("assignee_section") or {}).get("name")) or "").strip()
+        question = str(entry.get("question") or "").strip()
+        why = str(entry.get("why") or "").strip()
+
+        if decision in {"ask_user", "needs_user_input", "question"}:
+            user_questions.append(
+                {
+                    "task_gid": task_gid,
+                    "name": task.get("name"),
+                    "current_section": current_section,
+                    "question": question,
+                    "why": why,
+                }
+            )
+            results.append(
+                {
+                    "task_gid": task_gid,
+                    "name": task.get("name"),
+                    "status": "ask_user",
+                    "current_section": current_section,
+                    "question": question,
+                    "why": why,
+                }
+            )
+            continue
+        if decision in {"leave", "leave_as_is", "skip"}:
+            results.append(
+                {
+                    "task_gid": task_gid,
+                    "name": task.get("name"),
+                    "status": "left_as_is",
+                    "current_section": current_section,
+                    "why": why,
+                }
+            )
+            continue
+
+        category_slug = slugify_category(entry.get("category_slug") or "")
+        category = categories_by_slug.get(category_slug, {})
+        target_section_name = normalize_whitespace(
+            entry.get("target_section_name")
+            or category.get("section_name")
+            or category.get("suggested_section_name")
+            or category.get("name")
+        )
+        if not target_section_name:
+            user_questions.append(
+                {
+                    "task_gid": task_gid,
+                    "name": task.get("name"),
+                    "current_section": current_section,
+                    "question": question or "No target section was provided for this task.",
+                    "why": why or f"Category `{category_slug}` is missing a target section.",
+                }
+            )
+            results.append(
+                {
+                    "task_gid": task_gid,
+                    "name": task.get("name"),
+                    "status": "missing_target_section",
+                    "current_section": current_section,
+                    "category_slug": category_slug,
+                    "why": why,
+                }
+            )
+            continue
+
+        if confidence == "low" and not getattr(args, "include_low_confidence", False):
+            user_questions.append(
+                {
+                    "task_gid": task_gid,
+                    "name": task.get("name"),
+                    "current_section": current_section,
+                    "question": question or "Low-confidence task: confirm the bucket before moving it.",
+                    "why": why,
+                }
+            )
+            results.append(
+                {
+                    "task_gid": task_gid,
+                    "name": task.get("name"),
+                    "status": "low_confidence_requires_user",
+                    "current_section": current_section,
+                    "target_section": target_section_name,
+                    "confidence": confidence,
+                    "why": why,
+                }
+            )
+            continue
+
+        target_section = sections_by_name.get(target_section_name)
+        if not target_section and getattr(args, "apply", False):
+            created = api_request(
+                token=token,
+                method="POST",
+                path_or_url=f"/projects/{user_task_list_gid}/sections",
+                json_body={"data": {"name": target_section_name}},
+            ).get("data", {})
+            if isinstance(created, dict) and created.get("name"):
+                sections_by_name[str(created["name"])] = created
+                target_section = created
+                created_sections.append(str(created["name"]))
+
+        moved = False
+        if getattr(args, "apply", False) and target_section_name != current_section:
+            target_section_gid = str((target_section or {}).get("gid") or "").strip()
+            if not target_section_gid:
+                raise SystemExit(f"Unable to resolve or create target section `{target_section_name}` for task {task_gid}")
+            api_request(
+                token=token,
+                method="PUT",
+                path_or_url=f"/tasks/{task_gid}",
+                query={"opt_fields": "gid,name,assignee_section.gid,assignee_section.name"},
+                json_body={"data": {"assignee_section": target_section_gid}},
+            )
+            moved = True
+
+        results.append(
+            {
+                "task_gid": task_gid,
+                "name": task.get("name"),
+                "status": "moved" if moved else "planned",
+                "current_section": current_section,
+                "target_section": target_section_name,
+                "category_slug": category_slug,
+                "confidence": confidence,
+                "why": why,
+                "question": question,
+            }
+        )
+
+    payload = {
+        "workflow": INBOX_CLEANUP_PLAN_WORKFLOW,
+        "version": INBOX_CLEANUP_PLAN_VERSION,
+        "mode": "apply" if getattr(args, "apply", False) else "preview_plan",
+        "generated_at": now_iso(),
+        "workspace_gid": workspace,
+        "my_tasks": {
+            "gid": user_task_list_gid,
+            "name": user_task_list.get("name"),
+        },
+        "created_sections": created_sections,
+        "counts": {
+            "tasks_in_plan": len(plan.get("tasks", []) or []),
+            "tasks_known_open": len(tasks_by_gid),
+            "moved": sum(1 for item in results if item.get("status") == "moved"),
+            "planned_moves": sum(1 for item in results if item.get("status") in {"moved", "planned"}),
+            "ask_user": sum(1 for item in results if item.get("status") == "ask_user"),
+            "left_as_is": sum(1 for item in results if item.get("status") == "left_as_is"),
+            "low_confidence_requires_user": sum(1 for item in results if item.get("status") == "low_confidence_requires_user"),
+            "missing_target_section": sum(1 for item in results if item.get("status") == "missing_target_section"),
+            "missing_task": sum(1 for item in results if item.get("status") == "missing_task"),
+        },
+        "results": results,
+        "user_questions": user_questions,
+    }
+    return payload
+
+
+def command_inbox_cleanup(args: argparse.Namespace) -> Any:
+    enriched = build_inbox_cleanup_payload(args)
+    print_json(enriched, args.compact)
+    return enriched
+
+
+def daily_briefing_project_state(task_result: dict[str, Any]) -> str:
+    for reason in task_result.get("reasons", []) or []:
+        if isinstance(reason, str) and reason.startswith("Project state: "):
+            return reason.removeprefix("Project state: ").strip()
+    return ""
+
+
+def daily_briefing_due_date(task_result: dict[str, Any]) -> str | None:
+    for reason in task_result.get("reasons", []) or []:
+        if isinstance(reason, str) and reason.startswith("Due date: "):
+            return reason.removeprefix("Due date: ").strip()
+    return None
+
+
+def daily_briefing_primary_pr(task_result: dict[str, Any]) -> str | None:
+    linked_prs = task_result.get("linked_prs", []) or []
+    if not linked_prs:
+        return None
+    first = linked_prs[0]
+    pr_number = str(first.get("pr_number") or "").strip()
+    if not pr_number:
+        return None
+    return f"PR #{pr_number}"
+
+
+def daily_briefing_done_like(task_result: dict[str, Any]) -> bool:
+    return bool(DAILY_BRIEFING_DONE_LIKE_PATTERN.search(daily_briefing_project_state(task_result)))
+
+
+def daily_briefing_is_background_noise(task_result: dict[str, Any]) -> bool:
+    if str(task_result.get("work_type") or "") == "admin":
+        return True
+    return bool(DAILY_BRIEFING_ADMIN_NOISE_PATTERN.search(str(task_result.get("name") or "")))
+
+
+def daily_briefing_item(task_result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "task_gid": task_result.get("task_gid"),
+        "name": task_result.get("name"),
+        "url": task_result.get("permalink_url"),
+        "current_section": task_result.get("current_section"),
+        "target_section": task_result.get("target_section"),
+        "project_state": daily_briefing_project_state(task_result),
+        "work_type": task_result.get("work_type"),
+        "due_date": daily_briefing_due_date(task_result),
+        "pr": daily_briefing_primary_pr(task_result),
+        "linked_prs": task_result.get("linked_prs", []) or [],
+        "task_read": task_result.get("task_read"),
+        "next_action": ((task_result.get("manager_plan") or {}).get("next_action")),
+        "active_ai_action": task_result.get("active_ai_action") or {},
+        "task_result": task_result,
+    }
+
+
+def daily_briefing_bucket_score(bucket_name: str, task_result: dict[str, Any]) -> int:
+    score = 0
+    current_section = str(task_result.get("current_section") or "")
+    project_state = daily_briefing_project_state(task_result)
+    task_name = str(task_result.get("name") or "")
+    reasons_blob = " ".join(str(reason) for reason in (task_result.get("reasons") or []))
+
+    if daily_briefing_primary_pr(task_result):
+        score += 4
+    if "Recently assigned" in current_section:
+        score += 3
+    if daily_briefing_due_date(task_result):
+        score += 2
+    if (
+        DAILY_BRIEFING_URGENT_PATTERN.search(project_state)
+        or DAILY_BRIEFING_URGENT_PATTERN.search(task_name)
+        or DAILY_BRIEFING_URGENT_PATTERN.search(reasons_blob)
+    ):
+        score += 2
+    if bucket_name == "release_watch" and daily_briefing_done_like(task_result):
+        score += 3
+    if bucket_name == "needs_follow_up" and "Waiting" in current_section:
+        score += 2
+    if bucket_name == "ready_to_close" and "Likely Ready To Close" in current_section:
+        score += 2
+    return score
+
+
+def daily_briefing_bucket_key(task_result: dict[str, Any]) -> str:
+    action = str(((task_result.get("active_ai_action") or {}).get("action")) or "no_ai_action")
+
+    if daily_briefing_is_background_noise(task_result):
+        return "background"
+    if action == "ask_to_close":
+        return "ready_to_close"
+    if action == "ask_to_follow_up":
+        return "needs_follow_up"
+    if action == "ask_to_execute_now" and daily_briefing_done_like(task_result):
+        return "release_watch"
+    if action == "ask_to_verify":
+        return "needs_verification"
+    if action == "ask_to_execute_now" and not daily_briefing_done_like(task_result):
+        return "execute_now"
+    return "background"
+
+
+def daily_briefing_action_summary(bucket_name: str, item: dict[str, Any]) -> str:
+    if item.get("task_read"):
+        return str(item["task_read"])
+    if bucket_name == "execute_now":
+        if item.get("pr"):
+            return "Real execution signal detected; this looks like active code work."
+        return "This looks actionable now and worth pulling into an active work session."
+    if bucket_name == "release_watch":
+        return "Implementation appears done on our side; keep this visible for ship tracking and close-out."
+    if bucket_name == "needs_verification":
+        return "This looks like QA, confirmation, or post-ship validation work."
+    if bucket_name == "needs_follow_up":
+        return "This looks blocked on another person or team and needs one concrete follow-up."
+    if bucket_name == "ready_to_close":
+        return "Recent context suggests this may be ready for manual close-out."
+    return "Keep this visible, but it should not drive the day by default."
+
+
+def daily_briefing_bucket_seeds() -> list[dict[str, Any]]:
+    return [dict(seed) for seed in DAILY_BRIEFING_BUCKET_SEEDS]
+
+
+def daily_briefing_snapshot_task(task_context: dict[str, Any]) -> dict[str, Any]:
+    task = (task_context.get("task") or {}) if isinstance(task_context, dict) else {}
+    stories = (task_context.get("stories") or []) if isinstance(task_context, dict) else []
+    notes = strip_html_to_text(task.get("html_notes") or task.get("notes"))
+    recent_comment_excerpts = [
+        shorten_text(story_text(story), limit=180)
+        for story in recent_comments({"stories": stories}, limit=3)
+        if shorten_text(story_text(story), limit=180)
+    ]
+    combined_text = " ".join(
+        part
+        for part in [str(task.get("name") or ""), notes, *recent_comment_excerpts]
+        if part
+    )
+    linked_prs = extract_github_pr_links(combined_text)
+    follower_count = len([item for item in (task.get("followers") or []) if isinstance(item, dict)])
+    collaborator_count = len([item for item in (task.get("collaborators") or []) if isinstance(item, dict)])
+    return {
+        "task_gid": task.get("gid"),
+        "name": task.get("name"),
+        "url": task.get("permalink_url"),
+        "current_section": str(((task.get("assignee_section") or {}).get("name")) or "").strip(),
+        "due_date": short_date(task.get("due_on") or task.get("due_at")),
+        "completed": bool(task.get("completed")),
+        "project_memberships": task_membership_labels(task),
+        "project_names": task_project_names(task),
+        "linked_prs": linked_prs,
+        "primary_pr": primary_pr_label(linked_prs),
+        "notes_excerpt": shorten_text(notes, limit=280),
+        "recent_comment_excerpts": recent_comment_excerpts,
+        "follower_count": follower_count,
+        "collaborator_count": collaborator_count,
+        "assignee": ((task.get("assignee") or {}).get("name")),
+        "raw_signals": {
+            "has_due_date": bool(task.get("due_on") or task.get("due_at")),
+            "has_pr": bool(linked_prs),
+            "in_recently_assigned": str(((task.get("assignee_section") or {}).get("name")) or "").strip() == "Recently assigned",
+            "has_notes": bool(notes),
+            "has_recent_comments": bool(recent_comment_excerpts),
+        },
+    }
+
+
+def build_daily_briefing_plan_template(snapshot_payload: dict[str, Any]) -> dict[str, Any]:
+    task_templates = []
+    for task in snapshot_payload.get("tasks", []) or []:
+        if not isinstance(task, dict):
+            continue
+        task_templates.append(
+            {
+                "task_gid": task.get("task_gid"),
+                "name": task.get("name"),
+                "decision": "omit",
+                "bucket_slug": "",
+                "confidence": "low",
+                "why": "",
+                "next_action": "",
+                "question": "",
+                "notes": "",
+            }
+        )
+    return {
+        "workflow": DAILY_BRIEFING_PLAN_WORKFLOW,
+        "version": DAILY_BRIEFING_PLAN_VERSION,
+        "generated_at": now_iso(),
+        "my_tasks_gid": ((snapshot_payload.get("my_tasks") or {}).get("gid")),
+        "source": {
+            "workflow": DAILY_BRIEFING_SNAPSHOT_WORKFLOW,
+            "generated_at": snapshot_payload.get("generated_at"),
+        },
+        "overview": "",
+        "focus": "",
+        "final_markdown": "",
+        "categories": daily_briefing_bucket_seeds(),
+        "tasks": task_templates,
+    }
+
+
+def build_daily_briefing_snapshot_payload(args: argparse.Namespace) -> dict[str, Any]:
+    token = get_token(args)
+    context = load_context()
+    cache = load_cache()
+    workspace = workspace_default(args, context, cache)
+    if not workspace:
+        raise SystemExit("No workspace GID provided and no default workspace in asana-context.json")
+
+    user_task_list = my_tasks_project(token, workspace)
+    user_task_list_gid = str(user_task_list.get("gid") or "").strip()
+    if not user_task_list_gid:
+        raise SystemExit("Unable to resolve My Tasks for the selected workspace")
+
+    all_tasks = my_tasks_tasks(
+        token,
+        user_task_list_gid,
+        paginate=not args.no_paginate,
+        limit_pages=args.limit_pages,
+    )
+    filtered_tasks = [task for task in all_tasks if isinstance(task, dict)]
+    if args.max_tasks > 0:
+        filtered_tasks = filtered_tasks[: args.max_tasks]
+
+    task_contexts = fetch_task_review_context(
+        token,
+        [str(task.get("gid")) for task in filtered_tasks if task.get("gid")],
+    )
+    snapshot_tasks = []
+    for task in filtered_tasks:
+        task_gid = str(task.get("gid") or "").strip()
+        if not task_gid:
+            continue
+        snapshot_tasks.append(daily_briefing_snapshot_task(task_contexts.get(task_gid) or {"task": task, "stories": []}))
+
+    payload = {
+        "workflow": DAILY_BRIEFING_SNAPSHOT_WORKFLOW,
+        "version": DAILY_BRIEFING_PLAN_VERSION,
+        "generated_at": now_iso(),
+        "workspace_gid": workspace,
+        "my_tasks": {
+            "gid": user_task_list_gid,
+            "name": user_task_list.get("name"),
+        },
+        "open_task_count": len(all_tasks),
+        "tasks_considered": len(snapshot_tasks),
+        "current_section_counts": my_tasks_summary(
+            token,
+            workspace_gid=workspace,
+            cache=cache,
+            refresh=True,
+        ).get("section_counts", {}),
+        "starter_buckets": daily_briefing_bucket_seeds(),
+        "tasks": snapshot_tasks,
+        "instructions": {
+            "summary": "Use this snapshot to decide which tasks are actually actionable today. The agent should auto-author the daily briefing plan from this data, render it for the user, and only surface ask_user items when ambiguity materially changes the day plan.",
+            "required_task_fields": [
+                "decision",
+                "bucket_slug",
+                "confidence",
+                "why",
+                "next_action",
+                "question",
+            ],
+            "required_plan_fields": [
+                "overview",
+                "focus",
+                "final_markdown",
+            ],
+            "decision_values": [
+                "highlight",
+                "ask_user",
+                "omit",
+            ],
+        },
+    }
+    payload["plan_template"] = build_daily_briefing_plan_template(payload)
+    snapshot_path = write_json_file(getattr(args, "snapshot_file", None), payload)
+    plan_template_path = write_json_file(getattr(args, "plan_template_file", None), payload["plan_template"])
+    if snapshot_path:
+        payload["snapshot_file"] = snapshot_path
+    if plan_template_path:
+        payload["plan_template_file"] = plan_template_path
+    return payload
+
+
+def resolve_daily_briefing_plan_categories(plan: dict[str, Any]) -> list[dict[str, Any]]:
+    categories_by_slug: dict[str, dict[str, Any]] = {}
+    for seed in daily_briefing_bucket_seeds():
+        slug = slugify_category(seed.get("slug") or seed.get("name"))
+        entry = dict(seed)
+        entry["slug"] = slug
+        categories_by_slug[slug] = entry
+    for index, category in enumerate(plan.get("categories", []) or [], start=1):
+        if not isinstance(category, dict):
+            continue
+        slug = slugify_category(category.get("slug") or category.get("name"))
+        merged = dict(categories_by_slug.get(slug) or {})
+        merged.update(category)
+        merged["slug"] = slug
+        if "display_order" not in merged:
+            merged["display_order"] = len(categories_by_slug) + index
+        categories_by_slug[slug] = merged
+    return sorted(
+        categories_by_slug.values(),
+        key=lambda item: (
+            int(item.get("display_order") or 999),
+            str(item.get("name") or item.get("slug") or "").casefold(),
+        ),
+    )
+
+
+def build_daily_briefing_review_payload(args: argparse.Namespace) -> dict[str, Any]:
+    cleanup_args = argparse.Namespace(
+        workspace=getattr(args, "workspace", None),
+        source_section=list(DEFAULT_INBOX_CLEANUP_SOURCE_SECTIONS),
+        all_open=True,
+        apply=False,
+        skip_ready_comments=True,
+        manager_comments=False,
+        comment_research_todos=False,
+        max_tasks=getattr(args, "max_tasks", 0),
+        no_paginate=getattr(args, "no_paginate", False),
+        limit_pages=getattr(args, "limit_pages", 0),
+        compact=True,
+        token=getattr(args, "token", None),
+        command="daily-briefing",
+    )
+    cleanup_payload = build_inbox_cleanup_review_payload(cleanup_args)
+    task_results = cleanup_payload.get("tasks", []) or []
+    bucketed: dict[str, list[dict[str, Any]]] = {
+        "execute_now": [],
+        "release_watch": [],
+        "needs_verification": [],
+        "needs_follow_up": [],
+        "ready_to_close": [],
+        "background": [],
+    }
+    for task_result in task_results:
+        if not isinstance(task_result, dict):
+            continue
+        bucket_key = daily_briefing_bucket_key(task_result)
+        bucketed[bucket_key].append(daily_briefing_item(task_result))
+
+    for bucket_name, entries in bucketed.items():
+        entries.sort(
+            key=lambda entry: (
+                -daily_briefing_bucket_score(bucket_name, entry["task_result"]),
+                str(entry.get("name") or "").casefold(),
+            )
+        )
+        for entry in entries:
+            entry.pop("task_result", None)
+
+    summary = {
+        "open_task_count": int(((cleanup_payload.get("counts") or {}).get("all_open_tasks_in_my_tasks")) or len(task_results)),
+        "execute_now_count": len(bucketed["execute_now"]),
+        "release_watch_count": len(bucketed["release_watch"]),
+        "needs_verification_count": len(bucketed["needs_verification"]),
+        "needs_follow_up_count": len(bucketed["needs_follow_up"]),
+        "ready_to_close_count": len(bucketed["ready_to_close"]),
+        "background_count": len(bucketed["background"]),
+    }
+    payload = {
+        "briefing_date": datetime.now().strftime("%B %d, %Y"),
+        "generated_at": now_iso(),
+        "summary": summary,
+        "buckets": bucketed,
+        "source": {
+            "command": "python3 scripts/asana_api.py inbox-cleanup --all-open",
+            "workspace_gid": cleanup_payload.get("workspace_gid"),
+            "my_tasks": cleanup_payload.get("my_tasks"),
+        },
+    }
+    return payload
+
+
+def build_daily_briefing_plan_payload(args: argparse.Namespace) -> dict[str, Any]:
+    token = get_token(args)
+    context = load_context()
+    cache = load_cache()
+    workspace = workspace_default(args, context, cache)
+    if not workspace:
+        raise SystemExit("No workspace GID provided and no default workspace in asana-context.json")
+
+    plan = load_json_file(args.plan_file)
+    if str(plan.get("workflow") or "") != DAILY_BRIEFING_PLAN_WORKFLOW:
+        raise SystemExit(
+            f"Unsupported plan workflow in {args.plan_file}. Expected `{DAILY_BRIEFING_PLAN_WORKFLOW}`."
+        )
+    final_markdown = str(plan.get("final_markdown") or "").strip()
+    if not final_markdown:
+        raise SystemExit(
+            f"Daily briefing plan in {args.plan_file} must include a non-empty `final_markdown` field authored by the AI."
+        )
+
+    user_task_list = my_tasks_project(token, workspace)
+    user_task_list_gid = str(user_task_list.get("gid") or "").strip()
+    if not user_task_list_gid:
+        raise SystemExit("Unable to resolve My Tasks for the selected workspace")
+
+    all_tasks = my_tasks_tasks(
+        token,
+        user_task_list_gid,
+        paginate=not args.no_paginate,
+        limit_pages=args.limit_pages,
+    )
+    tasks_by_gid = {
+        str(task.get("gid")): task
+        for task in all_tasks
+        if isinstance(task, dict) and task.get("gid")
+    }
+    planned_task_gids = [
+        str(entry.get("task_gid") or "").strip()
+        for entry in (plan.get("tasks") or [])
+        if isinstance(entry, dict) and entry.get("task_gid")
+    ]
+    task_contexts = fetch_task_review_context(token, [gid for gid in planned_task_gids if gid in tasks_by_gid])
+    task_cards = {
+        gid: daily_briefing_snapshot_task(task_contexts.get(gid) or {"task": tasks_by_gid.get(gid) or {}, "stories": []})
+        for gid in planned_task_gids
+        if gid in tasks_by_gid
+    }
+
+    categories = resolve_daily_briefing_plan_categories(plan)
+    categories_by_slug = {
+        slugify_category(category.get("slug") or category.get("name")): category
+        for category in categories
+        if isinstance(category, dict)
+    }
+    buckets: dict[str, list[dict[str, Any]]] = {
+        slugify_category(category.get("slug") or category.get("name")): []
+        for category in categories
+        if isinstance(category, dict)
+    }
+    results: list[dict[str, Any]] = []
+    user_questions: list[dict[str, Any]] = []
+
+    for entry in plan.get("tasks", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        task_gid = str(entry.get("task_gid") or "").strip()
+        if not task_gid:
+            continue
+        task_card = task_cards.get(task_gid)
+        if not task_card:
+            results.append(
+                {
+                    "task_gid": task_gid,
+                    "name": entry.get("name"),
+                    "status": "missing_task",
+                    "why": "Task is not currently open in My Tasks.",
+                }
+            )
+            continue
+
+        decision = str(entry.get("decision") or "omit").strip().casefold()
+        confidence = str(entry.get("confidence") or "").strip().casefold()
+        why = normalize_whitespace(entry.get("why"))
+        question = normalize_whitespace(entry.get("question"))
+        next_action = normalize_whitespace(entry.get("next_action"))
+
+        if decision in {"ask_user", "question", "needs_user_input"}:
+            question_entry = dict(task_card)
+            question_entry.update(
+                {
+                    "why": why,
+                    "question": question,
+                    "next_action": next_action,
+                    "confidence": confidence,
+                }
+            )
+            user_questions.append(question_entry)
+            results.append(
+                {
+                    "task_gid": task_gid,
+                    "name": task_card.get("name"),
+                    "status": "ask_user",
+                    "why": why,
+                    "question": question,
+                }
+            )
+            continue
+
+        if decision in {"omit", "leave_as_is", "skip", "background"}:
+            results.append(
+                {
+                    "task_gid": task_gid,
+                    "name": task_card.get("name"),
+                    "status": "omitted",
+                    "why": why,
+                }
+            )
+            continue
+
+        bucket_slug = slugify_category(entry.get("bucket_slug") or "")
+        category = categories_by_slug.get(bucket_slug)
+        if decision in {"highlight", "include", "bucket"} and not category:
+            user_questions.append(
+                {
+                    **task_card,
+                    "why": why or f"Bucket `{bucket_slug}` is missing from the plan categories.",
+                    "question": question or "Which briefing bucket should this task belong in?",
+                    "next_action": next_action,
+                    "confidence": confidence,
+                }
+            )
+            results.append(
+                {
+                    "task_gid": task_gid,
+                    "name": task_card.get("name"),
+                    "status": "missing_bucket",
+                    "bucket_slug": bucket_slug,
+                    "why": why,
+                }
+            )
+            continue
+
+        if bucket_slug not in buckets:
+            buckets[bucket_slug] = []
+        highlighted = dict(task_card)
+        highlighted.update(
+            {
+                "why": why,
+                "next_action": next_action,
+                "question": question,
+                "confidence": confidence,
+                "bucket_slug": bucket_slug,
+                "notes": normalize_whitespace(entry.get("notes")),
+            }
+        )
+        buckets[bucket_slug].append(highlighted)
+        results.append(
+            {
+                "task_gid": task_gid,
+                "name": task_card.get("name"),
+                "status": "highlighted",
+                "bucket_slug": bucket_slug,
+                "why": why,
+            }
+        )
+
+    summary = {
+        "open_task_count": len(all_tasks),
+        "tasks_in_plan": len(plan.get("tasks", []) or []),
+        "highlighted_count": sum(1 for item in results if item.get("status") == "highlighted"),
+        "ask_user_count": sum(1 for item in results if item.get("status") == "ask_user"),
+        "omitted_count": sum(1 for item in results if item.get("status") == "omitted"),
+        "missing_task_count": sum(1 for item in results if item.get("status") == "missing_task"),
+        "missing_bucket_count": sum(1 for item in results if item.get("status") == "missing_bucket"),
+    }
+    payload = {
+        "workflow": DAILY_BRIEFING_PLAN_WORKFLOW,
+        "version": DAILY_BRIEFING_PLAN_VERSION,
+        "mode": "render_plan",
+        "briefing_date": datetime.now().strftime("%B %d, %Y"),
+        "generated_at": now_iso(),
+        "overview": normalize_whitespace(plan.get("overview"))
+        or "AI-selected daily briefing over the current My Tasks list.",
+        "focus": normalize_whitespace(plan.get("focus")),
+        "summary": summary,
+        "categories": categories,
+        "buckets": buckets,
+        "user_questions": user_questions,
+        "results": results,
+        "final_markdown": final_markdown,
+        "source": {
+            "command": "python3 scripts/asana_api.py daily-briefing",
+            "workspace_gid": workspace,
+            "my_tasks": {
+                "gid": user_task_list_gid,
+                "name": user_task_list.get("name"),
+            },
+        },
+    }
+    return payload
+
+
+def build_daily_briefing(args: argparse.Namespace) -> dict[str, Any]:
+    if getattr(args, "legacy_auto", False):
+        return build_daily_briefing_review_payload(args)
+    if getattr(args, "plan_file", None):
+        return build_daily_briefing_plan_payload(args)
+    return build_daily_briefing_snapshot_payload(args)
+
+
+def command_daily_briefing(args: argparse.Namespace) -> Any:
+    if getattr(args, "markdown", False) and not getattr(args, "plan_file", None) and not getattr(args, "legacy_auto", False):
+        raise SystemExit(
+            "daily-briefing --markdown now requires --plan-file. First run daily-briefing to emit a snapshot, let the AI write a plan JSON, then render that plan."
+        )
+    payload = build_daily_briefing(args)
+    if getattr(args, "markdown", False):
+        final_markdown = str(payload.get("final_markdown") or "").strip()
+        if not final_markdown:
+            raise SystemExit(
+                "daily-briefing --markdown requires the AI-authored plan JSON to include `final_markdown`."
+            )
+        print(final_markdown)
+    else:
+        print_json(payload, args.compact)
+    return payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Local Asana API helper")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    request_parser = subparsers.add_parser("request", help="Run a generic Asana API request")
+    request_parser.add_argument("method", help="HTTP method, e.g. GET/POST/PUT/DELETE")
+    request_parser.add_argument("path", help="Relative /path or full URL")
+    request_parser.add_argument("--query", action="append", help="Query param as key=value")
+    request_parser.add_argument("--opt-fields", help="Asana opt_fields value")
+    request_parser.add_argument("--opt-expand", help="Asana opt_expand value")
+    request_parser.add_argument("--data", help="JSON payload string")
+    request_parser.add_argument("--data-file", help="Path to JSON payload file")
+    request_parser.add_argument(
+        "--no-wrap-data",
+        action="store_true",
+        help="Do not auto-wrap JSON payloads in {\"data\": ...}",
+    )
+    request_parser.add_argument("--form", action="append", help="Multipart form field as key=value")
+    request_parser.add_argument("--file", action="append", help="Multipart file field as field=/abs/path")
+    request_parser.add_argument("--paginate", action="store_true", help="Follow Asana next_page links")
+    request_parser.add_argument("--limit-pages", type=int, default=0, help="Stop pagination after N pages")
+    add_common_output_flags(request_parser)
+    request_parser.set_defaults(func=command_request)
+
+    whoami_parser = subparsers.add_parser("whoami", help="Show the authenticated user")
+    add_common_output_flags(whoami_parser)
+    whoami_parser.set_defaults(func=command_whoami)
+
+    workspaces_parser = subparsers.add_parser("workspaces", help="List workspaces for the authenticated user")
+    add_common_output_flags(workspaces_parser)
+    workspaces_parser.set_defaults(func=command_workspaces)
+
+    teams_parser = subparsers.add_parser("teams", help="List teams in a workspace")
+    teams_parser.add_argument("--workspace", help="Workspace GID override")
+    add_common_output_flags(teams_parser)
+    teams_parser.set_defaults(func=command_teams)
+
+    users_parser = subparsers.add_parser("users", help="List users in a workspace")
+    users_parser.add_argument("--workspace", help="Workspace GID override")
+    users_parser.add_argument("--opt-fields", help="Override result fields")
+    users_parser.add_argument("--paginate", action="store_true", help="Follow Asana next_page links")
+    users_parser.add_argument("--limit-pages", type=int, default=0, help="Stop pagination after N pages")
+    add_common_output_flags(users_parser)
+    users_parser.set_defaults(func=command_users)
+
+    projects_parser = subparsers.add_parser("projects", help="List projects for a team")
+    projects_parser.add_argument("--team", help="Team GID or exact team name from asana-context.json")
+    add_common_output_flags(projects_parser)
+    projects_parser.set_defaults(func=command_projects)
+
+    task_parser = subparsers.add_parser("task", help="Inspect one or more tasks")
+    task_parser.add_argument("task_gids", nargs="+", help="Task gids; comma-separated values allowed")
+    task_parser.add_argument("--opt-fields", help="Override task fields")
+    add_common_output_flags(task_parser)
+    task_parser.set_defaults(func=command_task)
+
+    story_parser = subparsers.add_parser("story", help="Inspect one or more stories/comments by gid")
+    story_parser.add_argument("story_gids", nargs="+", help="Story gids; comma-separated values allowed")
+    story_parser.add_argument("--opt-fields", help="Override story fields")
+    add_common_output_flags(story_parser)
+    story_parser.set_defaults(func=command_story)
+
+    task_bundle_parser = subparsers.add_parser(
+        "task-bundle",
+        help="Fetch one or more tasks with comments, attachments, and optional project workflow context",
+    )
+    task_bundle_parser.add_argument("task_gids", nargs="+", help="Task gids; comma-separated values allowed")
+    task_bundle_parser.add_argument(
+        "--project-gid",
+        help="Project GID to include section order and project custom field settings",
+    )
+    task_bundle_parser.add_argument("--task-opt-fields", help="Override task fields")
+    task_bundle_parser.add_argument("--story-opt-fields", help="Override story fields")
+    task_bundle_parser.add_argument("--attachment-opt-fields", help="Override attachment fields")
+    add_common_output_flags(task_bundle_parser)
+    task_bundle_parser.set_defaults(func=command_task_bundle)
+
+    task_status_parser = subparsers.add_parser("task-status", help="Summarize completion and board-column status for one or more tasks")
+    task_status_parser.add_argument("task_gids", nargs="+", help="Task gids; comma-separated values allowed")
+    task_status_parser.add_argument("--project", help="Limit membership analysis to one project GID")
+    task_status_parser.add_argument("--opt-fields", help="Override task fields")
+    task_status_parser.add_argument(
+        "--include-task-position",
+        action="store_true",
+        help="Also look up the task's position inside its current section",
+    )
+    add_common_output_flags(task_status_parser)
+    task_status_parser.set_defaults(func=command_task_status)
+
+    project_parser = subparsers.add_parser("project", help="Inspect one or more projects")
+    project_parser.add_argument("project_gids", nargs="+", help="Project gids; comma-separated values allowed")
+    project_parser.add_argument("--opt-fields", help="Override project fields")
+    add_common_output_flags(project_parser)
+    project_parser.set_defaults(func=command_project)
+
+    board_parser = subparsers.add_parser("board", help="Return project sections in order with tasks in each section")
+    board_parser.add_argument("project_gid")
+    board_parser.add_argument("--opt-fields", help="Override per-task fields in board output")
+    board_parser.add_argument("--context", action="store_true", help="Include workflow context stats (field coverage, staleness, assignee distribution)")
+    add_common_output_flags(board_parser)
+    board_parser.set_defaults(func=command_project_board)
+
+    project_tasks_parser = subparsers.add_parser("project-tasks", help="List tasks in a project")
+    project_tasks_parser.add_argument("project_gid")
+    project_tasks_parser.add_argument("--opt-fields", help="Override task fields")
+    project_tasks_parser.add_argument("--paginate", action="store_true", help="Follow Asana next_page links")
+    project_tasks_parser.add_argument("--limit-pages", type=int, default=0, help="Stop pagination after N pages")
+    add_common_output_flags(project_tasks_parser)
+    project_tasks_parser.set_defaults(func=command_project_tasks)
+
+    project_assigned_parser = subparsers.add_parser(
+        "project-assigned-tasks",
+        help="List assigned work in a project, including matching subtasks with parent section context",
+    )
+    project_assigned_parser.add_argument("project_gid")
+    project_assigned_parser.add_argument("--workspace", help="Workspace GID override")
+    project_assigned_parser.add_argument(
+        "--assignee",
+        help="Assignee filter, defaults to the current user from asana-context.json; accepts gid, exact cached name, or exact cached email",
+    )
+    project_assigned_parser.add_argument("--completed", type=parse_bool, help="Filter by completion")
+    project_assigned_parser.add_argument("--opt-fields", help="Override result fields")
+    project_assigned_parser.add_argument(
+        "--include-task-position",
+        action="store_true",
+        help="Also look up each task's position inside its effective board section",
+    )
+    project_assigned_parser.add_argument(
+        "--include-comments",
+        action="store_true",
+        help="Include recent comment context for each task",
+    )
+    project_assigned_parser.add_argument(
+        "--comment-limit",
+        type=int,
+        default=3,
+        help="Maximum number of recent comments to keep per task when --include-comments is set",
+    )
+    project_assigned_parser.add_argument(
+        "--include-attachments",
+        action="store_true",
+        help="Include task attachments and derived image URLs for each task",
+    )
+    project_assigned_parser.add_argument("--paginate", action="store_true", help="Follow Asana next_page links")
+    project_assigned_parser.add_argument("--limit-pages", type=int, default=0, help="Stop pagination after N pages")
+    add_common_output_flags(project_assigned_parser)
+    project_assigned_parser.set_defaults(func=command_project_assigned_tasks)
+
+    sections_parser = subparsers.add_parser("sections", help="List sections in a project")
+    sections_parser.add_argument("project_gid")
+    sections_parser.add_argument("--opt-fields", help="Override section fields")
+    add_common_output_flags(sections_parser)
+    sections_parser.set_defaults(func=command_sections)
+
+    section_parser = subparsers.add_parser("section", help="Inspect one or more sections")
+    section_parser.add_argument("section_gids", nargs="+", help="Section gids; comma-separated values allowed")
+    section_parser.add_argument("--opt-fields", help="Override section fields")
+    add_common_output_flags(section_parser)
+    section_parser.set_defaults(func=command_section)
+
+    section_tasks_parser = subparsers.add_parser("section-tasks", help="List tasks in a section")
+    section_tasks_parser.add_argument("section_gid")
+    section_tasks_parser.add_argument("--opt-fields", help="Override task fields")
+    section_tasks_parser.add_argument("--paginate", action="store_true", help="Follow Asana next_page links")
+    section_tasks_parser.add_argument("--limit-pages", type=int, default=0, help="Stop pagination after N pages")
+    add_common_output_flags(section_tasks_parser)
+    section_tasks_parser.set_defaults(func=command_section_tasks)
+
+    create_section_parser = subparsers.add_parser("create-section", help="Create a section in a project")
+    create_section_parser.add_argument("project_gid")
+    create_section_parser.add_argument("--name", required=True)
+    add_common_output_flags(create_section_parser)
+    create_section_parser.set_defaults(func=command_create_section)
+
+    update_section_parser = subparsers.add_parser("update-section", help="Rename a section")
+    update_section_parser.add_argument("section_gid")
+    update_section_parser.add_argument("--name", required=True)
+    add_common_output_flags(update_section_parser)
+    update_section_parser.set_defaults(func=command_update_section)
+
+    close_out_sections_parser = subparsers.add_parser(
+        "close-out-sections",
+        help="Relocate tasks out of section(s) and delete the section(s) once empty",
+    )
+    close_out_sections_parser.add_argument("project_gid")
+    close_out_sections_parser.add_argument(
+        "--section",
+        action="append",
+        required=True,
+        help="Source section gid or exact name; pass multiple times for multiple sections",
+    )
+    close_out_sections_parser.add_argument(
+        "--move-to",
+        help="Destination section gid or exact name within the same project",
+    )
+    close_out_sections_parser.add_argument(
+        "--completed-mode",
+        choices=("all", "completed", "incomplete"),
+        default="all",
+        help="Which tasks to relocate before attempting deletion",
+    )
+    close_out_sections_parser.add_argument(
+        "--limit-pages",
+        type=int,
+        default=0,
+        help="Stop section task pagination after N pages while collecting tasks",
+    )
+    close_out_sections_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Move selected tasks and delete sections that end up empty",
+    )
+    add_common_output_flags(close_out_sections_parser)
+    close_out_sections_parser.set_defaults(func=command_close_out_sections)
+
+    search_parser = subparsers.add_parser("search-tasks", help="Search tasks within a workspace")
+    search_parser.add_argument("--text", required=True, help="Search text")
+    search_parser.add_argument("--workspace", help="Workspace GID override")
+    search_parser.add_argument("--project", help="Project GID filter")
+    search_parser.add_argument("--assignee", help="Assignee filter, e.g. me, user gid, exact cached user name, or exact cached email")
+    search_parser.add_argument("--completed", type=parse_bool, help="Filter by completion")
+    search_parser.add_argument("--opt-fields", help="Override result fields")
+    search_parser.add_argument("--paginate", action="store_true", help="Follow Asana next_page links")
+    search_parser.add_argument("--limit-pages", type=int, default=0, help="Stop pagination after N pages")
+    add_common_output_flags(search_parser)
+    search_parser.set_defaults(func=command_search_tasks)
+
+    inbox_cleanup_parser = subparsers.add_parser(
+        "inbox-cleanup",
+        help="Generate an AI-gated My Tasks cleanup snapshot or apply an AI-authored cleanup plan",
+    )
+    inbox_cleanup_parser.add_argument("--workspace", help="Workspace GID override")
+    inbox_cleanup_parser.add_argument(
+        "--source-section",
+        action="append",
+        default=list(DEFAULT_INBOX_CLEANUP_SOURCE_SECTIONS),
+        help="My Tasks section name to triage from; defaults to Recently assigned",
+    )
+    inbox_cleanup_parser.add_argument(
+        "--all-open",
+        action="store_true",
+        help="Ignore source-section filtering and include all open tasks in My Tasks",
+    )
+    inbox_cleanup_parser.add_argument(
+        "--snapshot-file",
+        help="Write the AI-gating snapshot JSON to this file in addition to stdout",
+    )
+    inbox_cleanup_parser.add_argument(
+        "--plan-template-file",
+        help="Write an editable cleanup plan template JSON to this file",
+    )
+    inbox_cleanup_parser.add_argument(
+        "--plan-file",
+        help="Path to an AI-authored cleanup plan JSON to preview or apply",
+    )
+    inbox_cleanup_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply the provided AI-authored plan file by moving tasks into the requested sections",
+    )
+    inbox_cleanup_parser.add_argument(
+        "--include-low-confidence",
+        action="store_true",
+        help="When applying a plan, also move tasks marked low confidence instead of leaving them for user review",
+    )
+    inbox_cleanup_parser.add_argument(
+        "--legacy-auto",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    inbox_cleanup_parser.add_argument(
+        "--skip-ready-comments",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    inbox_cleanup_parser.add_argument(
+        "--manager-comments",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    inbox_cleanup_parser.add_argument(
+        "--comment-research-todos",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    inbox_cleanup_parser.add_argument(
+        "--max-tasks",
+        type=int,
+        default=0,
+        help="Limit how many filtered tasks to process after section filtering",
+    )
+    inbox_cleanup_parser.add_argument(
+        "--no-paginate",
+        action="store_true",
+        help="Do not follow My Tasks next_page links",
+    )
+    inbox_cleanup_parser.add_argument(
+        "--limit-pages",
+        type=int,
+        default=0,
+        help="Stop My Tasks pagination after N pages",
+    )
+    add_common_output_flags(inbox_cleanup_parser)
+    inbox_cleanup_parser.set_defaults(func=command_inbox_cleanup)
+
+    daily_briefing_parser = subparsers.add_parser(
+        "daily-briefing",
+        help="Generate an AI-gated daily briefing snapshot or render an AI-authored morning briefing plan",
+    )
+    daily_briefing_parser.add_argument("--workspace", help="Workspace GID override")
+    daily_briefing_parser.add_argument(
+        "--max-tasks",
+        type=int,
+        default=0,
+        help="Limit how many My Tasks items to include in the briefing snapshot",
+    )
+    daily_briefing_parser.add_argument(
+        "--no-paginate",
+        action="store_true",
+        help="Do not follow My Tasks next_page links",
+    )
+    daily_briefing_parser.add_argument(
+        "--limit-pages",
+        type=int,
+        default=0,
+        help="Stop My Tasks pagination after N pages",
+    )
+    daily_briefing_parser.add_argument(
+        "--snapshot-file",
+        help="Write the daily briefing snapshot JSON to this file in addition to stdout",
+    )
+    daily_briefing_parser.add_argument(
+        "--plan-template-file",
+        help="Write an editable daily briefing plan template JSON to this file",
+    )
+    daily_briefing_parser.add_argument(
+        "--plan-file",
+        help="Path to an AI-authored daily briefing plan JSON to render",
+    )
+    daily_briefing_parser.add_argument(
+        "--markdown",
+        action="store_true",
+        help="Print the rendered markdown briefing from the provided AI-authored plan instead of JSON",
+    )
+    daily_briefing_parser.add_argument(
+        "--legacy-auto",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    add_common_output_flags(daily_briefing_parser)
+    daily_briefing_parser.set_defaults(func=command_daily_briefing)
+
+    create_task_parser = subparsers.add_parser("create-task", help="Create a task")
+    create_task_parser.add_argument("--name", required=True)
+    create_task_parser.add_argument("--workspace", help="Workspace GID override")
+    create_task_parser.add_argument("--project", help="Project GID")
+    create_task_parser.add_argument("--section", help="Section GID for placement")
+    create_task_parser.add_argument("--parent", help="Parent task GID")
+    create_task_parser.add_argument("--assignee", help="Assignee gid, me, exact cached user name, or exact cached email")
+    create_task_parser.add_argument("--notes")
+    create_task_parser.add_argument("--html-notes")
+    create_task_parser.add_argument("--due-on")
+    create_task_parser.add_argument("--due-at")
+    create_task_parser.add_argument("--custom-field", action="append", default=[], help="Custom field as gid=value")
+    create_task_parser.add_argument("--insert-before", help="Anchor task GID, section/project sentinel GID, or literal null")
+    create_task_parser.add_argument("--insert-after", help="Anchor task GID, section/project sentinel GID, or literal null")
+    add_common_output_flags(create_task_parser)
+    create_task_parser.set_defaults(func=command_create_task)
+
+    update_task_parser = subparsers.add_parser("update-task", help="Update a task")
+    update_task_parser.add_argument("task_gid")
+    update_task_parser.add_argument("--name")
+    update_task_parser.add_argument("--project", help="Project GID for placement")
+    update_task_parser.add_argument("--section", help="Section GID for placement")
+    update_task_parser.add_argument("--assignee", help="Assignee gid, me, exact cached user name, or exact cached email")
+    update_task_parser.add_argument("--notes")
+    update_task_parser.add_argument("--html-notes")
+    update_task_parser.add_argument("--due-on")
+    update_task_parser.add_argument("--due-at")
+    update_task_parser.add_argument("--completed", type=parse_bool)
+    update_task_parser.add_argument("--custom-field", action="append", default=[], help="Custom field as gid=value")
+    update_task_parser.add_argument("--insert-before", help="Anchor task GID, section/project sentinel GID, or literal null")
+    update_task_parser.add_argument("--insert-after", help="Anchor task GID, section/project sentinel GID, or literal null")
+    add_common_output_flags(update_task_parser)
+    update_task_parser.set_defaults(func=command_update_task)
+
+    comment_parser = subparsers.add_parser("comment-task", help="Create a task story/comment")
+    comment_parser.add_argument("task_gid")
+    comment_parser.add_argument("--text", help="Plain-text comment body")
+    comment_parser.add_argument("--text-file", help="Read plain-text comment body from file")
+    comment_parser.add_argument("--html-text", help="Rich-text HTML comment body")
+    comment_parser.add_argument("--html-text-file", help="Read rich-text HTML comment body from file")
+    add_common_output_flags(comment_parser)
+    comment_parser.set_defaults(func=command_comment_task)
+
+    update_story_parser = subparsers.add_parser("update-story", help="Update an existing story/comment")
+    update_story_parser.add_argument("story_gid")
+    update_story_parser.add_argument("--text", help="Plain-text comment body")
+    update_story_parser.add_argument("--text-file", help="Read plain-text comment body from file")
+    update_story_parser.add_argument("--html-text", help="Rich-text HTML comment body")
+    update_story_parser.add_argument("--html-text-file", help="Read rich-text HTML comment body from file")
+    add_common_output_flags(update_story_parser)
+    update_story_parser.set_defaults(func=command_update_story)
+
+    task_stories_parser = subparsers.add_parser("task-stories", help="List stories/comments on one or more tasks")
+    task_stories_parser.add_argument("task_gids", nargs="+", help="Task gids; comma-separated values allowed")
+    task_stories_parser.add_argument("--opt-fields", help="Override story fields")
+    task_stories_parser.add_argument("--paginate", action="store_true", help="Follow Asana next_page links")
+    task_stories_parser.add_argument("--limit-pages", type=int, default=0, help="Stop pagination after N pages")
+    add_common_output_flags(task_stories_parser)
+    task_stories_parser.set_defaults(func=command_task_stories)
+
+    task_comments_parser = subparsers.add_parser("task-comments", help="List only comment stories on one or more tasks, including text and html_text")
+    task_comments_parser.add_argument("task_gids", nargs="+", help="Task gids; comma-separated values allowed")
+    task_comments_parser.add_argument("--opt-fields", help="Override story fields")
+    task_comments_parser.add_argument("--paginate", action="store_true", help="Follow Asana next_page links")
+    task_comments_parser.add_argument("--limit-pages", type=int, default=0, help="Stop pagination after N pages")
+    add_common_output_flags(task_comments_parser)
+    task_comments_parser.set_defaults(func=command_task_comments)
+
+    task_projects_parser = subparsers.add_parser("task-projects", help="List projects one or more tasks belong to")
+    task_projects_parser.add_argument("task_gids", nargs="+", help="Task gids; comma-separated values allowed")
+    task_projects_parser.add_argument("--opt-fields", help="Override project fields")
+    add_common_output_flags(task_projects_parser)
+    task_projects_parser.set_defaults(func=command_task_projects)
+
+    add_task_project_parser = subparsers.add_parser("add-task-project", help="Add or move a task within a project/section")
+    add_task_project_parser.add_argument("task_gid")
+    add_task_project_parser.add_argument("project_gid")
+    add_task_project_parser.add_argument("--section", help="Section GID for placement")
+    add_task_project_parser.add_argument("--insert-before", help="Anchor task GID or literal null")
+    add_task_project_parser.add_argument("--insert-after", help="Anchor task GID or literal null")
+    add_common_output_flags(add_task_project_parser)
+    add_task_project_parser.set_defaults(func=command_add_task_project)
+
+    remove_task_project_parser = subparsers.add_parser("remove-task-project", help="Remove a task from a project")
+    remove_task_project_parser.add_argument("task_gid")
+    remove_task_project_parser.add_argument("project_gid")
+    add_common_output_flags(remove_task_project_parser)
+    remove_task_project_parser.set_defaults(func=command_remove_task_project)
+
+    add_task_followers_parser = subparsers.add_parser("add-task-followers", help="Add followers to a task")
+    add_task_followers_parser.add_argument("task_gid")
+    add_task_followers_parser.add_argument("followers", nargs="+", help="Follower gids, me, exact cached user names/emails; comma-separated values allowed")
+    add_common_output_flags(add_task_followers_parser)
+    add_task_followers_parser.set_defaults(func=command_add_task_followers)
+
+    remove_task_followers_parser = subparsers.add_parser("remove-task-followers", help="Remove followers from a task")
+    remove_task_followers_parser.add_argument("task_gid")
+    remove_task_followers_parser.add_argument("followers", nargs="+", help="Follower gids, me, exact cached user names/emails; comma-separated values allowed")
+    add_common_output_flags(remove_task_followers_parser)
+    remove_task_followers_parser.set_defaults(func=command_remove_task_followers)
+
+    tags_parser = subparsers.add_parser("tags", help="List tags in a workspace")
+    tags_parser.add_argument("--workspace", help="Workspace GID override")
+    tags_parser.add_argument("--opt-fields", help="Override tag fields")
+    tags_parser.add_argument("--paginate", action="store_true", help="Follow Asana next_page links")
+    tags_parser.add_argument("--limit-pages", type=int, default=0, help="Stop pagination after N pages")
+    add_common_output_flags(tags_parser)
+    tags_parser.set_defaults(func=command_tags)
+
+    create_tag_parser = subparsers.add_parser("create-tag", help="Create a tag")
+    create_tag_parser.add_argument("--name", required=True)
+    create_tag_parser.add_argument("--workspace", help="Workspace GID override")
+    create_tag_parser.add_argument("--color", help="Tag color")
+    create_tag_parser.add_argument("--notes")
+    add_common_output_flags(create_tag_parser)
+    create_tag_parser.set_defaults(func=command_create_tag)
+
+    workspace_custom_fields_parser = subparsers.add_parser("workspace-custom-fields", help="List custom fields in a workspace")
+    workspace_custom_fields_parser.add_argument("--workspace", help="Workspace GID override")
+    workspace_custom_fields_parser.add_argument("--opt-fields", help="Override field list")
+    workspace_custom_fields_parser.add_argument("--paginate", action="store_true", help="Follow Asana next_page links")
+    workspace_custom_fields_parser.add_argument("--limit-pages", type=int, default=0, help="Stop pagination after N pages")
+    add_common_output_flags(workspace_custom_fields_parser)
+    workspace_custom_fields_parser.set_defaults(func=command_workspace_custom_fields)
+
+    team_custom_fields_parser = subparsers.add_parser("team-custom-fields", help="List team custom field settings")
+    team_custom_fields_parser.add_argument("--team", help="Team GID or exact team name from asana-context.json")
+    team_custom_fields_parser.add_argument("--opt-fields", help="Override field list")
+    team_custom_fields_parser.add_argument("--paginate", action="store_true", help="Follow Asana next_page links")
+    team_custom_fields_parser.add_argument("--limit-pages", type=int, default=0, help="Stop pagination after N pages")
+    add_common_output_flags(team_custom_fields_parser)
+    team_custom_fields_parser.set_defaults(func=command_team_custom_fields)
+
+    project_custom_fields_parser = subparsers.add_parser("project-custom-fields", help="List custom field settings on one or more projects")
+    project_custom_fields_parser.add_argument("project_gids", nargs="+", help="Project gids; comma-separated values allowed")
+    project_custom_fields_parser.add_argument("--opt-fields", help="Override field list")
+    add_common_output_flags(project_custom_fields_parser)
+    project_custom_fields_parser.set_defaults(func=command_project_custom_fields)
+
+    task_custom_fields_parser = subparsers.add_parser("task-custom-fields", help="List custom fields on one or more tasks")
+    task_custom_fields_parser.add_argument("task_gids", nargs="+", help="Task gids; comma-separated values allowed")
+    task_custom_fields_parser.add_argument("--opt-fields", help="Override field list")
+    add_common_output_flags(task_custom_fields_parser)
+    task_custom_fields_parser.set_defaults(func=command_task_custom_fields)
+
+    create_custom_field_parser = subparsers.add_parser("create-custom-field", help="Create a workspace custom field")
+    create_custom_field_parser.add_argument("--name", required=True)
+    create_custom_field_parser.add_argument("--workspace", help="Workspace GID override")
+    create_custom_field_parser.add_argument(
+        "--resource-subtype",
+        required=True,
+        help="Asana custom field subtype, e.g. text, number, enum, multi_enum",
+    )
+    create_custom_field_parser.add_argument("--description")
+    create_custom_field_parser.add_argument("--precision", type=int)
+    create_custom_field_parser.add_argument("--enum-option", action="append", help="Enum option name; repeat for multiple values")
+    add_common_output_flags(create_custom_field_parser)
+    create_custom_field_parser.set_defaults(func=command_create_custom_field)
+
+    task_tags_parser = subparsers.add_parser("task-tags", help="List tags on one or more tasks")
+    task_tags_parser.add_argument("task_gids", nargs="+", help="Task gids; comma-separated values allowed")
+    task_tags_parser.add_argument("--opt-fields", help="Override tag fields")
+    add_common_output_flags(task_tags_parser)
+    task_tags_parser.set_defaults(func=command_task_tags)
+
+    add_task_tag_parser = subparsers.add_parser("add-task-tag", help="Add a tag to a task")
+    add_task_tag_parser.add_argument("task_gid")
+    add_task_tag_parser.add_argument("tag_gid", help="Tag gid or exact tag name")
+    add_task_tag_parser.add_argument("--workspace", help="Workspace GID override for tag-name resolution")
+    add_common_output_flags(add_task_tag_parser)
+    add_task_tag_parser.set_defaults(func=command_add_task_tag)
+
+    remove_task_tag_parser = subparsers.add_parser("remove-task-tag", help="Remove a tag from a task")
+    remove_task_tag_parser.add_argument("task_gid")
+    remove_task_tag_parser.add_argument("tag_gid", help="Tag gid or exact tag name")
+    remove_task_tag_parser.add_argument("--workspace", help="Workspace GID override for tag-name resolution")
+    add_common_output_flags(remove_task_tag_parser)
+    remove_task_tag_parser.set_defaults(func=command_remove_task_tag)
+
+    set_task_sorting_tag_parser = subparsers.add_parser(
+        "set-task-sorting-tag",
+        help="Set exactly one sorting tag on a task while preserving unrelated tags",
+    )
+    set_task_sorting_tag_parser.add_argument("task_gid")
+    set_task_sorting_tag_parser.add_argument("sorting_tag", help="Desired sorting tag gid or exact tag name")
+    set_task_sorting_tag_parser.add_argument("--workspace", help="Workspace GID override for tag-name resolution")
+    set_task_sorting_tag_parser.add_argument(
+        "--sorting-label",
+        action="append",
+        help="Allowed sorting tag name; repeat to override the default sorter set",
+    )
+    add_common_output_flags(set_task_sorting_tag_parser)
+    set_task_sorting_tag_parser.set_defaults(func=command_set_task_sorting_tag)
+
+    add_task_dependencies_parser = subparsers.add_parser("add-task-dependencies", help="Add dependencies to a task")
+    add_task_dependencies_parser.add_argument("task_gid")
+    add_task_dependencies_parser.add_argument("dependencies", nargs="+", help="Dependency task gids; comma-separated values allowed")
+    add_common_output_flags(add_task_dependencies_parser)
+    add_task_dependencies_parser.set_defaults(func=command_add_task_dependencies)
+
+    remove_task_dependencies_parser = subparsers.add_parser("remove-task-dependencies", help="Remove dependencies from a task")
+    remove_task_dependencies_parser.add_argument("task_gid")
+    remove_task_dependencies_parser.add_argument("dependencies", nargs="+", help="Dependency task gids; comma-separated values allowed")
+    add_common_output_flags(remove_task_dependencies_parser)
+    remove_task_dependencies_parser.set_defaults(func=command_remove_task_dependencies)
+
+    batch_parser = subparsers.add_parser("batch", help="Run an Asana batch request from a JSON array of actions")
+    batch_parser.add_argument("--actions", help="Inline JSON array of batch actions")
+    batch_parser.add_argument("--actions-file", help="Path to a JSON file containing a batch actions array")
+    add_common_output_flags(batch_parser)
+    batch_parser.set_defaults(func=command_batch)
+
+    create_project_parser = subparsers.add_parser("create-project", help="Create a project")
+    create_project_parser.add_argument("--name", required=True)
+    create_project_parser.add_argument("--team", help="Team GID or exact team name from asana-context.json")
+    create_project_parser.add_argument("--workspace", help="Workspace GID override")
+    create_project_parser.add_argument("--notes")
+    add_common_output_flags(create_project_parser)
+    create_project_parser.set_defaults(func=command_create_project)
+
+    update_project_parser = subparsers.add_parser("update-project", help="Update a project")
+    update_project_parser.add_argument("project_gid")
+    update_project_parser.add_argument("--name")
+    update_project_parser.add_argument("--notes")
+    update_project_parser.add_argument("--archived", type=parse_bool)
+    add_common_output_flags(update_project_parser)
+    update_project_parser.set_defaults(func=command_update_project)
+
+    context_parser = subparsers.add_parser("show-context", help="Print local workspace/team defaults")
+    add_common_output_flags(context_parser)
+    context_parser.set_defaults(func=command_show_context)
+
+    cache_parser = subparsers.add_parser("show-cache", help="Print the local Asana entity cache")
+    add_common_output_flags(cache_parser)
+    cache_parser.set_defaults(func=command_show_cache)
+
+    trigger_rule_parser = subparsers.add_parser(
+        "trigger-rule",
+        help="Trigger an existing Asana rule that has a 'web request received' trigger",
+    )
+    trigger_rule_parser.add_argument("trigger_identifier", help="Trigger identifier from the Asana rule's incoming web request URL")
+    trigger_rule_parser.add_argument("--task", dest="task_gid", required=True, help="Task GID where rule actions will be performed")
+    trigger_rule_parser.add_argument("--action-data", action="append", metavar="KEY=VALUE", help="Custom key=value data available as dynamic variables in rule actions (repeatable)")
+    add_common_output_flags(trigger_rule_parser)
+    trigger_rule_parser.set_defaults(func=command_trigger_rule)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/scout-config.yaml.tmpl
+++ b/templates/scout-config.yaml.tmpl
@@ -11,13 +11,19 @@ user:
   name: {{USER_NAME}}
   email: {{USER_EMAIL}}
   slack_id: {{USER_SLACK_ID}}
+  google_chat_id: {{USER_GOOGLE_CHAT_ID}}
+  jira_account_id: {{USER_JIRA_ACCOUNT_ID}}
+  asana_gid: {{USER_ASANA_GID}}
   github_username: {{GITHUB_USERNAME}}
 
 connectors:
   slack: {{SLACK_ENABLED}}
+  google_chat: {{GOOGLE_CHAT_ENABLED}}
   calendar: {{CALENDAR_ENABLED}}
   email: {{EMAIL_ENABLED}}
   linear: {{LINEAR_ENABLED}}
+  jira: {{JIRA_ENABLED}}
+  asana: {{ASANA_ENABLED}}
   github: {{GITHUB_ENABLED}}
   granola: {{GRANOLA_ENABLED}}
   drive: {{DRIVE_ENABLED}}
@@ -33,6 +39,10 @@ platform: {{PLATFORM}}
 scout_dir: {{SCOUT_DIR}}
 timezone: {{TIMEZONE}}
 github_repos: [{{GITHUB_REPOS}}]
+jira_projects: [{{JIRA_PROJECTS}}]
+jira_primary_project: {{JIRA_PRIMARY_PROJECT}}
+asana_projects: [{{ASANA_PROJECTS}}]
+asana_workspace_gid: {{ASANA_WORKSPACE_GID}}
 
 # Budget + session-limit awareness — consumed by scripts/budget-check.sh,
 # scripts/heartbeat.sh, and scripts/rate-limit-detect.sh.


### PR DESCRIPTION
## Summary

Adds three connectors to Scout — **Asana**, **Jira** (`jtk` CLI), and **Google Chat** (`gws` CLI) — plus connector-priority sweeps and supporting docs. The Asana connector is **CLI-first**: it ships a bundled, dependency-light `asana-api` CLI (PAT-based REST wrapper) with the claude.ai Asana MCP as runtime fallback. Jira and Google Chat follow the existing external-CLI pattern.

> Note for the maintainer: upstream currently has none of these connectors, so this is net-new. Happy to **split into per-connector PRs** (Asana / Jira / Google Chat) if you'd prefer smaller reviews — say the word.

## Connectors added

- **Asana (`asana:cli`)** — bundled `skills/asana-api/` CLI (`scripts/asana_api.py`, Python stdlib only). Reads tasks/sections/comments/stories, posts comments incl. `@mentions` (Asana rich-text `<a data-asana-gid>`). MCP fallback retained. Bootstrap stages the script into the vault; `request` subcommand is the raw-REST escape hatch.
- **Jira (`jtk:jira`)** — issue tracking, JQL search, sprint snapshot, status sync. Setup doc covers API-token + `jtk init`.
- **Google Chat (`gws:chat`)** — space/DM monitoring, outbound tracking, notifications.

## Supporting changes

- `phases/connectors/{asana,jira,google-chat}.md` — connector slot logic (inbound-scan / query / cross-check / update).
- `engine/scout/connectors.yaml` + `connectors.snapshot.json` + snapshot test — registry entries (`asana:cli`, `jtk:jira`, `gws:chat`).
- `commands/scout-setup.md`, `commands/scout-status.md` — detection + status rows.
- `engine/scout/docs/connectors/*-setup.md` — per-connector setup walkthroughs (token acquisition + storage).
- `templates/scout-config.yaml.tmpl` — connector flags + per-connector config keys.
- `phases/connectors/drive.md` — explicit Gemini Meeting Notes sweep.

## Testing

- `cd engine && uv run pytest tests/unit/` → **870 passed** (incl. new `test_install_stages_asana_api_cli`).
- `claude plugin validate .` → **passed**.
- Live-verified every Asana CLI command path + `jtk` against real workspaces.

## Reviewer notes

- ~99% of the line count is the vendored `asana_api.py` (≈6.6k lines, stdlib-only, self-contained).
- This branch also carries a couple of repo-local dev files (`AGENTS.md`, `CLAUDE.md` dev notes, `engine/uv.lock`) — **flag if you'd rather I drop them** from the contribution.
