### PR TITLE
fix(schedule): resolve tz from zoneinfo.default paths on macOS

### DIFF
--- a/engine/scout/scripts/schedule_tick.py
+++ b/engine/scout/scripts/schedule_tick.py
@@ -31,6 +31,7 @@ import datetime as _dt
 import fcntl
 import json
 import os
+import re
 import socket
 import subprocess
 import sys
@@ -159,9 +160,13 @@ def _local_tz_name(localtime: Path | None = None) -> str:
     localtime = localtime or Path("/etc/localtime")
     if localtime.is_symlink():
         target = str(localtime.resolve())
-        marker = "zoneinfo/"
-        if marker in target:
-            name = target.split(marker, 1)[1]
+        # The zone name is whatever follows the deepest zoneinfo* directory.
+        # macOS resolves through layouts like /var/db/timezone/tz/<ver>/zoneinfo/
+        # or /usr/share/zoneinfo.default/ depending on whether tzd has run, so
+        # a literal "zoneinfo/" match is not enough.
+        matches = list(re.finditer(r"/zoneinfo[^/]*/", target))
+        if matches:
+            name = target[matches[-1].end() :]
             try:
                 ZoneInfo(name)
                 return name
@@ -172,7 +177,7 @@ def _local_tz_name(localtime: Path | None = None) -> str:
                 )
         else:
             print(
-                "schedule_tick: /etc/localtime target has no 'zoneinfo/' component "
+                "schedule_tick: /etc/localtime target has no zoneinfo directory component "
                 f"({target!r}); falling back to UTC — set $TZ to your IANA zone",
                 file=sys.stderr,
             )

--- a/engine/tests/unit/test_schedule_tick.py
+++ b/engine/tests/unit/test_schedule_tick.py
@@ -900,11 +900,34 @@ def test_local_tz_name_env_tz_invalid_is_ignored_and_warns(monkeypatch, tmp_path
 
 
 def test_local_tz_name_resolves_symlink_zone(monkeypatch, tmp_path):
+    # Absolute symlink target. Hermetic fixture tree instead of the real
+    # /usr/share/zoneinfo: on macOS that chain resolves through host-specific
+    # layouts (/var/db/timezone/tz/<ver>/zoneinfo/ vs /usr/share/zoneinfo.default/),
+    # which made this test flaky across runner images.
     from scout.scripts import schedule_tick as st
 
     monkeypatch.delenv("TZ", raising=False)
+    zone_file = tmp_path / "zoneinfo" / "America" / "New_York"
+    zone_file.parent.mkdir(parents=True)
+    zone_file.write_bytes(b"TZif")
     link = tmp_path / "localtime"
-    link.symlink_to("/usr/share/zoneinfo/America/New_York")
+    link.symlink_to(zone_file)
+    assert st._local_tz_name(localtime=link) == "America/New_York"
+
+
+def test_local_tz_name_resolves_macos_zoneinfo_default_dir(monkeypatch, tmp_path):
+    # macOS layout where /usr/share/zoneinfo -> zoneinfo.default (pristine
+    # systems where tzd hasn't populated /var/db/timezone): the resolved
+    # target has a 'zoneinfo.default' component, not 'zoneinfo/'.
+    from scout.scripts import schedule_tick as st
+
+    monkeypatch.delenv("TZ", raising=False)
+    zone_file = tmp_path / "zoneinfo.default" / "America" / "New_York"
+    zone_file.parent.mkdir(parents=True)
+    zone_file.write_bytes(b"TZif")
+    (tmp_path / "zoneinfo").symlink_to("zoneinfo.default")  # dir-level indirection
+    link = tmp_path / "localtime"
+    link.symlink_to(tmp_path / "zoneinfo" / "America" / "New_York")
     assert st._local_tz_name(localtime=link) == "America/New_York"
 
 


### PR DESCRIPTION
## What

`_local_tz_name()` in `engine/scout/scripts/schedule_tick.py` now extracts the IANA zone name after the **deepest path component starting with `zoneinfo`** (`/zoneinfo[^/]*/`) instead of requiring a literal `zoneinfo/` substring in the resolved `/etc/localtime` target. The extracted name is still validated with `ZoneInfo()` before use.

The symlink-resolution tests are now hermetic (fixture trees under `tmp_path` instead of the host's real `/usr/share/zoneinfo`), and a new test covers the `zoneinfo.default` layout.

## Why

`test_local_tz_name_resolves_symlink_zone` failed on the macos-latest 3.12 job of [run 28643339267](https://github.com/Raven-Scout/scout-plugin/actions/runs/28643339267) on PR #181 (docs-only, so environmental). The captured stderr pinpointed the branch taken:

```
schedule_tick: /etc/localtime target has no 'zoneinfo/' component
('/usr/share/zoneinfo.default/America/New_York'); falling back to UTC
```

On macOS images where the `tzd` daemon hasn't populated `/var/db/timezone`, `/usr/share/zoneinfo` symlinks to `/usr/share/zoneinfo.default`, so `Path.resolve()` lands in a directory named `zoneinfo.default` and the old marker never matched. On hosts where the chain resolves to `/var/db/timezone/tz/<ver>/zoneinfo/…` it did match — hence the runner-dependent flakiness (the 3.11 macOS job passed in the same run).

This was a real production bug on such macOS systems, not just test flakiness: the scheduler would silently fall back to UTC and shift every `fires_at_local`.

## Reviewer notes

- The new `test_local_tz_name_resolves_macos_zoneinfo_default_dir` reproduced the CI failure byte-for-byte (same stderr) before the fix, and passes after.
- The old test symlinked to the real `/usr/share/zoneinfo/America/New_York`, so its outcome depended on the host's zoneinfo layout — that host dependence is what made it flaky; it now uses a fixture tree.
- Verified: all 48 tests in `tests/unit/test_schedule_tick.py` pass, ruff clean. Six unrelated failures elsewhere in the local unit suite reproduce on a clean tree and pass in CI (local typer/click env issue), so they're not regressions from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)