### PR TITLE
release: v0.8.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "scout",
       "source": "./",
       "description": "Autonomous knowledge management and daily briefing system for Claude Code",
-      "version": "0.7.3",
+      "version": "0.8.0",
       "author": {
         "name": "Jordan Burger"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scout",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "Autonomous knowledge management and daily briefing system. Monitors your work tools (Slack, Calendar, Linear, GitHub, etc.), synthesizes findings into a persistent knowledge base with a formal ontology, and delivers daily action items — all running unattended via scheduled Claude Code sessions. Six session types: Morning Briefing, Consolidation, Dreaming, Research, interactive Work sessions, and Meta Review. Pre-session hooks pre-compute KB staleness, recent git activity, PR state, and Claude Code session summaries before each run, trading a few seconds of shell work for large token savings inside the session.",
   "author": {
     "name": "Jordan Burger"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-13
+
+
 ### Added
 - **Event-trigger engine v1 (polling)** (`engine/scout/triggers/`, spec `docs/specs/event-triggers.md`) — the engine can now fire on **events**, not just time. Triggers are declared in the vault's `.scout-state/triggers.yaml` (source + enumerated `match.type` + attribute filters + one of three action shapes: `notify` / `run_skill` / `interactive`) and evaluated at the top of every 5-minute `schedule_tick`, before slot dispatch and failure-isolated from it. v1 ships three polling sources — `slack` (Web-API mention search), `github` (`gh api notifications`), and `scout_internal` (the engine's own JSONL event stream) — with the combined-query optimization (one `scan_since()` per source per tick, in-memory trigger×event matching). Dedup/cooldown/daily-cap state lives in `.scout-cache/trigger-fires.json` (sliding recent-ids window; caps reset at midnight ET; mandatory `daily_fire_cap` — the validator rejects unlimited triggers, obvious `scout_internal` fire-cycles, and unknown skills). Every fire is logged to `.scout-logs/trigger-fires-YYYY-MM-DD.jsonl` and emitted as a `trigger.fired` event into the engine event stream. New CLI: `scoutctl trigger {list,show,validate,reload,test,fire-now,stats}`. Gated behind the (off-by-default) `triggers_v1` manifest flag; `linear`/`gmail`/`gcal`/`file` sources and the v2 webhook receiver are deferred.
 

--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scout-engine"
-version = "0.7.3"
+version = "0.8.0"
 description = "Scout engine: CLI, hooks, runners, and Python library for the Scout productivity system."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/engine/scout/__init__.py
+++ b/engine/scout/__init__.py
@@ -1,3 +1,3 @@
 """Scout engine package."""
 
-__version__ = "0.7.3"
+__version__ = "0.8.0"


### PR DESCRIPTION
Automated release prep for v0.8.0. Review, ensure CI is green, and merge — then run `scripts/release.sh --finalize v0.8.0` to tag and publish the GitHub Release.