### PR TITLE
fix(connectors): reconcile mail connector key — probe `gmail` → canonical `email` (#172)

### DIFF
--- a/engine/scout/scripts/bootstrap.py
+++ b/engine/scout/scripts/bootstrap.py
@@ -28,6 +28,7 @@ from scout.scripts.bootstrap_lock import (
     acquire_lock_with_wait,
     release_lock,
 )
+from scout.scripts.connector_probes import normalize_connector_keys
 from scout.scripts.migrate_perfile import migrate_perfile
 from scout.scripts.phase_assembly import (
     parse_phase_file,
@@ -52,6 +53,13 @@ class BootstrapConfig:
     connector_inputs: dict[str, str]
     skip_jobs: bool = False
     skip_claude: bool = False
+
+    def __post_init__(self) -> None:
+        # Vaults configured before a probe-key rename (gmail → email) carry the
+        # legacy key in connectors.enabled; normalizing at construction covers
+        # every entrypoint (install / upgrade / migrate-legacy / backport) and
+        # lets upgrade persist the canonical key back into scout-config.yaml.
+        self.enabled_connectors = normalize_connector_keys(self.enabled_connectors)
 
 
 @dataclass

--- a/engine/scout/scripts/connector_probes.py
+++ b/engine/scout/scripts/connector_probes.py
@@ -15,6 +15,20 @@ import yaml
 
 from scout.errors import ConfigError
 
+# Legacy probe/config keys and their canonical replacements. The probe key is
+# what gets written into scout-config.yaml `connectors.enabled`, and phase
+# sections are gated on `requires:` matching it exactly — a stale key in an
+# existing vault would silently drop every section it gates (#172: `gmail` vs
+# the phase key `email`).
+CONNECTOR_KEY_ALIASES: dict[str, str] = {
+    "gmail": "email",
+}
+
+
+def normalize_connector_keys(keys: set[str]) -> set[str]:
+    """Map legacy connector keys to their canonical names. Idempotent."""
+    return {CONNECTOR_KEY_ALIASES.get(k, k) for k in keys}
+
 
 class ProbeKind(Enum):
     MCP_TOOL = "mcp_tool"  # primary is an MCP tool name to call

--- a/engine/tests/unit/fixtures/phases/connectors/dummy-mixed.md
+++ b/engine/tests/unit/fixtures/phases/connectors/dummy-mixed.md
@@ -15,9 +15,9 @@ phase: connector
 name: dummy-mixed
 slot: query
 mode: [briefing]
-requires: gmail
+requires: email
 ---
 
-## Gmail Side
+## Email Side
 
-Gmail {{USER_NAME}}.
+Email {{USER_NAME}}.

--- a/engine/tests/unit/test_connector_key_invariant.py
+++ b/engine/tests/unit/test_connector_key_invariant.py
@@ -1,0 +1,108 @@
+"""Connector key-namespace invariant (#172, connector-catalog spec §7).
+
+`connectors.enabled` in scout-config.yaml is populated from the keys of
+templates/connector-probes.yaml, and phase sections are gated on their
+`requires:` frontmatter matching one of those keys exactly. A phase whose
+`requires:` does not resolve to a probe key is *silently un-enableable*:
+select_sections drops its sections with no error, no warning — just missing
+brain-file content. That is exactly what happened to the mail connector
+(probe key `gmail` vs phase key `email` dropped every email section from
+assembled SKILL.md), and this suite exists so the mismatch class fails CI
+instead of shipping.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scout.scripts.bootstrap import BootstrapConfig
+from scout.scripts.connector_probes import (
+    CONNECTOR_KEY_ALIASES,
+    load_registry,
+    normalize_connector_keys,
+)
+from scout.scripts.phase_assembly import parse_phase_file, select_sections
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+PHASES_ROOT = REPO_ROOT / "phases"
+SHIPPED_PROBES = REPO_ROOT / "templates" / "connector-probes.yaml"
+
+
+def _shipped_probe_keys() -> set[str]:
+    return set(load_registry(SHIPPED_PROBES))
+
+
+def _phase_requires() -> dict[str, set[Path]]:
+    """Every non-null `requires:` key in shipped phases → the files using it."""
+    out: dict[str, set[Path]] = {}
+    for pf in sorted(PHASES_ROOT.rglob("*.md")):
+        for section in parse_phase_file(pf):
+            if section.requires is not None:
+                out.setdefault(section.requires, set()).add(pf.relative_to(PHASES_ROOT))
+    return out
+
+
+def test_every_phase_requires_resolves_to_a_shipped_probe_key():
+    """A `requires:` key with no probe entry can never be enabled by /scout-setup."""
+    probe_keys = _shipped_probe_keys()
+    unresolved = {key: sorted(map(str, files)) for key, files in _phase_requires().items() if key not in probe_keys}
+    assert not unresolved, (
+        f"Phase `requires:` keys that resolve to no connector-probes.yaml entry (silently un-enableable): {unresolved}"
+    )
+
+
+def test_phases_use_canonical_keys_not_aliases():
+    """Aliases exist only to migrate legacy configs; phases must gate on canonical keys."""
+    aliased = set(_phase_requires()) & set(CONNECTOR_KEY_ALIASES)
+    assert not aliased, f"Phase `requires:` uses legacy alias keys: {sorted(aliased)}"
+
+
+def test_aliases_map_onto_shipped_probe_keys_without_colliding():
+    probe_keys = _shipped_probe_keys()
+    for legacy, canonical in CONNECTOR_KEY_ALIASES.items():
+        assert canonical in probe_keys, f"alias {legacy!r} → {canonical!r} which is not a shipped probe key"
+        assert legacy not in probe_keys, f"alias {legacy!r} is still also a shipped probe key (ambiguous)"
+
+
+def test_normalize_maps_legacy_gmail_and_is_idempotent():
+    assert normalize_connector_keys({"gmail", "slack"}) == {"email", "slack"}
+    assert normalize_connector_keys({"email", "slack"}) == {"email", "slack"}
+    assert normalize_connector_keys(set()) == set()
+    # Unknown keys (e.g. from a user probe overlay) pass through untouched.
+    assert normalize_connector_keys({"devin"}) == {"devin"}
+
+
+def test_legacy_gmail_config_selects_the_real_email_phase():
+    """The #172 regression, end to end on the shipped email phase.
+
+    A pre-rename vault has `gmail` in connectors.enabled. Un-normalized, that
+    key matches nothing in phases/connectors/email.md and the whole phase is
+    dropped; normalized, every section survives selection.
+    """
+    sections = parse_phase_file(PHASES_ROOT / "connectors" / "email.md")
+    assert sections, "email phase parsed to zero sections"
+
+    dropped = select_sections(sections, enabled_connectors={"gmail"})
+    assert dropped == [], "raw legacy key should not match — otherwise the alias is redundant"
+
+    kept = select_sections(sections, enabled_connectors=normalize_connector_keys({"gmail"}))
+    assert len(kept) == len(sections)
+
+
+def test_bootstrap_config_normalizes_enabled_connectors(tmp_path):
+    """Every bootstrap entrypoint funnels through BootstrapConfig, so
+    normalization there migrates legacy configs on the next /scout-update."""
+    cfg = BootstrapConfig(
+        vault=tmp_path,
+        plugin_root=REPO_ROOT,
+        instance_name="Scout",
+        instance_name_lower="scout",
+        user_name="Alex",
+        user_email="alex@example.com",
+        timezone="America/New_York",
+        platform="macos",
+        plugin_version="0.0.0",
+        enabled_connectors={"gmail", "slack"},
+        connector_inputs={},
+    )
+    assert cfg.enabled_connectors == {"email", "slack"}

--- a/engine/tests/unit/test_phase_assembly.py
+++ b/engine/tests/unit/test_phase_assembly.py
@@ -80,10 +80,10 @@ def test_select_filters_mixed_connectors_within_file():
     only_slack = select_sections(sections, enabled_connectors={"slack"})
     assert len(only_slack) == 1
     assert only_slack[0].requires == "slack"
-    only_gmail = select_sections(sections, enabled_connectors={"gmail"})
-    assert len(only_gmail) == 1
-    assert only_gmail[0].requires == "gmail"
-    both = select_sections(sections, enabled_connectors={"slack", "gmail"})
+    only_email = select_sections(sections, enabled_connectors={"email"})
+    assert len(only_email) == 1
+    assert only_email[0].requires == "email"
+    both = select_sections(sections, enabled_connectors={"slack", "email"})
     assert len(both) == 2
 
 

--- a/templates/connector-probes.yaml
+++ b/templates/connector-probes.yaml
@@ -10,7 +10,10 @@ slack:
 calendar:
   primary: mcp__claude_ai_Google_Calendar__list_calendars
   fallbacks: []
-gmail:
+# Provider-neutral mail key — must match `requires: email` in phases/connectors/email.md.
+# Gmail is the current (only) provider; legacy configs saying `gmail` are
+# normalized to `email` by scout.scripts.connector_probes.normalize_connector_keys.
+email:
   primary: mcp__claude_ai_Gmail__list_labels
   fallbacks: []
 linear:
@@ -24,6 +27,9 @@ github:
     - github_repos
 granola:
   primary: mcp__claude_ai_Granola__list_meetings
+  fallbacks: []
+fathom:
+  primary: mcp__fathom__list_meetings
   fallbacks: []
 drive:
   primary: mcp__claude_ai_Google_Drive__list_recent_files


### PR DESCRIPTION
Standalone fix for the connector key-namespace bug identified in the connector-catalog spec §7 (#152) and confirmed in the 2026-06-30 design review — split out as recommended there, independent of the catalog work. Fixes #172.

## The bug

The mail connector was named by **two different keys** across the namespaces that must agree:

- probe/config key (`templates/connector-probes.yaml`, `scout-config.yaml` `connectors.enabled`): **`gmail`**
- phase gate (`phases/connectors/email.md`): **`requires: email`**

`select_sections` keeps a section only when its `requires:` key is in `enabled_connectors`, so with Gmail enabled the assembler **silently dropped every email section** from assembled `SKILL.md` — no error, just missing behavior. Tests never caught it because the fixture (`dummy-mixed.md`) used `requires: gmail`, matching the probe key instead of the real phase key.

## The fix (spec §7's recommended resolution)

Standardize on the provider-neutral **`email`**, keep `gmail` as a legacy alias:

- **`templates/connector-probes.yaml`** — probe key renamed `gmail` → `email` (same Gmail probe tool). A future Outlook/IMAP probe maps to the same capability key: one phase, many providers.
- **`connector_probes.py`** — new `CONNECTOR_KEY_ALIASES = {"gmail": "email"}` + `normalize_connector_keys()`.
- **`bootstrap.py`** — `BootstrapConfig.__post_init__` normalizes `enabled_connectors`. Every entrypoint (install / upgrade / migrate-legacy / phases backport) constructs `BootstrapConfig`, so a pre-rename vault's `gmail` keeps working immediately, and the next `/scout-update` idempotently rewrites `connectors.enabled` to the canonical key — no manual migration.
- **Fixture** — `dummy-mixed.md` now uses the canonical `email` key.

## Regression guard

New `engine/tests/unit/test_connector_key_invariant.py`:

- every `requires:` key in shipped `phases/` resolves to a shipped probe-registry key (a key with no probe entry is silently un-enableable — this is the CI check spec §7 calls for);
- phases must gate on canonical keys, never alias keys;
- aliases must map onto real probe keys without colliding with them;
- end-to-end #172 reproduction: a legacy `{"gmail"}` config selects zero sections of the real email phase raw, and **all** sections once normalized;
- `BootstrapConfig` normalization itself.

## Also fixed in passing

The new invariant test immediately flagged a second instance of the same class: `phases/connectors/fathom.md` gates on `requires: fathom`, but no probe entry existed, so nothing could ever write `fathom` into `connectors.enabled` via setup. Added the missing probe (`mcp__fathom__list_meetings`, the same tool the phase itself uses). Happy to split this into its own PR if preferred.

## Verification

- `ruff format` / `ruff check` clean
- full engine suite: **896 passed, 1 skipped** (the vault-parity test that only runs with `SCOUT_DATA_DIR` set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)