### PR TITLE
feat(skills): add scout-ask, a read-side traversal contract for the KB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **`scout-ask` skill** (`skills/scout-ask/`) — a read-side traversal contract for the KB, closing the gap where every prior skill and phase told a session how to *write* the knowledge base and nothing told an interactive agent how to *read* it. A session opened in the vault (e.g. via the macOS app's Cowork/terminal deeplink) previously had no orientation at all: no vault `CLAUDE.md`, no `.claude/skills`, and the assembled `SKILL.md` / `DREAMING.md` / `RESEARCH.md` at the root are background-run prompts, not reader guidance. Three steps — resolve the entity to its canonical file (`ls knowledge-base/projects/`, not a vault-wide grep, and never a whole read of the ~130k-token `knowledge-base.md` index); read the `**Last verified:**` freshness gate and answer from the record when it is same-day; drill to live sources only when the gate opens, using the source coordinates the synthesis already recorded (Slack thread ts, `gh pr view`, Linear IDs, Drive doc IDs) rather than re-discovering them. Measured against a no-skill baseline on a project-status question (3 reps each): tool calls 9–12 → 3, turns 10–13 → 5, input tokens 417–590k → 184k, wall clock 51–63s → 33–35s, cost $0.65–1.02 → $0.42–0.56, with answer quality preserved and the KB's own `[single-source]` / `[unverified]` hedges carried through. All three with-skill reps converged on the identical call path.
+
 ## [0.8.0] - 2026-07-13
 
 

--- a/skills/scout-ask/SKILL.md
+++ b/skills/scout-ask/SKILL.md
@@ -14,7 +14,7 @@ Work the three steps in order. Most questions are done after step 2.
 One cheap listing beats a vault-wide search. For a project or initiative:
 
 ```bash
-ls knowledge-base/projects/          # 8-ish slugs; match the user's words to one
+ls knowledge-base/projects/          # match the user's words to a slug
 ```
 
 Then read `knowledge-base/projects/<slug>/<slug>.md`. That single file is the canonical record — it carries the header status *and* every dated update in reverse-chronological order.
@@ -33,8 +33,8 @@ rg -l -i "<entity>" knowledge-base/projects knowledge-base/people knowledge-base
 
 The first line under the title is `**Last verified:** <timestamp> (<session type>)`. That timestamp is the gate:
 
-- **Verified within the last day or two** — answer from the file and cite the timestamp. The recorded state *is* the current state; a live re-query returns the same facts and costs several turns.
-- **Older, or no `Last verified:` line at all** — answer from the file, say how old it is, and offer to drill.
+- **Within the file's freshness budget** — answer from the file and cite the timestamp. The recorded state *is* the current state; a live re-query returns the same facts and costs several turns. The budget is the one `/scout-status` and the KB pre-filter hook already use: 3 days for a high-priority file, 7 for medium, 14 for low, defaulting to medium when the file carries no priority.
+- **Past its budget, or no `Last verified:` line at all** — answer from the file, say how old it is, and offer to drill.
 
 The file's own hedges are load-bearing and belong in your answer: `[unverified]`, `[single-source]`, "not yet decided — do not record a verdict". Carry them through rather than flattening them into fact.
 
@@ -66,4 +66,4 @@ When you do, **use the reference the KB already recorded** — every synthesis c
 | Vault-wide `grep` for the entity | `ls knowledge-base/projects/` and match the slug |
 | Re-querying Linear/GitHub to confirm what the file states | Check the freshness gate; a same-day timestamp is the confirmation |
 | Loading MCP connector schemas before reading the KB | Read the file first — most questions never need a connector |
-| Reading `knowledge-base.md` to find where something lives | Entity files, then a scoped `rg` |
+| Reading `knowledge-base/knowledge-base.md` to find where something lives | Entity files, then a scoped `rg` |

--- a/skills/scout-ask/SKILL.md
+++ b/skills/scout-ask/SKILL.md
@@ -33,8 +33,8 @@ rg -l -i "<entity>" knowledge-base/projects knowledge-base/people knowledge-base
 
 The first line under the title is `**Last verified:** <timestamp> (<session type>)`. That timestamp is the gate:
 
-- **Within the file's freshness budget** — answer from the file and cite the timestamp. The recorded state *is* the current state; a live re-query returns the same facts and costs several turns. The budget is the one `/scout-status` and the KB pre-filter hook already use: 3 days for a high-priority file, 7 for medium, 14 for low, defaulting to medium when the file carries no priority.
-- **Past its budget, or no `Last verified:` line at all** — answer from the file, say how old it is, and offer to drill.
+- **Recently verified** — answer from the file and cite the timestamp. The recorded state *is* the current state; a live re-query returns the same facts and costs several turns.
+- **Old enough that the answer could mislead, or no `Last verified:` line at all** — answer from the file, say how old it is, and offer to drill.
 
 The file's own hedges are load-bearing and belong in your answer: `[unverified]`, `[single-source]`, "not yet decided — do not record a verdict". Carry them through rather than flattening them into fact.
 

--- a/skills/scout-ask/SKILL.md
+++ b/skills/scout-ask/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: scout-ask
+description: Use when the user asks what the state of something is — a project, initiative, person, decision, meeting, or open thread — and a Scout vault is present. Also use when the user asks what Scout knows about a topic, or asks a question that would otherwise be answered by searching Slack, Linear, GitHub, or Gmail directly.
+---
+
+# Asking Scout
+
+Scout has already done the investigation. Every KB file is a synthesis that a prior session built from live connectors and stamped with the date it was verified. Answering is **retrieval against a canonical file**, not a fresh investigation — and the vault is laid out so one file holds the answer.
+
+Work the three steps in order. Most questions are done after step 2.
+
+## 1. Resolve the entity to its canonical file
+
+One cheap listing beats a vault-wide search. For a project or initiative:
+
+```bash
+ls knowledge-base/projects/          # 8-ish slugs; match the user's words to one
+```
+
+Then read `knowledge-base/projects/<slug>/<slug>.md`. That single file is the canonical record — it carries the header status *and* every dated update in reverse-chronological order.
+
+Use the map below for other entity types. When the entity resolves to a file, you are done searching: read it and go to step 2.
+
+**When nothing matches**, search the entity files rather than the vault:
+
+```bash
+rg -l -i "<entity>" knowledge-base/projects knowledge-base/people knowledge-base/ontology/entities
+```
+
+`knowledge-base/knowledge-base.md` is a running session-history log, not a router — it is ~130k tokens and reading it costs more context than the rest of the vault combined. Reach it only through a scoped `rg` with line numbers, and only after the entity files come up empty.
+
+## 2. Read the freshness gate, then answer
+
+The first line under the title is `**Last verified:** <timestamp> (<session type>)`. That timestamp is the gate:
+
+- **Verified within the last day or two** — answer from the file and cite the timestamp. The recorded state *is* the current state; a live re-query returns the same facts and costs several turns.
+- **Older, or no `Last verified:` line at all** — answer from the file, say how old it is, and offer to drill.
+
+The file's own hedges are load-bearing and belong in your answer: `[unverified]`, `[single-source]`, "not yet decided — do not record a verdict". Carry them through rather than flattening them into fact.
+
+**You are done when you can state:** the status and owner, what moved most recently, what is still open, and which of it is the user's. The canonical file's header plus its newest dated update almost always supplies all four. Reaching for action items, meeting notes, or a second project file after that is re-investigating what the file already told you.
+
+## 3. Drill to live sources only when the gate opens
+
+Drill when the gate is stale, when the user asks about something the file marks unresolved, or when they explicitly ask you to re-check.
+
+When you do, **use the reference the KB already recorded** — every synthesis cites its source with the exact coordinates: Slack channel + thread ts, `gh pr view <n> --repo <org>/<repo>`, Linear issue IDs, Drive doc IDs. Go straight to that coordinate. Re-discovering it through a search or an issue-list query is the expensive path Scout ran so you wouldn't have to.
+
+## Map
+
+| Question | Canonical file |
+|---|---|
+| Project / initiative status | `knowledge-base/projects/<slug>/<slug>.md` |
+| A person | `knowledge-base/people/<name>.md`, then `knowledge-base/people.md`. These carry roster facts (role, team, contact) and a seeded `works_on` list that under-reports current work — for what they are *actually* on now, name the projects it lists and read those project files |
+| What's on my plate | `action-items/action-items-<YYYY-MM-DD>.md` (today's date) |
+| A meeting | `meetings/<series>/<date>.md` **and** `knowledge-base/meetings/<series>/<date>.md` — both exist, check both |
+| Typed / graph query | `python3 knowledge-base/ontology/parser.py query --type task --status open` (`--help` for traverse, related, path) |
+| A Slack channel | `knowledge-base/channels.md` |
+| What Scout is unsure about | `knowledge-base/review-queue.md`, `knowledge-base/research-queue/` |
+
+## Common mistakes
+
+| Mistake | Instead |
+|---|---|
+| `ls` the vault root to orient | Go straight to the map; the layout is fixed |
+| Vault-wide `grep` for the entity | `ls knowledge-base/projects/` and match the slug |
+| Re-querying Linear/GitHub to confirm what the file states | Check the freshness gate; a same-day timestamp is the confirmation |
+| Loading MCP connector schemas before reading the KB | Read the file first — most questions never need a connector |
+| Reading `knowledge-base.md` to find where something lives | Entity files, then a scoped `rg` |


