### PR TITLE
fix(scheduler): let on_miss=skip slots fire on time (#193)

### DIFF
--- a/engine/scout/defaults/schedule.yaml
+++ b/engine/scout/defaults/schedule.yaml
@@ -9,6 +9,21 @@
 # that aggregation surfaces (connectors.yaml `required_in_types`,
 # alert routing) reference. See:
 #   ~/scout-app/docs/superpowers/specs/2026-05-04-schedule-v2-design.md
+#
+# `on_miss` — what happens when a tick finds the slot's target already past
+# (the machine was asleep, or the 5-min tick simply landed late):
+#
+#   fire      Run it, as long as we're still within `missed_window_hours`
+#             of the target. Past that the slot goes stale and is skipped.
+#   collapse  Same window rule, but among slots of the SAME type that are
+#             all overdue, only the one with the latest target runs — so a
+#             laptop opened at 22:30 runs dreaming-nightly, not the older
+#             dreaming-evening as well.
+#   skip      Deprecated, retained for vaults whose seeded schedule.yaml
+#             still sets it. Now behaves like `fire`; before #193 it could
+#             never fire at all.
+#
+# Prefer `collapse` for any type with more than one slot.
 
 schema_version: 1
 
@@ -73,7 +88,7 @@ slots:
     fires_at_local: "18:30"
     weekdays: [Mon, Tue, Wed, Thu, Fri, Sat, Sun]
     missed_window_hours: 4
-    on_miss: skip
+    on_miss: collapse
     cooldown_minutes: 120
 
   dreaming-nightly:
@@ -82,7 +97,7 @@ slots:
     fires_at_local: "22:00"
     weekdays: [Mon, Tue, Wed, Thu, Fri, Sat, Sun]
     missed_window_hours: 6
-    on_miss: skip
+    on_miss: collapse
     cooldown_minutes: 120
 
   dreaming-weekend-morning:
@@ -91,7 +106,7 @@ slots:
     fires_at_local: "07:00"
     weekdays: [Sat, Sun]
     missed_window_hours: 4
-    on_miss: skip
+    on_miss: collapse
     cooldown_minutes: 120
 
   research:
@@ -100,5 +115,5 @@ slots:
     fires_at_local: "14:00"
     weekdays: [Mon, Tue, Wed, Thu, Fri]
     missed_window_hours: 4
-    on_miss: skip
+    on_miss: collapse
     cooldown_minutes: 240

--- a/engine/scout/schedule.snapshot.json
+++ b/engine/scout/schedule.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_from": "scout-plugin@dc6ad86",
+  "generated_from": "scout-plugin@c592291",
   "slots": [
     {
       "key": "morning-briefing",
@@ -97,7 +97,7 @@
         "Sat",
         "Sun"
       ],
-      "on_miss": "skip"
+      "on_miss": "collapse"
     },
     {
       "key": "dreaming-nightly",
@@ -113,7 +113,7 @@
         "Sat",
         "Sun"
       ],
-      "on_miss": "skip"
+      "on_miss": "collapse"
     },
     {
       "key": "dreaming-weekend-morning",
@@ -124,7 +124,7 @@
         "Sat",
         "Sun"
       ],
-      "on_miss": "skip"
+      "on_miss": "collapse"
     },
     {
       "key": "research",
@@ -138,7 +138,7 @@
         "Thu",
         "Fri"
       ],
-      "on_miss": "skip"
+      "on_miss": "collapse"
     }
   ]
 }

--- a/engine/scout/scripts/schedule_tick.py
+++ b/engine/scout/scripts/schedule_tick.py
@@ -442,7 +442,17 @@ def _apply_miss_rules(candidates: list[SlotCandidate], *, now: _dt.datetime) -> 
         within_window = (now - c.target) <= window
 
         if policy is OnMissPolicy.SKIP:
-            decisions[c.slot_key] = Decision(action="skip", reason="on_miss=skip")
+            # `skip` means "don't fire *late*", not "never fire". Every candidate
+            # reaching this point is already past its target — _compute_due_slots
+            # filters out `target > now` — so skipping unconditionally left no
+            # code path by which a skip-policy slot could ever fire, silently
+            # disabling all dreaming and research sessions (#193). The per-slot
+            # missed_window_hours is what bounds "late"; beyond it the slot goes
+            # stale exactly as it does under `fire`.
+            if within_window:
+                decisions[c.slot_key] = Decision(action="fire")
+            else:
+                decisions[c.slot_key] = Decision(action="skip", reason="stale-after-window")
             continue
 
         if policy is OnMissPolicy.FIRE:

