### PR TITLE
feat(triggers): event-trigger engine v1 (polling)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **Event-trigger engine v1 (polling)** (`engine/scout/triggers/`, spec `docs/specs/event-triggers.md`) — the engine can now fire on **events**, not just time. Triggers are declared in the vault's `.scout-state/triggers.yaml` (source + enumerated `match.type` + attribute filters + one of three action shapes: `notify` / `run_skill` / `interactive`) and evaluated at the top of every 5-minute `schedule_tick`, before slot dispatch and failure-isolated from it. v1 ships three polling sources — `slack` (Web-API mention search), `github` (`gh api notifications`), and `scout_internal` (the engine's own JSONL event stream) — with the combined-query optimization (one `scan_since()` per source per tick, in-memory trigger×event matching). Dedup/cooldown/daily-cap state lives in `.scout-cache/trigger-fires.json` (sliding recent-ids window; caps reset at midnight ET; mandatory `daily_fire_cap` — the validator rejects unlimited triggers, obvious `scout_internal` fire-cycles, and unknown skills). Every fire is logged to `.scout-logs/trigger-fires-YYYY-MM-DD.jsonl` and emitted as a `trigger.fired` event into the engine event stream. New CLI: `scoutctl trigger {list,show,validate,reload,test,fire-now,stats}`. Gated behind the (off-by-default) `triggers_v1` manifest flag; `linear`/`gmail`/`gcal`/`file` sources and the v2 webhook receiver are deferred.
+
 ## [0.7.3] - 2026-06-23
 
 

--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -858,6 +858,248 @@ def _register_schedule() -> None:
 _register_schedule()
 
 
