### PR TITLE
feat(preflight): pre-session connector preflight with per-slot-type on_degraded policy (connector-resilience Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **Pre-session connector preflight (connector-resilience Phase 1, #181)** — scheduled runs no longer launch blind when critical connectors are down. A new `scoutctl connectors preflight` gate runs in all three runner templates alongside the budget check, health-checking every connector critical for the slot type at zero model-token cost (`claude mcp list` for MCP connectors matched by a new per-connector `harness_server_name` field; a `preflight_command` bash probe — e.g. `gh auth status` — for CLI-based ones; connectors with neither field are simply not probed). The run is degraded iff **any** critical connector is determinably down; the slot type's `on_degraded` policy — a new `connector_policy` block in `scout-config.yaml` (`skip` | `warn` | `run`, global default + per-slot-type overrides) — then decides: `skip` exits 3 (the runner converts it to an orderly budget-check-style skip and a Telegram/alert-log notification fires), `warn` writes `.scout-cache/connector-degradation-pending.md` for the session to consume (banner the degradation; record no false "nothing found" signals), `run` preserves today's behavior and is the default — existing installs are unaffected until they opt in. The preflight **fails open** on any probe error (a broken probe must never block runs), and because fail-open + glyph parsing means a CLI format change would silently disable the protection, a persisted inconclusive-streak counter alerts after 3 consecutive inconclusive probes. Healthy runs stamp `last_healthy_run` per slot type in `.scout-state/connector-preflight-state.json` so Phase 2 gap records get accurate windows. Phase 2 (gap tracking + post-session reconciliation, gated on #121) and Phase 3 (`/scout-backfill`) are not part of this change.
+
 ## [0.7.3] - 2026-06-23
 
 

--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -254,6 +254,8 @@ def _register_connectors() -> None:
                 "detail": c.remediation.detail,
             },
             "notes": c.notes,
+            "harness_server_name": c.harness_server_name,
+            "preflight_command": c.preflight_command,
         }
         typer.echo(_json.dumps(record, indent=2))
 
@@ -264,6 +266,50 @@ def _register_connectors() -> None:
 
         load_registry()  # exercise the path; raises ConfigError on bad YAML
         typer.echo("reloaded")
