### PR TITLE
fix(runner): bound concurrency-lock age; take over wedged sessions (#204)

### DIFF
--- a/engine/tests/integration/test_run_scout_lock.py
+++ b/engine/tests/integration/test_run_scout_lock.py
@@ -1,0 +1,150 @@
+"""Integration test for the concurrency-lock guard in templates/run-scout.sh.tmpl.
+
+Renders the runner template with a stubbed claude-with-retry.sh and drives the
+lock-guard branches with real holder processes.
+
+Regression context: the guard was liveness-only (`kill -0 $PID`), so a session
+that was alive but not progressing — host slept mid-run, wedged network call —
+held the lock indefinitely and every subsequent scheduled slot silently exited
+0 (41h and 21h outages observed, invisible to every audit surface because the
+skip path is exit 0 and last-fire.json still records the fire). The guard now
+bounds the lock by age: a live holder past SCOUT_LOCK_MAX_AGE_SECS is reaped
+(TERM, grace, KILL), the reap is recorded in failures.log, and the new session
+takes over the lock.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]  # …/scout-plugin
+TEMPLATE = REPO_ROOT / "templates" / "run-scout.sh.tmpl"
+
+# The reap path is TERM → 5s grace → KILL, so give runs comfortable headroom.
+RUN_TIMEOUT_S = 30
+
+
+def _render(tmpl: Path, scout_dir: Path) -> Path:
+    text = tmpl.read_text(encoding="utf-8")
+    for placeholder, value in {
+        "{{SCOUT_DIR}}": str(scout_dir),
+        "{{CLAUDE_BIN}}": "/usr/bin/true",  # never reached — the retry wrapper is stubbed
+        "{{INSTANCE_NAME_LOWER}}": "scout",
+        "{{INSTANCE_NAME}}": "Scout",
+        "{{MAX_BUDGET}}": "25",
+        "{{USER_NAME}}": "Alex",
+        "{{USER_SLACK_ID}}": "U0123456789",
+    }.items():
+        text = text.replace(placeholder, value)
+    out = scout_dir / "run-scout.sh"
+    out.write_text(text, encoding="utf-8")
+    out.chmod(0o755)
+    return out
+
+
+def _stub_retry_wrapper(scout_dir: Path) -> Path:
+    """Stand-in for scripts/claude-with-retry.sh: records that the session
+    body was reached (i.e. the lock was acquired), then succeeds."""
+    marker = scout_dir / "session-ran.marker"
+    stub = scout_dir / "scripts" / "claude-with-retry.sh"
+    stub.parent.mkdir(parents=True, exist_ok=True)
+    stub.write_text(f'#!/bin/bash\ntouch "{marker}"\nexit 0\n', encoding="utf-8")
+    stub.chmod(0o755)
+    return marker
+
+
+def _run(script: Path, *, max_age_s: int) -> subprocess.CompletedProcess:
+    env = {**os.environ, "SCOUT_LOCK_MAX_AGE_SECS": str(max_age_s)}
+    return subprocess.run(
+        [str(script)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=RUN_TIMEOUT_S,
+    )
+
+
+def _run_log(scout_dir: Path) -> str:
+    logs = sorted((scout_dir / ".scout-logs").glob("scout-*.log"))
+    assert logs, "runner should always create its per-run log"
+    return "\n".join(log.read_text(encoding="utf-8") for log in logs)
+
+
+def test_fresh_alive_holder_still_skips(tmp_path: Path) -> None:
+    """A live holder under the age ceiling keeps the original skip behavior."""
+    scout_dir = tmp_path / "Scout"
+    scout_dir.mkdir()
+    script = _render(TEMPLATE, scout_dir)
+    marker = _stub_retry_wrapper(scout_dir)
+    log_dir = scout_dir / ".scout-logs"
+    log_dir.mkdir()
+    holder = subprocess.Popen(["sleep", "300"])
+    try:
+        lock = log_dir / ".scout-session.lock"
+        lock.write_text(f"{holder.pid}\n", encoding="utf-8")  # mtime = now → fresh
+
+        result = _run(script, max_age_s=3600)
+
+        assert result.returncode == 0, result.stderr
+        assert "Another Scout session running" in _run_log(scout_dir)
+        assert not marker.exists(), "a fresh live holder must not be taken over"
+        assert holder.poll() is None, "a fresh live holder must not be killed"
+        assert lock.read_text(encoding="utf-8").strip() == str(holder.pid)
+    finally:
+        holder.kill()
+        holder.wait()
+
+
+def test_wedged_holder_is_reaped_and_lock_taken_over(tmp_path: Path) -> None:
+    """A live holder past the age ceiling is killed, logged, and replaced."""
+    scout_dir = tmp_path / "Scout"
+    scout_dir.mkdir()
+    script = _render(TEMPLATE, scout_dir)
+    marker = _stub_retry_wrapper(scout_dir)
+    log_dir = scout_dir / ".scout-logs"
+    log_dir.mkdir()
+    holder = subprocess.Popen(["sleep", "300"])
+    try:
+        lock = log_dir / ".scout-session.lock"
+        lock.write_text(f"{holder.pid}\n", encoding="utf-8")
+        held_since = time.time() - 120
+        os.utime(lock, (held_since, held_since))  # lock written 120s ago
+
+        result = _run(script, max_age_s=30)
+
+        assert result.returncode == 0, result.stderr
+        log = _run_log(scout_dir)
+        assert "Reaping wedged Scout session" in log
+        failures = (log_dir / "failures.log").read_text(encoding="utf-8")
+        assert f"Reaped wedged session PID {holder.pid}" in failures, (
+            "the reap must be visible to audit surfaces, not just the per-run log"
+        )
+        assert marker.exists(), "the new session must proceed after the takeover"
+        assert holder.wait(timeout=10) != 0, "the wedged holder must be killed"
+        assert not lock.exists(), "the takeover session must clean up its own lock on exit"
+    finally:
+        holder.kill()
+        holder.wait()
+
+
+def test_dead_holder_stale_lock_still_removed(tmp_path: Path) -> None:
+    """Guard: the pre-existing crashed-holder branch keeps working."""
+    scout_dir = tmp_path / "Scout"
+    scout_dir.mkdir()
+    script = _render(TEMPLATE, scout_dir)
+    marker = _stub_retry_wrapper(scout_dir)
+    log_dir = scout_dir / ".scout-logs"
+    log_dir.mkdir()
+    dead = subprocess.Popen(["sleep", "0"])
+    dead.wait()  # reaped → kill -0 fails for this PID
+    lock = log_dir / ".scout-session.lock"
+    lock.write_text(f"{dead.pid}\n", encoding="utf-8")
+
+    result = _run(script, max_age_s=3600)
+
+    assert result.returncode == 0, result.stderr
+    assert marker.exists(), "a crashed holder's lock must not block the run"
+    assert not lock.exists()

--- a/templates/run-dreaming.sh.tmpl
+++ b/templates/run-dreaming.sh.tmpl
@@ -16,13 +16,42 @@ LOCK_FILE="$LOG_DIR/.scout-session.lock"
 # Ensure log directory exists
 mkdir -p "$LOG_DIR"
 
-# Concurrency guard — only one {{INSTANCE_NAME}} session at a time
+# Concurrency guard — only one {{INSTANCE_NAME}} session at a time.
+# Liveness alone is not enough: a holder that is alive but not progressing
+# (host slept mid-run, wedged network call) passes `kill -0` forever and
+# would silently block every subsequent slot. Real sessions finish in
+# minutes, so a holder past LOCK_MAX_AGE_SECS is wedged by definition —
+# reap it and take over, and record the reap in failures.log so the
+# takeover is visible to audit surfaces (not just this run's log).
+LOCK_MAX_AGE_SECS="${SCOUT_LOCK_MAX_AGE_SECS:-7200}"   # 2h ceiling, env-overridable
 if [ -f "$LOCK_FILE" ]; then
     LOCK_PID=$(cat "$LOCK_FILE" 2>/dev/null)
     if kill -0 "$LOCK_PID" 2>/dev/null; then
-        echo "=== Another {{INSTANCE_NAME}} session running (PID $LOCK_PID) — skipping ===" >> "$LOG_FILE"
-        exit 0
+        # Lock age = seconds since the holder wrote the lock at session start.
+        # Sourced from the lock file's mtime: macOS ps has no `etimes` keyword,
+        # so elapsed-seconds-of-PID is not portable. GNU stat first (errors on
+        # BSD), BSD stat second; unknown age → treat the holder as fresh.
+        LOCK_MTIME=$(stat -c %Y "$LOCK_FILE" 2>/dev/null || stat -f %m "$LOCK_FILE" 2>/dev/null || echo "")
+        LOCK_AGE=""
+        case "$LOCK_MTIME" in
+            ''|*[!0-9]*) ;;
+            *) LOCK_AGE=$(( $(date +%s) - LOCK_MTIME )) ;;
+        esac
+        if [ -n "$LOCK_AGE" ] && [ "$LOCK_AGE" -gt "$LOCK_MAX_AGE_SECS" ]; then
+            echo "=== Reaping wedged {{INSTANCE_NAME}} session (PID $LOCK_PID, lock held ${LOCK_AGE}s > ${LOCK_MAX_AGE_SECS}s) ===" >> "$LOG_FILE"
+            echo "Reaped wedged session PID $LOCK_PID after ${LOCK_AGE}s at $(date)" >> "$LOG_DIR/failures.log"
+            kill -TERM "$LOCK_PID" 2>/dev/null || true
+            sleep 5
+            # KILL before removing the lock: a KILLed holder cannot run its
+            # EXIT trap, so it cannot delete the lock this run is about to own.
+            kill -KILL "$LOCK_PID" 2>/dev/null || true
+            rm -f "$LOCK_FILE"
+        else
+            echo "=== Another {{INSTANCE_NAME}} session running (PID $LOCK_PID) — skipping ===" >> "$LOG_FILE"
+            exit 0
+        fi
     else
+        # Stale lock file — previous session crashed
         rm -f "$LOCK_FILE"
     fi
 fi

--- a/templates/run-research.sh.tmpl
+++ b/templates/run-research.sh.tmpl
@@ -16,13 +16,42 @@ LOCK_FILE="$LOG_DIR/.scout-session.lock"
 # Ensure log directory exists
 mkdir -p "$LOG_DIR"
 
-# Concurrency guard — only one {{INSTANCE_NAME}} session at a time
+# Concurrency guard — only one {{INSTANCE_NAME}} session at a time.
+# Liveness alone is not enough: a holder that is alive but not progressing
+# (host slept mid-run, wedged network call) passes `kill -0` forever and
+# would silently block every subsequent slot. Real sessions finish in
+# minutes, so a holder past LOCK_MAX_AGE_SECS is wedged by definition —
+# reap it and take over, and record the reap in failures.log so the
+# takeover is visible to audit surfaces (not just this run's log).
+LOCK_MAX_AGE_SECS="${SCOUT_LOCK_MAX_AGE_SECS:-7200}"   # 2h ceiling, env-overridable
 if [ -f "$LOCK_FILE" ]; then
     LOCK_PID=$(cat "$LOCK_FILE" 2>/dev/null)
     if kill -0 "$LOCK_PID" 2>/dev/null; then
-        echo "=== Another {{INSTANCE_NAME}} session running (PID $LOCK_PID) — skipping ===" >> "$LOG_FILE"
-        exit 0
+        # Lock age = seconds since the holder wrote the lock at session start.
+        # Sourced from the lock file's mtime: macOS ps has no `etimes` keyword,
+        # so elapsed-seconds-of-PID is not portable. GNU stat first (errors on
+        # BSD), BSD stat second; unknown age → treat the holder as fresh.
+        LOCK_MTIME=$(stat -c %Y "$LOCK_FILE" 2>/dev/null || stat -f %m "$LOCK_FILE" 2>/dev/null || echo "")
+        LOCK_AGE=""
+        case "$LOCK_MTIME" in
+            ''|*[!0-9]*) ;;
+            *) LOCK_AGE=$(( $(date +%s) - LOCK_MTIME )) ;;
+        esac
+        if [ -n "$LOCK_AGE" ] && [ "$LOCK_AGE" -gt "$LOCK_MAX_AGE_SECS" ]; then
+            echo "=== Reaping wedged {{INSTANCE_NAME}} session (PID $LOCK_PID, lock held ${LOCK_AGE}s > ${LOCK_MAX_AGE_SECS}s) ===" >> "$LOG_FILE"
+            echo "Reaped wedged session PID $LOCK_PID after ${LOCK_AGE}s at $(date)" >> "$LOG_DIR/failures.log"
+            kill -TERM "$LOCK_PID" 2>/dev/null || true
+            sleep 5
+            # KILL before removing the lock: a KILLed holder cannot run its
+            # EXIT trap, so it cannot delete the lock this run is about to own.
+            kill -KILL "$LOCK_PID" 2>/dev/null || true
+            rm -f "$LOCK_FILE"
+        else
+            echo "=== Another {{INSTANCE_NAME}} session running (PID $LOCK_PID) — skipping ===" >> "$LOG_FILE"
+            exit 0
+        fi
     else
+        # Stale lock file — previous session crashed
         rm -f "$LOCK_FILE"
     fi
 fi

--- a/templates/run-scout.sh.tmpl
+++ b/templates/run-scout.sh.tmpl
@@ -22,12 +22,40 @@ if ! grep -q '.scout-logs' "$SCOUT_DIR/.gitignore" 2>/dev/null; then
     echo '.scout-logs/' >> "$SCOUT_DIR/.gitignore"
 fi
 
-# Concurrency guard — only one {{INSTANCE_NAME}} session at a time
+# Concurrency guard — only one {{INSTANCE_NAME}} session at a time.
+# Liveness alone is not enough: a holder that is alive but not progressing
+# (host slept mid-run, wedged network call) passes `kill -0` forever and
+# would silently block every subsequent slot. Real sessions finish in
+# minutes, so a holder past LOCK_MAX_AGE_SECS is wedged by definition —
+# reap it and take over, and record the reap in failures.log so the
+# takeover is visible to audit surfaces (not just this run's log).
+LOCK_MAX_AGE_SECS="${SCOUT_LOCK_MAX_AGE_SECS:-7200}"   # 2h ceiling, env-overridable
 if [ -f "$LOCK_FILE" ]; then
     LOCK_PID=$(cat "$LOCK_FILE" 2>/dev/null)
     if kill -0 "$LOCK_PID" 2>/dev/null; then
-        echo "=== Another {{INSTANCE_NAME}} session running (PID $LOCK_PID) — skipping ===" >> "$LOG_FILE"
-        exit 0
+        # Lock age = seconds since the holder wrote the lock at session start.
+        # Sourced from the lock file's mtime: macOS ps has no `etimes` keyword,
+        # so elapsed-seconds-of-PID is not portable. GNU stat first (errors on
+        # BSD), BSD stat second; unknown age → treat the holder as fresh.
+        LOCK_MTIME=$(stat -c %Y "$LOCK_FILE" 2>/dev/null || stat -f %m "$LOCK_FILE" 2>/dev/null || echo "")
+        LOCK_AGE=""
+        case "$LOCK_MTIME" in
+            ''|*[!0-9]*) ;;
+            *) LOCK_AGE=$(( $(date +%s) - LOCK_MTIME )) ;;
+        esac
+        if [ -n "$LOCK_AGE" ] && [ "$LOCK_AGE" -gt "$LOCK_MAX_AGE_SECS" ]; then
+            echo "=== Reaping wedged {{INSTANCE_NAME}} session (PID $LOCK_PID, lock held ${LOCK_AGE}s > ${LOCK_MAX_AGE_SECS}s) ===" >> "$LOG_FILE"
+            echo "Reaped wedged session PID $LOCK_PID after ${LOCK_AGE}s at $(date)" >> "$LOG_DIR/failures.log"
+            kill -TERM "$LOCK_PID" 2>/dev/null || true
+            sleep 5
+            # KILL before removing the lock: a KILLed holder cannot run its
+            # EXIT trap, so it cannot delete the lock this run is about to own.
+            kill -KILL "$LOCK_PID" 2>/dev/null || true
+            rm -f "$LOCK_FILE"
+        else
+            echo "=== Another {{INSTANCE_NAME}} session running (PID $LOCK_PID) — skipping ===" >> "$LOG_FILE"
+            exit 0
+        fi
     else
         # Stale lock file — previous session crashed
         rm -f "$LOCK_FILE"


### PR DESCRIPTION
Fixes #204.

## What

The concurrency guard in the runner templates was liveness-only (`kill -0 $PID`): a holder that is alive but not progressing — host slept mid-run, wedged network call — held `.scout-session.lock` indefinitely and **every subsequent slot silently exited 0** (41h25m and ~21h total outages observed; see the issue and its second-occurrence comment).

This PR age-bounds the lock:

- `LOCK_MAX_AGE_SECS` (default **7200s**, overridable via `SCOUT_LOCK_MAX_AGE_SECS`) — per the issue's comment, an age bound is "necessary and, on this evidence, sufficient" since a suspended holder passes `kill -0` by construction.
- A live holder past the ceiling is reaped: `TERM` → 5s → `KILL`, then takeover. `KILL` lands **before** `rm -f "$LOCK_FILE"` so a KILLed holder (which cannot run its EXIT trap) can never delete the *new* session's lock; `|| true` on the kills because the templates run `set -euo pipefail`.
- The reap is logged to the per-run log **and** `failures.log` so audit surfaces see the takeover. (Verified this cannot poison budget backoff — that reads the usage-tracker JSONL, not `failures.log`.)

## Two deliberate deviations from the issue's snippet

1. **Age source is lock-file mtime, not `ps -o etimes=`.** macOS `ps` rejects the `etimes` keyword, so the snippet (with its `[ -n "$LOCK_AGE" ]` guard) would have been a **silent no-op on the primary launchd/macOS platform**. The lock is written once at session start, so mtime age == hold age. GNU `stat -c %Y` is tried first because it errors cleanly on BSD, whereas BSD-first is dangerous (`stat -f %m FILE` on GNU *succeeds* and prints the mount point). Unknown/non-numeric age falls back to the old skip behavior.
2. **Applied to all three runner templates** (`run-scout`, `run-dreaming`, `run-research`) — they guard the *same* lock file with byte-identical blocks, and dreaming slots were part of the observed outage table. Trim to run-scout-only if preferred.

## Tests

New `engine/tests/integration/test_run_scout_lock.py` (renders the template, drives real holder processes):

- fresh live holder → still skips (holder untouched, lock intact)
- wedged holder (mtime aged past ceiling) → reaped and taken over (asserts the reap log line, the `failures.log` audit line, the new session ran, holder killed, lock cleaned on exit) — **watched failing on main** with the bug's exact "Another Scout session running … skipping" signature
- dead-PID stale lock → still removed (guards the pre-existing crashed-holder branch)

## Validation

- pytest: **1006 passed, 10 skipped, 0 failed** vs main baseline 1003/10/0 (same env) — +3 are the new tests, no other deltas.
- ruff check / format, mypy, version guard, manifests green; CI shellcheck invocation green (default-severity shows only the pre-existing SC1083 `{{PLACEHOLDER}}` warnings).

## Known limitation / review question

Only the runner PID is killed (as the issue's snippet does); its `caffeinate`/`claude` children are orphaned, so a reaped-but-actually-alive `claude` could briefly spend budget alongside the new session until it exits. A `pgrep -P` descendant walk would close this at the cost of complexity the issue didn't ask for — flagged for review rather than assumed.

> Notes for release: installed vaults pick this up on the next template re-render (`/scout-update` / bootstrap upgrade). The issue comment's "second, separate defect" — retry relaunching into a just-slept host — remains out of scope and overlaps #206's sleep-aware-backoff follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