--- a/engine/tests/unit/test_schedule_tick.py
+++ b/engine/tests/unit/test_schedule_tick.py
@@ -14,6 +14,7 @@ from scout.errors import ConfigError
 from scout.events import Event
 from scout.schedule import (
     OnMissPolicy,
+    Schedule,
     Slot,
     SlotRuntime,
     SlotType,
@@ -152,19 +153,113 @@ def test_apply_miss_rules_fire_outside_window_skips():
     assert "stale" in decisions["morning-briefing"].reason
 
 
-def test_apply_miss_rules_skip_policy_always_skips():
-    sched = load_default_schedule()
+def _skip_slot() -> Slot:
+    """A research-shaped `on_miss: skip` slot, independent of the shipped defaults.
+
+    The defaults no longer use `skip` (see #193), but the policy remains
+    supported for vaults whose seeded schedule.yaml still sets it, so these
+    tests synthesize the slot rather than reading it out of the defaults.
+    """
+    return _slot(
+        "research",
+        type_=SlotType.RESEARCH,
+        fires_at="14:00",
+        missed_window_hours=4,
+        on_miss=OnMissPolicy.SKIP,
+        cooldown_minutes=240,
+    )
+
+
+def test_apply_miss_rules_skip_policy_fires_when_exactly_on_time():
+    """Regression for #193: `on_miss: skip` must mean "don't fire *late*", not "never fire".
+
+    `_compute_due_slots` only ever yields candidates whose target has already
+    passed, so a SKIP branch that skips unconditionally leaves no code path by
+    which the slot can fire — every dreaming and research session was
+    permanently inert. `now == target` is the tightest possible case.
+    """
+    et = ZoneInfo("America/New_York")
+    target = datetime(2026, 5, 11, 14, 0, tzinfo=et)
+    candidate = SlotCandidate(
+        slot_key="research",
+        slot=_skip_slot(),
+        target=target,
+        last_fire=None,
+    )
+    decisions = _apply_miss_rules([candidate], now=target)
+    assert decisions["research"].action == "fire"
+
+
+def test_apply_miss_rules_skip_policy_fires_within_window():
+    """A skip-policy slot still fires while inside `missed_window_hours`.
+
+    The 5-minute tick interval means a tick almost never lands exactly on the
+    target, so "on time" has to tolerate at least one tick of latency; the
+    per-slot window is what bounds it.
+    """
     et = ZoneInfo("America/New_York")
     now = datetime(2026, 5, 11, 14, 30, tzinfo=et)
     candidate = SlotCandidate(
         slot_key="research",
-        slot=sched["research"],
+        slot=_skip_slot(),
+        target=datetime(2026, 5, 11, 14, 0, tzinfo=et),
+        last_fire=None,
+    )
+    decisions = _apply_miss_rules([candidate], now=now)
+    assert decisions["research"].action == "fire"
+
+
+def test_apply_miss_rules_skip_policy_skips_after_window():
+    """Beyond `missed_window_hours` a skip-policy slot goes stale, as before."""
+    et = ZoneInfo("America/New_York")
+    # missed_window_hours=4 → 18:00 is the edge; 18:01 is past it.
+    now = datetime(2026, 5, 11, 18, 1, tzinfo=et)
+    candidate = SlotCandidate(
+        slot_key="research",
+        slot=_skip_slot(),
         target=datetime(2026, 5, 11, 14, 0, tzinfo=et),
         last_fire=None,
     )
     decisions = _apply_miss_rules([candidate], now=now)
     assert decisions["research"].action == "skip"
-    assert "on_miss=skip" in decisions["research"].reason
+    assert decisions["research"].reason == "stale-after-window"
+
+
+def test_skip_policy_slot_can_fire_through_composed_pipeline():
+    """Composed-path guard for #193.
+
+    The original test hand-built a `SlotCandidate`, so it never exercised the
+    interaction that caused the bug: `_compute_due_slots` guarantees
+    `now >= target`, which made the unconditional SKIP branch unreachable-by-
+    fire. Driving both functions together is what actually pins the fix.
+    """
+    et = ZoneInfo("America/New_York")
+    sched = Schedule({"research": _skip_slot()})
+    now = datetime(2026, 5, 11, 14, 2, tzinfo=et)  # one tick past target
+    decisions = _apply_miss_rules(_compute_due_slots(sched, {}, now), now=now)
+    assert decisions["research"].action == "fire"
+
+
+def test_default_schedule_has_no_permanently_inert_slots():
+    """Every shipped slot must be able to fire at some tick during a full week.
+
+    Guards the class of bug in #193 at the schedule level: a policy/config
+    combination that can never produce `action="fire"` is a silent total
+    failure of that session type, which is exactly what went unnoticed for
+    three months.
+    """
+    tz = ZoneInfo("America/New_York")
+    sched = load_default_schedule()
+    # Mon 2026-05-11 .. Sun 2026-05-17, sampled every 5 min (the real tick interval).
+    start = datetime(2026, 5, 11, 0, 0, tzinfo=tz)
+    ever_fired: set[str] = set()
+    for step in range(7 * 24 * 12):
+        now = start + timedelta(minutes=5 * step)
+        for key, decision in _apply_miss_rules(_compute_due_slots(sched, {}, now), now=now).items():
+            if decision.action == "fire":
+                ever_fired.add(key)
+    never_fires = set(sched.keys()) - ever_fired
+    assert not never_fires, f"slots that can never fire: {sorted(never_fires)}"
 
 
 def test_apply_miss_rules_collapse_within_type_fires_only_latest():
@@ -628,7 +723,13 @@ def test_slot_fired_event_has_full_payload_per_v0_5_spec(tmp_path, monkeypatch):
 
 
 def test_slot_skipped_event_has_slot_type_and_target_local(tmp_path, monkeypatch):
-    """slot.skipped payload must contain slot_type and target_local per v0.5+ spec."""
+    """slot.skipped payload must contain slot_type and target_local per v0.5+ spec.
+
+    The skip is provoked by staleness: target 00:01 against a frozen 08:05 now is
+    ~8h overdue, well past `missed_window_hours: 1`. (This test previously used
+    `on_miss: skip` with a 24h window, which only skipped because of the #193
+    bug — a slot inside its window now correctly fires.)
+    """
     monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
     (tmp_path / ".scout-state").mkdir()
     (tmp_path / ".scout-logs").mkdir()
@@ -637,7 +738,7 @@ def test_slot_skipped_event_has_slot_type_and_target_local(tmp_path, monkeypatch
         "schema_version: 1\nslots:\n  research-slot:\n"
         "    type: research\n    runner: run-research.sh\n    fires_at_local: '00:01'\n"
         "    weekdays: [Mon, Tue, Wed, Thu, Fri, Sat, Sun]\n"
-        "    missed_window_hours: 24\n    on_miss: skip\n    cooldown_minutes: 5\n"
+        "    missed_window_hours: 1\n    on_miss: fire\n    cooldown_minutes: 5\n"
     )
     with (
         patch("scout.scripts.schedule_tick._now", return_value=_FROZEN_NOW),


### PR DESCRIPTION
Fixes #193.

## What was wrong

`_apply_miss_rules` skipped `on_miss: skip` slots unconditionally. `_compute_due_slots` only ever yields candidates whose target has already passed — it filters out `target > now` — so **there was no code path by which a skip-policy slot could fire**. `within_window` was computed and then never read in the SKIP branch; `FIRE` and `COLLAPSE` both consult it, which is why briefing and consolidation worked.

The policy meant "never fire" rather than "don't fire late". In the shipped defaults that is four slots — `dreaming-evening`, `dreaming-nightly`, `dreaming-weekend-morning`, `research` — so **every dreaming and research session was permanently inert** on any vault using the seeded schedule, with no error surfaced anywhere. `missed_window_hours` and `cooldown_minutes` on those slots were dead config.

I verified the report rather than taking it on faith. Beyond replicating the reporter's script byte-for-byte, I swept a full week at 1-minute granularity against the unfixed defaults — 10,080 ticks, zero fires for all four slots, while all six briefing/consolidation slots fired.

## This is a spec defect, not just a coding slip

Worth flagging for reviewers, because it changes what needs following up. The schedule-v2 design spec (in the `Scout` repo, `docs/superpowers/specs/2026-05-04-schedule-v2-design.md`) **mandates this behavior**:

> §4 step 4 — **`skip`** — emit `slot.skipped` with `reason="on_miss=skip"`. Always.

It also prescribes `on_miss: skip` for exactly these four slots (lines 119–146). So the implementation faithfully transcribed the spec, and the spec guaranteed the inertness.

The spec contradicts itself, which is what makes the deviation safe: the same section closes with

> Catch-up after extended sleep is **the same code path** — the on_miss + missed_window rules naturally do the right thing without a separate "catch-up mode."

That cannot hold for `skip` slots when `missed_window` is never consulted. This PR resolves the contradiction in favor of the catch-up intent.

## The fix

The SKIP branch now mirrors FIRE, bounding "late" by the slot's existing `missed_window_hours`:

```python
if policy is OnMissPolicy.SKIP:
    if within_window:
        decisions[c.slot_key] = Decision(action="fire")
    else:
        decisions[c.slot_key] = Decision(action="skip", reason="stale-after-window")
    continue
```

This is the issue's Option 1. Option 2 (`on_time_grace_minutes`) was rejected on the reporter's own telemetry: a tick landed within ±6 min of a dreaming target on only 2 of the last 12 days, so a narrow grace window leaves dreaming mostly inert — a less-broken bug rather than a fix. The existing 4h/6h windows are wide enough to survive a sleeping laptop.

`skip` consequently becomes a synonym for `fire`, and is documented as deprecated.

**Shipped defaults move the four slots to `collapse`.** This is the load-bearing reason not to simply use `fire`: a machine asleep at 18:30 that opens at 22:30 now runs `dreaming-nightly` and collapses `dreaming-evening` into it, instead of running the stale 18:30 session first and deferring nightly behind a 120-minute cooldown.

Existing vaults are **not** affected by the defaults change — they keep the `skip` seeded into `.scout-state/schedule.yaml` and are fixed by the code path above. That is why the code fix was mandatory and a defaults-only change would have been insufficient.

`on_miss` is now documented in `defaults/schedule.yaml`; it was previously described only in the sibling repo's spec.

## Tests

`test_apply_miss_rules_skip_policy_always_skips` asserted the bug with `now` 30 minutes past target, so it passed while encoding it. Replaced by:

- `..._fires_when_exactly_on_time` — `now == target`, the tightest case, and the exact regression.
- `..._fires_within_window` — 30 min past target (the inverted old assertion).
- `..._skips_after_window` — past `missed_window_hours` → `stale-after-window`.
- `test_skip_policy_slot_can_fire_through_composed_pipeline` — drives `_compute_due_slots` → `_apply_miss_rules` together. The original test hand-built its `SlotCandidate`, which is precisely why it never exercised the interaction that caused the bug.
- `test_default_schedule_has_no_permanently_inert_slots` — sweeps a full week at the real 5-minute tick interval and fails if any shipped slot can never fire. This generalizes the bug class: it fails on the pre-fix tree naming all four slots, so it would have caught this at authoring time.

The policy tests synthesize their own `skip` slot rather than reading one out of the defaults, so they keep testing the deprecated policy now that no default uses it.

One pre-existing test, `test_slot_skipped_event_has_slot_type_and_target_local`, was **relying on the bug** to produce a skip event (`on_miss: skip` with a 24h window, 8h past target). Its actual intent is the `slot.skipped` payload shape, so it now provokes a skip via staleness instead.

## Verification

All CI gates run locally: **995 passed, 10 skipped** (skips are environmental — no `textual`, no `SCOUT_DATA_DIR`), `ruff check`, `ruff format --check`, `mypy` (86 files), plus both snapshot drift checks. `schedule.snapshot.json` is regenerated in this PR, as the defaults change trips that gate.

Post-fix behavior on the shipped defaults:

```
18:30:00 exact  dreaming-evening: fire       research: skip(stale-after-window)
22:00:01        dreaming-nightly: fire       dreaming-evening: skip(collapsed-into=dreaming-nightly)
```

The week-long sweep now reaches all ten slots.

## Deliberately out of scope

- **Slot-liveness detector.** Not included, per the issue's offer to split it. Confirmed the gap is real: nothing in the repo joins `schedule.yaml` against `last-fire.json` — that file is written and read *only* by `schedule_tick` as an mtime-keyed perf cache. `bootstrap_doctor.py:272-280` checks that `schedule.yaml` exists and parses, nothing more. Filing separately.
- **Spec update** (`Scout` repo): §4 step 4 needs rewriting, and the `slot.skipped` reason enum in both that spec and `2026-04-25-scout-event-architecture-design.md` should drop `on_miss=skip`, which this PR makes unreachable.
- **`Scout/ScoutTests/Fixtures/schedule.snapshot.json`** is a vendored copy of the regenerated snapshot and is now further out of date. Note it was *already* stale before this change (`generated_from: scout-plugin@dc6ad86` vs `c592291`) and no Swift test consumes it, so it is not a gate — but the dual-write in `schedule_snapshot.py` looks for `~/scout-app/ScoutTests/Fixtures`, which does not exist in a `Projects/RavenScout/Scout` checkout layout, so it silently warns and skips. Probably worth its own issue.