+
+    @connectors_app.command("preflight")
+    def cli_connectors_preflight(
+        slot_type: str = typer.Option(
+            "",
+            "--slot-type",
+            help="Slot type to gate (briefing | consolidation | dreaming | research | manual).",
+        ),
+        mode: str = typer.Option(
+            "",
+            "--mode",
+            help="Dispatcher slot key (SCOUT_FORCE_MODE); resolved to a slot type via the schedule.",
+        ),
+        claude_bin: str = typer.Option(
+            "claude",
+            "--claude-bin",
+            help="Claude Code binary used for the `claude mcp list` probe.",
+        ),
+        timeout: float = typer.Option(
+            60.0,
+            "--timeout",
+            help="Per-probe timeout in seconds (timeout → inconclusive, fail open).",
+        ),
+    ) -> None:
+        """Pre-session connector preflight (connector-resilience Phase 1).
+
+        Probes the connectors critical for the slot type and applies the
+        vault's `connector_policy` (scout-config.yaml). Exit codes: 0 =
+        proceed, 3 = policy skip (the runner converts this to an orderly
+        skip), 4 = inconclusive probe (the runner fails open).
+        """
+        from scout.scripts.connector_preflight import run as preflight_run
+
+        if not slot_type and not mode:
+            typer.echo("pass --slot-type or --mode", err=True)
+            raise typer.Exit(code=2)
+        raise typer.Exit(
+            preflight_run(
+                slot_type=slot_type or None,
+                mode=mode or None,
+                claude_bin=claude_bin,
+                timeout=timeout,
+            )
+        )
 
     @connectors_app.command("probe-registry")
     def cli_connectors_probe_registry(

--- a/engine/scout/connectors.py
+++ b/engine/scout/connectors.py
@@ -58,6 +58,17 @@ class Connector:
     required_in_types: tuple[SlotType, ...]
     remediation: Remediation
     notes: str = ""
+    # Pre-session preflight wiring (connector-resilience Phase 1). Exactly
+    # how the preflight probes this connector before a scheduled run:
+    #   harness_server_name — matched VERBATIM against `claude mcp list`
+    #     output (e.g. "claude.ai Slack"); registry keys / display names
+    #     cannot be mechanically mapped to harness server names.
+    #   preflight_command — a bash probe run directly (exit 0 = healthy),
+    #     harness-independent (e.g. "gh auth status").
+    # A connector with neither field is not preflight-checkable and is
+    # simply not probed.
+    harness_server_name: str = ""
+    preflight_command: str = ""
 
     def required_in_mode(self, mode: str) -> bool:
         """DEPRECATED: keyed on slot key. Prefer ``required_in_type``.
@@ -198,6 +209,8 @@ def _build_connector(key: str, raw: dict[str, Any]) -> Connector:
             required_in_types=required_in_types,
             remediation=remediation,
             notes=raw.get("notes", "") or "",
+            harness_server_name=raw.get("harness_server_name", "") or "",
+            preflight_command=raw.get("preflight_command", "") or "",
         )
     except (KeyError, ValueError) as e:
         raise ConfigError(f"connector {key} entry is malformed: {e}") from e

--- a/engine/scout/connectors.yaml
+++ b/engine/scout/connectors.yaml
@@ -12,6 +12,13 @@
 #         first_fix: string  (≤180 chars; goes into Slack/Telegram DMs)
 #         detail:    string  (multi-line allowed; goes into connector-health.md)
 #       notes: string (optional)
+#       harness_server_name: string (optional) — matched VERBATIM against
+#         `claude mcp list` output by the pre-session preflight
+#         (scoutctl connectors preflight). Omit for connectors that don't
+#         appear in `claude mcp list` (local bridges, browser extensions).
+#       preflight_command: string (optional) — bash probe run by the
+#         preflight instead of the MCP list (exit 0 = healthy).
+#       A connector with neither probe field is simply not preflight-probed.
 #
 # `key` is the value emitted by hooks/connector_log.py's classify() — i.e.,
 # what the JSONL `connector` field will read as. Hooks compute the key from
@@ -38,6 +45,7 @@ connectors:
     tier: official
     capabilities: [inbound, outbound]
     required_in_types: [briefing, consolidation, dreaming, research]
+    harness_server_name: "claude.ai Slack"
     remediation:
       first_fix: "Reconnect Slack at https://claude.ai/settings/connectors — claude.ai Slack OAuth likely expired."
       detail: |
@@ -52,6 +60,7 @@ connectors:
     tier: official
     capabilities: [inbound]
     required_in_types: [briefing, consolidation, dreaming, research]
+    harness_server_name: "claude.ai Linear"
     remediation:
       first_fix: "Reconnect Linear at https://claude.ai/settings/connectors — claude.ai Linear OAuth likely expired."
       detail: |
@@ -64,6 +73,7 @@ connectors:
     tier: official
     capabilities: [inbound]
     required_in_types: [briefing, consolidation]
+    harness_server_name: "claude.ai Gmail"
     remediation:
       first_fix: "Reconnect Gmail at https://claude.ai/settings/connectors — Google OAuth likely needs refresh."
       detail: |
@@ -77,6 +87,7 @@ connectors:
     tier: official
     capabilities: [inbound]
     required_in_types: [briefing, consolidation]
+    harness_server_name: "claude.ai Google Calendar"
     remediation:
       first_fix: "Reconnect Google Calendar at https://claude.ai/settings/connectors (same Google auth as Gmail)."
       detail: |
@@ -94,6 +105,7 @@ connectors:
     # Sat/Sun. (The "required" list is the safety net — if it WERE called and
     # failed, alerting still fires.)
     required_in_types: [briefing, consolidation]
+    harness_server_name: "claude.ai Granola"
     remediation:
       first_fix: "Reconnect Granola at https://claude.ai/settings/connectors — Granola tokens expire periodically."
       detail: |
@@ -122,6 +134,7 @@ connectors:
     capabilities: [inbound]
     # Same weekday-oriented scope as Granola — Phase 1e weekday-mandatory.
     required_in_types: [briefing, consolidation]
+    harness_server_name: "claude.ai Google Drive"
     remediation:
       first_fix: "Reconnect Google Drive at https://claude.ai/settings/connectors."
       detail: "Google Drive connector — same reconnect flow as Gmail at https://claude.ai/settings/connectors."
@@ -133,6 +146,7 @@ connectors:
     # Used in briefing + consolidation for PR queue review and in research for
     # deep PR/issue dives. Not required for dreaming (introspection-only).
     required_in_types: [briefing, consolidation, research]
+    preflight_command: "gh auth status"
     remediation:
       first_fix: "Run `gh auth status`; if expired, `gh auth login` to re-auth. Token lives in macOS keychain."
       detail: |

--- a/engine/scout/scripts/connector_preflight.py
+++ b/engine/scout/scripts/connector_preflight.py
@@ -1,0 +1,516 @@
+"""Pre-session connector preflight — Layers 1-2 of the connector-resilience
+design (docs/superpowers/specs/2026-07-01-connector-resilience-design.md).
+
+Probes the health of every connector critical for the upcoming slot type
+*before* the main Claude session launches, at zero model-token cost:
+
+  * MCP connectors — parsed out of one ``claude mcp list`` invocation and
+    matched verbatim by the connector's ``harness_server_name``.
+  * Bash-probed connectors — the connector's ``preflight_command`` run
+    directly (e.g. ``gh auth status``), harness-independently.
+  * Connectors with neither field are not preflight-checkable and are
+    simply not probed.
+
+The run is **degraded** iff any probed critical connector is determinably
+not connected (there is deliberately no quorum knob — tolerance is tuned by
+which connectors are marked critical in ``required_in_types``). The slot
+type's ``on_degraded`` policy (``connector_policy`` in the vault's
+scout-config.yaml) then decides: ``skip`` (alert + exit 3), ``warn`` (write
+``.scout-cache/connector-degradation-pending.md`` for the session to
+consume, exit 0), or ``run`` (exit 0 — the default, today's behavior).
+
+Exit-code contract consumed by the run-*.sh runner templates:
+  0 = proceed, 3 = policy skip (runner converts to an orderly ``exit 0``),
+  4 = inconclusive (probe errored/unparseable — the runner FAILS OPEN).
+
+Error handling per the spec: a broken probe must never block runs, but
+because fail-open + glyph parsing means a routine CLI format change would
+silently disable the whole protection, an inconclusive-streak counter is
+persisted and an alert fires when it crosses ``INCONCLUSIVE_ALERT_STREAK``.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scout import paths
+from scout.connectors import Connector, ConnectorRegistry, load_registry
+from scout.events import now_iso
+from scout.schedule import SlotType, load_default_schedule, load_schedule
+
+EXIT_PROCEED = 0
+EXIT_SKIP_DEGRADED = 3
+EXIT_INCONCLUSIVE = 4
+
+DEFAULT_TIMEOUT_SECONDS = 60.0
+INCONCLUSIVE_ALERT_STREAK = 3
+
+STATE_FILENAME = "connector-preflight-state.json"
+DEGRADATION_PENDING_FILENAME = "connector-degradation-pending.md"
+
+
+class OnDegraded(enum.Enum):
+    SKIP = "skip"
+    WARN = "warn"
+    RUN = "run"
+
+
+class ProbeStatus(enum.Enum):
+    CONNECTED = "connected"
+    NEEDS_AUTH = "needs_auth"
+    FAILED = "failed"
+    PENDING = "pending"
+    # harness_server_name not present in `claude mcp list` output at all —
+    # the harness has no such server configured, so the session can't use it.
+    MISSING = "missing"
+    # The probe itself errored/timed out — health undeterminable. Unknowns
+    # never count toward degraded (fail open); they count toward inconclusive.
+    UNKNOWN = "unknown"
+
+
+_STATUS_HUMAN = {
+    ProbeStatus.CONNECTED: "connected",
+    ProbeStatus.NEEDS_AUTH: "needs authentication",
+    ProbeStatus.FAILED: "failed to connect",
+    ProbeStatus.PENDING: "pending approval",
+    ProbeStatus.MISSING: "not configured in `claude mcp list`",
+    ProbeStatus.UNKNOWN: "probe inconclusive",
+}
+
+# `claude mcp list` status markers (Claude Code 2.1.185). NOT a stable CLI
+# contract — an unrecognized format parses to nothing, which classifies as
+# inconclusive (never degraded) and feeds the inconclusive-streak alert.
+_MARKER_TO_STATUS = {
+    "✔ Connected": ProbeStatus.CONNECTED,
+    "! Needs authentication": ProbeStatus.NEEDS_AUTH,
+    "✘ Failed to connect": ProbeStatus.FAILED,
+    "⏸ Pending approval": ProbeStatus.PENDING,
+}
+
+# One row per server: `<name>: <url-or-command> - <marker>`. The name is
+# everything before the first ": " (plugin-scoped names contain colons but
+# never colon-space); the marker is anchored to end-of-line so " - " inside
+# the target column can't confuse the split.
+_LINE_RE = re.compile(
+    r"^(?P<name>.+?): .* - (?P<marker>" + "|".join(re.escape(m) for m in _MARKER_TO_STATUS) + r")\s*$"
+)
+
+
+def parse_mcp_list(text: str) -> dict[str, ProbeStatus]:
+    """Parse ``claude mcp list`` output into {server_name: status}.
+
+    Unrecognized lines (preamble, blanks, future format changes) are
+    skipped; a wholly unparseable output yields an empty dict, which the
+    caller treats as inconclusive — never as degraded.
+    """
+    statuses: dict[str, ProbeStatus] = {}
+    for line in text.splitlines():
+        m = _LINE_RE.match(line.strip())
+        if m:
+            statuses[m.group("name")] = _MARKER_TO_STATUS[m.group("marker")]
+    return statuses
+
+
+@dataclass(frozen=True)
+class ConnectorProbe:
+    key: str
+    display_name: str
+    status: ProbeStatus
+
+    @property
+    def healthy(self) -> bool:
+        return self.status is ProbeStatus.CONNECTED
+
+    @property
+    def down(self) -> bool:
+        """Determinably not connected (unknown is neither healthy nor down)."""
+        return self.status not in (ProbeStatus.CONNECTED, ProbeStatus.UNKNOWN)
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    slot_type: SlotType
+    probes: tuple[ConnectorProbe, ...]
+
+    @property
+    def dark(self) -> list[ConnectorProbe]:
+        return [p for p in self.probes if p.down]
+
+    @property
+    def degraded(self) -> bool:
+        """Degraded iff ANY probed critical connector is determinably down."""
+        return bool(self.dark)
+
+    @property
+    def inconclusive(self) -> bool:
+        """No determinable outage, but at least one probe couldn't decide."""
+        return not self.degraded and any(p.status is ProbeStatus.UNKNOWN for p in self.probes)
+
+
+# ----- probes ---------------------------------------------------------------
+
+
+def _run_mcp_list(claude_bin: str, timeout: float) -> dict[str, ProbeStatus] | None:
+    """Health-check every configured MCP server via ``claude mcp list``.
+
+    Returns None when the probe is inconclusive: the binary is missing, the
+    command errors or times out, or the output parses to no statuses at all.
+    """
+    try:
+        proc = subprocess.run(
+            [claude_bin, "mcp", "list"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        print(f"[connector-preflight] `{claude_bin} mcp list` failed: {e}", file=sys.stderr)
+        return None
+    if proc.returncode != 0:
+        print(
+            f"[connector-preflight] `{claude_bin} mcp list` exited {proc.returncode}",
+            file=sys.stderr,
+        )
+        return None
+    statuses = parse_mcp_list(proc.stdout)
+    return statuses or None
+
+
+def _run_bash_probe(command: str, timeout: float = DEFAULT_TIMEOUT_SECONDS) -> ProbeStatus:
+    """Run a connector's ``preflight_command``; exit 0 = healthy.
+
+    A non-zero exit is a determinable "down" (that's what the probe command
+    is for); failure to launch or a timeout is UNKNOWN (fail open).
+    """
+    try:
+        proc = subprocess.run(command, shell=True, capture_output=True, timeout=timeout)
+    except (OSError, subprocess.SubprocessError) as e:
+        print(f"[connector-preflight] probe `{command}` errored: {e}", file=sys.stderr)
+        return ProbeStatus.UNKNOWN
+    return ProbeStatus.CONNECTED if proc.returncode == 0 else ProbeStatus.FAILED
+
+
+def evaluate(
+    registry: ConnectorRegistry,
+    slot_type: SlotType,
+    mcp_statuses: Mapping[str, ProbeStatus] | None,
+    *,
+    run_bash: Callable[[str], ProbeStatus] | None = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> PreflightResult:
+    """Classify the upcoming run from probe results.
+
+    ``mcp_statuses`` is the parsed ``claude mcp list`` map, or None when
+    that probe was inconclusive — MCP-matched connectors then read UNKNOWN.
+    """
+
+    def _default_bash(command: str) -> ProbeStatus:
+        return _run_bash_probe(command, timeout=timeout)
+
+    bash = run_bash if run_bash is not None else _default_bash
+
+    probes: list[ConnectorProbe] = []
+    for key in registry.critical_for_slot_type(slot_type):
+        c: Connector = registry[key]
+        if c.harness_server_name:
+            if mcp_statuses is None:
+                status = ProbeStatus.UNKNOWN
+            else:
+                status = mcp_statuses.get(c.harness_server_name, ProbeStatus.MISSING)
+        elif c.preflight_command:
+            status = bash(c.preflight_command)
+        else:
+            continue  # not preflight-checkable — simply not probed
+        probes.append(ConnectorProbe(key=key, display_name=c.display_name, status=status))
+    return PreflightResult(slot_type=slot_type, probes=tuple(probes))
+
+
+# ----- policy ---------------------------------------------------------------
+
+
+def resolve_policy(config: Mapping[str, Any], slot_type: SlotType) -> OnDegraded:
+    """Resolve the ``on_degraded`` policy for a slot type from the vault config.
+
+    Malformed values fall back (bad override → the global default; bad
+    global → ``run``) with a stderr warning rather than crashing the runner.
+    """
+    block = config.get("connector_policy")
+    if block is None:
+        return OnDegraded.RUN
+    if not isinstance(block, Mapping):
+        print(
+            "[connector-preflight] connector_policy is not a mapping — falling back to on_degraded: run",
+            file=sys.stderr,
+        )
+        return OnDegraded.RUN
+
+    try:
+        default = OnDegraded(block.get("on_degraded", "run"))
+    except ValueError:
+        print(
+            f"[connector-preflight] unknown connector_policy.on_degraded value "
+            f"{block.get('on_degraded')!r} — falling back to run",
+            file=sys.stderr,
+        )
+        default = OnDegraded.RUN
+
+    overrides = block.get("overrides")
+    if not isinstance(overrides, Mapping):
+        if overrides is not None:
+            print(
+                "[connector-preflight] connector_policy.overrides is not a mapping — ignoring",
+                file=sys.stderr,
+            )
+        return default
+    raw = overrides.get(slot_type.value)
+    if raw is None:
+        return default
+    try:
+        return OnDegraded(raw)
+    except ValueError:
+        print(
+            f"[connector-preflight] unknown connector_policy.overrides.{slot_type.value} value "
+            f"{raw!r} — falling back to {default.value}",
+            file=sys.stderr,
+        )
+        return default
+
+
+def _load_vault_config(data_dir: Path) -> dict[str, Any]:
+    """Tolerantly read the vault's scout-config.yaml (where the
+    ``connector_policy`` block lives). Missing/malformed → {} (policy
+    defaults to ``run``) with a stderr note, never a crash."""
+    path = data_dir / "scout-config.yaml"
+    if not path.exists():
+        return {}
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, yaml.YAMLError) as e:
+        print(f"[connector-preflight] could not read {path}: {e} — using defaults", file=sys.stderr)
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def resolve_slot_type(mode: str, data_dir: Path | None = None) -> SlotType:
+    """Resolve the dispatcher's slot key (``SCOUT_FORCE_MODE``) to a slot type.
+
+    Order: manual variants (never gated) → exact slot-key match in the vault
+    schedule (falling back to plugin defaults) → a bare slot-type value →
+    MANUAL (unknown keys are not gated rather than guessed at).
+    """
+    if mode == "manual" or mode.endswith("-manual"):
+        return SlotType.MANUAL
+
+    target = data_dir if data_dir is not None else paths.data_dir()
+    vault_schedule = target / ".scout-state" / "schedule.yaml"
+    try:
+        sched = load_schedule(vault_schedule) if vault_schedule.exists() else load_default_schedule()
+    except Exception as e:  # malformed schedule must not break the gate
+        print(f"[connector-preflight] schedule load failed: {e}", file=sys.stderr)
+        sched = None
+    if sched is not None and mode in sched:
+        return sched[mode].type
+
+    try:
+        return SlotType(mode)
+    except ValueError:
+        print(
+            f"[connector-preflight] unknown mode {mode!r} — treating as manual (no gate)",
+            file=sys.stderr,
+        )
+        return SlotType.MANUAL
+
+
+# ----- state (inconclusive streak + last healthy run) ------------------------
+
+
+def _state_path(data_dir: Path) -> Path:
+    return paths.state_dir(data_dir) / STATE_FILENAME
+
+
+def _load_state(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        data = {}
+    if not isinstance(data, dict):
+        data = {}
+    data.setdefault("inconclusive_streak", 0)
+    if not isinstance(data.get("last_healthy_run"), dict):
+        data["last_healthy_run"] = {}
+    return data
+
+
+def _save_state(path: Path, state: dict[str, Any]) -> None:
+    """Best-effort persist — a state write failure must never fail the gate."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+    except OSError as e:
+        print(f"[connector-preflight] could not write {path}: {e}", file=sys.stderr)
+
+
+# ----- alerting --------------------------------------------------------------
+
+
+def _send_telegram_alert(body: str) -> None:
+    """Best-effort Telegram DM; missing secrets / network failures are logged
+    and swallowed (module-level indirection so tests can capture)."""
+    try:
+        from scout.scripts.notify_telegram import send
+
+        send(tier="action_required", body=body)
+    except Exception as e:
+        print(f"[connector-preflight] telegram alert failed: {e}", file=sys.stderr)
+
+
+def _alert(data_dir: Path, body: str) -> None:
+    """Fire the degradation notification channel: append to the connector
+    alerts log (same file the health report uses) + best-effort Telegram."""
+    log_path = paths.logs_dir(data_dir) / "connector-alerts.log"
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", encoding="utf-8") as f:
+            f.write(f"{now_iso()} [preflight] {body}\n")
+    except OSError as e:
+        print(f"[connector-preflight] could not append {log_path}: {e}", file=sys.stderr)
+    _send_telegram_alert(body)
+
+
+def _write_degradation_pending(data_dir: Path, slot_type: SlotType, dark: list[ConnectorProbe]) -> None:
+    """Warn-mode seam: the pre-session file the session phases consume (the
+    preflight cannot export env vars into the session — see #121)."""
+    lines = "\n".join(f"- {p.display_name} — {_STATUS_HUMAN[p.status]}" for p in dark)
+    body = (
+        f"# Connector degradation notice — preflight {now_iso()}\n\n"
+        f"The pre-session connector preflight found these connectors critical for this "
+        f"`{slot_type.value}` run NOT connected:\n\n"
+        f"{lines}\n\n"
+        "Instructions for this session:\n\n"
+        "1. Prepend a degradation banner to your output naming these connectors.\n"
+        '2. Do NOT record "nothing found"-style negative signals for them — the absence\n'
+        "   of signal from a dark connector is not the absence of data.\n"
+        "3. Delete this file once consumed so it does not leak into the next run.\n"
+    )
+    path = paths.cache_dir(data_dir) / DEGRADATION_PENDING_FILENAME
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+    except OSError as e:
+        print(f"[connector-preflight] could not write {path}: {e}", file=sys.stderr)
+
+
+# ----- top-level entry --------------------------------------------------------
+
+
+def run(
+    *,
+    slot_type: str | None = None,
+    mode: str | None = None,
+    data_dir: Path | None = None,
+    claude_bin: str = "claude",
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    registry: ConnectorRegistry | None = None,
+) -> int:
+    """Execute the preflight and return the runner exit code.
+
+    Exactly one of ``slot_type`` (a SlotType value) or ``mode`` (the
+    dispatcher's slot key) selects the slot type. ``data_dir`` and
+    ``registry`` are injectable for tests; production callers leave them None.
+    """
+    target = data_dir if data_dir is not None else paths.data_dir()
+
+    if slot_type is not None:
+        try:
+            st = SlotType(slot_type)
+        except ValueError:
+            print(f"[connector-preflight] unknown slot type {slot_type!r} — failing open", file=sys.stderr)
+            return EXIT_INCONCLUSIVE
+    elif mode is not None:
+        st = resolve_slot_type(mode, data_dir=target)
+    else:
+        raise ValueError("pass slot_type or mode")
+
+    reg = registry if registry is not None else load_registry(data_dir=target)
+    criticals = [reg[k] for k in reg.critical_for_slot_type(st)]
+    probeable = [c for c in criticals if c.harness_server_name or c.preflight_command]
+    if not probeable:
+        print(f"[connector-preflight] {st.value}: no preflight-checkable critical connectors — proceeding")
+        return EXIT_PROCEED
+
+    policy = resolve_policy(_load_vault_config(target), st)
+
+    mcp_statuses: dict[str, ProbeStatus] | None = {}
+    if any(c.harness_server_name for c in probeable):
+        mcp_statuses = _run_mcp_list(claude_bin, timeout)
+    result = evaluate(reg, st, mcp_statuses, timeout=timeout)
+
+    state_path = _state_path(target)
+    state = _load_state(state_path)
+
+    if result.degraded:
+        state["inconclusive_streak"] = 0
+        _save_state(state_path, state)
+        dark_desc = ", ".join(f"{p.display_name} ({_STATUS_HUMAN[p.status]})" for p in result.dark)
+        print(f"[connector-preflight] {st.value}: DEGRADED — {dark_desc}; policy: {policy.value}")
+        if policy is OnDegraded.SKIP:
+            _alert(
+                target,
+                f"Preflight: skipping {st.value} run — critical connectors down: {dark_desc}",
+            )
+            return EXIT_SKIP_DEGRADED
+        if policy is OnDegraded.WARN:
+            _write_degradation_pending(target, st, result.dark)
+        return EXIT_PROCEED
+
+    if result.inconclusive:
+        state["inconclusive_streak"] = int(state.get("inconclusive_streak", 0)) + 1
+        _save_state(state_path, state)
+        streak = state["inconclusive_streak"]
+        print(f"[connector-preflight] {st.value}: inconclusive probe (streak: {streak}) — failing open")
+        if streak == INCONCLUSIVE_ALERT_STREAK:
+            _alert(
+                target,
+                f"Preflight has been inconclusive for {streak} consecutive runs — "
+                "the probe may be broken (e.g. `claude mcp list` output format changed). "
+                "Connector-degradation protection is effectively disabled until this is fixed.",
+            )
+        return EXIT_INCONCLUSIVE
+
+    state["inconclusive_streak"] = 0
+    state["last_healthy_run"][st.value] = now_iso()
+    _save_state(state_path, state)
+    print(f"[connector-preflight] {st.value}: all critical connectors healthy — proceeding")
+    return EXIT_PROCEED
+
+
+__all__ = [
+    "DEFAULT_TIMEOUT_SECONDS",
+    "DEGRADATION_PENDING_FILENAME",
+    "EXIT_INCONCLUSIVE",
+    "EXIT_PROCEED",
+    "EXIT_SKIP_DEGRADED",
+    "INCONCLUSIVE_ALERT_STREAK",
+    "STATE_FILENAME",
+    "ConnectorProbe",
+    "OnDegraded",
+    "PreflightResult",
+    "ProbeStatus",
+    "evaluate",
+    "parse_mcp_list",
+    "resolve_policy",
+    "resolve_slot_type",
+    "run",
+]

--- a/engine/tests/unit/test_cli_connectors_subapp.py
+++ b/engine/tests/unit/test_cli_connectors_subapp.py
@@ -59,3 +59,33 @@ def test_probe_registry_default_is_tab_separated():
     parts = first.split("\t")
     assert len(parts) == 3
     assert parts[1] in ("bash", "mcp_tool")
+
+
+# ----- `scoutctl connectors preflight` (connector-resilience Phase 1) -------
+
+
+def test_preflight_manual_slot_type_proceeds(tmp_path, monkeypatch):
+    """Manual runs have no critical connectors — the gate is a no-op."""
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    result = runner.invoke(app, ["connectors", "preflight", "--slot-type", "manual"])
+    assert result.exit_code == 0, result.stdout
+
+
+def test_preflight_skip_policy_exits_3(tmp_path, monkeypatch):
+    """Degraded + skip policy → exit 3 (the runner converts this to an
+    orderly skip)."""
+    from scout.scripts import connector_preflight as cp
+
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    (tmp_path / "scout-config.yaml").write_text("connector_policy:\n  on_degraded: skip\n")
+    monkeypatch.setattr(cp, "_run_mcp_list", lambda claude_bin, timeout: {})
+    monkeypatch.setattr(cp, "_send_telegram_alert", lambda body: None)
+    # The seed roster's briefing-critical claude.ai connectors all read
+    # MISSING against an empty status map → degraded.
+    result = runner.invoke(app, ["connectors", "preflight", "--slot-type", "briefing"])
+    assert result.exit_code == 3, result.stdout
+
+
+def test_preflight_requires_mode_or_slot_type():
+    result = runner.invoke(app, ["connectors", "preflight"])
+    assert result.exit_code not in (0, 3)

--- a/engine/tests/unit/test_connector_preflight.py
+++ b/engine/tests/unit/test_connector_preflight.py
@@ -1,0 +1,432 @@
+"""Unit tests for scout.scripts.connector_preflight (Layers 1-2 of the
+connector-resilience design, docs/superpowers/specs/2026-07-01).
+
+Exit-code contract (consumed by the run-*.sh runner templates):
+  0 = proceed, 3 = policy skip (degraded), 4 = inconclusive (runner fails open).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from scout.connectors import load_registry
+from scout.schedule import SlotType
+from scout.scripts import connector_preflight as cp
+from scout.scripts.connector_preflight import (
+    EXIT_INCONCLUSIVE,
+    EXIT_PROCEED,
+    EXIT_SKIP_DEGRADED,
+    INCONCLUSIVE_ALERT_STREAK,
+    OnDegraded,
+    ProbeStatus,
+    evaluate,
+    parse_mcp_list,
+    resolve_policy,
+    resolve_slot_type,
+    run,
+)
+
+# Anonymized `claude mcp list` output (Claude Code 2.1.185 format): a
+# "Checking..." preamble line, then one `<name>: <target> - <marker>` row per
+# server. Covers all four status markers plus a plugin-scoped name whose
+# colons must not confuse the name capture.
+MCP_LIST_OUTPUT = dedent(
+    """\
+    Checking MCP server health…
+
+    claude.ai Slack: https://mcp.slack.com/mcp - ✔ Connected
+    claude.ai Linear: https://mcp.linear.app/mcp - ✘ Failed to connect
+    claude.ai Notion: https://mcp.notion.com/mcp - ! Needs authentication
+    claude.ai Acme Tools: https://mcp.acme.example/mcp - ⏸ Pending approval
+    plugin:example:tools: npx @example/mcp-server - ✔ Connected
+    """
+)
+
+
+# ----- parse_mcp_list -------------------------------------------------------
+
+
+def test_parse_mcp_list_parses_every_status_marker() -> None:
+    statuses = parse_mcp_list(MCP_LIST_OUTPUT)
+    assert statuses["claude.ai Slack"] is ProbeStatus.CONNECTED
+    assert statuses["claude.ai Linear"] is ProbeStatus.FAILED
+    assert statuses["claude.ai Notion"] is ProbeStatus.NEEDS_AUTH
+    assert statuses["claude.ai Acme Tools"] is ProbeStatus.PENDING
+
+
+def test_parse_mcp_list_handles_plugin_scoped_names_verbatim() -> None:
+    """Plugin-scoped server names contain colons; the name is everything
+    before the first ': ' separator."""
+    statuses = parse_mcp_list(MCP_LIST_OUTPUT)
+    assert statuses["plugin:example:tools"] is ProbeStatus.CONNECTED
+
+
+def test_parse_mcp_list_skips_preamble_and_blank_lines() -> None:
+    statuses = parse_mcp_list(MCP_LIST_OUTPUT)
+    assert len(statuses) == 5
+
+
+def test_parse_mcp_list_unparseable_output_yields_nothing() -> None:
+    """A CLI format change must yield an empty parse (→ inconclusive
+    upstream), never a bogus degraded verdict."""
+    assert parse_mcp_list("error: unknown command 'mcp'\n") == {}
+    assert parse_mcp_list("") == {}
+
+
+# ----- policy resolution ----------------------------------------------------
+
+
+def test_resolve_policy_defaults_to_run_when_block_missing() -> None:
+    assert resolve_policy({}, SlotType.BRIEFING) is OnDegraded.RUN
+
+
+def test_resolve_policy_global_default() -> None:
+    cfg = {"connector_policy": {"on_degraded": "skip"}}
+    assert resolve_policy(cfg, SlotType.BRIEFING) is OnDegraded.SKIP
+
+
+def test_resolve_policy_per_slot_override_wins() -> None:
+    cfg = {
+        "connector_policy": {
+            "on_degraded": "run",
+            "overrides": {"briefing": "skip", "dreaming": "warn"},
+        }
+    }
+    assert resolve_policy(cfg, SlotType.BRIEFING) is OnDegraded.SKIP
+    assert resolve_policy(cfg, SlotType.DREAMING) is OnDegraded.WARN
+    assert resolve_policy(cfg, SlotType.RESEARCH) is OnDegraded.RUN
+
+
+def test_resolve_policy_malformed_block_falls_back_to_run(capsys) -> None:
+    assert resolve_policy({"connector_policy": "yes please"}, SlotType.BRIEFING) is OnDegraded.RUN
+    assert "connector_policy" in capsys.readouterr().err
+
+
+def test_resolve_policy_unknown_value_falls_back(capsys) -> None:
+    cfg = {"connector_policy": {"on_degraded": "maybe"}}
+    assert resolve_policy(cfg, SlotType.BRIEFING) is OnDegraded.RUN
+    assert "on_degraded" in capsys.readouterr().err
+
+
+def test_resolve_policy_bad_override_falls_back_to_global(capsys) -> None:
+    cfg = {"connector_policy": {"on_degraded": "warn", "overrides": {"briefing": "nope"}}}
+    assert resolve_policy(cfg, SlotType.BRIEFING) is OnDegraded.WARN
+    assert "overrides" in capsys.readouterr().err
+
+
+# ----- mode → slot type resolution ------------------------------------------
+
+
+def test_resolve_slot_type_from_default_schedule_key(tmp_path: Path) -> None:
+    assert resolve_slot_type("morning-briefing", data_dir=tmp_path) is SlotType.BRIEFING
+    assert resolve_slot_type("midday-consolidation", data_dir=tmp_path) is SlotType.CONSOLIDATION
+
+
+def test_resolve_slot_type_manual_variants(tmp_path: Path) -> None:
+    assert resolve_slot_type("manual", data_dir=tmp_path) is SlotType.MANUAL
+    assert resolve_slot_type("dreaming-manual", data_dir=tmp_path) is SlotType.MANUAL
+    assert resolve_slot_type("research-manual", data_dir=tmp_path) is SlotType.MANUAL
+
+
+def test_resolve_slot_type_accepts_bare_type_value(tmp_path: Path) -> None:
+    assert resolve_slot_type("briefing", data_dir=tmp_path) is SlotType.BRIEFING
+
+
+def test_resolve_slot_type_unknown_key_falls_back_to_manual(tmp_path: Path) -> None:
+    assert resolve_slot_type("acme-run", data_dir=tmp_path) is SlotType.MANUAL
+
+
+# ----- classification -------------------------------------------------------
+
+
+def _overlay_registry(tmp_path: Path, body: str):
+    """Build a registry whose only critical connectors are the overlay's."""
+    state = tmp_path / ".scout-state"
+    state.mkdir(parents=True, exist_ok=True)
+    # Neutralize every seed connector so the test roster is exactly the overlay.
+    seed_off = "\n".join(f"  {key}:\n    required_in_types: []" for key in load_registry(data_dir=tmp_path).keys())
+    (state / "connectors.local.yaml").write_text(f"connectors:\n{seed_off}\n{body}")
+    return load_registry(data_dir=tmp_path)
+
+
+BRIEFING_ROSTER = """\
+  mcp:acme_chat:
+    display_name: Acme Chat
+    tier: community
+    capabilities: [inbound]
+    required_in_types: [briefing]
+    harness_server_name: "claude.ai Acme Chat"
+    remediation: {first_fix: "reconnect", detail: "reconnect"}
+  mcp:acme_tracker:
+    display_name: Acme Tracker
+    tier: community
+    capabilities: [inbound]
+    required_in_types: [briefing]
+    harness_server_name: "claude.ai Acme Tracker"
+    remediation: {first_fix: "reconnect", detail: "reconnect"}
+  unprobed:
+    display_name: Unprobed Source
+    tier: community
+    capabilities: [inbound]
+    required_in_types: [briefing]
+    remediation: {first_fix: "n/a", detail: "n/a"}
+"""
+
+
+def test_evaluate_all_connected_is_healthy(tmp_path: Path) -> None:
+    reg = _overlay_registry(tmp_path, BRIEFING_ROSTER)
+    statuses = {
+        "claude.ai Acme Chat": ProbeStatus.CONNECTED,
+        "claude.ai Acme Tracker": ProbeStatus.CONNECTED,
+    }
+    result = evaluate(reg, SlotType.BRIEFING, statuses)
+    assert not result.degraded
+    assert not result.inconclusive
+    # The unprobed connector has neither probe field — it is simply not probed.
+    assert {p.key for p in result.probes} == {"mcp:acme_chat", "mcp:acme_tracker"}
+
+
+def test_evaluate_any_critical_down_is_degraded(tmp_path: Path) -> None:
+    reg = _overlay_registry(tmp_path, BRIEFING_ROSTER)
+    statuses = {
+        "claude.ai Acme Chat": ProbeStatus.NEEDS_AUTH,
+        "claude.ai Acme Tracker": ProbeStatus.CONNECTED,
+    }
+    result = evaluate(reg, SlotType.BRIEFING, statuses)
+    assert result.degraded
+    assert [p.key for p in result.dark] == ["mcp:acme_chat"]
+
+
+def test_evaluate_server_missing_from_list_is_degraded(tmp_path: Path) -> None:
+    """A critical connector whose harness_server_name is absent from the
+    `claude mcp list` output is unusable by the session — degraded."""
+    reg = _overlay_registry(tmp_path, BRIEFING_ROSTER)
+    statuses = {"claude.ai Acme Chat": ProbeStatus.CONNECTED}
+    result = evaluate(reg, SlotType.BRIEFING, statuses)
+    assert result.degraded
+    assert [p.key for p in result.dark] == ["mcp:acme_tracker"]
+    assert result.dark[0].status is ProbeStatus.MISSING
+
+
+def test_evaluate_no_statuses_is_inconclusive_not_degraded(tmp_path: Path) -> None:
+    reg = _overlay_registry(tmp_path, BRIEFING_ROSTER)
+    result = evaluate(reg, SlotType.BRIEFING, None)
+    assert not result.degraded
+    assert result.inconclusive
+
+
+def test_evaluate_bash_probe_success_and_failure(tmp_path: Path) -> None:
+    reg = _overlay_registry(
+        tmp_path,
+        """\
+  clitool:
+    display_name: CLI Tool
+    tier: community
+    capabilities: [inbound]
+    required_in_types: [briefing]
+    preflight_command: "true"
+    remediation: {first_fix: "n/a", detail: "n/a"}
+""",
+    )
+    ok = evaluate(reg, SlotType.BRIEFING, None, run_bash=lambda cmd: ProbeStatus.CONNECTED)
+    assert not ok.degraded and not ok.inconclusive
+    down = evaluate(reg, SlotType.BRIEFING, None, run_bash=lambda cmd: ProbeStatus.FAILED)
+    assert down.degraded
+
+
+def test_evaluate_real_bash_probe_runs_command(tmp_path: Path) -> None:
+    reg = _overlay_registry(
+        tmp_path,
+        """\
+  goodcli:
+    display_name: Good CLI
+    tier: community
+    capabilities: [inbound]
+    required_in_types: [briefing]
+    preflight_command: "true"
+    remediation: {first_fix: "n/a", detail: "n/a"}
+  badcli:
+    display_name: Bad CLI
+    tier: community
+    capabilities: [inbound]
+    required_in_types: [briefing]
+    preflight_command: "false"
+    remediation: {first_fix: "n/a", detail: "n/a"}
+""",
+    )
+    result = evaluate(reg, SlotType.BRIEFING, None)
+    assert result.degraded
+    assert [p.key for p in result.dark] == ["badcli"]
+
+
+def test_evaluate_degraded_wins_over_inconclusive(tmp_path: Path) -> None:
+    """MCP list probe failed (unknown) but a bash probe found a hard down —
+    the run IS determinably degraded; unknowns alone fail open."""
+    reg = _overlay_registry(
+        tmp_path,
+        BRIEFING_ROSTER
+        + """\
+  badcli:
+    display_name: Bad CLI
+    tier: community
+    capabilities: [inbound]
+    required_in_types: [briefing]
+    preflight_command: "false"
+    remediation: {first_fix: "n/a", detail: "n/a"}
+""",
+    )
+    result = evaluate(reg, SlotType.BRIEFING, None)
+    assert result.degraded
+    assert not result.inconclusive
+
+
+# ----- run() ----------------------------------------------------------------
+
+
+def _vault_with_policy(tmp_path: Path, policy_yaml: str) -> Path:
+    vault = tmp_path / "vault"
+    vault.mkdir(parents=True, exist_ok=True)
+    (vault / "scout-config.yaml").write_text(policy_yaml)
+    return vault
+
+
+@pytest.fixture
+def alerts(monkeypatch) -> list[str]:
+    sent: list[str] = []
+    monkeypatch.setattr(cp, "_send_telegram_alert", lambda body: sent.append(body))
+    return sent
+
+
+@pytest.fixture
+def degraded_probe(monkeypatch):
+    monkeypatch.setattr(
+        cp, "_run_mcp_list", lambda claude_bin, timeout: {"claude.ai Acme Chat": ProbeStatus.NEEDS_AUTH}
+    )
+
+
+def _briefing_registry(vault: Path):
+    return _overlay_registry(
+        vault,
+        """\
+  mcp:acme_chat:
+    display_name: Acme Chat
+    tier: community
+    capabilities: [inbound]
+    required_in_types: [briefing]
+    harness_server_name: "claude.ai Acme Chat"
+    remediation: {first_fix: "reconnect", detail: "reconnect"}
+""",
+    )
+
+
+def test_run_skip_policy_exits_3_and_alerts(tmp_path: Path, alerts, degraded_probe) -> None:
+    vault = _vault_with_policy(tmp_path, "connector_policy:\n  on_degraded: skip\n")
+    rc = run(slot_type="briefing", data_dir=vault, registry=_briefing_registry(vault))
+    assert rc == EXIT_SKIP_DEGRADED
+    assert len(alerts) == 1
+    assert "Acme Chat" in alerts[0]
+    log = (vault / ".scout-logs" / "connector-alerts.log").read_text()
+    assert "Acme Chat" in log
+    # skip must NOT leave a warn-mode pending file
+    assert not (vault / ".scout-cache" / "connector-degradation-pending.md").exists()
+
+
+def test_run_warn_policy_exits_0_and_writes_pending_file(tmp_path: Path, alerts, degraded_probe) -> None:
+    vault = _vault_with_policy(tmp_path, "connector_policy:\n  on_degraded: warn\n")
+    rc = run(slot_type="briefing", data_dir=vault, registry=_briefing_registry(vault))
+    assert rc == EXIT_PROCEED
+    pending = vault / ".scout-cache" / "connector-degradation-pending.md"
+    assert pending.exists()
+    body = pending.read_text()
+    assert "Acme Chat" in body
+    assert "needs authentication" in body
+    assert alerts == []
+
+
+def test_run_run_policy_exits_0_without_side_effects(tmp_path: Path, alerts, degraded_probe) -> None:
+    vault = _vault_with_policy(tmp_path, "connector_policy:\n  on_degraded: run\n")
+    rc = run(slot_type="briefing", data_dir=vault, registry=_briefing_registry(vault))
+    assert rc == EXIT_PROCEED
+    assert alerts == []
+    assert not (vault / ".scout-cache" / "connector-degradation-pending.md").exists()
+
+
+def test_run_default_policy_is_run(tmp_path: Path, alerts, degraded_probe) -> None:
+    """No connector_policy block at all → today's behavior (no gate)."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    rc = run(slot_type="briefing", data_dir=vault, registry=_briefing_registry(vault))
+    assert rc == EXIT_PROCEED
+
+
+def test_run_healthy_stamps_last_healthy_run_and_resets_streak(tmp_path: Path, alerts, monkeypatch) -> None:
+    vault = _vault_with_policy(tmp_path, "connector_policy:\n  on_degraded: skip\n")
+    monkeypatch.setattr(cp, "_run_mcp_list", lambda claude_bin, timeout: {"claude.ai Acme Chat": ProbeStatus.CONNECTED})
+    state_path = vault / ".scout-state" / "connector-preflight-state.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps({"inconclusive_streak": 2, "last_healthy_run": {}}))
+
+    rc = run(slot_type="briefing", data_dir=vault, registry=_briefing_registry(vault))
+    assert rc == EXIT_PROCEED
+    state = json.loads(state_path.read_text())
+    assert state["inconclusive_streak"] == 0
+    assert state["last_healthy_run"]["briefing"]  # ISO timestamp recorded
+
+
+def test_run_degraded_under_warn_does_not_stamp_healthy(tmp_path: Path, alerts, degraded_probe) -> None:
+    """Spec Layer 1 step 6: a degraded run that proceeds under warn/run is
+    NOT a healthy run."""
+    vault = _vault_with_policy(tmp_path, "connector_policy:\n  on_degraded: warn\n")
+    run(slot_type="briefing", data_dir=vault, registry=_briefing_registry(vault))
+    state_path = vault / ".scout-state" / "connector-preflight-state.json"
+    if state_path.exists():
+        assert "briefing" not in json.loads(state_path.read_text()).get("last_healthy_run", {})
+
+
+def test_run_inconclusive_exits_4_and_alerts_at_streak_threshold(tmp_path: Path, alerts, monkeypatch) -> None:
+    vault = _vault_with_policy(tmp_path, "connector_policy:\n  on_degraded: skip\n")
+    monkeypatch.setattr(cp, "_run_mcp_list", lambda claude_bin, timeout: None)
+    reg = _briefing_registry(vault)
+    for i in range(INCONCLUSIVE_ALERT_STREAK):
+        rc = run(slot_type="briefing", data_dir=vault, registry=reg)
+        assert rc == EXIT_INCONCLUSIVE
+        # Alert fires exactly once, when the streak crosses the threshold.
+        assert len(alerts) == (1 if i + 1 >= INCONCLUSIVE_ALERT_STREAK else 0)
+    assert "inconclusive" in alerts[0]
+
+
+def test_run_manual_slot_type_is_a_no_op(tmp_path: Path, alerts, monkeypatch) -> None:
+    """Manual sessions have no critical connectors; the probe must not run."""
+
+    def _boom(claude_bin, timeout):  # pragma: no cover - would fail the test
+        raise AssertionError("probe must not be invoked for manual runs")
+
+    monkeypatch.setattr(cp, "_run_mcp_list", _boom)
+    vault = _vault_with_policy(tmp_path, "connector_policy:\n  on_degraded: skip\n")
+    rc = run(slot_type="manual", data_dir=vault)
+    assert rc == EXIT_PROCEED
+
+
+def test_run_resolves_mode_to_slot_type(tmp_path: Path, alerts, degraded_probe) -> None:
+    vault = _vault_with_policy(
+        tmp_path,
+        "connector_policy:\n  on_degraded: run\n  overrides:\n    briefing: skip\n",
+    )
+    rc = run(mode="morning-briefing", data_dir=vault, registry=_briefing_registry(vault))
+    assert rc == EXIT_SKIP_DEGRADED
+
+
+def test_run_unknown_slot_type_string_fails_open(tmp_path: Path, alerts) -> None:
+    vault = _vault_with_policy(tmp_path, "connector_policy:\n  on_degraded: skip\n")
+    rc = run(slot_type="not-a-type", data_dir=vault)
+    assert rc == EXIT_INCONCLUSIVE
+
+
+def test_run_malformed_vault_config_falls_back_to_run_policy(tmp_path: Path, alerts, degraded_probe) -> None:
+    vault = _vault_with_policy(tmp_path, "connector_policy: [broken\n")
+    rc = run(slot_type="briefing", data_dir=vault, registry=_briefing_registry(vault))
+    assert rc == EXIT_PROCEED

--- a/engine/tests/unit/test_connectors_yaml.py
+++ b/engine/tests/unit/test_connectors_yaml.py
@@ -98,6 +98,23 @@ def test_critical_connectors_filter_by_slot_type():
     assert "github" not in dreaming_critical  # gh used in research, not dreaming
 
 
+def test_preflight_probe_fields_on_seed_connectors():
+    """Preflight wiring (connector-resilience Phase 1): claude.ai-hosted
+    connectors carry harness_server_name; gh rides a bash probe; connectors
+    with neither field are simply not preflight-probed."""
+    reg = load_registry()
+    assert reg["mcp:claude_ai_Slack"].harness_server_name == "claude.ai Slack"
+    assert reg["mcp:claude_ai_Linear"].harness_server_name == "claude.ai Linear"
+    assert reg["mcp:claude_ai_Google_Calendar"].harness_server_name == "claude.ai Google Calendar"
+    assert reg["github"].preflight_command == "gh auth status"
+    assert reg["github"].harness_server_name == ""
+    # Local-bridge / extension connectors don't appear in `claude mcp list`
+    # reliably — shipped un-probed; users opt in via the overlay.
+    assert reg["mcp:whatsapp-mcp"].harness_server_name == ""
+    assert reg["mcp:whatsapp-mcp"].preflight_command == ""
+    assert reg["notify:telegram"].harness_server_name == ""
+
+
 def test_unknown_connector_raises():
     reg = load_registry()
     with pytest.raises(KeyError):

--- a/engine/tests/unit/test_runner_preflight_templates.py
+++ b/engine/tests/unit/test_runner_preflight_templates.py
@@ -1,0 +1,124 @@
+"""Functional tests for the connector-preflight gate in the runner templates.
+
+Renders each run-*.sh.tmpl into a tmp vault with a stub scoutctl (scripted
+exit code) and a stub claude-with-retry.sh (writes a marker instead of
+launching Claude), then runs the rendered script under bash and asserts the
+spec's runner contract: exit 3 → orderly skip (runner exits 0, session never
+launches); any other non-zero preflight exit → fail open (session launches);
+and MODE is defined before the preflight call in every template.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TEMPLATES_DIR = REPO_ROOT / "templates"
+
+RUNNER_TEMPLATES = ("run-scout.sh.tmpl", "run-dreaming.sh.tmpl", "run-research.sh.tmpl")
+
+# The MODE each runner falls back to when SCOUT_FORCE_MODE is unset.
+DEFAULT_MODES = {
+    "run-scout.sh.tmpl": "manual",
+    "run-dreaming.sh.tmpl": "dreaming-manual",
+    "run-research.sh.tmpl": "research-manual",
+}
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+def _render_runner(tmp_path: Path, template_name: str, preflight_rc: int) -> tuple[Path, Path]:
+    """Render one runner template into a tmp vault with stubbed dependencies.
+
+    Returns (runner_script, vault). Side-effect files under tmp_path:
+      preflight-args  — argv the stub scoutctl was called with
+      session-ran     — created iff the claude-with-retry stub was reached
+    """
+    vault = tmp_path / "vault"
+    (vault / "scripts").mkdir(parents=True)
+
+    scoutctl_stub = tmp_path / "scoutctl-stub"
+    _write_executable(
+        scoutctl_stub,
+        f'#!/bin/bash\necho "$@" > "{tmp_path}/preflight-args"\nexit {preflight_rc}\n',
+    )
+    _write_executable(
+        vault / "scripts" / "claude-with-retry.sh",
+        f'#!/bin/bash\ntouch "{tmp_path}/session-ran"\nexit 0\n',
+    )
+
+    template_vars = {
+        "INSTANCE_NAME": "Scout",
+        "INSTANCE_NAME_LOWER": "scout",
+        "USER_NAME": "Alex",
+        "USER_SLACK_ID": "U0000000000",
+        "SCOUT_DIR": str(vault),
+        "SCOUTCTL_BIN": str(scoutctl_stub),
+        "CLAUDE_BIN": "/usr/bin/true",
+        "MAX_BUDGET": "5.00",
+    }
+    text = (TEMPLATES_DIR / template_name).read_text(encoding="utf-8")
+    for key, value in template_vars.items():
+        text = text.replace("{{" + key + "}}", value)
+
+    runner = vault / template_name.removesuffix(".tmpl")
+    _write_executable(runner, text)
+    return runner, vault
+
+
+def _run(runner: Path, tmp_path: Path, mode: str | None = None) -> subprocess.CompletedProcess[str]:
+    env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "HOME": str(tmp_path)}
+    if mode is not None:
+        env["SCOUT_FORCE_MODE"] = mode
+    return subprocess.run(["bash", str(runner)], env=env, capture_output=True, text=True, timeout=60)
+
+
+def _log_text(vault: Path) -> str:
+    return "".join(p.read_text(encoding="utf-8") for p in (vault / ".scout-logs").glob("*.log"))
+
+
+@pytest.mark.parametrize("template_name", RUNNER_TEMPLATES)
+def test_preflight_exit_3_is_an_orderly_skip(tmp_path: Path, template_name: str) -> None:
+    runner, vault = _render_runner(tmp_path, template_name, preflight_rc=3)
+    proc = _run(runner, tmp_path, mode="morning-briefing")
+    assert proc.returncode == 0, proc.stderr
+    assert not (tmp_path / "session-ran").exists()
+    assert "skipping this run (degraded)" in _log_text(vault)
+
+
+@pytest.mark.parametrize("template_name", RUNNER_TEMPLATES)
+def test_preflight_error_fails_open(tmp_path: Path, template_name: str) -> None:
+    """Any non-3 non-zero exit is a preflight error, never a skip."""
+    runner, vault = _render_runner(tmp_path, template_name, preflight_rc=4)
+    proc = _run(runner, tmp_path, mode="morning-briefing")
+    assert proc.returncode == 0, proc.stderr
+    assert (tmp_path / "session-ran").exists()
+    assert "failing open" in _log_text(vault)
+
+
+@pytest.mark.parametrize("template_name", RUNNER_TEMPLATES)
+def test_preflight_proceed_launches_session(tmp_path: Path, template_name: str) -> None:
+    runner, _ = _render_runner(tmp_path, template_name, preflight_rc=0)
+    proc = _run(runner, tmp_path, mode="morning-briefing")
+    assert proc.returncode == 0, proc.stderr
+    assert (tmp_path / "session-ran").exists()
+    assert "--mode morning-briefing" in (tmp_path / "preflight-args").read_text()
+
+
+@pytest.mark.parametrize("template_name", RUNNER_TEMPLATES)
+def test_mode_is_defined_before_the_preflight_call(tmp_path: Path, template_name: str) -> None:
+    """With SCOUT_FORCE_MODE unset, the preflight must still receive the
+    runner's fallback MODE — i.e. MODE is assigned above the gate block
+    (the dreaming/research templates used to define it after the gates)."""
+    runner, _ = _render_runner(tmp_path, template_name, preflight_rc=0)
+    proc = _run(runner, tmp_path, mode=None)
+    assert proc.returncode == 0, proc.stderr
+    args = (tmp_path / "preflight-args").read_text()
+    assert f"--mode {DEFAULT_MODES[template_name]}" in args

--- a/phases/core/00-run-modes.md
+++ b/phases/core/00-run-modes.md
@@ -41,3 +41,5 @@ Two rules for declaring an outage honestly:
 2. **The claim must match the log.** An "unreachable" claim with zero recorded calls to that connector is invalid — the failed probe call is the proof-of-attempt.
 
 Per-mode scope rules (like Weekend Scope above) that *intentionally* skip a source are fine — the outage rule is about sources the mode *should* have scanned.
+
+**Consume the preflight notice first.** If `.scout-cache/connector-degradation-pending.md` exists, the pre-session connector preflight already found critical connectors down before this run started (the run proceeded under a `warn` policy). Prepend a degradation banner to your output naming those connectors, do NOT record "nothing found"-style negative signals for them — absence of signal from a dark connector is not absence of data — and delete the file once consumed so it doesn't leak into the next run.

--- a/phases/modes/kb-deep-work.md
+++ b/phases/modes/kb-deep-work.md
@@ -24,6 +24,8 @@ Before doing anything else, read the caches that the runner script generated bef
 
 Prefer these caches over live tool calls during scoring. Fall back to live queries only when a cache is missing, obviously stale, or you need deeper detail (e.g., full PR diff, full session transcript).
 
+Also check `.scout-cache/connector-degradation-pending.md`. If it exists, the pre-session preflight found critical connectors down before this run: prepend a degradation banner naming them, record no "nothing found"-style negative signals for them, and delete the file once consumed.
+
 ***
 
 ### Step 2-pre: Scan for Inline Comments

--- a/templates/run-dreaming.sh.tmpl
+++ b/templates/run-dreaming.sh.tmpl
@@ -29,6 +29,11 @@ fi
 echo $$ > "$LOCK_FILE"
 trap 'rm -f "$LOCK_FILE"' EXIT
 
+# Mode is set by the dispatcher (SCOUT_FORCE_MODE). For manual invocations
+# without SCOUT_FORCE_MODE set, default to "dreaming-manual". Defined before
+# the pre-session gates — the connector preflight needs it.
+MODE="${SCOUT_FORCE_MODE:-dreaming-manual}"
+
 # The prompt instructs Claude to read DREAMING.md and execute it
 PROMPT="You are {{INSTANCE_NAME}} running in DREAMING mode — the evening self-improvement and KB deep work session. Your working directory is {{SCOUT_DIR}}.
 
@@ -72,9 +77,25 @@ if [ -x "$BUDGET_CHECK" ]; then
     fi
 fi
 
-# Mode is set by the dispatcher (SCOUT_FORCE_MODE). For manual invocations
-# without SCOUT_FORCE_MODE set, default to "dreaming-manual".
-MODE="${SCOUT_FORCE_MODE:-dreaming-manual}"
+# Connector preflight — probe critical-connector health (via `claude mcp list`
+# + bash probes) before spending any model tokens. Policy per slot type comes
+# from the connector_policy block in scout-config.yaml (default: run — no gate).
+# Exit 3 = policy skip (orderly, like a budget skip); any other non-zero exit
+# is a preflight error and the run FAILS OPEN.
+SCOUTCTL_BIN="{{SCOUTCTL_BIN}}"
+if [ ! -x "$SCOUTCTL_BIN" ] && command -v scoutctl >/dev/null 2>&1; then
+    SCOUTCTL_BIN="$(command -v scoutctl)"
+fi
+if [ -x "$SCOUTCTL_BIN" ]; then
+    PREFLIGHT_RC=0
+    "$SCOUTCTL_BIN" connectors preflight --mode "$MODE" --claude-bin "$CLAUDE_BIN" >> "$LOG_FILE" 2>&1 || PREFLIGHT_RC=$?
+    if [ "$PREFLIGHT_RC" -eq 3 ]; then
+        echo "=== Connector preflight: skipping this run (degraded) ===" >> "$LOG_FILE"
+        exit 0
+    elif [ "$PREFLIGHT_RC" -ne 0 ]; then
+        echo "=== Connector preflight errored (rc=$PREFLIGHT_RC) — failing open ===" >> "$LOG_FILE"
+    fi
+fi
 
 START_TIME=$(date +%s)
 

--- a/templates/run-research.sh.tmpl
+++ b/templates/run-research.sh.tmpl
@@ -29,6 +29,11 @@ fi
 echo $$ > "$LOCK_FILE"
 trap 'rm -f "$LOCK_FILE"' EXIT
 
+# Mode is set by the dispatcher (SCOUT_FORCE_MODE). For manual invocations
+# without SCOUT_FORCE_MODE set, default to "research-manual". Defined before
+# the pre-session gates — the connector preflight needs it.
+MODE="${SCOUT_FORCE_MODE:-research-manual}"
+
 PROMPT="You are {{INSTANCE_NAME}} running in RESEARCH mode — the knowledge expansion session. Your working directory is {{SCOUT_DIR}}.
 
 Step 1: Read {{SCOUT_DIR}}/RESEARCH.md in full.
@@ -57,9 +62,25 @@ if [ -x "$BUDGET_CHECK" ]; then
     fi
 fi
 
-# Mode is set by the dispatcher (SCOUT_FORCE_MODE). For manual invocations
-# without SCOUT_FORCE_MODE set, default to "research-manual".
-MODE="${SCOUT_FORCE_MODE:-research-manual}"
+# Connector preflight — probe critical-connector health (via `claude mcp list`
+# + bash probes) before spending any model tokens. Policy per slot type comes
+# from the connector_policy block in scout-config.yaml (default: run — no gate).
+# Exit 3 = policy skip (orderly, like a budget skip); any other non-zero exit
+# is a preflight error and the run FAILS OPEN.
+SCOUTCTL_BIN="{{SCOUTCTL_BIN}}"
+if [ ! -x "$SCOUTCTL_BIN" ] && command -v scoutctl >/dev/null 2>&1; then
+    SCOUTCTL_BIN="$(command -v scoutctl)"
+fi
+if [ -x "$SCOUTCTL_BIN" ]; then
+    PREFLIGHT_RC=0
+    "$SCOUTCTL_BIN" connectors preflight --mode "$MODE" --claude-bin "$CLAUDE_BIN" >> "$LOG_FILE" 2>&1 || PREFLIGHT_RC=$?
+    if [ "$PREFLIGHT_RC" -eq 3 ]; then
+        echo "=== Connector preflight: skipping this run (degraded) ===" >> "$LOG_FILE"
+        exit 0
+    elif [ "$PREFLIGHT_RC" -ne 0 ]; then
+        echo "=== Connector preflight errored (rc=$PREFLIGHT_RC) — failing open ===" >> "$LOG_FILE"
+    fi
+fi
 
 START_TIME=$(date +%s)
 

--- a/templates/run-scout.sh.tmpl
+++ b/templates/run-scout.sh.tmpl
@@ -84,6 +84,26 @@ if [ -x "$BUDGET_CHECK" ]; then
     fi
 fi
 
+# Connector preflight — probe critical-connector health (via `claude mcp list`
+# + bash probes) before spending any model tokens. Policy per slot type comes
+# from the connector_policy block in scout-config.yaml (default: run — no gate).
+# Exit 3 = policy skip (orderly, like a budget skip); any other non-zero exit
+# is a preflight error and the run FAILS OPEN.
+SCOUTCTL_BIN="{{SCOUTCTL_BIN}}"
+if [ ! -x "$SCOUTCTL_BIN" ] && command -v scoutctl >/dev/null 2>&1; then
+    SCOUTCTL_BIN="$(command -v scoutctl)"
+fi
+if [ -x "$SCOUTCTL_BIN" ]; then
+    PREFLIGHT_RC=0
+    "$SCOUTCTL_BIN" connectors preflight --mode "$MODE" --claude-bin "$CLAUDE_BIN" >> "$LOG_FILE" 2>&1 || PREFLIGHT_RC=$?
+    if [ "$PREFLIGHT_RC" -eq 3 ]; then
+        echo "=== Connector preflight: skipping this run (degraded) ===" >> "$LOG_FILE"
+        exit 0
+    elif [ "$PREFLIGHT_RC" -ne 0 ]; then
+        echo "=== Connector preflight errored (rc=$PREFLIGHT_RC) — failing open ===" >> "$LOG_FILE"
+    fi
+fi
+
 START_TIME=$(date +%s)
 
 # Run Claude in print mode through the retry wrapper — capture exit code without triggering set -e.

--- a/templates/scout-config.yaml.tmpl
+++ b/templates/scout-config.yaml.tmpl
@@ -58,6 +58,27 @@ off_peak:
   start: 23
   end: 6
 
+# Connector resilience — what to do when a connector critical for the upcoming
+# slot type is down at session start. Probed by `scoutctl connectors preflight`
+# (via `claude mcp list` + bash probes) before the session launches, at zero
+# model-token cost. Values:
+#   skip — don't run the session at all (an alert fires instead)
+#   warn — run, but tell the session which connectors are dark so it banners
+#          the degradation and records no false "nothing found" signals
+#   run  — today's behavior: no gate
+connector_policy:
+  on_degraded: run
+  # Recommended posture once you opt in (uncomment to enable). briefing and
+  # consolidation are suggested as `warn` rather than `skip` for now: the
+  # `claude mcp list` probe has a known false-positive mode, and until the
+  # gap-tracking safety net (connector-resilience Phase 2) lands, a
+  # false-positive under `skip` would silently drop runs with no recorded gap.
+  # overrides:
+  #   briefing:       warn
+  #   consolidation:  warn
+  #   dreaming:       warn
+  #   research:       run
+
 # Whether Scout keeps itself up to date. Set during /scout-setup; toggle via
 # /scout-update. When enabled, a scheduled run applies sidecar-clean upgrades
 # and notifies you on conflict (auto-apply ships in a later version).


### PR DESCRIPTION
Implements **Phase 1** of the connector-resilience design (#181 — `docs/superpowers/specs/2026-07-01-connector-resilience-design.md`): the pre-session connector preflight (Layers 1–2). Phase 2 (gap records in `.scout-state/gaps.jsonl` + post-session reconciliation — gated on #121) and Phase 3 (`/scout-backfill`) are **intentionally not included**.

## What's in

- **`scoutctl connectors preflight --mode <slot-key> | --slot-type <type>`** (`engine/scout/scripts/connector_preflight.py`) — probes every connector critical for the slot type before the main session launches, at zero model-token cost:
  - MCP connectors parsed out of one `claude mcp list` invocation, matched **verbatim** by a new `harness_server_name` field on the connector roster (registry keys/display names can't be mechanically mapped to harness server names, per the spec).
  - Bash-probed connectors via a new `preflight_command` field (`github` → `gh auth status`), harness-independent.
  - A connector with neither field is simply not probed.
  - **Degraded iff any critical connector is determinably down** — no quorum/threshold knob, by design.
- **`connector_policy` block** in `scout-config.yaml` (`templates/scout-config.yaml.tmpl`): `on_degraded: skip | warn | run`, global default + per-slot-type `overrides`. **Shipped default is `run`** — existing installs see zero behavior change until they opt in. Malformed config falls back with a stderr warning, never crashes the runner.
- **Runner integration** in all three `run-*.sh.tmpl`, following the budget-check precedent: exit **3** = policy skip → runner logs it and exits 0 (orderly, like a budget skip); **any other non-zero exit fails open** — a preflight crash never masquerades as a deliberate skip. `MODE` is hoisted above the gate block in the dreaming/research runners (it was defined after them).
- **Warn seam**: preflight writes `.scout-cache/connector-degradation-pending.md` naming the dark connectors; the session phases (`phases/core/00-run-modes.md`, `phases/modes/kb-deep-work.md`) consume it — prepend a degradation banner, record no "nothing found"-style negative signals for dark connectors, delete after consuming.
- **Skip alert**: appends to `.scout-logs/connector-alerts.log` + best-effort Telegram (`action_required`), swallowing missing-secret/network failures.
- **Error handling per spec**: `claude mcp list` failure/timeout/unparseable output → *inconclusive*, exit 4, runner fails open. A persisted inconclusive-streak counter (`.scout-state/connector-preflight-state.json`) fires the alert channel once the streak hits 3 — fail-open + glyph parsing means a routine CLI format change would otherwise silently disable the whole protection.
- **`last_healthy_run[slot_type]`** stamped on healthy preflights (same state file) so Phase 2 gap records get accurate `from` windows from day one. Per spec, a degraded run proceeding under `warn`/`run` does **not** stamp it.

## ⚠️ Reviewable decision: recommended posture is `warn`, not `skip`, for briefing/consolidation

The spec's recommended posture sets briefing/consolidation to `skip`. This PR's commented-out recommended block in `scout-config.yaml.tmpl` suggests **`warn`** for them instead, deliberately: the `claude mcp list` probe has a known false-positive mode (anthropics/claude-code#44535), and until the Phase-2 reconciliation/gap-tracking safety net exists, a false-positive under `skip` silently drops runs with **no recorded gap** — exactly the "silent loss" this design exists to prevent. `warn` still runs the session, banners the degradation, and suppresses false negative signals. Once Phase 2 lands, flipping the recommendation back to `skip` is a one-line template change. (Note the *shipped default* is `run` either way; this only affects the suggested opt-in posture.) Happy to flip to `skip` if you'd rather match the spec text as written.

## Scope notes / follow-ups

- **Persistent-degraded-streak alert** (guards the stuck-`skip` trap from phantom/zombie connectors, anthropics/claude-code#48275): out of scope here; noted as a follow-up — the state file already gives it a natural home.
- **Un-probed seed connectors**: `mcp:fathom`, `mcp:claude-in-chrome`, `mcp:whatsapp-mcp` ship without probe fields — they don't reliably appear in `claude mcp list` (browser extension / local bridge), and a wrong `harness_server_name` would read as permanently degraded. Users can wire them via the `connectors.local.yaml` overlay; the fields are overlay-able like the rest of the roster.
- Known Phase-1 limitation (documented in the spec): a fail-open blind run goes unrecorded until Layer 1b ships in Phase 2.
- `connectors.snapshot.json` is unaffected — the cross-repo projection only carries key/display_name/tier (verified with `--check`).

## Testing

- `engine/tests/unit/test_connector_preflight.py` — parser fixtures for all four status markers incl. plugin-scoped names (anonymized per CLAUDE.md), unparseable → inconclusive-not-degraded, policy resolution incl. malformed fallbacks, mode→slot-type resolution, degraded classification (any-critical-down; missing-from-list = down; unknowns fail open; bash probes), run() exit codes, warn pending file, skip alert, healthy stamp, streak alert.
- `engine/tests/unit/test_runner_preflight_templates.py` — renders each runner template into a tmp vault with stubbed scoutctl/claude and runs it under bash: exit 3 → orderly skip (session never launches), exit ≠ 0/3 → fail open, MODE defined before the gate (verified these fail against the pre-change templates).
- Full suite: **938 passed**; `ruff format --check`, `ruff check`, `mypy` clean (same commands as CI, from `engine/` with `.venv/bin/*`).
- Live end-to-end on a real config (44 MCP servers): healthy path classifies correctly and stamps state; a forced-degraded `warn` run writes the pending file naming the dark connector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)