### PR DESCRIPTION
## Problem

Every existing skill and phase tells a *scheduled* session how to **write** the knowledge base. Nothing tells an interactive agent how to **read** it.

A session opened in the vault — e.g. via the macOS app's Cowork/terminal deeplink — lands with no orientation at all: no vault `CLAUDE.md`, no `.claude/skills`, and the assembled `SKILL.md` / `DREAMING.md` / `RESEARCH.md` at the root are background-run prompts, not reader guidance. The producer-side guidance in `phases/core/kb-management.md` is thorough about file types and quality bars, but has no counterpart for traversal.

The result is not wrong answers — it's wasted motion. Baseline sessions `ls` the vault root, grep the whole vault (including the ~130k-token `knowledge-base.md` index), load MCP connector schemas, and re-query Linear/GitHub to confirm facts the KB verified hours earlier.

## What this adds

`skills/scout-ask/SKILL.md` — three steps:

1. **Resolve the entity to its canonical file.** `ls knowledge-base/projects/` and match the slug, rather than a vault-wide grep. `knowledge-base.md` is a session-history log, not a router — reached only via scoped `rg`, never read whole.
2. **Read the freshness gate.** The `**Last verified:**` stamp decides whether to answer from the record or drill. A same-day stamp *is* the confirmation.
3. **Drill only when the gate opens** — using the source coordinates the synthesis already recorded (Slack channel + thread ts, `gh pr view`, Linear issue IDs, Drive doc IDs) rather than re-discovering them.

