### PR TITLE
fix(runner): classify lid-close sleep as transient (#206)

### DIFF
--- a/engine/tests/integration/test_claude_with_retry.py
+++ b/engine/tests/integration/test_claude_with_retry.py
@@ -85,6 +85,32 @@ def test_retries_on_connection_closed_mid_response(tmp_path: Path) -> None:
     assert _attempts(scout_dir) == 2, "wrapper should have retried after the dropped connection"
 
 
+def test_retries_on_sleep_mid_response(tmp_path: Path) -> None:
+    """Lid-close/clamshell sleep must be retried like any other sleep death.
+
+    Regression context: a lid-close mid-run makes the CLI emit "Your computer
+    went to sleep mid-response" — a different string from the idle-sleep
+    "Connection closed mid-response" already covered — so the wrapper
+    hard-failed with zero retries and the whole session's work was discarded.
+    """
+    scout_dir = tmp_path / "Scout"
+    scout_dir.mkdir()
+    script = _render(TEMPLATE, scout_dir)
+    fake = _fake_claude(
+        scout_dir,
+        first_attempt_output=(
+            "API Error: Your computer went to sleep mid-response. The response above may be incomplete."
+        ),
+        first_attempt_exit=1,
+    )
+    log_file = scout_dir / "run.log"
+
+    result = _run(script, fake, log_file)
+
+    assert result.returncode == 0, log_file.read_text()
+    assert _attempts(scout_dir) == 2, "wrapper should have retried after the lid-close sleep"
+
+
 def test_existing_transient_pattern_still_retries(tmp_path: Path) -> None:
     """Guard: editing the regex alternation must not break a pre-existing pattern."""
     scout_dir = tmp_path / "Scout"

--- a/templates/scripts/claude-with-retry.sh.tmpl
+++ b/templates/scripts/claude-with-retry.sh.tmpl
@@ -8,6 +8,9 @@
 #   - "Stream idle timeout - partial response received"
 #   - "Connection closed mid-response"             (socket torn down mid-stream,
 #                                                    e.g. machine slept overnight)
+#   - "went to sleep mid-response"                  (lid-close/clamshell sleep;
+#                                                    idle sleep surfaces as the
+#                                                    line above instead)
 #   - "529 Overloaded"                              (Anthropic upstream temp)
 #
 # Does NOT retry on:
@@ -48,7 +51,7 @@ if [ "${SCOUT_RETRY_DISABLE:-0}" = "1" ]; then
 fi
 
 # Pipe-separated grep -E regex. Keep narrow — anything matched here triggers a retry.
-TRANSIENT_PATTERNS='socket connection was closed unexpectedly|Unable to connect to API \(ECONNRESET\)|Unable to connect to API \(ConnectionRefused\)|Stream idle timeout|Connection closed mid-response|529 Overloaded'
+TRANSIENT_PATTERNS='socket connection was closed unexpectedly|Unable to connect to API \(ECONNRESET\)|Unable to connect to API \(ConnectionRefused\)|Stream idle timeout|Connection closed mid-response|went to sleep mid-response|529 Overloaded'
 
 # Auth-failure class (HTTP 401/403). NOT retried — re-authentication needs a human —
 # but surfaced with a concrete remediation instead of the opaque "not classified"


### PR DESCRIPTION
Fixes #206.

## What

Adds `went to sleep mid-response` to `TRANSIENT_PATTERNS` in `templates/scripts/claude-with-retry.sh.tmpl`, exactly as #151 added `Connection closed mid-response`. The Claude CLI emits this string on a lid-close/clamshell sleep (idle sleep surfaces as the connection-closed line instead), so those runs died with **zero retries** and the whole session's work was discarded — $5.54 reconstructed cost on the observed occurrence.

The pattern matches on the fragment rather than the full sentence for robustness to CLI prefix wording. No new classification class; header comment updated alongside.

## Tests

New `test_retries_on_sleep_mid_response` in `engine/tests/integration/test_claude_with_retry.py`, mirroring #151's test. It feeds the wrapper the verbatim production line (`API Error: Your computer went to sleep mid-response. The response above may be incomplete.`) and asserts a second attempt runs. **Watched failing before the fix** — on main it dies with the exact "Failure not classified as transient — no retry" signature — and passes after.

## Validation

- pytest: **1004 passed, 10 skipped, 0 failed** vs main baseline 1003/10/0 (same env) — the +1 is the new test, no other deltas.
- ruff check / format, mypy, shellcheck (CI invocation), version guard, manifests: all green.

## Out of scope (per the issue's own caveat)

A retry 60s after failure on a still-closed lid just exhausts `MAX_ATTEMPTS=2`; the filer offered sleep-aware backoff as separate scope, and #204's comments independently flag the same "retry launched into a sleeping host" defect. Worth its own issue.

> Note for release: installed vaults pick this up on the next template re-render (`/scout-update` / bootstrap upgrade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