+def _register_triggers() -> None:
+    """scoutctl trigger {list,show,validate,reload,test,fire-now,stats}.
+
+    Event-trigger operations over the vault's .scout-state/triggers.yaml
+    (docs/specs/event-triggers.md). Mirrors the schedule sub-app pattern.
+    `trigger serve` (the v2 webhook receiver) is intentionally absent.
+    """
+
+    trigger_app = typer.Typer(help="Event-trigger operations (vault triggers.yaml).")
+    app.add_typer(trigger_app, name="trigger")
+
+    def _load_vault_triggers():
+        from scout import paths as _paths
+        from scout.triggers.config import load_triggers, triggers_path
+
+        path = triggers_path(_paths.data_dir())
+        if not path.exists():
+            return path, None
+        return path, load_triggers(path)
+
+    def _trigger_record(t) -> dict:
+        return {
+            "id": t.id,
+            "enabled": t.enabled,
+            "source": t.source,
+            "match": dict(t.match),
+            "action": {"kind": t.action.kind.value, **t.action.params},
+            "cooldown_seconds": t.cooldown_seconds,
+            "daily_fire_cap": t.daily_fire_cap,
+            "allow_cycle": t.allow_cycle,
+        }
+
+    @trigger_app.command("list")
+    def cli_trigger_list(
+        as_json: bool = typer.Option(
+            False,
+            "--json/--no-json",
+            help="Emit a JSON array of full trigger records instead of tab-separated lines.",
+        ),
+    ) -> None:
+        """List the configured triggers."""
+        import json as _json
+
+        _path, triggers = _load_vault_triggers()
+        if triggers is None:
+            typer.echo("(no triggers.yaml; no triggers configured)")
+            return
+        if as_json:
+            typer.echo(_json.dumps([_trigger_record(t) for t in triggers]))
+            return
+        for t in triggers:
+            enabled = "enabled" if t.enabled else "disabled"
+            typer.echo(f"{t.id}\t{t.source}\t{t.match_type}\t{t.action.kind.value}\t{enabled}\tcap={t.daily_fire_cap}")
+
+    @trigger_app.command("show")
+    def cli_trigger_show(trigger_id: str) -> None:
+        """Show one trigger's full record (incl. dedup/fire state) as JSON."""
+        import json as _json
+
+        from scout import paths as _paths
+        from scout.triggers.dedup import DedupStore
+        from scout.triggers.engine import dedup_path
+
+        _path, triggers = _load_vault_triggers()
+        found = next((t for t in (triggers or []) if t.id == trigger_id), None)
+        if found is None:
+            typer.echo(f"unknown trigger: {trigger_id}", err=True)
+            raise typer.Exit(code=1)
+        record = _trigger_record(found)
+        record["fire_state"] = DedupStore(dedup_path(_paths.data_dir())).state(trigger_id)
+        typer.echo(_json.dumps(record, indent=2))
+
+    @trigger_app.command("validate")
+    def cli_trigger_validate(
+        target: Path | None = typer.Option(
+            None,
+            "--target",
+            "-t",
+            help="Validate the triggers.yaml at this path instead of the vault canonical.",
+        ),
+    ) -> None:
+        """Check triggers.yaml without applying it; exit 0 on success."""
+        from scout.triggers.config import load_triggers
+
+        if target is not None:
+            if not target.exists():
+                typer.echo(f"target does not exist: {target}", err=True)
+                raise typer.Exit(code=1)
+            try:
+                load_triggers(target)
+            except ConfigError as e:
+                typer.echo(str(e), err=True)
+                raise typer.Exit(code=1) from e
+            typer.echo(f"triggers OK: {target}")
+            return
+
+        try:
+            path, triggers = _load_vault_triggers()
+        except ConfigError as e:
+            typer.echo(str(e), err=True)
+            raise typer.Exit(code=1) from e
+        if triggers is None:
+            typer.echo("triggers OK: (no triggers.yaml; no triggers configured)")
+        else:
+            typer.echo(f"triggers OK: {path} ({len(triggers)} trigger(s))")
+
+    @trigger_app.command("reload")
+    def cli_trigger_reload() -> None:
+        """Force-reload triggers.yaml (fires use a per-tick snapshot; next tick picks this up)."""
+        _path, _triggers = _load_vault_triggers()
+        typer.echo("reloaded")
+
+    @trigger_app.command("test")
+    def cli_trigger_test(
+        trigger_id: str,
+        window_minutes: int = typer.Option(60, "--window-minutes", help="How far back to scan for events."),
+    ) -> None:
+        """Simulate one trigger against the last hour of source events. Never dispatches."""
+        import datetime as _dt
+        import json as _json
+
+        from scout import paths as _paths
+        from scout.triggers.dedup import DedupStore
+        from scout.triggers.engine import dedup_path
+        from scout.triggers.matcher import matches
+        from scout.triggers.sources import get_source
+
+        _path, triggers = _load_vault_triggers()
+        found = next((t for t in (triggers or []) if t.id == trigger_id), None)
+        if found is None:
+            typer.echo(f"unknown trigger: {trigger_id}", err=True)
+            raise typer.Exit(code=1)
+
+        vault = _paths.data_dir()
+        source = get_source(found.source, vault=vault)
+        healthy, reason = source.health_check()
+        if not healthy:
+            typer.echo(f"source {found.source} is not healthy: {reason}", err=True)
+            raise typer.Exit(code=1)
+
+        since = (_dt.datetime.now(tz=_dt.UTC) - _dt.timedelta(minutes=window_minutes)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        events = source.scan_since(since)
+        dedup = DedupStore(dedup_path(vault))
+        matched = [
+            {
+                "source_event_id": e.source_event_id,
+                "ts": e.ts,
+                "fields": e.normalized_match_fields,
+                "already_fired": not dedup.is_new(trigger_id, e.source_event_id),
+            }
+            for e in events
+            if matches(found.match, e)
+        ]
+        typer.echo(_json.dumps({"scanned": len(events), "matched": matched}, indent=2))
+
+    @trigger_app.command("fire-now")
+    def cli_trigger_fire_now(trigger_id: str) -> None:
+        """Manually fire a trigger with a synthetic event (development aid)."""
+        import datetime as _dt
+
+        from scout import paths as _paths
+        from scout.events import now_iso
+        from scout.ids import new_ulid
+        from scout.triggers.dedup import DedupStore
+        from scout.triggers.dispatcher import dispatch, log_fire
+        from scout.triggers.engine import dedup_path
+        from scout.triggers.sources.base import ConnectorEvent
+
+        _path, triggers = _load_vault_triggers()
+        found = next((t for t in (triggers or []) if t.id == trigger_id), None)
+        if found is None:
+            typer.echo(f"unknown trigger: {trigger_id}", err=True)
+            raise typer.Exit(code=1)
+
+        vault = _paths.data_dir()
+        event = ConnectorEvent(
+            source=found.source,
+            source_event_id=f"manual-{new_ulid()}",
+            ts=now_iso(),
+            raw_payload={"manual": True},
+            normalized_match_fields={"type": found.match_type, "manual": True},
+        )
+        outcome = dispatch(found, event, vault=vault)
+        now = _dt.datetime.now(tz=_dt.UTC)
+        DedupStore(dedup_path(vault)).record_fire(trigger_id, event.source_event_id, now)
+        log_fire(_paths.logs_dir(vault), outcome, extra={"source": found.source, "manual": True})
+        if outcome.status != "ok":
+            typer.echo(f"failed: {outcome.detail.get('error', outcome.detail)}", err=True)
+            raise typer.Exit(code=1)
+        typer.echo(f"fired: {trigger_id} ({found.action.kind.value})")
+
+    @trigger_app.command("stats")
+    def cli_trigger_stats(
+        days: int = typer.Option(7, "--days", help="How many days of fire logs to roll up."),
+        as_json: bool = typer.Option(False, "--json/--no-json", help="Emit JSON instead of text."),
+    ) -> None:
+        """Roll-up: fires by trigger and fires by day, from trigger-fires-*.jsonl."""
+        import datetime as _dt
+        import json as _json
+
+        from scout import paths as _paths
+        from scout.triggers.dispatcher import FIRE_LOG_PREFIX
+
+        log_dir = _paths.logs_dir(_paths.data_dir())
+        today = _dt.datetime.now(tz=_dt.UTC).date()
+        by_trigger: dict[str, dict[str, int]] = {}
+        by_day: dict[str, int] = {}
+        for offset in range(days):
+            day = (today - _dt.timedelta(days=offset)).isoformat()
+            log_path = log_dir / f"{FIRE_LOG_PREFIX}{day}.jsonl"
+            if not log_path.exists():
+                continue
+            for line in log_path.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = _json.loads(line)
+                except _json.JSONDecodeError:
+                    continue
+                tid = row.get("trigger_id", "?")
+                entry = by_trigger.setdefault(tid, {"total": 0, "ok": 0, "error": 0})
+                entry["total"] += 1
+                entry["ok" if row.get("status") == "ok" else "error"] += 1
+                by_day[day] = by_day.get(day, 0) + 1
+
+        if as_json:
+            typer.echo(_json.dumps({"days": days, "by_trigger": by_trigger, "by_day": by_day}))
+            return
+        if not by_trigger:
+            typer.echo(f"(no trigger fires in the last {days} day(s))")
+            return
+        for tid in sorted(by_trigger):
+            e = by_trigger[tid]
+            typer.echo(f"{tid}\ttotal={e['total']}\tok={e['ok']}\terror={e['error']}")
+        for day in sorted(by_day):
+            typer.echo(f"{day}\t{by_day[day]}")
+
+
+_register_triggers()
+
+
 def _register_notify() -> None:
     """scoutctl notify {telegram} — outbound notification commands.
 

--- a/engine/scout/manifest.py
+++ b/engine/scout/manifest.py
@@ -69,6 +69,10 @@ def build_manifest() -> EngineManifest:
             "kb_ontology_v1": True,  # Plan 2
             "tui_v1": True,  # Plan 2
             "schedule_v2": True,  # Plan 5
+            # Event triggers (docs/specs/event-triggers.md). Opt-in: flips
+            # True once the polling matcher + dedup/cooldown are verified
+            # across a week of live runs.
+            "triggers_v1": False,
         },
         subcommands=_list_subcommands(),
     )

--- a/engine/scout/scripts/schedule_tick.py
+++ b/engine/scout/scripts/schedule_tick.py
@@ -697,6 +697,29 @@ def run() -> Event:
         )
 
 
+def _evaluate_triggers(*, vault: Path, log_dir: Path) -> None:
+    """Run trigger evaluation before schedule evaluation. Never raises.
+
+    evaluate() isolates its own per-source/per-trigger failures; this guard
+    exists for the layers above it (import errors, config-path crashes) so
+    the trigger subsystem can never take down slot dispatch.
+    """
+    try:
+        from scout.triggers import engine as triggers_engine
+
+        triggers_engine.evaluate(
+            vault=vault,
+            emit_event=lambda **kw: _emit_event(log_dir, **kw),
+        )
+    except Exception as exc:
+        _emit_event(
+            log_dir,
+            kind="triggers.evaluate.failed",
+            source="cli:schedule_tick",
+            payload={"error": f"{type(exc).__name__}: {exc}"},
+        )
+
+
 def _do_tick(
     *,
     vault: Path,
@@ -705,6 +728,9 @@ def _do_tick(
     tracker_path: Path,
     started_at: float,
 ) -> Event:
+    # Event triggers evaluate first (spec: docs/specs/event-triggers.md §Event flow).
+    _evaluate_triggers(vault=vault, log_dir=log_dir)
+
     schedule = _load_or_default(vault)
     last_fire = _get_last_fire_index(state_dir, tracker_path)
     now = _now()

--- a/engine/scout/triggers/__init__.py
+++ b/engine/scout/triggers/__init__.py
@@ -1,0 +1,10 @@
+"""Event-trigger engine (v1 polling) — fires on events, not time.
+
+Spec: docs/specs/event-triggers.md. The schedule dispatcher fires on time;
+this package adds the second fire-condition source: external events (Slack
+mentions, GitHub notifications) and internal engine events, declared in the
+vault's ``.scout-state/triggers.yaml`` and evaluated at the top of every
+5-minute ``schedule_tick``.
+"""
+
+from __future__ import annotations

--- a/engine/scout/triggers/actions/__init__.py
+++ b/engine/scout/triggers/actions/__init__.py
@@ -1,0 +1,3 @@
+"""Trigger action handlers: notify / run_skill / interactive."""
+
+from __future__ import annotations

--- a/engine/scout/triggers/actions/_summary.py
+++ b/engine/scout/triggers/actions/_summary.py
@@ -1,0 +1,21 @@
+"""One-line event summaries shared by the action handlers."""
+
+from __future__ import annotations
+
+from scout.triggers.config import Trigger
+from scout.triggers.sources.base import ConnectorEvent
+
+_SUMMARY_FIELD_ORDER = ("text", "title", "slot_key", "reason")
+MAX_SUMMARY_CHARS = 280
+
+
+def summarize(trigger: Trigger, event: ConnectorEvent) -> str:
+    """``[trigger:<id>] <source>/<type>: <best content field>`` — surface-safe."""
+    fields = event.normalized_match_fields
+    content = next(
+        (str(fields[k]) for k in _SUMMARY_FIELD_ORDER if fields.get(k)),
+        event.source_event_id,
+    )
+    if len(content) > MAX_SUMMARY_CHARS:
+        content = content[: MAX_SUMMARY_CHARS - 1] + "…"
+    return f"[trigger:{trigger.id}] {event.source}/{event.match_type}: {content}"

--- a/engine/scout/triggers/actions/interactive.py
+++ b/engine/scout/triggers/actions/interactive.py
@@ -1,0 +1,63 @@
+"""``interactive`` action: write a needs-attention artifact + loud push.
+
+Scout shouldn't decide autonomously here — the fire produces a structured
+block in ``<vault>/needs-attention.md`` that ``/scout-work`` walks through,
+plus a best-effort ``action_required`` push so the user knows something is
+waiting. Zero LLM spend until the user acts.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from scout.triggers.actions._summary import summarize
+from scout.triggers.actions.notify import _default_send_telegram
+from scout.triggers.config import Trigger
+from scout.triggers.sources.base import ConnectorEvent
+
+ARTIFACT_FILENAME = "needs-attention.md"
+_HEADER = "# Needs attention\n\nTrigger fires waiting on you. Work through them with `/scout-work`.\n"
+
+
+def run(
+    trigger: Trigger,
+    event: ConnectorEvent,
+    *,
+    vault: Path,
+    send_telegram: Callable[..., Any] | None = None,
+) -> dict[str, Any]:
+    send_telegram = send_telegram or _default_send_telegram
+    artifact = vault / ARTIFACT_FILENAME
+    summary = summarize(trigger, event)
+
+    block_lines = [
+        f"## {event.ts} — trigger `{trigger.id}`",
+        "",
+        f"- source: {event.source} / {event.match_type}",
+        f"- event id: `{event.source_event_id}`",
+        f"- summary: {summary}",
+    ]
+    link = event.normalized_match_fields.get("permalink") or event.normalized_match_fields.get("url")
+    if link:
+        block_lines.append(f"- link: {link}")
+    preload = trigger.action.params.get("preload")
+    if preload:
+        block_lines.append(f"- preload: `{preload}`")
+    block_lines += ["- next: open an interactive session and run `/scout-work`", ""]
+
+    if not artifact.exists():
+        artifact.write_text(_HEADER + "\n", encoding="utf-8")
+    with artifact.open("a", encoding="utf-8") as f:
+        f.write("\n".join(block_lines) + "\n")
+
+    # The push is best-effort — the artifact is the durable surface.
+    notified: list[str] = []
+    try:
+        send_telegram(tier="action_required", body=f"{summary}\n→ waiting in {ARTIFACT_FILENAME}")
+        notified.append("telegram")
+    except Exception:  # noqa: BLE001 — missing secrets must not lose the artifact
+        pass
+
+    return {"artifact": str(artifact), "notified": notified}

--- a/engine/scout/triggers/actions/notify.py
+++ b/engine/scout/triggers/actions/notify.py
@@ -1,0 +1,55 @@
+"""``notify`` action: push the matched event to surfaces. No LLM spend.
+
+v1 supports one surface: ``telegram`` (the engine's existing outbound,
+``scout.scripts.notify_telegram``). Unknown surfaces are recorded as
+unsupported rather than failing the fire — but if NO surface delivers,
+the action fails so the fire log shows the notification was lost.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from scout.triggers.actions._summary import summarize
+from scout.triggers.config import Trigger
+from scout.triggers.sources.base import ConnectorEvent
+
+DEFAULT_SURFACES = ["telegram"]
+
+
+def _default_send_telegram(*, tier: str, body: str) -> None:
+    from scout.scripts.notify_telegram import send
+
+    send(tier=tier, body=body)
+
+
+def run(
+    trigger: Trigger,
+    event: ConnectorEvent,
+    *,
+    vault: Path,
+    send_telegram: Callable[..., Any] | None = None,
+) -> dict[str, Any]:
+    send_telegram = send_telegram or _default_send_telegram
+    surfaces = trigger.action.params.get("via") or DEFAULT_SURFACES
+    body = summarize(trigger, event)
+
+    results: dict[str, str] = {}
+    delivered = 0
+    for surface in surfaces:
+        if surface == "telegram":
+            try:
+                send_telegram(tier="info", body=body)
+            except Exception as e:  # noqa: BLE001 — per-surface isolation
+                results[surface] = f"error: {type(e).__name__}: {e}"
+            else:
+                results[surface] = "sent"
+                delivered += 1
+        else:
+            results[surface] = "unsupported surface (v1 supports: telegram)"
+
+    if delivered == 0:
+        raise RuntimeError(f"notify delivered to no surface: {results}")
+    return {"surfaces": results}

--- a/engine/scout/triggers/actions/run_skill.py
+++ b/engine/scout/triggers/actions/run_skill.py
@@ -1,0 +1,83 @@
+"""``run_skill`` action: spawn a Scout runner with the event payload attached.
+
+The event payload is written to ``.scout-cache/trigger-events/<...>.json``
+and its path exported as ``$SCOUT_TRIGGER_EVENT_PATH`` (spec Open Question
+#3) so the skill can read what fired it. The runner (default
+``run-scout.sh``, same contract as scheduled slots) is spawned detached
+with ``SCOUT_FORCE_MODE=<skill>``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from scout.triggers.config import Trigger
+from scout.triggers.sources.base import ConnectorEvent
+
+DEFAULT_RUNNER = "run-scout.sh"
+EVENT_PAYLOAD_DIR = ".scout-cache/trigger-events"
+
+
+def _default_spawn(cmd: list[str], env: dict[str, str]) -> int:
+    proc = subprocess.Popen(
+        cmd,
+        cwd=env.get("SCOUT_DATA_DIR"),
+        env=env,
+        start_new_session=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return proc.pid
+
+
+def _safe_filename(raw: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]", "_", raw)
+
+
+def write_event_payload(trigger: Trigger, event: ConnectorEvent, *, vault: Path) -> Path:
+    payload_dir = vault / EVENT_PAYLOAD_DIR
+    payload_dir.mkdir(parents=True, exist_ok=True)
+    name = _safe_filename(f"{trigger.id}-{event.source_event_id}") + ".json"
+    payload_path = payload_dir / name
+    payload = {
+        "trigger_id": trigger.id,
+        "source": event.source,
+        "event": {
+            "source_event_id": event.source_event_id,
+            "ts": event.ts,
+            "normalized_match_fields": event.normalized_match_fields,
+            "raw_payload": event.raw_payload,
+        },
+    }
+    payload_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return payload_path
+
+
+def run(
+    trigger: Trigger,
+    event: ConnectorEvent,
+    *,
+    vault: Path,
+    spawn: Callable[[list[str], dict[str, str]], int] | None = None,
+) -> dict[str, Any]:
+    spawn = spawn or _default_spawn
+    skill = str(trigger.action.params["skill"])
+    runner = str(trigger.action.params.get("runner", DEFAULT_RUNNER))
+
+    payload_path = write_event_payload(trigger, event, vault=vault)
+
+    env = os.environ.copy()
+    env["SCOUT_FORCE_MODE"] = skill
+    env["SCOUT_DATA_DIR"] = str(vault)
+    env["SCOUT_TRIGGER_ID"] = trigger.id
+    env["SCOUT_TRIGGER_EVENT_PATH"] = str(payload_path)
+
+    pid = spawn([str(vault / runner)], env)
+    return {"skill": skill, "runner": runner, "pid": pid, "event_payload_path": str(payload_path)}

--- a/engine/scout/triggers/config.py
+++ b/engine/scout/triggers/config.py
@@ -1,0 +1,203 @@
+"""triggers.yaml loader + validator.
+
+The vault-canonical trigger definition lives at
+``~/Scout/.scout-state/triggers.yaml`` (alongside ``schedule.yaml``). No
+plugin-shipped defaults: an absent file means no triggers, by design —
+triggers are opt-in.
+
+Validation rules (spec §Trigger-config validation rules): every trigger
+needs ``id``/``source``/``match``/``action``; ``daily_fire_cap`` is
+mandatory (no default-unlimited — runaway cost is the #1 risk);
+``match.type`` must be in the source's ``SUPPORTED_MATCH_TYPES``;
+``run_skill`` actions must name an installed skill; obvious
+scout_internal fire-cycles are rejected unless ``allow_cycle: true``.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scout.errors import ConfigError
+from scout.triggers.sources import SOURCE_NAMES, supported_match_types
+
+TRIGGERS_FILENAME = "triggers.yaml"
+
+
+class ActionKind(enum.Enum):
+    NOTIFY = "notify"
+    RUN_SKILL = "run_skill"
+    INTERACTIVE = "interactive"
+
+
+@dataclass(frozen=True)
+class Action:
+    """One trigger's action: the kind plus its kind-specific params."""
+
+    kind: ActionKind
+    params: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Trigger:
+    """One validated trigger. Frozen — load_triggers rebuilds; never mutated."""
+
+    id: str
+    source: str
+    match: dict[str, Any]
+    action: Action
+    daily_fire_cap: int
+    cooldown_seconds: int = 0
+    enabled: bool = True
+    allow_cycle: bool = False
+
+    @property
+    def match_type(self) -> str:
+        return str(self.match["type"])
+
+
+def triggers_path(vault: Path) -> Path:
+    """Vault-canonical triggers.yaml location (sibling of schedule.yaml)."""
+    return vault / ".scout-state" / TRIGGERS_FILENAME
+
+
+def default_installed_skills(plugin_root: Path | None = None) -> set[str]:
+    """Names of skills shipped by this plugin checkout (``<root>/skills/*/``)."""
+    if plugin_root is None:
+        plugin_root = Path(__file__).parent.parent.parent.parent
+    skills_dir = plugin_root / "skills"
+    if not skills_dir.is_dir():
+        return set()
+    return {p.name for p in skills_dir.iterdir() if p.is_dir()}
+
+
+def load_triggers(
+    path: Path,
+    *,
+    installed_skills: set[str] | None = None,
+) -> list[Trigger]:
+    """Load + validate a triggers.yaml. Raises ConfigError on any violation."""
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except FileNotFoundError as e:
+        raise ConfigError(f"triggers yaml at {path} not found") from e
+    except yaml.YAMLError as e:
+        raise ConfigError(f"triggers yaml at {path} is malformed: {e}") from e
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        raise ConfigError(f"triggers yaml at {path} is not a mapping")
+
+    version = data.get("schema_version", 1)
+    if version != 1:
+        raise ConfigError(f"triggers yaml at {path} has schema_version {version}; engine supports 1")
+
+    raw_triggers = data.get("triggers", [])
+    if not isinstance(raw_triggers, list):
+        raise ConfigError(f"triggers yaml at {path}: 'triggers' must be a list")
+
+    if installed_skills is None:
+        installed_skills = default_installed_skills()
+
+    triggers: list[Trigger] = []
+    seen_ids: set[str] = set()
+    for i, raw in enumerate(raw_triggers):
+        trigger = _build_trigger(i, raw, installed_skills=installed_skills)
+        if trigger.id in seen_ids:
+            raise ConfigError(f"trigger {trigger.id!r}: duplicate id")
+        seen_ids.add(trigger.id)
+        triggers.append(trigger)
+    return triggers
+
+
+def _build_trigger(index: int, raw: Any, *, installed_skills: set[str]) -> Trigger:
+    label = f"trigger[{index}]"
+    if not isinstance(raw, dict):
+        raise ConfigError(f"{label}: expected a mapping, got {type(raw).__name__}")
+
+    trigger_id = raw.get("id")
+    if not isinstance(trigger_id, str) or not trigger_id.strip():
+        raise ConfigError(f"{label}: missing required field 'id'")
+    label = f"trigger {trigger_id!r}"
+
+    for required in ("source", "match", "action"):
+        if required not in raw:
+            raise ConfigError(f"{label}: missing required field '{required}'")
+
+    source = raw["source"]
+    if source not in SOURCE_NAMES:
+        raise ConfigError(f"{label}: unknown source {source!r}; supported: {', '.join(SOURCE_NAMES)}")
+
+    match = raw["match"]
+    if not isinstance(match, dict) or "type" not in match:
+        raise ConfigError(f"{label}: match.type is required")
+    match_type = match["type"]
+    allowed = supported_match_types(source)
+    if match_type not in allowed:
+        raise ConfigError(
+            f"{label}: match.type {match_type!r} is not supported by source {source!r}; supported: {', '.join(allowed)}"
+        )
+
+    action_raw = raw["action"]
+    if not isinstance(action_raw, dict) or "kind" not in action_raw:
+        raise ConfigError(f"{label}: action.kind is required")
+    try:
+        kind = ActionKind(action_raw["kind"])
+    except ValueError as e:
+        raise ConfigError(
+            f"{label}: action.kind {action_raw['kind']!r} is not one of {[k.value for k in ActionKind]}"
+        ) from e
+    params = {k: v for k, v in action_raw.items() if k != "kind"}
+
+    if kind is ActionKind.RUN_SKILL:
+        skill = params.get("skill")
+        if not isinstance(skill, str) or not skill.strip():
+            raise ConfigError(f"{label}: action.kind=run_skill requires action.skill")
+        if skill not in installed_skills:
+            raise ConfigError(
+                f"{label}: action.skill {skill!r} is not an installed skill; "
+                f"installed: {', '.join(sorted(installed_skills)) or '(none)'}"
+            )
+
+    if "daily_fire_cap" not in raw:
+        raise ConfigError(f"{label}: daily_fire_cap is required (no default-unlimited)")
+    try:
+        cap = int(raw["daily_fire_cap"])
+    except (TypeError, ValueError) as e:
+        raise ConfigError(f"{label}: daily_fire_cap must be an integer") from e
+    if cap < 1:
+        raise ConfigError(f"{label}: daily_fire_cap must be >= 1, got {cap}")
+
+    try:
+        cooldown = int(raw.get("cooldown_seconds", 0))
+    except (TypeError, ValueError) as e:
+        raise ConfigError(f"{label}: cooldown_seconds must be an integer") from e
+    if cooldown < 0:
+        raise ConfigError(f"{label}: cooldown_seconds must be >= 0, got {cooldown}")
+
+    allow_cycle = bool(raw.get("allow_cycle", False))
+
+    # Cycle guard: a scout_internal trigger that fires a skill on trigger.fired
+    # re-enters the trigger pipeline — an obvious fire loop. Opt out explicitly.
+    is_refire_cycle = source == "scout_internal" and match_type == "trigger.fired" and kind is ActionKind.RUN_SKILL
+    if is_refire_cycle and not allow_cycle:
+        raise ConfigError(
+            f"{label}: match.type 'trigger.fired' with action.kind 'run_skill' creates a fire cycle; "
+            f"set allow_cycle: true if this is intentional"
+        )
+
+    return Trigger(
+        id=trigger_id,
+        source=source,
+        match=dict(match),
+        action=Action(kind=kind, params=params),
+        daily_fire_cap=cap,
+        cooldown_seconds=cooldown,
+        enabled=bool(raw.get("enabled", True)),
+        allow_cycle=allow_cycle,
+    )

--- a/engine/scout/triggers/dedup.py
+++ b/engine/scout/triggers/dedup.py
@@ -1,0 +1,142 @@
+"""Per-trigger dedup + cooldown + daily-cap state.
+
+Backing file: ``.scout-cache/trigger-fires.json``, keyed by trigger id::
+
+    {
+      "slack_mention_alex": {
+        "last_fire_ts": "2026-05-19T14:32:11Z",
+        "last_seen_event_id": "1747663931.001234",
+        "recent_event_ids": ["...", ...],
+        "fires_today": 7,
+        "fires_today_date": "2026-05-19",
+        "cap_notified_date": "2026-05-19"
+      }
+    }
+
+``fires_today_date`` is the ET date (America/New_York) — daily caps reset at
+00:00 ET, NOT 00:00 UTC, matching the rest of Scout's day-boundary semantics.
+
+``is_new`` consults both ``last_seen_event_id`` and a sliding window of the
+100 most recent fired event ids, so non-monotonic event ids can't re-fire.
+Contract is at-least-once with dedup: a corrupt/deleted cache file starts
+fresh rather than raising (the tick must never die on dedup state).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import datetime as dt
+import json
+import os
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+DEFAULT_RECENT_WINDOW = 100
+DAY_BOUNDARY_ZONE = ZoneInfo("America/New_York")
+
+
+def _parse_iso_z(ts: str) -> dt.datetime:
+    if ts.endswith("Z"):
+        ts = ts[:-1] + "+00:00"
+    return dt.datetime.fromisoformat(ts)
+
+
+def _utc_z(now: dt.datetime) -> str:
+    return now.astimezone(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class DedupStore:
+    """Read/write view over trigger-fires.json. One instance per tick."""
+
+    def __init__(self, path: Path, *, recent_window: int = DEFAULT_RECENT_WINDOW) -> None:
+        self._path = path
+        self._recent_window = recent_window
+        self._state: dict[str, dict[str, Any]] = {}
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                loaded = json.load(f)
+            if isinstance(loaded, dict):
+                self._state = {k: v for k, v in loaded.items() if isinstance(v, dict)}
+        except (OSError, json.JSONDecodeError):
+            # Missing or corrupt cache → start fresh (at-least-once contract).
+            self._state = {}
+
+    # ----- queries ---------------------------------------------------------
+
+    def is_new(self, trigger_id: str, event_id: str) -> bool:
+        entry = self._state.get(trigger_id)
+        if entry is None:
+            return True
+        if event_id == entry.get("last_seen_event_id"):
+            return False
+        return event_id not in entry.get("recent_event_ids", [])
+
+    def in_cooldown(self, trigger_id: str, cooldown_seconds: int, now: dt.datetime) -> bool:
+        if cooldown_seconds <= 0:
+            return False
+        entry = self._state.get(trigger_id)
+        if entry is None or not entry.get("last_fire_ts"):
+            return False
+        try:
+            last_fire = _parse_iso_z(entry["last_fire_ts"])
+        except ValueError:
+            return False
+        return (now - last_fire) < dt.timedelta(seconds=cooldown_seconds)
+
+    def fires_today(self, trigger_id: str, now: dt.datetime) -> int:
+        entry = self._state.get(trigger_id)
+        if entry is None:
+            return 0
+        if entry.get("fires_today_date") != self._day(now):
+            return 0
+        return int(entry.get("fires_today", 0))
+
+    def cap_notified_today(self, trigger_id: str, now: dt.datetime) -> bool:
+        entry = self._state.get(trigger_id)
+        return entry is not None and entry.get("cap_notified_date") == self._day(now)
+
+    def state(self, trigger_id: str) -> dict[str, Any]:
+        """A copy of one trigger's raw entry (for `scoutctl trigger show`)."""
+        return dict(self._state.get(trigger_id, {}))
+
+    # ----- mutations -------------------------------------------------------
+
+    def record_fire(self, trigger_id: str, event_id: str, now: dt.datetime) -> None:
+        entry = self._state.setdefault(trigger_id, {})
+        today = self._day(now)
+        fires = int(entry.get("fires_today", 0)) if entry.get("fires_today_date") == today else 0
+        recent = [e for e in entry.get("recent_event_ids", []) if e != event_id]
+        recent.append(event_id)
+        entry.update(
+            {
+                "last_fire_ts": _utc_z(now),
+                "last_seen_event_id": event_id,
+                "recent_event_ids": recent[-self._recent_window :],
+                "fires_today": fires + 1,
+                "fires_today_date": today,
+            }
+        )
+        self._save()
+
+    def mark_cap_notified(self, trigger_id: str, now: dt.datetime) -> None:
+        entry = self._state.setdefault(trigger_id, {})
+        entry["cap_notified_date"] = self._day(now)
+        self._save()
+
+    # ----- internals -------------------------------------------------------
+
+    def _day(self, now: dt.datetime) -> str:
+        return now.astimezone(DAY_BOUNDARY_ZONE).date().isoformat()
+
+    def _save(self) -> None:
+        """Atomic write (tmp + rename). Best-effort — never raises."""
+        tmp = self._path.with_suffix(".json.tmp")
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            with tmp.open("w", encoding="utf-8") as f:
+                json.dump(self._state, f, indent=1)
+            os.replace(tmp, self._path)
+        except OSError:
+            with contextlib.suppress(OSError):
+                tmp.unlink()

--- a/engine/scout/triggers/dispatcher.py
+++ b/engine/scout/triggers/dispatcher.py
@@ -1,0 +1,79 @@
+"""Route matched events to their action handlers; record fire outcomes.
+
+One matched (trigger, event) pair → one :class:`FireOutcome`, whatever
+happens: action handlers may raise, and the dispatcher converts that to a
+``status="error"`` outcome so a single bad fire can never break the tick.
+
+Fire audit rows go to ``.scout-logs/trigger-fires-YYYY-MM-DD.jsonl``
+(UTC-dated, same convention as the schedule event logs).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from scout.events import now_iso
+from scout.triggers.actions import interactive, notify, run_skill
+from scout.triggers.config import ActionKind, Trigger
+from scout.triggers.sources.base import ConnectorEvent
+
+FIRE_LOG_PREFIX = "trigger-fires-"
+
+
+@dataclass(frozen=True)
+class FireOutcome:
+    """What happened when one trigger fired on one event."""
+
+    trigger_id: str
+    event_id: str
+    action_kind: str
+    status: str  # "ok" | "error"
+    detail: dict[str, Any] = field(default_factory=dict)
+    ts: str = ""
+
+
+def dispatch(
+    trigger: Trigger,
+    event: ConnectorEvent,
+    *,
+    vault: Path,
+    send_telegram: Callable[..., Any] | None = None,
+    spawn: Callable[[list[str], dict[str, str]], int] | None = None,
+) -> FireOutcome:
+    """Run the trigger's action against the event. Never raises."""
+    kind = trigger.action.kind
+    try:
+        if kind is ActionKind.NOTIFY:
+            detail = notify.run(trigger, event, vault=vault, send_telegram=send_telegram)
+        elif kind is ActionKind.RUN_SKILL:
+            detail = run_skill.run(trigger, event, vault=vault, spawn=spawn)
+        else:
+            detail = interactive.run(trigger, event, vault=vault, send_telegram=send_telegram)
+        status = "ok"
+    except Exception as e:  # noqa: BLE001 — one bad fire must not kill the tick
+        detail = {"error": f"{type(e).__name__}: {e}"}
+        status = "error"
+    return FireOutcome(
+        trigger_id=trigger.id,
+        event_id=event.source_event_id,
+        action_kind=kind.value,
+        status=status,
+        detail=detail,
+        ts=now_iso(),
+    )
+
+
+def log_fire(log_dir: Path, outcome: FireOutcome, *, extra: dict[str, Any] | None = None) -> None:
+    """Append one audit row to trigger-fires-<UTC-date>.jsonl."""
+    log_dir.mkdir(parents=True, exist_ok=True)
+    utc_date = outcome.ts[:10]
+    log_path = log_dir / f"{FIRE_LOG_PREFIX}{utc_date}.jsonl"
+    row = asdict(outcome)
+    if extra:
+        row.update(extra)
+    with log_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(row) + "\n")

--- a/engine/scout/triggers/engine.py
+++ b/engine/scout/triggers/engine.py
@@ -1,0 +1,183 @@
+"""Per-tick trigger evaluation — the v1 polling loop.
+
+Called from ``schedule_tick`` every 5 minutes, before schedule evaluation::
+
+    for each source with enabled triggers:        # one connector call each
+        events = source.scan_since(now - lookback)
+        for each (trigger, event):                # in-memory matching
+            dedup.is_new? matcher.matches? cooldown? daily cap?
+            → dispatcher.dispatch(...)
+
+Tick cost is O(sources) connector calls + O(triggers × events) in-memory
+match operations (spec §Event flow). Contract is at-least-once with dedup:
+the scan window is a fixed lookback (default 60 min), and every event id
+that fired is remembered in the dedup store, so re-scanned events can't
+re-fire while a genuinely missed tick still gets a second chance.
+
+Failure isolation: a bad triggers.yaml, a dark connector, or a crashing
+action is recorded in the result (and the fire log / event stream) — it
+never raises into the tick.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from scout import paths
+from scout.errors import ConfigError
+from scout.triggers.config import Trigger, load_triggers, triggers_path
+from scout.triggers.dedup import DedupStore
+from scout.triggers.dispatcher import FireOutcome, dispatch, log_fire
+from scout.triggers.matcher import matches
+from scout.triggers.sources import TriggerSource, get_source
+
+DEFAULT_LOOKBACK_MINUTES = 60
+DEDUP_FILENAME = "trigger-fires.json"
+
+
+@dataclass
+class EvalResult:
+    """Summary of one trigger-evaluation pass."""
+
+    fired: list[FireOutcome] = field(default_factory=list)
+    throttled: list[dict[str, Any]] = field(default_factory=list)
+    skipped_sources: list[dict[str, str]] = field(default_factory=list)
+    errors: list[dict[str, str]] = field(default_factory=list)
+    triggers_evaluated: int = 0
+    events_scanned: int = 0
+
+
+def dedup_path(vault: Path) -> Path:
+    return paths.cache_dir(vault) / DEDUP_FILENAME
+
+
+def evaluate(
+    *,
+    vault: Path,
+    now: dt.datetime | None = None,
+    sources: dict[str, TriggerSource] | None = None,
+    send_telegram: Callable[..., Any] | None = None,
+    spawn: Callable[[list[str], dict[str, str]], int] | None = None,
+    emit_event: Callable[..., Any] | None = None,
+    lookback_minutes: int = DEFAULT_LOOKBACK_MINUTES,
+    installed_skills: set[str] | None = None,
+) -> EvalResult:
+    """Evaluate all enabled triggers once. Never raises.
+
+    ``sources`` / ``send_telegram`` / ``spawn`` / ``emit_event`` are seams for
+    tests and for the tick (which passes its own event emitter). ``emit_event``
+    is called with ``kind=`` / ``source=`` / ``payload=`` keywords.
+    """
+    result = EvalResult()
+    now = now or dt.datetime.now(tz=dt.UTC)
+    emit = emit_event or (lambda **kw: None)
+
+    config_path = triggers_path(vault)
+    if not config_path.exists():
+        return result
+
+    try:
+        triggers = load_triggers(config_path, installed_skills=installed_skills)
+    except ConfigError as e:
+        result.errors.append({"config": str(e)})
+        return result
+
+    enabled = [t for t in triggers if t.enabled]
+    result.triggers_evaluated = len(enabled)
+    if not enabled:
+        return result
+
+    by_source: dict[str, list[Trigger]] = {}
+    for trigger in enabled:
+        by_source.setdefault(trigger.source, []).append(trigger)
+
+    dedup = DedupStore(dedup_path(vault))
+    log_dir = paths.logs_dir(vault)
+    since_iso = (now - dt.timedelta(minutes=lookback_minutes)).astimezone(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    for source_name, source_triggers in by_source.items():
+        try:
+            source = sources[source_name] if sources is not None else get_source(source_name, vault=vault)
+        except (KeyError, ConfigError) as e:
+            result.errors.append({"source": source_name, "error": f"unavailable: {e}"})
+            continue
+
+        healthy, reason = source.health_check()
+        if not healthy:
+            result.skipped_sources.append({"source": source_name, "reason": reason})
+            continue
+
+        try:
+            events = source.scan_since(since_iso)
+        except Exception as e:  # noqa: BLE001 — one dark connector must not blind the rest
+            result.errors.append({"source": source_name, "error": f"{type(e).__name__}: {e}"})
+            continue
+        result.events_scanned += len(events)
+
+        for trigger in source_triggers:
+            for event in events:
+                if not dedup.is_new(trigger.id, event.source_event_id):
+                    continue
+                if not matches(trigger.match, event):
+                    continue
+                if dedup.in_cooldown(trigger.id, trigger.cooldown_seconds, now):
+                    continue
+                if dedup.fires_today(trigger.id, now) >= trigger.daily_fire_cap:
+                    _throttle(trigger, dedup, result, now, emit, send_telegram)
+                    break  # paused until midnight ET; skip remaining events
+
+                outcome = dispatch(trigger, event, vault=vault, send_telegram=send_telegram, spawn=spawn)
+                dedup.record_fire(trigger.id, event.source_event_id, now)
+                log_fire(log_dir, outcome, extra={"source": source_name, "match_type": event.match_type})
+                emit(
+                    kind="trigger.fired",
+                    source=f"trigger:{trigger.id}",
+                    payload={
+                        "trigger_id": trigger.id,
+                        "source": source_name,
+                        "event_id": event.source_event_id,
+                        "match_type": event.match_type,
+                        "action": trigger.action.kind.value,
+                        "status": outcome.status,
+                    },
+                )
+                result.fired.append(outcome)
+
+    return result
+
+
+def _throttle(
+    trigger: Trigger,
+    dedup: DedupStore,
+    result: EvalResult,
+    now: dt.datetime,
+    emit: Callable[..., Any],
+    send_telegram: Callable[..., Any] | None,
+) -> None:
+    """Record a daily-cap hit; self-throttling notice fires once per ET day."""
+    result.throttled.append({"trigger_id": trigger.id, "reason": f"daily_fire_cap {trigger.daily_fire_cap} reached"})
+    if dedup.cap_notified_today(trigger.id, now):
+        return
+    dedup.mark_cap_notified(trigger.id, now)
+    emit(
+        kind="trigger.throttled",
+        source=f"trigger:{trigger.id}",
+        payload={"trigger_id": trigger.id, "daily_fire_cap": trigger.daily_fire_cap},
+    )
+    body = (
+        f"trigger `{trigger.id}` hit its daily cap "
+        f"({trigger.daily_fire_cap}/{trigger.daily_fire_cap} today); pausing until midnight ET."
+    )
+    try:
+        if send_telegram is not None:
+            send_telegram(tier="info", body=body)
+        else:
+            from scout.triggers.actions.notify import _default_send_telegram
+
+            _default_send_telegram(tier="info", body=body)
+    except Exception:  # noqa: BLE001 — the notice is best-effort
+        pass

--- a/engine/scout/triggers/matcher.py
+++ b/engine/scout/triggers/matcher.py
@@ -1,0 +1,59 @@
+"""Match trigger filter rules against normalized connector events.
+
+The match language is deliberately small (enumerated types + typed attribute
+filters — no regex, per the spec's prior-art survey):
+
+- ``type`` must equal the event's normalized type. Mandatory.
+- Any other key is an attribute filter against ``normalized_match_fields``:
+  scalar → equality; list → membership; the literal ``"any"`` (or a list
+  containing it) → wildcard.
+- ``exclude_<field>: <value|list>`` inverts: matching values REJECT the event.
+- ``exclude_self: true`` rejects events the source flagged ``is_self`` (the
+  Scout user's own activity).
+
+A filter naming a field the event doesn't carry does not match (strict).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from scout.triggers.sources.base import ConnectorEvent
+
+_EXCLUDE_PREFIX = "exclude_"
+
+
+def _is_wildcard(expected: Any) -> bool:
+    return expected == "any" or (isinstance(expected, list) and "any" in expected)
+
+
+def matches(match: dict[str, Any], event: ConnectorEvent) -> bool:
+    """Return True iff ``event`` satisfies every rule in ``match``."""
+    fields = event.normalized_match_fields
+    if match.get("type") != fields.get("type"):
+        return False
+
+    for key, expected in match.items():
+        if key == "type":
+            continue
+        if key == "exclude_self":
+            if expected and fields.get("is_self"):
+                return False
+            continue
+        if key.startswith(_EXCLUDE_PREFIX):
+            field_name = key[len(_EXCLUDE_PREFIX) :]
+            rejected = expected if isinstance(expected, list) else [expected]
+            if fields.get(field_name) in rejected:
+                return False
+            continue
+        if _is_wildcard(expected):
+            continue
+        if key not in fields:
+            return False
+        actual = fields[key]
+        if isinstance(expected, list):
+            if actual not in expected:
+                return False
+        elif actual != expected:
+            return False
+    return True

--- a/engine/scout/triggers/sources/__init__.py
+++ b/engine/scout/triggers/sources/__init__.py
@@ -1,0 +1,48 @@
+"""Trigger source registry.
+
+v1 ships three pollers: ``slack``, ``github``, ``scout_internal``.
+``linear``, ``gmail``, ``gcal``, and ``file`` are spec'd but deferred —
+adding one means writing the module and appending its name here.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+from scout.errors import ConfigError
+from scout.triggers.sources.base import ConnectorEvent, TriggerSource
+
+__all__ = ["ConnectorEvent", "TriggerSource", "SOURCE_NAMES", "get_source", "supported_match_types"]
+
+# Module name == source name under scout.triggers.sources.
+SOURCE_NAMES: tuple[str, ...] = ("slack", "github", "scout_internal")
+
+
+def get_source(name: str, *, vault) -> TriggerSource:
+    """Construct one trigger source wired to the given vault path."""
+    if name == "slack":
+        from scout.triggers.sources.slack import SlackSource
+
+        return SlackSource.for_vault(vault)
+    if name == "github":
+        from scout.triggers.sources.github import GitHubSource
+
+        return GitHubSource()
+    if name == "scout_internal":
+        from scout import paths
+        from scout.triggers.sources.scout_internal import ScoutInternalSource
+
+        return ScoutInternalSource(paths.logs_dir(vault))
+    raise ConfigError(f"unknown trigger source: {name!r}; supported: {', '.join(SOURCE_NAMES)}")
+
+
+def supported_match_types(source: str) -> list[str]:
+    """Return the source module's ``SUPPORTED_MATCH_TYPES`` constant.
+
+    Lazy import so config validation doesn't pay for every source's
+    dependencies. Raises ``ConfigError`` for unknown sources.
+    """
+    if source not in SOURCE_NAMES:
+        raise ConfigError(f"unknown trigger source: {source!r}; supported: {', '.join(SOURCE_NAMES)}")
+    module = importlib.import_module(f"scout.triggers.sources.{source}")
+    return list(module.SUPPORTED_MATCH_TYPES)

--- a/engine/scout/triggers/sources/base.py
+++ b/engine/scout/triggers/sources/base.py
@@ -1,0 +1,54 @@
+"""Connector contract for trigger sources (spec §Connector contract).
+
+Every ``sources/*.py`` implements :class:`TriggerSource`: a ``scan_since(ts)``
+poller returning normalized :class:`ConnectorEvent` rows, plus a per-tick
+``health_check``. The webhook half of the protocol is v2-only; v1 pollers
+return ``False`` / ``None``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class ConnectorEvent:
+    """One normalized event from a trigger source.
+
+    ``normalized_match_fields`` is what the matcher reads — each source
+    flattens its native event shape into a stable set of keys, always
+    including ``type`` (the source-scoped match type, e.g. ``mention``).
+    ``source_event_id`` is connector-specific (Slack message TS, GitHub
+    notification thread id, engine event ULID) and feeds dedup.
+    """
+
+    source: str
+    source_event_id: str
+    ts: str  # ISO 8601 UTC
+    raw_payload: dict[str, Any] = field(default_factory=dict)
+    normalized_match_fields: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def match_type(self) -> str:
+        return str(self.normalized_match_fields.get("type", ""))
+
+
+@runtime_checkable
+class TriggerSource(Protocol):
+    """What every trigger source must implement."""
+
+    name: str
+    SUPPORTED_MATCH_TYPES: list[str]
+
+    def scan_since(self, ts: str) -> list[ConnectorEvent]:
+        """Return all events from this source since ``ts``. Idempotent."""
+        ...
+
+    def health_check(self) -> tuple[bool, str]:
+        """Return (is_healthy, reason). Called per tick."""
+        ...
+
+    def supports_webhook(self) -> bool:
+        """v2 only — does this source emit signed webhooks?"""
+        ...

--- a/engine/scout/triggers/sources/github.py
+++ b/engine/scout/triggers/sources/github.py
@@ -1,0 +1,109 @@
+"""GitHub trigger source — polls ``gh api notifications``.
+
+One ``gh`` call per tick returns every unread notification thread since the
+scan timestamp; the notification ``reason`` maps 1:1 onto the match types
+below. Requires an authenticated ``gh`` CLI (same prerequisite as the
+``github`` connector probe).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Callable
+
+from scout.errors import ConfigError
+from scout.triggers.sources.base import ConnectorEvent
+
+# GitHub notification `reason` values we normalize into match types.
+SUPPORTED_MATCH_TYPES: list[str] = [
+    "assign",
+    "author",
+    "comment",
+    "mention",
+    "review_requested",
+    "state_change",
+    "subscribed",
+    "team_mention",
+]
+
+GH_TIMEOUT_SECONDS = 30
+
+
+def _default_run_gh(args: list[str]) -> tuple[int, str, str]:
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=GH_TIMEOUT_SECONDS,
+        )
+    except FileNotFoundError:
+        return 127, "", "gh: command not found"
+    except subprocess.TimeoutExpired:
+        return 124, "", f"gh {' '.join(args)}: timed out after {GH_TIMEOUT_SECONDS}s"
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+class GitHubSource:
+    """Poll GitHub notification threads for the authenticated user."""
+
+    name = "github"
+    SUPPORTED_MATCH_TYPES = SUPPORTED_MATCH_TYPES
+
+    def __init__(self, *, run_gh: Callable[[list[str]], tuple[int, str, str]] | None = None) -> None:
+        self._run_gh = run_gh or _default_run_gh
+
+    def scan_since(self, ts: str) -> list[ConnectorEvent]:
+        rc, stdout, stderr = self._run_gh(["api", f"notifications?since={ts}&all=false"])
+        if rc != 0:
+            raise ConfigError(f"gh api notifications failed (exit {rc}): {stderr.strip() or stdout.strip()}")
+        try:
+            threads = json.loads(stdout or "[]")
+        except json.JSONDecodeError as e:
+            raise ConfigError(f"gh api notifications returned non-JSON output: {e}") from e
+        if not isinstance(threads, list):
+            raise ConfigError("gh api notifications: expected a JSON array")
+
+        events: list[ConnectorEvent] = []
+        for thread in threads:
+            if not isinstance(thread, dict):
+                continue
+            updated_at = str(thread.get("updated_at", ""))
+            # GitHub honors `since` server-side, but re-filter client-side so
+            # a lenient/mocked backend can't replay old threads.
+            if not updated_at or updated_at <= ts:
+                continue
+            reason = str(thread.get("reason", ""))
+            subject = thread.get("subject") or {}
+            repo = (thread.get("repository") or {}).get("full_name", "")
+            thread_id = str(thread.get("id", ""))
+            events.append(
+                ConnectorEvent(
+                    source=self.name,
+                    # A later update to the same thread is a new event.
+                    source_event_id=f"{thread_id}:{updated_at}",
+                    ts=updated_at,
+                    raw_payload=dict(thread),
+                    normalized_match_fields={
+                        "type": reason,
+                        "reason": reason,
+                        "repo": repo,
+                        "title": subject.get("title", ""),
+                        "subject_type": subject.get("type", ""),
+                        "url": subject.get("url", ""),
+                        "thread_id": thread_id,
+                    },
+                )
+            )
+        events.sort(key=lambda e: e.ts)
+        return events
+
+    def health_check(self) -> tuple[bool, str]:
+        rc, _stdout, stderr = self._run_gh(["auth", "status"])
+        if rc != 0:
+            return False, f"gh auth status failed: {stderr.strip() or f'exit {rc}'}"
+        return True, "ok"
+
+    def supports_webhook(self) -> bool:
+        return False

--- a/engine/scout/triggers/sources/scout_internal.py
+++ b/engine/scout/triggers/sources/scout_internal.py
@@ -1,0 +1,99 @@
+"""scout_internal trigger source — the engine's own event stream.
+
+v1 reads the JSONL event logs the schedule dispatcher already writes
+(``.scout-logs/schedule-events-YYYY-MM-DD.jsonl``); when the v0.5 SQLite
+event store lands, ``scan_since`` becomes a SELECT against it (spec
+§Event-store integration).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scout.triggers.sources.base import ConnectorEvent
+
+# Engine event kinds the dispatcher emits today (schedule_tick + triggers +
+# notify). A trigger's match.type must name one of these.
+SUPPORTED_MATCH_TYPES: list[str] = [
+    "notification.sent",
+    "schedule.tick.completed",
+    "schedule.tick.skipped",
+    "slot.fire_failed",
+    "slot.fired",
+    "slot.skipped",
+    "trigger.fired",
+]
+
+EVENT_LOG_GLOB = "schedule-events-*.jsonl"
+
+
+class ScoutInternalSource:
+    """Scan the engine's JSONL event logs for rows newer than ``ts``."""
+
+    name = "scout_internal"
+    SUPPORTED_MATCH_TYPES = SUPPORTED_MATCH_TYPES
+
+    def __init__(self, log_dir: Path) -> None:
+        self._log_dir = log_dir
+
+    def scan_since(self, ts: str) -> list[ConnectorEvent]:
+        if not self._log_dir.is_dir():
+            return []
+        since_date = ts[:10]
+        events: list[ConnectorEvent] = []
+        for log_path in sorted(self._log_dir.glob(EVENT_LOG_GLOB)):
+            # File names are UTC-dated; skip files that can't contain rows > ts.
+            file_date = log_path.stem.removeprefix("schedule-events-")
+            if file_date < since_date:
+                continue
+            events.extend(self._scan_file(log_path, ts))
+        events.sort(key=lambda e: e.ts)
+        return events
+
+    def _scan_file(self, log_path: Path, since_ts: str) -> list[ConnectorEvent]:
+        out: list[ConnectorEvent] = []
+        try:
+            lines = log_path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            return out
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(row, dict):
+                continue
+            row_id, row_ts, kind = row.get("id"), row.get("ts"), row.get("kind")
+            if not (isinstance(row_id, str) and isinstance(row_ts, str) and isinstance(kind, str)):
+                continue
+            # Both timestamps are ISO-8601 UTC "Z" strings → lexicographic
+            # comparison is chronological.
+            if row_ts <= since_ts:
+                continue
+            raw_payload = row.get("payload")
+            payload: dict = raw_payload if isinstance(raw_payload, dict) else {}
+            fields = {k: v for k, v in payload.items() if k != "type"}
+            fields["type"] = kind
+            fields["event_source"] = row.get("source", "")
+            out.append(
+                ConnectorEvent(
+                    source=self.name,
+                    source_event_id=row_id,
+                    ts=row_ts,
+                    raw_payload=dict(row),
+                    normalized_match_fields=fields,
+                )
+            )
+        return out
+
+    def health_check(self) -> tuple[bool, str]:
+        if not self._log_dir.is_dir():
+            return False, f"log dir does not exist: {self._log_dir}"
+        return True, "ok"
+
+    def supports_webhook(self) -> bool:
+        return False

--- a/engine/scout/triggers/sources/slack.py
+++ b/engine/scout/triggers/sources/slack.py
@@ -1,0 +1,160 @@
+"""Slack trigger source — polls the Slack Web API for mentions.
+
+v1 supports ``mention`` only: one ``search.messages`` call per tick for
+``<@USER_ID>``, filtered client-side by timestamp (the combined-query
+optimization — one connector call serves every slack trigger).
+
+Auth: a user token with ``search:read`` at
+``~/.scout-secrets/slack-search-token`` (mode 600, same convention as the
+Telegram secrets). The Scout user's Slack ID comes from
+``scout-config.yaml`` → ``connectors.inputs.user_slack_id``.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Callable
+from pathlib import Path
+
+import yaml
+
+from scout.errors import ConfigError
+from scout.triggers.sources.base import ConnectorEvent
+
+SUPPORTED_MATCH_TYPES: list[str] = ["mention"]
+
+SEARCH_URL = "https://slack.com/api/search.messages"
+TOKEN_FILENAME = "slack-search-token"
+SECRETS_DIR = Path.home() / ".scout-secrets"
+DEFAULT_TIMEOUT = 15.0
+PAGE_SIZE = 100
+
+
+def _parse_iso_z(ts: str) -> dt.datetime:
+    if ts.endswith("Z"):
+        ts = ts[:-1] + "+00:00"
+    return dt.datetime.fromisoformat(ts)
+
+
+def _default_http_get(url: str, *, params: dict, headers: dict, timeout: float) -> dict:
+    import requests
+
+    resp = requests.get(url, params=params, headers=headers, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _read_token() -> str:
+    """Read the Slack search token (mode-600 enforced, Telegram-secret style)."""
+    path = SECRETS_DIR / TOKEN_FILENAME
+    if not path.exists():
+        raise ConfigError(f"Missing secret: {path}. Create it (mode 600) with a Slack token that has search:read.")
+    mode = path.stat().st_mode & 0o777
+    if mode & 0o077:
+        raise ConfigError(f"{path} has insecure permissions {oct(mode)}; expected 600. Run: chmod 600 {path}")
+    value = path.read_text(encoding="utf-8").strip()
+    if not value:
+        raise ConfigError(f"Secret file is empty: {path}.")
+    return value
+
+
+def _user_id_from_config(vault: Path) -> str | None:
+    cfg_path = vault / "scout-config.yaml"
+    if not cfg_path.exists():
+        return None
+    try:
+        cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+    except (yaml.YAMLError, UnicodeDecodeError, OSError):
+        return None
+    value = ((cfg.get("connectors") or {}).get("inputs") or {}).get("user_slack_id")
+    return value or None
+
+
+class SlackSource:
+    """Poll Slack mentions of the Scout user via ``search.messages``."""
+
+    name = "slack"
+    SUPPORTED_MATCH_TYPES = SUPPORTED_MATCH_TYPES
+
+    def __init__(
+        self,
+        *,
+        user_id: str | None = None,
+        token_reader: Callable[[], str] | None = None,
+        http_get: Callable[..., dict] | None = None,
+    ) -> None:
+        self._user_id = user_id
+        self._token_reader = token_reader or _read_token
+        self._http_get = http_get or _default_http_get
+
+    @classmethod
+    def for_vault(cls, vault: Path) -> SlackSource:
+        return cls(user_id=_user_id_from_config(vault))
+
+    def scan_since(self, ts: str) -> list[ConnectorEvent]:
+        if not self._user_id:
+            raise ConfigError("slack trigger source: user_slack_id is not configured (scout-config.yaml)")
+        token = self._token_reader()
+        since_epoch = _parse_iso_z(ts).timestamp()
+
+        data = self._http_get(
+            SEARCH_URL,
+            params={
+                "query": f"<@{self._user_id}>",
+                "count": PAGE_SIZE,
+                "sort": "timestamp",
+                "sort_dir": "desc",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=DEFAULT_TIMEOUT,
+        )
+        if not data.get("ok"):
+            raise ConfigError(f"slack search.messages failed: {data.get('error', 'unknown_error')}")
+
+        events: list[ConnectorEvent] = []
+        for msg in (data.get("messages") or {}).get("matches", []):
+            msg_ts = str(msg.get("ts", ""))
+            try:
+                epoch = float(msg_ts)
+            except ValueError:
+                continue
+            if epoch <= since_epoch:
+                continue
+            author = msg.get("user", "")
+            channel = msg.get("channel") or {}
+            iso = (
+                dt.datetime.fromtimestamp(epoch, tz=dt.UTC).strftime("%Y-%m-%dT%H:%M:%S.")
+                + f"{int(epoch * 1000) % 1000:03d}Z"
+            )
+            events.append(
+                ConnectorEvent(
+                    source=self.name,
+                    source_event_id=msg_ts,
+                    ts=iso,
+                    raw_payload=dict(msg),
+                    normalized_match_fields={
+                        "type": "mention",
+                        "author": author,
+                        "author_name": msg.get("username", ""),
+                        "channel": channel.get("id", ""),
+                        "channel_name": channel.get("name", ""),
+                        "text": msg.get("text", ""),
+                        "permalink": msg.get("permalink", ""),
+                        "is_self": bool(author) and author == self._user_id,
+                    },
+                )
+            )
+        events.sort(key=lambda e: e.source_event_id)
+        return events
+
+    def health_check(self) -> tuple[bool, str]:
+        if not self._user_id:
+            return False, "user_slack_id not configured in scout-config.yaml"
+        try:
+            self._token_reader()
+        except ConfigError as e:
+            return False, str(e)
+        return True, "ok"
+
+    def supports_webhook(self) -> bool:
+        return False

--- a/engine/tests/unit/test_cli_trigger_subapp.py
+++ b/engine/tests/unit/test_cli_trigger_subapp.py
@@ -1,0 +1,220 @@
+"""CLI smoke tests for `scoutctl trigger {list,show,validate,reload,test,fire-now,stats}`.
+
+Mirrors test_cli_schedule_subapp.py. Fixtures are synthetic/anonymized per
+CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+
+import yaml
+from typer.testing import CliRunner
+
+from scout.cli import app
+
+runner = CliRunner()
+
+
+def _write_triggers(vault: Path, triggers: list[dict]) -> Path:
+    state = vault / ".scout-state"
+    state.mkdir(parents=True, exist_ok=True)
+    p = state / "triggers.yaml"
+    p.write_text(yaml.safe_dump({"schema_version": 1, "triggers": triggers}), encoding="utf-8")
+    return p
+
+
+def _notify_trigger(**overrides) -> dict:
+    t = {
+        "id": "slack_mention_alex",
+        "source": "slack",
+        "match": {"type": "mention", "user": "U0123456789"},
+        "action": {"kind": "notify", "via": ["telegram"]},
+        "cooldown_seconds": 0,
+        "daily_fire_cap": 200,
+    }
+    t.update(overrides)
+    return t
+
+
+def _internal_trigger(**overrides) -> dict:
+    t = {
+        "id": "slot_failures",
+        "source": "scout_internal",
+        "match": {"type": "slot.fire_failed"},
+        "action": {"kind": "interactive"},
+        "cooldown_seconds": 0,
+        "daily_fire_cap": 10,
+    }
+    t.update(overrides)
+    return t
+
+
+# ----- list -------------------------------------------------------------------
+
+
+def test_trigger_list_without_file_reports_none(fake_data_dir: Path):
+    result = runner.invoke(app, ["trigger", "list"])
+    assert result.exit_code == 0, result.output
+    assert "no triggers" in result.output.lower()
+
+
+def test_trigger_list_tab_separated(fake_data_dir: Path):
+    _write_triggers(fake_data_dir, [_notify_trigger(), _internal_trigger()])
+    result = runner.invoke(app, ["trigger", "list"])
+    assert result.exit_code == 0, result.output
+    lines = [line for line in result.output.splitlines() if line.strip()]
+    assert len(lines) == 2
+    assert lines[0].startswith("slack_mention_alex\tslack\tmention\tnotify")
+    assert "\t" in lines[0]
+
+
+def test_trigger_list_json_full_records(fake_data_dir: Path):
+    _write_triggers(fake_data_dir, [_notify_trigger()])
+    result = runner.invoke(app, ["trigger", "list", "--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data[0]["id"] == "slack_mention_alex"
+    assert data[0]["source"] == "slack"
+    assert data[0]["match"] == {"type": "mention", "user": "U0123456789"}
+    assert data[0]["action"]["kind"] == "notify"
+    assert data[0]["daily_fire_cap"] == 200
+    assert data[0]["enabled"] is True
+
+
+# ----- show -------------------------------------------------------------------
+
+
+def test_trigger_show_includes_fire_state(fake_data_dir: Path):
+    _write_triggers(fake_data_dir, [_notify_trigger()])
+    result = runner.invoke(app, ["trigger", "show", "slack_mention_alex"])
+    assert result.exit_code == 0, result.output
+    record = json.loads(result.output)
+    assert record["id"] == "slack_mention_alex"
+    assert record["cooldown_seconds"] == 0
+    assert "fire_state" in record  # dedup-store view (empty before first fire)
+
+
+def test_trigger_show_unknown_id_exits_nonzero(fake_data_dir: Path):
+    _write_triggers(fake_data_dir, [_notify_trigger()])
+    result = runner.invoke(app, ["trigger", "show", "no-such-trigger"])
+    assert result.exit_code != 0
+    assert "no-such-trigger" in result.output
+
+
+# ----- validate / reload ---------------------------------------------------------
+
+
+def test_trigger_validate_ok(fake_data_dir: Path):
+    _write_triggers(fake_data_dir, [_notify_trigger()])
+    result = runner.invoke(app, ["trigger", "validate"])
+    assert result.exit_code == 0, result.output
+    assert "OK" in result.output
+
+
+def test_trigger_validate_without_file_is_ok(fake_data_dir: Path):
+    result = runner.invoke(app, ["trigger", "validate"])
+    assert result.exit_code == 0, result.output
+
+
+def test_trigger_validate_rejects_missing_cap(fake_data_dir: Path, tmp_path: Path):
+    t = _notify_trigger()
+    del t["daily_fire_cap"]
+    target = tmp_path / "candidate.yaml"
+    target.write_text(yaml.safe_dump({"schema_version": 1, "triggers": [t]}), encoding="utf-8")
+    result = runner.invoke(app, ["trigger", "validate", "--target", str(target)])
+    assert result.exit_code != 0
+    assert "daily_fire_cap" in result.output
+
+
+def test_trigger_reload_succeeds(fake_data_dir: Path):
+    _write_triggers(fake_data_dir, [_notify_trigger()])
+    result = runner.invoke(app, ["trigger", "reload"])
+    assert result.exit_code == 0
+    assert "reloaded" in result.output.lower()
+
+
+# ----- test (dry-run matching) -----------------------------------------------------
+
+
+def test_trigger_test_simulates_against_recent_events(fake_data_dir: Path):
+    _write_triggers(fake_data_dir, [_internal_trigger()])
+    # A fresh slot.fire_failed row in the engine event stream (< 1h old).
+    now = dt.datetime.now(tz=dt.UTC)
+    ts = now.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    log = fake_data_dir / ".scout-logs" / f"schedule-events-{ts[:10]}.jsonl"
+    row = {
+        "id": "01TESTEVENT00000000000000",
+        "ts": ts,
+        "kind": "slot.fire_failed",
+        "source": "cli:schedule_tick",
+        "payload": {"slot_key": "research", "error": "FileNotFoundError"},
+    }
+    log.write_text(json.dumps(row) + "\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["trigger", "test", "slot_failures"])
+    assert result.exit_code == 0, result.output
+    assert "01TESTEVENT00000000000000" in result.output
+    # Dry-run: nothing dispatched, no fire recorded.
+    assert not (fake_data_dir / ".scout-cache" / "trigger-fires.json").exists()
+    assert not (fake_data_dir / "needs-attention.md").exists()
+
+
+def test_trigger_test_unknown_id_exits_nonzero(fake_data_dir: Path):
+    _write_triggers(fake_data_dir, [_notify_trigger()])
+    result = runner.invoke(app, ["trigger", "test", "nope"])
+    assert result.exit_code != 0
+
+
+# ----- fire-now ----------------------------------------------------------------------
+
+
+def test_trigger_fire_now_dispatches_synthetic_event(fake_data_dir: Path):
+    _write_triggers(fake_data_dir, [_internal_trigger()])
+    result = runner.invoke(app, ["trigger", "fire-now", "slot_failures"])
+    assert result.exit_code == 0, result.output
+    # Interactive action wrote the artifact; the fire was recorded + logged.
+    assert (fake_data_dir / "needs-attention.md").exists()
+    assert (fake_data_dir / ".scout-cache" / "trigger-fires.json").exists()
+    assert list((fake_data_dir / ".scout-logs").glob("trigger-fires-*.jsonl"))
+
+
+def test_trigger_fire_now_unknown_id_exits_nonzero(fake_data_dir: Path):
+    _write_triggers(fake_data_dir, [_notify_trigger()])
+    result = runner.invoke(app, ["trigger", "fire-now", "nope"])
+    assert result.exit_code != 0
+
+
+# ----- stats -------------------------------------------------------------------------
+
+
+def test_trigger_stats_rolls_up_fire_logs(fake_data_dir: Path):
+    log_dir = fake_data_dir / ".scout-logs"
+    today = dt.datetime.now(tz=dt.UTC).strftime("%Y-%m-%d")
+
+    def row(trigger_id: str, status: str = "ok") -> str:
+        return json.dumps(
+            {
+                "trigger_id": trigger_id,
+                "event_id": "x",
+                "action_kind": "notify",
+                "status": status,
+                "detail": {},
+                "ts": f"{today}T10:00:00.000Z",
+            }
+        )
+
+    (log_dir / f"trigger-fires-{today}.jsonl").write_text(
+        "\n".join([row("slack_mention_alex"), row("slack_mention_alex", "error"), row("gh_reviews")]) + "\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["trigger", "stats", "--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["by_trigger"]["slack_mention_alex"]["total"] == 2
+    assert data["by_trigger"]["slack_mention_alex"]["error"] == 1
+    assert data["by_trigger"]["gh_reviews"]["total"] == 1
+    assert data["by_day"][today] == 3

--- a/engine/tests/unit/test_schedule_tick_triggers.py
+++ b/engine/tests/unit/test_schedule_tick_triggers.py
@@ -1,0 +1,74 @@
+"""schedule_tick ↔ triggers integration: evaluate() runs on every tick, isolated.
+
+Per the spec's event-flow diagram, ``triggers.evaluate()`` runs from the same
+5-minute tick as ``schedule.evaluate()`` — before it — and a trigger-side
+crash must never take down slot dispatch.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from scout.events import Event
+from scout.scripts.schedule_tick import run as tick_run
+
+
+def _minimal_vault(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    (tmp_path / ".scout-state").mkdir()
+    (tmp_path / ".scout-logs").mkdir()
+    (tmp_path / ".scout-state" / "schedule.yaml").write_text(
+        "schema_version: 1\nslots:\n  smoke-slot:\n"
+        "    type: manual\n    runner: run-scout.sh\n    fires_at_local: '00:01'\n"
+        "    weekdays: [Mon, Tue, Wed, Thu, Fri, Sat, Sun]\n"
+        "    missed_window_hours: 24\n    on_miss: skip\n    cooldown_minutes: 5\n"
+    )
+
+
+def test_tick_evaluates_triggers(tmp_path, monkeypatch):
+    _minimal_vault(tmp_path, monkeypatch)
+    with (
+        patch("scout.scripts.schedule_tick._network_ready", return_value=True),
+        patch("scout.scripts.schedule_tick.subprocess.Popen") as mock_popen,
+        patch("scout.triggers.engine.evaluate") as mock_evaluate,
+    ):
+        mock_popen.return_value.pid = 99999
+        ev = tick_run()
+
+    assert isinstance(ev, Event)
+    assert ev.kind == "schedule.tick.completed"
+    assert mock_evaluate.call_count == 1
+    kwargs = mock_evaluate.call_args.kwargs
+    assert kwargs["vault"] == tmp_path
+    assert kwargs["emit_event"] is not None
+
+
+def test_trigger_crash_does_not_break_slot_dispatch(tmp_path, monkeypatch):
+    _minimal_vault(tmp_path, monkeypatch)
+    with (
+        patch("scout.scripts.schedule_tick._network_ready", return_value=True),
+        patch("scout.scripts.schedule_tick.subprocess.Popen") as mock_popen,
+        patch("scout.triggers.engine.evaluate", side_effect=RuntimeError("boom")),
+    ):
+        mock_popen.return_value.pid = 99999
+        ev = tick_run()
+
+    # The tick still completes...
+    assert ev.kind == "schedule.tick.completed"
+
+    # ...and the failure is visible in the engine event stream.
+    rows = []
+    for log in (tmp_path / ".scout-logs").glob("schedule-events-*.jsonl"):
+        rows += [json.loads(line) for line in log.read_text().splitlines()]
+    failed = [r for r in rows if r["kind"] == "triggers.evaluate.failed"]
+    assert len(failed) == 1
+    assert "boom" in failed[0]["payload"]["error"]
+
+
+def test_manifest_declares_triggers_v1_flag():
+    from scout.manifest import build_manifest
+
+    m = build_manifest()
+    # Opt-in per spec: flips True once polling+dedup are verified live.
+    assert m.features["triggers_v1"] is False

--- a/engine/tests/unit/test_triggers_config.py
+++ b/engine/tests/unit/test_triggers_config.py
@@ -1,0 +1,212 @@
+"""triggers.yaml loading + validation (engine/scout/triggers/config.py).
+
+All fixture content is synthetic/anonymized per CLAUDE.md (people Alex/Priya/Sam,
+GitHub example-org/<repo>, Slack IDs are fake).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scout.errors import ConfigError
+from scout.triggers.config import ActionKind, Trigger, load_triggers
+
+SKILLS = {"scout-dream", "scout-research"}
+
+
+def _base_trigger(**overrides) -> dict:
+    t = {
+        "id": "slack_mention_alex",
+        "enabled": True,
+        "source": "slack",
+        "match": {"type": "mention", "user": "U0123456789"},
+        "action": {"kind": "notify", "via": ["telegram"]},
+        "cooldown_seconds": 0,
+        "daily_fire_cap": 200,
+    }
+    t.update(overrides)
+    return t
+
+
+def _write(tmp_path: Path, triggers: list[dict], *, schema_version: int = 1) -> Path:
+    p = tmp_path / "triggers.yaml"
+    p.write_text(yaml.safe_dump({"schema_version": schema_version, "triggers": triggers}), encoding="utf-8")
+    return p
+
+
+def _load(tmp_path: Path, triggers: list[dict], **kw) -> list[Trigger]:
+    kw.setdefault("installed_skills", SKILLS)
+    return load_triggers(_write(tmp_path, triggers), **kw)
+
+
+# ----- happy path -----------------------------------------------------------
+
+
+def test_valid_file_loads_full_record(tmp_path):
+    (trigger,) = _load(tmp_path, [_base_trigger()])
+    assert trigger.id == "slack_mention_alex"
+    assert trigger.enabled is True
+    assert trigger.source == "slack"
+    assert trigger.match == {"type": "mention", "user": "U0123456789"}
+    assert trigger.match_type == "mention"
+    assert trigger.action.kind is ActionKind.NOTIFY
+    assert trigger.action.params == {"via": ["telegram"]}
+    assert trigger.cooldown_seconds == 0
+    assert trigger.daily_fire_cap == 200
+    assert trigger.allow_cycle is False
+
+
+def test_enabled_defaults_true_and_false_is_parsed(tmp_path):
+    t = _base_trigger()
+    del t["enabled"]
+    t2 = _base_trigger(id="second", enabled=False)
+    first, second = _load(tmp_path, [t, t2])
+    assert first.enabled is True
+    assert second.enabled is False
+
+
+def test_run_skill_with_installed_skill_loads(tmp_path):
+    t = _base_trigger(action={"kind": "run_skill", "skill": "scout-dream"})
+    (trigger,) = _load(tmp_path, [t])
+    assert trigger.action.kind is ActionKind.RUN_SKILL
+    assert trigger.action.params["skill"] == "scout-dream"
+
+
+def test_empty_triggers_list_is_valid(tmp_path):
+    assert _load(tmp_path, []) == []
+
+
+# ----- structural validation ------------------------------------------------
+
+
+def test_missing_file_raises_config_error(tmp_path):
+    with pytest.raises(ConfigError):
+        load_triggers(tmp_path / "nope.yaml", installed_skills=SKILLS)
+
+
+def test_unsupported_schema_version_rejected(tmp_path):
+    p = _write(tmp_path, [_base_trigger()], schema_version=2)
+    with pytest.raises(ConfigError, match="schema_version"):
+        load_triggers(p, installed_skills=SKILLS)
+
+
+@pytest.mark.parametrize("field", ["id", "source", "match", "action"])
+def test_missing_required_field_rejected(tmp_path, field):
+    t = _base_trigger()
+    del t[field]
+    with pytest.raises(ConfigError):
+        _load(tmp_path, [t])
+
+
+def test_duplicate_ids_rejected(tmp_path):
+    with pytest.raises(ConfigError, match="duplicate"):
+        _load(tmp_path, [_base_trigger(), _base_trigger()])
+
+
+# ----- cap / cooldown rules --------------------------------------------------
+
+
+def test_missing_daily_fire_cap_rejected(tmp_path):
+    """No default-unlimited — runaway cost is the #1 risk (spec)."""
+    t = _base_trigger()
+    del t["daily_fire_cap"]
+    with pytest.raises(ConfigError, match="daily_fire_cap"):
+        _load(tmp_path, [t])
+
+
+def test_daily_fire_cap_below_one_rejected(tmp_path):
+    with pytest.raises(ConfigError, match="daily_fire_cap"):
+        _load(tmp_path, [_base_trigger(daily_fire_cap=0)])
+
+
+def test_negative_cooldown_rejected(tmp_path):
+    with pytest.raises(ConfigError, match="cooldown_seconds"):
+        _load(tmp_path, [_base_trigger(cooldown_seconds=-1)])
+
+
+def test_cooldown_defaults_to_zero(tmp_path):
+    t = _base_trigger()
+    del t["cooldown_seconds"]
+    (trigger,) = _load(tmp_path, [t])
+    assert trigger.cooldown_seconds == 0
+
+
+# ----- source / match validation ---------------------------------------------
+
+
+def test_unknown_source_rejected(tmp_path):
+    with pytest.raises(ConfigError, match="source"):
+        _load(tmp_path, [_base_trigger(source="carrier_pigeon")])
+
+
+def test_match_without_type_rejected(tmp_path):
+    with pytest.raises(ConfigError, match="match.type"):
+        _load(tmp_path, [_base_trigger(match={"user": "U0123456789"})])
+
+
+def test_match_type_not_supported_by_source_rejected(tmp_path):
+    """Each sources/*.py exposes SUPPORTED_MATCH_TYPES; validator cross-checks."""
+    with pytest.raises(ConfigError, match="match.type"):
+        _load(tmp_path, [_base_trigger(match={"type": "review_requested"})])
+
+
+def test_github_source_supports_review_requested(tmp_path):
+    t = _base_trigger(
+        source="github",
+        match={"type": "review_requested", "repo": ["example-org/widget-factory"]},
+        action={"kind": "interactive"},
+    )
+    (trigger,) = _load(tmp_path, [t])
+    assert trigger.source == "github"
+
+
+# ----- action validation -------------------------------------------------------
+
+
+def test_unknown_action_kind_rejected(tmp_path):
+    with pytest.raises(ConfigError, match="action.kind"):
+        _load(tmp_path, [_base_trigger(action={"kind": "self_destruct"})])
+
+
+def test_run_skill_without_skill_rejected(tmp_path):
+    with pytest.raises(ConfigError, match="skill"):
+        _load(tmp_path, [_base_trigger(action={"kind": "run_skill"})])
+
+
+def test_run_skill_with_uninstalled_skill_rejected(tmp_path):
+    t = _base_trigger(action={"kind": "run_skill", "skill": "not-a-real-skill"})
+    with pytest.raises(ConfigError, match="not-a-real-skill"):
+        _load(tmp_path, [t])
+
+
+# ----- cycle guard --------------------------------------------------------------
+
+
+def _cycle_trigger(**overrides) -> dict:
+    t = _base_trigger(
+        id="internal_refire",
+        source="scout_internal",
+        match={"type": "trigger.fired"},
+        action={"kind": "run_skill", "skill": "scout-dream"},
+    )
+    t.update(overrides)
+    return t
+
+
+def test_scout_internal_trigger_fired_run_skill_cycle_rejected(tmp_path):
+    with pytest.raises(ConfigError, match="allow_cycle"):
+        _load(tmp_path, [_cycle_trigger()])
+
+
+def test_cycle_allowed_with_explicit_flag(tmp_path):
+    (trigger,) = _load(tmp_path, [_cycle_trigger(allow_cycle=True)])
+    assert trigger.allow_cycle is True
+
+
+def test_scout_internal_notify_on_trigger_fired_is_fine(tmp_path):
+    t = _cycle_trigger(action={"kind": "notify", "via": ["telegram"]})
+    (trigger,) = _load(tmp_path, [t])
+    assert trigger.action.kind is ActionKind.NOTIFY

--- a/engine/tests/unit/test_triggers_dedup.py
+++ b/engine/tests/unit/test_triggers_dedup.py
@@ -1,0 +1,131 @@
+"""Dedup + cooldown + daily-cap state (.scout-cache/trigger-fires.json).
+
+Day boundaries are ET (America/New_York) per the spec — caps reset at
+00:00 ET, not 00:00 UTC.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+
+from scout.triggers.dedup import DedupStore
+
+T0 = dt.datetime(2026, 7, 1, 16, 0, 0, tzinfo=dt.UTC)  # 12:00 ET
+
+
+def _store(tmp_path: Path, **kw) -> DedupStore:
+    return DedupStore(tmp_path / "trigger-fires.json", **kw)
+
+
+# ----- is_new ---------------------------------------------------------------
+
+
+def test_unseen_event_is_new(tmp_path):
+    store = _store(tmp_path)
+    assert store.is_new("slack_mention_alex", "1700000000.000100")
+
+
+def test_recorded_event_is_not_new(tmp_path):
+    store = _store(tmp_path)
+    store.record_fire("slack_mention_alex", "1700000000.000100", T0)
+    assert not store.is_new("slack_mention_alex", "1700000000.000100")
+
+
+def test_dedup_is_per_trigger(tmp_path):
+    store = _store(tmp_path)
+    store.record_fire("slack_mention_alex", "1700000000.000100", T0)
+    assert store.is_new("other_trigger", "1700000000.000100")
+
+
+def test_recent_ids_window_slides(tmp_path):
+    """Beyond the sliding window, old event ids age out (non-monotonic id safety)."""
+    store = _store(tmp_path, recent_window=3)
+    for i in range(5):
+        store.record_fire("t", f"ev-{i}", T0 + dt.timedelta(seconds=i))
+    # ev-0 and ev-1 have aged out of the window of 3.
+    assert store.is_new("t", "ev-0")
+    assert not store.is_new("t", "ev-3")
+    assert not store.is_new("t", "ev-4")
+
+
+# ----- persistence ------------------------------------------------------------
+
+
+def test_state_persists_across_instances(tmp_path):
+    _store(tmp_path).record_fire("t", "ev-1", T0)
+    reloaded = _store(tmp_path)
+    assert not reloaded.is_new("t", "ev-1")
+    assert reloaded.fires_today("t", T0) == 1
+
+
+def test_file_shape_matches_spec(tmp_path):
+    store = _store(tmp_path)
+    store.record_fire("slack_mention_alex", "1700000000.000100", T0)
+    data = json.loads((tmp_path / "trigger-fires.json").read_text())
+    entry = data["slack_mention_alex"]
+    assert entry["last_fire_ts"] == "2026-07-01T16:00:00Z"
+    assert entry["last_seen_event_id"] == "1700000000.000100"
+    assert entry["fires_today"] == 1
+    assert entry["fires_today_date"] == "2026-07-01"  # ET date
+
+
+def test_corrupt_cache_file_starts_fresh(tmp_path):
+    p = tmp_path / "trigger-fires.json"
+    p.write_text("{not json", encoding="utf-8")
+    store = DedupStore(p)
+    assert store.is_new("t", "ev-1")
+    store.record_fire("t", "ev-1", T0)  # must not raise
+    assert not store.is_new("t", "ev-1")
+
+
+# ----- cooldown ----------------------------------------------------------------
+
+
+def test_cooldown_blocks_within_gap(tmp_path):
+    store = _store(tmp_path)
+    store.record_fire("t", "ev-1", T0)
+    assert store.in_cooldown("t", 1800, T0 + dt.timedelta(minutes=10))
+    assert not store.in_cooldown("t", 1800, T0 + dt.timedelta(minutes=40))
+
+
+def test_zero_cooldown_never_blocks(tmp_path):
+    store = _store(tmp_path)
+    store.record_fire("t", "ev-1", T0)
+    assert not store.in_cooldown("t", 0, T0 + dt.timedelta(seconds=1))
+
+
+def test_never_fired_trigger_is_not_in_cooldown(tmp_path):
+    assert not _store(tmp_path).in_cooldown("t", 3600, T0)
+
+
+# ----- daily cap (ET day boundary) ----------------------------------------------
+
+
+def test_fires_today_counts_within_et_day(tmp_path):
+    store = _store(tmp_path)
+    store.record_fire("t", "ev-1", T0)
+    store.record_fire("t", "ev-2", T0 + dt.timedelta(hours=1))
+    assert store.fires_today("t", T0 + dt.timedelta(hours=2)) == 2
+
+
+def test_fires_today_resets_at_midnight_et_not_utc(tmp_path):
+    store = _store(tmp_path)
+    # 2026-07-02T03:00Z is still 2026-07-01 23:00 ET (EDT, UTC-4).
+    late_et = dt.datetime(2026, 7, 2, 3, 0, 0, tzinfo=dt.UTC)
+    store.record_fire("t", "ev-1", late_et)
+    assert store.fires_today("t", late_et) == 1
+    # 2026-07-02T05:00Z crosses into 2026-07-02 ET (01:00 ET) → reset.
+    next_et_day = dt.datetime(2026, 7, 2, 5, 0, 0, tzinfo=dt.UTC)
+    assert store.fires_today("t", next_et_day) == 0
+
+
+def test_cap_notified_flag_is_per_et_day(tmp_path):
+    store = _store(tmp_path)
+    assert not store.cap_notified_today("t", T0)
+    store.mark_cap_notified("t", T0)
+    assert store.cap_notified_today("t", T0)
+    # Next ET day: flag resets so a new cap-hit notifies again.
+    tomorrow = T0 + dt.timedelta(days=1)
+    assert not store.cap_notified_today("t", tomorrow)

--- a/engine/tests/unit/test_triggers_dispatch.py
+++ b/engine/tests/unit/test_triggers_dispatch.py
@@ -1,0 +1,190 @@
+"""Dispatcher routing + the three action handlers (notify / run_skill / interactive).
+
+Fixtures are synthetic/anonymized per CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scout.triggers.config import Action, ActionKind, Trigger
+from scout.triggers.dispatcher import FireOutcome, dispatch, log_fire
+from scout.triggers.sources.base import ConnectorEvent
+
+
+def _trigger(kind: ActionKind = ActionKind.NOTIFY, params: dict | None = None, **kw) -> Trigger:
+    defaults = {
+        "id": "slack_mention_alex",
+        "source": "slack",
+        "match": {"type": "mention"},
+        "daily_fire_cap": 10,
+    }
+    defaults.update(kw)
+    return Trigger(action=Action(kind=kind, params=params or {}), **defaults)
+
+
+def _event(**fields) -> ConnectorEvent:
+    return ConnectorEvent(
+        source="slack",
+        source_event_id="1782910800.000200",
+        ts="2026-07-01T13:00:00.000Z",
+        raw_payload={"text": "ping <@U0123456789>"},
+        normalized_match_fields={
+            "type": "mention",
+            "author": "priya",
+            "channel": "C0123456789",
+            "text": "ping <@U0123456789> can you review?",
+            **fields,
+        },
+    )
+
+
+class _FakeTelegram:
+    def __init__(self, fail: bool = False):
+        self.calls: list[dict] = []
+        self.fail = fail
+
+    def __call__(self, *, tier: str, body: str):
+        if self.fail:
+            from scout.errors import ConfigError
+
+            raise ConfigError("Missing secret: telegram-bot-token")
+        self.calls.append({"tier": tier, "body": body})
+
+
+# ----- notify -----------------------------------------------------------------
+
+
+def test_notify_dispatch_sends_to_telegram(fake_data_dir: Path):
+    telegram = _FakeTelegram()
+    trigger = _trigger(ActionKind.NOTIFY, {"via": ["telegram"]})
+    outcome = dispatch(trigger, _event(), vault=fake_data_dir, send_telegram=telegram)
+
+    assert isinstance(outcome, FireOutcome)
+    assert outcome.status == "ok"
+    assert outcome.trigger_id == "slack_mention_alex"
+    assert outcome.event_id == "1782910800.000200"
+    assert outcome.action_kind == "notify"
+    assert len(telegram.calls) == 1
+    body = telegram.calls[0]["body"]
+    assert "slack_mention_alex" in body
+    assert "can you review" in body
+    assert telegram.calls[0]["tier"] == "info"
+
+
+def test_notify_with_no_working_surface_is_an_error(fake_data_dir: Path):
+    trigger = _trigger(ActionKind.NOTIFY, {"via": ["telegram"]})
+    outcome = dispatch(trigger, _event(), vault=fake_data_dir, send_telegram=_FakeTelegram(fail=True))
+    assert outcome.status == "error"
+    assert "telegram" in json.dumps(outcome.detail)
+
+
+def test_notify_unknown_surface_is_recorded_but_not_fatal(fake_data_dir: Path):
+    telegram = _FakeTelegram()
+    trigger = _trigger(ActionKind.NOTIFY, {"via": ["pager", "telegram"]})
+    outcome = dispatch(trigger, _event(), vault=fake_data_dir, send_telegram=telegram)
+    assert outcome.status == "ok"
+    assert outcome.detail["surfaces"]["pager"].startswith("unsupported")
+    assert outcome.detail["surfaces"]["telegram"] == "sent"
+
+
+# ----- run_skill -----------------------------------------------------------------
+
+
+def test_run_skill_writes_payload_and_spawns_runner(fake_data_dir: Path):
+    spawned: list[tuple[list[str], dict]] = []
+
+    def spawn(cmd: list[str], env: dict) -> int:
+        spawned.append((cmd, env))
+        return 4242
+
+    trigger = _trigger(ActionKind.RUN_SKILL, {"skill": "scout-dream"}, id="internal_dream")
+    outcome = dispatch(trigger, _event(), vault=fake_data_dir, spawn=spawn)
+
+    assert outcome.status == "ok"
+    assert outcome.detail["pid"] == 4242
+    assert outcome.detail["skill"] == "scout-dream"
+
+    (cmd, env) = spawned[0]
+    assert cmd[0].endswith("run-scout.sh")
+    assert env["SCOUT_FORCE_MODE"] == "scout-dream"
+    assert env["SCOUT_TRIGGER_ID"] == "internal_dream"
+    assert env["SCOUT_DATA_DIR"] == str(fake_data_dir)
+
+    payload_path = Path(env["SCOUT_TRIGGER_EVENT_PATH"])
+    assert payload_path.exists()
+    payload = json.loads(payload_path.read_text())
+    assert payload["trigger_id"] == "internal_dream"
+    assert payload["event"]["source_event_id"] == "1782910800.000200"
+    assert payload["event"]["normalized_match_fields"]["author"] == "priya"
+
+
+def test_run_skill_spawn_failure_is_an_error(fake_data_dir: Path):
+    def spawn(cmd: list[str], env: dict) -> int:
+        raise FileNotFoundError("run-scout.sh not found")
+
+    trigger = _trigger(ActionKind.RUN_SKILL, {"skill": "scout-dream"})
+    outcome = dispatch(trigger, _event(), vault=fake_data_dir, spawn=spawn)
+    assert outcome.status == "error"
+    assert "run-scout.sh" in outcome.detail["error"]
+
+
+def test_run_skill_honors_custom_runner(fake_data_dir: Path):
+    spawned: list[tuple[list[str], dict]] = []
+    trigger = _trigger(ActionKind.RUN_SKILL, {"skill": "scout-dream", "runner": "custom-runner.sh"})
+    dispatch(trigger, _event(), vault=fake_data_dir, spawn=lambda cmd, env: spawned.append((cmd, env)) or 1)
+    assert spawned[0][0][0].endswith("custom-runner.sh")
+
+
+# ----- interactive ------------------------------------------------------------------
+
+
+def test_interactive_appends_needs_attention_artifact(fake_data_dir: Path):
+    telegram = _FakeTelegram()
+    trigger = _trigger(ActionKind.INTERACTIVE, {"preload": "review_pr"}, id="gh_review", source="github")
+    outcome = dispatch(trigger, _event(), vault=fake_data_dir, send_telegram=telegram)
+
+    assert outcome.status == "ok"
+    artifact = fake_data_dir / "needs-attention.md"
+    assert artifact.exists()
+    text = artifact.read_text()
+    assert "gh_review" in text
+    assert "1782910800.000200" in text
+
+    # Interactive pushes are loud (action_required).
+    assert telegram.calls and telegram.calls[0]["tier"] == "action_required"
+
+    # A second fire appends, never overwrites.
+    dispatch(trigger, _event(), vault=fake_data_dir, send_telegram=telegram)
+    assert artifact.read_text().count("## ") == 2
+
+
+def test_interactive_without_telegram_is_still_ok(fake_data_dir: Path):
+    trigger = _trigger(ActionKind.INTERACTIVE)
+    outcome = dispatch(trigger, _event(), vault=fake_data_dir, send_telegram=_FakeTelegram(fail=True))
+    assert outcome.status == "ok"  # artifact written; push is best-effort
+    assert (fake_data_dir / "needs-attention.md").exists()
+
+
+# ----- fire log ----------------------------------------------------------------------
+
+
+def test_log_fire_appends_utc_dated_jsonl(fake_data_dir: Path):
+    log_dir = fake_data_dir / ".scout-logs"
+    outcome = FireOutcome(
+        trigger_id="slack_mention_alex",
+        event_id="1782910800.000200",
+        action_kind="notify",
+        status="ok",
+        detail={"surfaces": {"telegram": "sent"}},
+        ts="2026-07-01T13:05:00.000Z",
+    )
+    log_fire(log_dir, outcome)
+    log_path = log_dir / "trigger-fires-2026-07-01.jsonl"
+    assert log_path.exists()
+    row = json.loads(log_path.read_text().splitlines()[0])
+    assert row["trigger_id"] == "slack_mention_alex"
+    assert row["event_id"] == "1782910800.000200"
+    assert row["status"] == "ok"
+    assert row["ts"] == "2026-07-01T13:05:00.000Z"

--- a/engine/tests/unit/test_triggers_evaluate.py
+++ b/engine/tests/unit/test_triggers_evaluate.py
@@ -1,0 +1,267 @@
+"""triggers.evaluate(): the per-tick polling loop (combined-query + dedup + caps).
+
+Fixtures are synthetic/anonymized per CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+
+import yaml
+
+from scout.triggers.engine import evaluate
+from scout.triggers.sources.base import ConnectorEvent
+
+NOW = dt.datetime(2026, 7, 1, 16, 0, 0, tzinfo=dt.UTC)  # 12:00 ET
+SKILLS = {"scout-dream"}
+
+
+class FakeSource:
+    """Scriptable TriggerSource stand-in; records scan_since calls."""
+
+    SUPPORTED_MATCH_TYPES = ["mention"]
+
+    def __init__(
+        self, name: str, events: list[ConnectorEvent], *, healthy: bool = True, error: Exception | None = None
+    ):
+        self.name = name
+        self.events = events
+        self.healthy = healthy
+        self.error = error
+        self.scan_calls: list[str] = []
+
+    def scan_since(self, ts: str) -> list[ConnectorEvent]:
+        self.scan_calls.append(ts)
+        if self.error is not None:
+            raise self.error
+        return self.events
+
+    def health_check(self) -> tuple[bool, str]:
+        return (True, "ok") if self.healthy else (False, "token missing")
+
+    def supports_webhook(self) -> bool:
+        return False
+
+
+def _mention(event_id: str, *, author: str = "priya", text: str = "ping") -> ConnectorEvent:
+    return ConnectorEvent(
+        source="slack",
+        source_event_id=event_id,
+        ts="2026-07-01T15:55:00.000Z",
+        raw_payload={},
+        normalized_match_fields={"type": "mention", "author": author, "text": text, "is_self": False},
+    )
+
+
+def _write_triggers(vault: Path, triggers: list[dict]) -> None:
+    state = vault / ".scout-state"
+    state.mkdir(parents=True, exist_ok=True)
+    (state / "triggers.yaml").write_text(yaml.safe_dump({"schema_version": 1, "triggers": triggers}), encoding="utf-8")
+
+
+def _notify_trigger(**overrides) -> dict:
+    t = {
+        "id": "slack_mention_alex",
+        "source": "slack",
+        "match": {"type": "mention"},
+        "action": {"kind": "notify", "via": ["telegram"]},
+        "cooldown_seconds": 0,
+        "daily_fire_cap": 10,
+    }
+    t.update(overrides)
+    return t
+
+
+class _Telegram:
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    def __call__(self, *, tier: str, body: str):
+        self.calls.append({"tier": tier, "body": body})
+
+
+def _evaluate(vault: Path, sources: dict, *, telegram=None, emitted=None, now=NOW, **kw):
+    def emit_event(**kwargs):
+        if emitted is not None:
+            emitted.append(kwargs)
+
+    kw.setdefault("installed_skills", SKILLS)
+    return evaluate(
+        vault=vault,
+        now=now,
+        sources=sources,
+        send_telegram=telegram or _Telegram(),
+        emit_event=emit_event,
+        **kw,
+    )
+
+
+# ----- basics -------------------------------------------------------------------
+
+
+def test_no_triggers_file_is_a_noop(fake_data_dir: Path):
+    result = _evaluate(fake_data_dir, {})
+    assert result.fired == []
+    assert result.triggers_evaluated == 0
+    assert not (fake_data_dir / ".scout-cache" / "trigger-fires.json").exists()
+
+
+def test_matching_event_fires_and_is_logged(fake_data_dir: Path):
+    _write_triggers(fake_data_dir, [_notify_trigger()])
+    telegram = _Telegram()
+    emitted: list[dict] = []
+    src = FakeSource("slack", [_mention("ev-1", text="ping <@U0123456789>")])
+
+    result = _evaluate(fake_data_dir, {"slack": src}, telegram=telegram, emitted=emitted)
+
+    assert len(result.fired) == 1
+    assert result.fired[0].status == "ok"
+    assert telegram.calls and "ping" in telegram.calls[0]["body"]
+
+    # One combined scan per source per tick.
+    assert len(src.scan_calls) == 1
+
+    # Audit log row written under .scout-logs/trigger-fires-<date>.jsonl.
+    log_files = list((fake_data_dir / ".scout-logs").glob("trigger-fires-*.jsonl"))
+    assert len(log_files) == 1
+    row = json.loads(log_files[0].read_text().splitlines()[0])
+    assert row["trigger_id"] == "slack_mention_alex"
+
+    # trigger.fired emitted into the engine event stream.
+    fired_events = [e for e in emitted if e["kind"] == "trigger.fired"]
+    assert len(fired_events) == 1
+    assert fired_events[0]["source"] == "trigger:slack_mention_alex"
+    assert fired_events[0]["payload"]["event_id"] == "ev-1"
+
+
+def test_same_event_does_not_refire_on_next_tick(fake_data_dir: Path):
+    _write_triggers(fake_data_dir, [_notify_trigger()])
+    events = [_mention("ev-1")]
+    first = _evaluate(fake_data_dir, {"slack": FakeSource("slack", events)})
+    second = _evaluate(fake_data_dir, {"slack": FakeSource("slack", events)}, now=NOW + dt.timedelta(minutes=5))
+    assert len(first.fired) == 1
+    assert second.fired == []
+
+
+def test_non_matching_event_does_not_fire(fake_data_dir: Path):
+    _write_triggers(fake_data_dir, [_notify_trigger(match={"type": "mention", "author": "sam"})])
+    result = _evaluate(fake_data_dir, {"slack": FakeSource("slack", [_mention("ev-1", author="priya")])})
+    assert result.fired == []
+    assert result.events_scanned == 1
+
+
+def test_one_event_can_fire_multiple_triggers_independently(fake_data_dir: Path):
+    _write_triggers(
+        fake_data_dir,
+        [_notify_trigger(), _notify_trigger(id="slack_mention_backup")],
+    )
+    result = _evaluate(fake_data_dir, {"slack": FakeSource("slack", [_mention("ev-1")])})
+    assert sorted(o.trigger_id for o in result.fired) == ["slack_mention_alex", "slack_mention_backup"]
+
+
+def test_disabled_trigger_is_ignored(fake_data_dir: Path):
+    _write_triggers(fake_data_dir, [_notify_trigger(enabled=False)])
+    src = FakeSource("slack", [_mention("ev-1")])
+    result = _evaluate(fake_data_dir, {"slack": src})
+    assert result.fired == []
+    # No enabled trigger for the source → don't even pay the connector call.
+    assert src.scan_calls == []
+
+
+# ----- cooldown / caps -----------------------------------------------------------
+
+
+def test_cooldown_blocks_second_fire_within_gap(fake_data_dir: Path):
+    _write_triggers(fake_data_dir, [_notify_trigger(cooldown_seconds=3600)])
+    result = _evaluate(
+        fake_data_dir,
+        {"slack": FakeSource("slack", [_mention("ev-1"), _mention("ev-2")])},
+    )
+    assert len(result.fired) == 1
+
+
+def test_daily_cap_throttles_and_notifies_once(fake_data_dir: Path):
+    _write_triggers(fake_data_dir, [_notify_trigger(daily_fire_cap=1)])
+    telegram = _Telegram()
+    emitted: list[dict] = []
+    result = _evaluate(
+        fake_data_dir,
+        {"slack": FakeSource("slack", [_mention("ev-1"), _mention("ev-2"), _mention("ev-3")])},
+        telegram=telegram,
+        emitted=emitted,
+    )
+    assert len(result.fired) == 1
+    assert len(result.throttled) == 1
+
+    throttle_events = [e for e in emitted if e["kind"] == "trigger.throttled"]
+    assert len(throttle_events) == 1
+    cap_notices = [c for c in telegram.calls if "cap" in c["body"]]
+    assert len(cap_notices) == 1
+
+    # Next tick, still over cap: stays throttled but does NOT re-notify.
+    telegram2 = _Telegram()
+    emitted2: list[dict] = []
+    again = _evaluate(
+        fake_data_dir,
+        {"slack": FakeSource("slack", [_mention("ev-4")])},
+        telegram=telegram2,
+        emitted=emitted2,
+        now=NOW + dt.timedelta(minutes=5),
+    )
+    assert again.fired == []
+    assert len(again.throttled) == 1
+    assert [c for c in telegram2.calls if "cap" in c["body"]] == []
+
+
+# ----- failure isolation ------------------------------------------------------------
+
+
+def test_unhealthy_source_is_skipped_and_recorded(fake_data_dir: Path):
+    _write_triggers(fake_data_dir, [_notify_trigger()])
+    src = FakeSource("slack", [_mention("ev-1")], healthy=False)
+    result = _evaluate(fake_data_dir, {"slack": src})
+    assert result.fired == []
+    assert result.skipped_sources == [{"source": "slack", "reason": "token missing"}]
+    assert src.scan_calls == []
+
+
+def test_source_scan_error_does_not_break_other_sources(fake_data_dir: Path):
+    _write_triggers(
+        fake_data_dir,
+        [
+            _notify_trigger(),
+            _notify_trigger(id="gh_reviews", source="github", match={"type": "review_requested"}),
+        ],
+    )
+    gh_event = ConnectorEvent(
+        source="github",
+        source_event_id="1001:2026-07-01T15:58:00Z",
+        ts="2026-07-01T15:58:00Z",
+        raw_payload={},
+        normalized_match_fields={"type": "review_requested", "repo": "example-org/widget-factory"},
+    )
+    broken = FakeSource("slack", [], error=RuntimeError("rate limited"))
+    working = FakeSource("github", [gh_event])
+    result = _evaluate(fake_data_dir, {"slack": broken, "github": working})
+
+    assert [o.trigger_id for o in result.fired] == ["gh_reviews"]
+    assert len(result.errors) == 1
+    assert result.errors[0]["source"] == "slack"
+
+
+def test_invalid_triggers_yaml_is_reported_not_raised(fake_data_dir: Path):
+    state = fake_data_dir / ".scout-state"
+    state.mkdir(exist_ok=True)
+    (state / "triggers.yaml").write_text("triggers: [{id: broken}]", encoding="utf-8")
+    result = _evaluate(fake_data_dir, {})
+    assert result.fired == []
+    assert result.errors and "config" in result.errors[0]
+
+
+def test_scan_window_is_bounded_by_lookback(fake_data_dir: Path):
+    _write_triggers(fake_data_dir, [_notify_trigger()])
+    src = FakeSource("slack", [])
+    _evaluate(fake_data_dir, {"slack": src}, lookback_minutes=60)
+    assert src.scan_calls == ["2026-07-01T15:00:00Z"]

--- a/engine/tests/unit/test_triggers_matcher.py
+++ b/engine/tests/unit/test_triggers_matcher.py
@@ -1,0 +1,86 @@
+"""Matcher semantics: trigger match rules vs normalized connector events.
+
+Fixtures are synthetic/anonymized per CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from scout.triggers.matcher import matches
+from scout.triggers.sources.base import ConnectorEvent
+
+
+def _event(match_type: str = "mention", **fields: Any) -> ConnectorEvent:
+    return ConnectorEvent(
+        source="slack",
+        source_event_id="1700000000.000100",
+        ts="2026-07-01T12:00:00.000Z",
+        raw_payload={},
+        normalized_match_fields={"type": match_type, **fields},
+    )
+
+
+def test_type_must_match():
+    assert matches({"type": "mention"}, _event("mention"))
+    assert not matches({"type": "mention"}, _event("reaction"))
+
+
+def test_scalar_filter_requires_equality():
+    ev = _event(author="alex", channel="C0123456789")
+    assert matches({"type": "mention", "author": "alex"}, ev)
+    assert not matches({"type": "mention", "author": "priya"}, ev)
+
+
+def test_list_filter_means_membership():
+    ev = _event(channel="C0123456789")
+    assert matches({"type": "mention", "channel": ["C0123456789", "C0000000001"]}, ev)
+    assert not matches({"type": "mention", "channel": ["C0000000001"]}, ev)
+
+
+def test_any_is_a_wildcard():
+    ev = _event(channel="C0123456789")
+    assert matches({"type": "mention", "channel": "any"}, ev)
+    assert matches({"type": "mention", "channel": ["any"]}, ev)
+
+
+def test_filter_key_missing_from_event_does_not_match():
+    ev = _event(author="alex")
+    assert not matches({"type": "mention", "channel": "C0123456789"}, ev)
+
+
+def test_exclude_prefix_inverts_equality():
+    """exclude_author: X → events authored by X never match."""
+    by_alex = _event(author="alex")
+    by_priya = _event(author="priya")
+    match = {"type": "mention", "exclude_author": "alex"}
+    assert not matches(match, by_alex)
+    assert matches(match, by_priya)
+
+
+def test_exclude_with_list_value():
+    by_sam = _event(author="sam")
+    match = {"type": "mention", "exclude_author": ["alex", "priya"]}
+    assert matches(match, by_sam)
+    assert not matches(match, _event(author="priya"))
+
+
+def test_exclude_self_flag_reads_is_self_field():
+    """Sources set is_self=True on events authored by the Scout user."""
+    own = _event(is_self=True)
+    other = _event(is_self=False)
+    assert not matches({"type": "mention", "exclude_self": True}, own)
+    assert matches({"type": "mention", "exclude_self": True}, other)
+    # exclude_self: false is a no-op.
+    assert matches({"type": "mention", "exclude_self": False}, own)
+
+
+def test_extra_event_fields_are_ignored():
+    ev = _event(author="alex", channel="C0123456789", text="ping <@U0123456789>")
+    assert matches({"type": "mention"}, ev)
+
+
+def test_boolean_and_numeric_filters():
+    ev = _event(is_self=False, reply_count=3)
+    assert matches({"type": "mention", "reply_count": 3}, ev)
+    assert not matches({"type": "mention", "reply_count": 4}, ev)

--- a/engine/tests/unit/test_triggers_sources.py
+++ b/engine/tests/unit/test_triggers_sources.py
@@ -1,0 +1,253 @@
+"""Trigger source pollers: slack, github, scout_internal.
+
+All fixture payloads are synthetic/anonymized per CLAUDE.md (people
+Alex/Priya/Sam, GitHub example-org/<repo>, Slack acme-co workspace).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scout.errors import ConfigError
+from scout.triggers.sources import get_source, supported_match_types
+from scout.triggers.sources.github import GitHubSource
+from scout.triggers.sources.scout_internal import ScoutInternalSource
+from scout.triggers.sources.slack import SlackSource
+
+SINCE = "2026-07-01T12:00:00Z"  # epoch 1782648000... (only relative order matters)
+
+# ----- registry ---------------------------------------------------------------
+
+
+def test_supported_match_types_unknown_source_raises():
+    with pytest.raises(ConfigError):
+        supported_match_types("carrier_pigeon")
+
+
+def test_get_source_returns_each_v1_source(tmp_path):
+    for name in ("slack", "github", "scout_internal"):
+        src = get_source(name, vault=tmp_path)
+        assert src.name == name
+        assert src.SUPPORTED_MATCH_TYPES
+        assert src.supports_webhook() is False
+
+
+def test_get_source_unknown_raises(tmp_path):
+    with pytest.raises(ConfigError):
+        get_source("carrier_pigeon", vault=tmp_path)
+
+
+# ----- slack --------------------------------------------------------------------
+
+
+def _slack_api_payload() -> dict:
+    def msg(ts: str, user: str, username: str, text: str) -> dict:
+        return {
+            "ts": ts,
+            "user": user,
+            "username": username,
+            "text": text,
+            "channel": {"id": "C0123456789", "name": "general"},
+            "permalink": f"https://acme-co.slack.com/archives/C0123456789/p{ts.replace('.', '')}",
+        }
+
+    return {
+        "ok": True,
+        "messages": {
+            "matches": [
+                # 2026-07-01T13:00:00Z — after SINCE (12:00Z = epoch 1782907200).
+                msg("1782910800.000200", "U0000000002", "priya", "ping <@U0123456789> can you review?"),
+                # Authored by the Scout user themselves.
+                msg("1782910900.000300", "U0123456789", "alex", "note to self <@U0123456789>"),
+                # 2026-07-01T11:00:00Z — before SINCE; must be filtered out.
+                msg("1782903600.000100", "U0000000003", "sam", "old mention <@U0123456789>"),
+            ]
+        },
+    }
+
+
+def _slack_source(payload: dict, calls: list | None = None) -> SlackSource:
+    def http_get(url: str, *, params: dict, headers: dict, timeout: float):
+        if calls is not None:
+            calls.append((url, params, headers))
+        return payload
+
+    return SlackSource(
+        user_id="U0123456789",
+        token_reader=lambda: "xoxp-test-token",
+        http_get=http_get,
+    )
+
+
+def test_slack_scan_since_filters_and_normalizes():
+    calls: list = []
+    events = _slack_source(_slack_api_payload(), calls).scan_since(SINCE)
+
+    # One combined query for all slack triggers.
+    assert len(calls) == 1
+    url, params, headers = calls[0]
+    assert "search.messages" in url
+    assert "<@U0123456789>" in params["query"]
+    assert headers["Authorization"] == "Bearer xoxp-test-token"
+
+    # The pre-SINCE message is dropped.
+    assert len(events) == 2
+    by_priya, by_self = events
+    assert by_priya.source == "slack"
+    assert by_priya.source_event_id == "1782910800.000200"
+    f = by_priya.normalized_match_fields
+    assert f["type"] == "mention"
+    assert f["author"] == "U0000000002"
+    assert f["channel"] == "C0123456789"
+    assert f["is_self"] is False
+    assert "can you review" in f["text"]
+    assert by_self.normalized_match_fields["is_self"] is True
+
+
+def test_slack_api_error_raises():
+    src = _slack_source({"ok": False, "error": "invalid_auth"})
+    with pytest.raises(ConfigError, match="invalid_auth"):
+        src.scan_since(SINCE)
+
+
+def test_slack_health_check_reports_missing_user_id():
+    src = SlackSource(user_id=None, token_reader=lambda: "xoxp-test-token", http_get=lambda *a, **k: {})
+    healthy, reason = src.health_check()
+    assert healthy is False
+    assert "user" in reason.lower()
+
+
+def test_slack_health_check_ok_with_token_and_user():
+    src = _slack_source(_slack_api_payload())
+    assert src.health_check() == (True, "ok")
+
+
+# ----- github ---------------------------------------------------------------------
+
+
+def _gh_notifications() -> list[dict]:
+    return [
+        {
+            "id": "1001",
+            "reason": "review_requested",
+            "updated_at": "2026-07-01T13:05:00Z",
+            "unread": True,
+            "repository": {"full_name": "example-org/widget-factory"},
+            "subject": {
+                "title": "feat: add conveyor belt",
+                "type": "PullRequest",
+                "url": "https://api.github.com/repos/example-org/widget-factory/pulls/42",
+            },
+        },
+        {
+            "id": "1002",
+            "reason": "mention",
+            "updated_at": "2026-07-01T11:00:00Z",  # before SINCE → filtered
+            "unread": True,
+            "repository": {"full_name": "example-org/gadget-works"},
+            "subject": {
+                "title": "bug: gears misaligned",
+                "type": "Issue",
+                "url": "https://api.github.com/repos/example-org/gadget-works/issues/7",
+            },
+        },
+    ]
+
+
+def test_github_scan_since_maps_reason_to_match_type():
+    calls: list = []
+
+    def run_gh(args: list[str]) -> tuple[int, str, str]:
+        calls.append(args)
+        return 0, json.dumps(_gh_notifications()), ""
+
+    events = GitHubSource(run_gh=run_gh).scan_since(SINCE)
+
+    assert calls and calls[0][0] == "api"
+    assert f"since={SINCE}" in calls[0][1]
+
+    assert len(events) == 1
+    (ev,) = events
+    assert ev.source == "github"
+    assert ev.source_event_id == "1001:2026-07-01T13:05:00Z"
+    f = ev.normalized_match_fields
+    assert f["type"] == "review_requested"
+    assert f["repo"] == "example-org/widget-factory"
+    assert f["title"] == "feat: add conveyor belt"
+    assert f["subject_type"] == "PullRequest"
+
+
+def test_github_gh_failure_raises():
+    src = GitHubSource(run_gh=lambda args: (1, "", "gh: Not logged in"))
+    with pytest.raises(ConfigError, match="gh"):
+        src.scan_since(SINCE)
+
+
+def test_github_health_check_uses_auth_status():
+    ok_src = GitHubSource(run_gh=lambda args: (0, "Logged in", ""))
+    assert ok_src.health_check() == (True, "ok")
+    bad_src = GitHubSource(run_gh=lambda args: (1, "", "not logged in"))
+    healthy, _reason = bad_src.health_check()
+    assert healthy is False
+
+
+# ----- scout_internal ------------------------------------------------------------
+
+
+def _write_events_log(log_dir, date: str, rows: list[dict]) -> None:
+    p = log_dir / f"schedule-events-{date}.jsonl"
+    with p.open("a", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+def test_scout_internal_reads_engine_event_stream(tmp_path):
+    log_dir = tmp_path / ".scout-logs"
+    log_dir.mkdir()
+    _write_events_log(
+        log_dir,
+        "2026-06-30",
+        [
+            {
+                "id": "01OLD000000000000000000000",
+                "ts": "2026-06-30T09:00:00.000Z",
+                "kind": "slot.fired",
+                "source": "cli:schedule_tick",
+                "payload": {"slot_key": "morning-briefing"},
+            }
+        ],
+    )
+    _write_events_log(
+        log_dir,
+        "2026-07-01",
+        [
+            {
+                "id": "01NEW000000000000000000000",
+                "ts": "2026-07-01T13:00:00.000Z",
+                "kind": "slot.fire_failed",
+                "source": "cli:schedule_tick",
+                "payload": {"slot_key": "research", "error": "FileNotFoundError: runner"},
+            },
+            {"not": "a valid row"},  # malformed rows are skipped, not fatal
+        ],
+    )
+
+    events = ScoutInternalSource(log_dir).scan_since(SINCE)
+
+    assert len(events) == 1
+    (ev,) = events
+    assert ev.source == "scout_internal"
+    assert ev.source_event_id == "01NEW000000000000000000000"
+    f = ev.normalized_match_fields
+    assert f["type"] == "slot.fire_failed"
+    assert f["slot_key"] == "research"
+    assert f["event_source"] == "cli:schedule_tick"
+
+
+def test_scout_internal_missing_log_dir_is_unhealthy_and_empty(tmp_path):
+    src = ScoutInternalSource(tmp_path / "missing")
+    healthy, _ = src.health_check()
+    assert healthy is False
+    assert src.scan_since(SINCE) == []


### PR DESCRIPTION
Implements the v1 **polling** path of the event-trigger architecture per [docs/specs/event-triggers.md](docs/specs/event-triggers.md) (design spec merged in #174). The engine can now fire on **events**, not just time — same dispatcher tick, same observability surface.

## What's in

**New module tree `engine/scout/triggers/`**
- `config.py` — loads/validates the vault's `.scout-state/triggers.yaml` (sibling of `schedule.yaml`). Enforces all the spec's validation rules: mandatory `id`/`source`/`match`/`action`, **mandatory `daily_fire_cap`** (no default-unlimited), `match.type` cross-checked against each source's `SUPPORTED_MATCH_TYPES`, `run_skill` must name an installed skill, `cooldown_seconds >= 0`, `daily_fire_cap >= 1`, and the `scout_internal` fire-cycle guard (`trigger.fired` + `run_skill` rejected unless `allow_cycle: true`).
- `matcher.py` — enumerated match types + typed attribute filters (scalar equality, list membership, `"any"` wildcard, `exclude_<field>`, `exclude_self`). No regex, per the spec's prior-art survey.
- `dedup.py` — `.scout-cache/trigger-fires.json` in the spec's shape, plus a sliding window of the 100 most recent fired event ids (non-monotonic id safety). Cooldown is independent of dedup; daily caps reset at **midnight ET**, not UTC. Corrupt/missing cache starts fresh (at-least-once contract).
- `dispatcher.py` — routes matched events to actions, never raises into the tick; appends audit rows to `.scout-logs/trigger-fires-YYYY-MM-DD.jsonl`.
- `actions/` — `notify` (Telegram surface, no LLM spend), `run_skill` (writes the event payload JSON and spawns the vault runner with `SCOUT_FORCE_MODE=<skill>`, `SCOUT_TRIGGER_ID`, `SCOUT_TRIGGER_EVENT_PATH` — spec Open Question #3), `interactive` (appends a structured block to `<vault>/needs-attention.md` + best-effort `action_required` push).
- `sources/` — `ConnectorEvent` + `TriggerSource` protocol (`base.py`) and three v1 pollers (see below).
- `engine.py` — `evaluate()`: the combined-query loop. **One `scan_since()` per source per tick**, in-memory trigger×event matching, per-source/per-trigger failure isolation, cap-hit self-throttling DM (once per ET day) + `trigger.throttled` event.

**Tick integration** — `triggers.evaluate()` runs from the existing 5-minute tick in `schedule_tick.py`, before `schedule.evaluate()`, wrapped so a trigger-side crash emits `triggers.evaluate.failed` and never takes down slot dispatch. Every fire emits a `trigger.fired` `Event` into the engine event stream (`schedule-events-*.jsonl`) via the tick's own emitter.

**CLI** — `scoutctl trigger {list,show,validate,reload,test,fire-now,stats}`, mirroring the `scoutctl schedule` sub-app pattern (lazy imports, `--json` variants, exit codes). `trigger serve` (v2 receiver) intentionally absent.

**Manifest** — new `triggers_v1` feature flag, ships `False` per spec (flips after the polling matcher + dedup/cooldown are verified across a week of live runs).

## Sources shipped (2 external + 1 internal)

| source | poll surface | match types |
|---|---|---|
| `slack` | Web API `search.messages` for `<@user>` (token at `~/.scout-secrets/slack-search-token`, mode-600 enforced; user id from `scout-config.yaml`) | `mention` |
| `github` | `gh api notifications?since=...` (authenticated `gh` CLI) | the 8 notification reasons (`mention`, `review_requested`, `assign`, ...) |
| `scout_internal` | the engine's own `schedule-events-*.jsonl` stream | engine event kinds (`slot.fired`, `slot.fire_failed`, `trigger.fired`, ...) |

**Deferred** (per "start with 2–3 sources"): `linear`, `gmail`, `gcal`, `file` sources; the `receiver/` webhook subtree (v2); the research-doc safeguards beyond the spec's validation rules (per-trigger exponential backoff, global fires/min token bucket, lineage-depth counter, DLQ) — the mandatory daily cap + cycle guard + cooldown cover v1; SQLite event store (v0.5 — `scout_internal` reads the JSONL stream until then, exactly as the spec's gate #3 recommends).

## Deviations from the spec (deliberate)

- `triggers.yaml` lives at `.scout-state/triggers.yaml` (sibling of `schedule.yaml`) rather than the vault root mentioned in the companion doc.
- The interactive artifact is `needs-attention.md` (generic) — this repo is public and installs for any user, so no person-named filenames.
- Slack v1 is mention-only; `thread_reply`/`reaction`/`keyword`/`dm` come with later source iterations.

## Testing

- 76 new unit tests (TDD, red-green per module): config validation, matcher semantics, dedup/cooldown/ET-day caps, all three sources (injected transports — no network), dispatcher + all three actions, `evaluate()` (dedup across ticks, cap throttle + notify-once, failure isolation, combined-query), tick integration, CLI smoke tests.
- Full engine suite: **987 passed** (1 skipped — live-vault parity test, as before). `ruff check`, `ruff format --check`, `mypy scout`, and `versioning check` all clean.
- All fixtures anonymized per CLAUDE.md (Alex/Priya/Sam, `example-org/*`, fake Slack ids, `acme-co` workspace). `parser-corpus.json` untouched.

## Note: earlier macOS CI failures were pre-existing on `main`

The initial CI runs here failed `test (macos-latest, *)` on `test_local_tz_name_resolves_symlink_zone` — a pre-existing breakage from the updated `macos-latest` runner image (`/etc/localtime` resolves through `/usr/share/zoneinfo.default/`, which `_local_tz_name`'s literal `'zoneinfo/'` match missed), unrelated to this branch. That's now fixed on `main` by #182, and this branch is rebased on top of it; a duplicate fix briefly carried here was dropped in the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
