### PR TITLE
fix(metadata): point plugin homepage/repository at Raven-Scout org repo

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,8 +13,8 @@
       "author": {
         "name": "Jordan Burger"
       },
-      "homepage": "https://github.com/jordanrburger/scout-plugin",
-      "repository": "https://github.com/jordanrburger/scout-plugin",
+      "homepage": "https://github.com/Raven-Scout/scout-plugin",
+      "repository": "https://github.com/Raven-Scout/scout-plugin",
       "keywords": [
         "knowledge-management",
         "briefing",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,8 +5,8 @@
   "author": {
     "name": "Jordan Burger"
   },
-  "homepage": "https://github.com/jordanrburger/scout-plugin",
-  "repository": "https://github.com/jordanrburger/scout-plugin",
+  "homepage": "https://github.com/Raven-Scout/scout-plugin",
+  "repository": "https://github.com/Raven-Scout/scout-plugin",
   "keywords": [
     "knowledge-management",
     "briefing",

--- a/engine/scout/scripts/self_update.py
+++ b/engine/scout/scripts/self_update.py
@@ -13,9 +13,7 @@ import urllib.request
 from collections.abc import Callable
 from dataclasses import dataclass
 
-RAW_MARKETPLACE_URL = (
-    "https://raw.githubusercontent.com/jordanrburger/scout-plugin/main/.claude-plugin/marketplace.json"
-)
+RAW_MARKETPLACE_URL = "https://raw.githubusercontent.com/Raven-Scout/scout-plugin/main/.claude-plugin/marketplace.json"
 
 
 @dataclass(frozen=True)

--- a/engine/tests/unit/test_versioning.py
+++ b/engine/tests/unit/test_versioning.py
@@ -28,7 +28,7 @@ def _fake_plugin(tmp_path: Path, version: str = "1.2.3") -> Path:
                         "source": "./",
                         "description": "Autonomous knowledge management",
                         "version": version,
-                        "homepage": "https://github.com/jordanrburger/scout-plugin",
+                        "homepage": "https://github.com/Raven-Scout/scout-plugin",
                         "keywords": ["knowledge-management", "briefing"],
                     }
                 ],

--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # Scout one-command installer.
-#   curl -fsSL https://raw.githubusercontent.com/jordanrburger/scout-plugin/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/Raven-Scout/scout-plugin/main/install.sh | bash
 # Sets up the PLUGIN + ENGINE. The interactive vault is then created with /scout-setup.
 #
 # Flags: --check  (verify preconditions only; make no changes)
 set -euo pipefail
 
-MARKETPLACE="jordanrburger/scout-plugin"
+MARKETPLACE="Raven-Scout/scout-plugin"
 CHECK_ONLY=0
 [ "${1:-}" = "--check" ] && CHECK_ONLY=1
 


### PR DESCRIPTION
## Why

The plugin metadata still pointed at the pre-org personal repo (`jordanrburger/scout-plugin`). The canonical repo is `Raven-Scout/scout-plugin`. This was flagged as **open item 1 on Raven-Scout/Scout#74** (in-app updates design) — its raw-URL fallback can now default to the org URL.

## What changed

All live references to the old repo slug:

- `.claude-plugin/plugin.json` — `homepage` + `repository`
- `.claude-plugin/marketplace.json` — `homepage` + `repository`
- `install.sh` — curl one-liner in the header comment + `MARKETPLACE` slug
- `engine/scout/scripts/self_update.py` — `RAW_MARKETPLACE_URL` (the self-update version check)
- `engine/tests/unit/test_versioning.py` — fixture URL, for consistency only

## What was deliberately left alone

- Historical design docs under `docs/plans/` and `docs/specs/` (dated records; old `jordanrburger/…` links redirect via GitHub after the repo transfer): the two 2026-06-02 release-system docs, the 2026-06-14 connector-probe design (issue #97 link), and the PR #25 motivation links in `scoutctl-bootstrap-auto.md`.

## Test assertions

No test asserts these URLs — `test_versioning.py` only uses the URL as fixture data in `_fake_plugin`. Updated it anyway so fixtures match reality.

`pytest tests/unit/test_versioning.py tests/unit/test_self_update.py` → 17 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)