Plus a map for other entity types and a mistakes table built from observed baseline behaviour.

## Measurements

Real `claude -p` sessions in a live vault, question: *"What is the status of the Semantic Layer initiative?"*, 3 reps per arm.

| | tool calls | turns | input tokens | wall clock | cost |
|---|---|---|---|---|---|
| baseline | 10.3 | 11.3 | 505,128 | 58.3s | $0.821 |
| with `scout-ask` | 3.0 | 5.0 | 183,625 | 33.5s | $0.467 |
| | **−71%** | **−56%** | **−64%** | **−43%** | **−43%** |

All three with-skill reps converged on an **identical** call path — skill → `ls projects/` → read the one file. Zero variance.

Answer quality held or improved: the with-skill answer leads with the freshness stamp, preserves the file's `[single-source]` hedge, and separates the user's items from the team's.

**Caveat on the baseline:** the harness allowlist denied its live MCP/`gh` calls, so baselines burned 3–4 calls on permission errors. In a real session those succeed and cost *more*. The baseline understates the waste.

## Overfit checks

- **Stale file** (`kai-data-apps`, verified 2026-06-01) — correctly triggered a drill instead of answering from the record. The gate's other branch works.
- **Person question** — costs more (7 calls), because person entity files are seeded from the roster and under-report current work. The map now says so.
- A rewrite of that person row steering toward `rg -l` made it **worse** (7 → 11 calls, grep spiral) and was reverted on the evidence.
- **Discovery** — fires on differently-phrased questions with no "status"/"initiative" vocabulary, off the description alone.

## Related — the delivery surface

This is the read-side half of a two-part feature. The macOS app can already launch a session, but nothing told that session how to navigate the vault once it arrived — the door existed with nothing behind it. `scout-ask` is what stands behind it.

- Raven-Scout/Scout#81 — Cowork/Desktop deeplink should open scoped to the Scout folder (the terminal route already scopes correctly; only the Desktop deeplink is missing a folder param)
- Raven-Scout/Scout#82 — global prompt input on every screen, launching Claude in the Scout folder

Together those turn the app into an ask-anything surface over the KB: type a question anywhere, get an answer grounded in the vault with links back to the live sources. This PR is what makes the answer cheap and repeatable.

## Scope

Skill only. A vault `CLAUDE.md` and an `upgrade()` seeding fix were prototyped alongside and deliberately dropped: the question path needs neither, and interactive capture into the vault isn't a workflow that exists yet (entries today are manual via `inbox.md` or automated via a scheduled run).

Follow-up worth considering separately: a `scout-capture` skill holding capture routing plus pointers to the phase-assembled conventions — measured 21 → 8 tool calls on a wishlist-capture task — if and when interactive capture becomes real.

