### PR TITLE
refactor(day-boundary): one configured-zone authority — config.today() (#207)

### DIFF
--- a/engine/scout/action_items/add_comment.py
+++ b/engine/scout/action_items/add_comment.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import datetime as dt
 from pathlib import Path
 
-from scout import paths
+from scout import config, paths
 from scout.action_items._common import resolve_target
 from scout.action_items.parser import parse_file
 from scout.action_items.writer import insert_below
@@ -29,9 +29,12 @@ from scout.events import Event, now_iso
 from scout.ids import new_ulid
 
 
-def _today() -> dt.date:
-    """Indirection so tests can monkeypatch the date without freezing time."""
-    return dt.date.today()
+def _today(data_dir: Path | None = None) -> dt.date:
+    """Today in the configured day-boundary zone (scout.config.today, #207).
+
+    Indirection so tests can monkeypatch the date without freezing time.
+    """
+    return config.today(data_dir)
 
 
 def add_comment(
@@ -55,7 +58,7 @@ def add_comment(
     GUI-authored comments. The reader (`render.py`, `_common.py`) keys on
     this ``<author>:`` prefix to bind the line to the task as a comment.
     """
-    target_path = paths.action_items_daily_path(data=data_dir, date=date or _today())
+    target_path = paths.action_items_daily_path(data=data_dir, date=date or _today(data_dir))
 
     # Parse if file exists; otherwise pass empty items list and let
     # resolve_target produce the right error (unknown prefix for by_id,

--- a/engine/scout/action_items/delete_comment.py
+++ b/engine/scout/action_items/delete_comment.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import datetime as dt
 from pathlib import Path
 
-from scout import paths
+from scout import config, paths
 from scout.action_items._common import (
     list_comment_lines,
     resolve_target,
@@ -30,8 +30,12 @@ from scout.events import Event, now_iso
 from scout.ids import new_ulid
 
 
-def _today() -> dt.date:
-    return dt.date.today()
+def _today(data_dir: Path | None = None) -> dt.date:
+    """Today in the configured day-boundary zone (scout.config.today, #207).
+
+    Indirection so tests can monkeypatch the date without freezing time.
+    """
+    return config.today(data_dir)
 
 
 def delete_comment(
@@ -43,7 +47,7 @@ def delete_comment(
     date: dt.date | None = None,
     data_dir: Path | None = None,
 ) -> Event:
-    target_path = paths.action_items_daily_path(data=data_dir, date=date or _today())
+    target_path = paths.action_items_daily_path(data=data_dir, date=date or _today(data_dir))
 
     items = parse_file(target_path) if target_path.exists() else []
     match, item_ulid, via = resolve_target(

--- a/engine/scout/action_items/edit_comment.py
+++ b/engine/scout/action_items/edit_comment.py
@@ -11,7 +11,7 @@ import datetime as dt
 import re
 from pathlib import Path
 
-from scout import paths
+from scout import config, paths
 from scout.action_items._common import (
     list_comment_lines,
     resolve_target,
@@ -26,8 +26,12 @@ from scout.ids import new_ulid
 _AUTHOR_PREFIX_RE = re.compile(r"^(?P<head>\s+-\s+[A-Za-z][A-Za-z0-9._-]*\s*:\s+).*$")
 
 
-def _today() -> dt.date:
-    return dt.date.today()
+def _today(data_dir: Path | None = None) -> dt.date:
+    """Today in the configured day-boundary zone (scout.config.today, #207).
+
+    Indirection so tests can monkeypatch the date without freezing time.
+    """
+    return config.today(data_dir)
 
 
 def edit_comment(
@@ -43,7 +47,7 @@ def edit_comment(
     if not new_text.strip():
         raise ActionItemError("edit-comment: --new-text must not be empty")
 
-    target_path = paths.action_items_daily_path(data=data_dir, date=date or _today())
+    target_path = paths.action_items_daily_path(data=data_dir, date=date or _today(data_dir))
 
     items = parse_file(target_path) if target_path.exists() else []
     match, item_ulid, via = resolve_target(

--- a/engine/scout/action_items/mark_done.py
+++ b/engine/scout/action_items/mark_done.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import datetime as dt
 from pathlib import Path
 
-from scout import paths
+from scout import config, paths
 from scout.action_items._common import resolve_target
 from scout.action_items.parser import parse_file
 from scout.action_items.writer import flip_checkbox
@@ -18,9 +18,12 @@ from scout.events import Event, now_iso
 from scout.ids import new_ulid
 
 
-def _today() -> dt.date:
-    """Indirection so tests can monkeypatch the date without freezing time."""
-    return dt.date.today()
+def _today(data_dir: Path | None = None) -> dt.date:
+    """Today in the configured day-boundary zone (scout.config.today, #207).
+
+    Indirection so tests can monkeypatch the date without freezing time.
+    """
+    return config.today(data_dir)
 
 
 def mark_done(
@@ -39,7 +42,7 @@ def mark_done(
     haven't been prefixed yet) — open tasks normally, done tasks when
     undoing (#116).
     """
-    target_path = paths.action_items_daily_path(data=data_dir, date=date or _today())
+    target_path = paths.action_items_daily_path(data=data_dir, date=date or _today(data_dir))
 
     # Parse if file exists; otherwise pass empty items list and let
     # resolve_target produce the right error (unknown prefix for by_id,

--- a/engine/scout/action_items/materialize.py
+++ b/engine/scout/action_items/materialize.py
@@ -23,13 +23,11 @@ from __future__ import annotations
 
 import datetime as _dt
 from pathlib import Path
-from zoneinfo import ZoneInfo
 
 from scout import paths
-from scout.config import load_config
+from scout.config import resolve_timezone
 
 LOOKBACK_DAYS = 7
-DEFAULT_TZ = "America/New_York"
 
 _BANNER = (
     "**Mechanical carry-forward** — materialized at {now} from "
@@ -37,19 +35,6 @@ _BANNER = (
     "briefing/consolidation rewrites this file in full; until then every open "
     "item below carries as-is so nothing is invisible."
 )
-
-
-def _configured_tz(data_dir: Path | None) -> ZoneInfo:
-    """User timezone from the merged config; falls back to DEFAULT_TZ.
-
-    Mirrors pre_session_data's fallback rather than raising — the backstop
-    must never block a run over a config problem.
-    """
-    try:
-        tz_name = load_config(data_dir).get("user", {}).get("timezone") or DEFAULT_TZ
-        return ZoneInfo(tz_name)
-    except Exception:
-        return ZoneInfo(DEFAULT_TZ)
 
 
 def _human_date(d: _dt.date) -> str:
@@ -77,7 +62,9 @@ def materialize(
     Returns the created path, or None when there was nothing to do (the file
     already exists, or no prior daily file exists within LOOKBACK_DAYS).
     """
-    tz = _configured_tz(data_dir)
+    # resolve_timezone never raises — the backstop must never block a run
+    # over a config problem (fallback lives inside the resolver; #207).
+    tz = resolve_timezone(data_dir)
     now = _dt.datetime.now(tz)
     target_date = date or now.date()
     target = paths.action_items_daily_path(data_dir, date=target_date)

--- a/engine/scout/action_items/snooze.py
+++ b/engine/scout/action_items/snooze.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import datetime as dt
 from pathlib import Path
 
-from scout import paths
+from scout import config, paths
 from scout.action_items._common import resolve_target
 from scout.action_items.parser import parse_file
 from scout.action_items.writer import insert_below
@@ -24,9 +24,12 @@ from scout.events import Event, now_iso
 from scout.ids import new_ulid
 
 
-def _today() -> dt.date:
-    """Indirection so tests can monkeypatch the date without freezing time."""
-    return dt.date.today()
+def _today(data_dir: Path | None = None) -> dt.date:
+    """Today in the configured day-boundary zone (scout.config.today, #207).
+
+    Indirection so tests can monkeypatch the date without freezing time.
+    """
+    return config.today(data_dir)
 
 
 def snooze(
@@ -51,7 +54,7 @@ def snooze(
     """
     if not isinstance(until, dt.date):
         raise ActionItemError(f"snooze: until must be a date, got {type(until).__name__}")
-    target_path = paths.action_items_daily_path(data=data_dir, date=date or _today())
+    target_path = paths.action_items_daily_path(data=data_dir, date=date or _today(data_dir))
 
     # Parse if file exists; otherwise pass empty items list and let
     # resolve_target produce the right error (unknown prefix for by_id,

--- a/engine/scout/cli.py
+++ b/engine/scout/cli.py
@@ -165,9 +165,9 @@ def session_cc_cache_cmd(
         help="Instance name suffix to exclude (skip Scout's own sessions).",
     ),
     timezone: str = typer.Option(
-        "America/New_York",
+        None,
         "--timezone",
-        help="IANA zone for the rendered timestamps.",
+        help="IANA zone for the rendered timestamps (default: the vault's configured timezone).",
     ),
 ) -> None:
     """Refresh .scout-cache/cc-sessions.md with metadata from recent CC sessions."""

--- a/engine/scout/config.py
+++ b/engine/scout/config.py
@@ -8,15 +8,21 @@ Precedence (low → high, later overrides earlier):
 
 from __future__ import annotations
 
+import datetime as _dt
 import os
 from importlib.resources import as_file, files
 from pathlib import Path
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import yaml
 
 from scout import paths
 from scout.errors import ConfigError
+
+# Packaged default zone (mirrors user.timezone in defaults/scout-config.yaml).
+# Also the terminal fallback when the configured zone is missing or invalid.
+DEFAULT_TIMEZONE = "America/New_York"
 
 
 def _read_yaml(path: Path) -> dict[str, Any]:
@@ -76,3 +82,59 @@ def load_config(data_dir: Path | None = None) -> dict[str, Any]:
     merged = _deep_merge(defaults, user_overrides)
     merged = _deep_merge(merged, env_overrides)
     return merged
+
+
+# ----- day boundary ---------------------------------------------------------
+#
+# Scout's "today" (daily action-items filename, trigger daily caps, freshness
+# math, rendered timestamps) is a civil date in ONE zone: the user's configured
+# timezone. Before #207 the codebase had multiple authorities — the configured
+# zone, bare host-clock date.today(), and hardcoded America/New_York — which
+# agreed only while the config read was broken. Everything below is the single
+# Python-side authority; the shell-side twin is templates/scripts/scout-tz.sh,
+# which resolves the same config field.
+
+
+def timezone_or_default(tz_name: object) -> ZoneInfo:
+    """ZoneInfo for ``tz_name``, falling back to :data:`DEFAULT_TIMEZONE`.
+
+    The fallback lives INSIDE the resolver on purpose (#207): a missing,
+    malformed, or unknown zone shifts every consumer to the same default
+    together, instead of each call site inventing its own fallback and
+    splitting the day boundary between surfaces.
+    """
+    if isinstance(tz_name, str) and tz_name:
+        try:
+            return ZoneInfo(tz_name)
+        except Exception:
+            pass
+    return ZoneInfo(DEFAULT_TIMEZONE)
+
+
+def resolve_timezone(data_dir: Path | None = None) -> ZoneInfo:
+    """The configured day-boundary zone for ``data_dir``'s vault.
+
+    Never raises — config problems degrade to :data:`DEFAULT_TIMEZONE` so a
+    bad edit can never make a run timezone-blind (mirrors scout-tz.sh).
+    """
+    try:
+        user = load_config(data_dir).get("user")
+        tz_name = user.get("timezone") if isinstance(user, dict) else None
+    except Exception:
+        tz_name = None
+    return timezone_or_default(tz_name)
+
+
+def now(data_dir: Path | None = None) -> _dt.datetime:
+    """Wall-clock now in the configured zone (tz-aware)."""
+    return _dt.datetime.now(resolve_timezone(data_dir))
+
+
+def today(data_dir: Path | None = None) -> _dt.date:
+    """THE day boundary: today's civil date in the configured zone.
+
+    Every writer or reader that derives a daily filename, a daily cap, or a
+    "today" label must come through here (or :func:`resolve_timezone`) so the
+    whole system flips dates at the same instant (#207).
+    """
+    return now(data_dir).date()

--- a/engine/scout/hooks/connector_log.py
+++ b/engine/scout/hooks/connector_log.py
@@ -4,7 +4,7 @@ Direct port of ~/Scout/hooks/connector-log.sh. Behavior identical:
   - Short-circuits when SCOUT_MODE is unset (interactive sessions).
   - Emits one row to .scout-logs/connector-calls-YYYY-MM-DD.jsonl per call.
   - Tag-classifies tool_name → connector key (preserves bash classify() exactly).
-  - ET-date-stamps the JSONL filename (TZ=America/New_York).
+  - Date-stamps the JSONL filename in the configured timezone (#207).
   - Truncates error snippets at 160 chars (matches bash original).
   - Never raises — hooks must never break a session.
 
@@ -19,9 +19,9 @@ import os
 import sys
 from datetime import UTC, datetime
 from typing import IO, Any
-from zoneinfo import ZoneInfo
 
 from scout import paths
+from scout.config import today as config_today
 from scout.events import Event, now_iso
 from scout.ids import new_ulid
 
@@ -159,7 +159,7 @@ def run(*, stdin: IO[str] | None = None) -> Event | None:
     if err_snippet:
         record["err"] = err_snippet
 
-    et_date = _et_date()
+    et_date = _local_date()
     log_dir = paths.data_dir() / ".scout-logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     out_path = log_dir / f"connector-calls-{et_date}.jsonl"
@@ -187,9 +187,9 @@ def run(*, stdin: IO[str] | None = None) -> Event | None:
     )
 
 
-def _et_date() -> str:
-    """Eastern-Time date string YYYY-MM-DD."""
-    return datetime.now(ZoneInfo("America/New_York")).date().isoformat()
+def _local_date() -> str:
+    """Configured-zone date string YYYY-MM-DD (scout.config.today, #207)."""
+    return config_today().isoformat()
 
 
 def main() -> int:

--- a/engine/scout/hooks/kb_pre_filter.py
+++ b/engine/scout/hooks/kb_pre_filter.py
@@ -28,13 +28,21 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 from scout import paths
+from scout.config import resolve_timezone
 from scout.events import Event, now_iso
 from scout.ids import new_ulid
 
-# Eastern Time — bash uses this implicitly via the system TZ when parsing
-# wall-clock dates with `date -j -f ... +%s`, then subtracts UTC-epoch seconds.
-# We must replicate the UTC-epoch arithmetic to stay correct across DST.
-ET = ZoneInfo("America/New_York")
+
+def _boundary_zone() -> ZoneInfo:
+    """Configured zone for freshness math (was hardcoded ET; #207).
+
+    The bash original used the system TZ implicitly when parsing wall-clock
+    dates with `date -j -f ... +%s`, then subtracted UTC-epoch seconds. We
+    replicate the UTC-epoch arithmetic to stay correct across DST — but the
+    zone is now the configured one, resolved per run.
+    """
+    return resolve_timezone()
+
 
 # Per-filename freshness budget (in hours). Bash lines 33-37.
 FRESHNESS_OVERRIDES: dict[str, int] = {
@@ -167,13 +175,16 @@ def extract_date_string(path: Path, *, lines: list[str] | None = None) -> str:
     return line.strip()
 
 
-def parse_date(s: str) -> datetime | None:
+def parse_date(s: str, tz: ZoneInfo | None = None) -> datetime | None:
     """Parse a date string against the 5 known formats. Returns None on failure.
 
     Bash lines 53-77 — also strips ' at ', ' ET'/' EDT'/' EST' tails, and
     parentheticals in its own pre-clean. We trust extract_date_string to have
     already cleaned the string, but apply the same minimal pre-clean here for
     parity (callers may pass raw strings).
+
+    The wall-clock date is interpreted in ``tz`` (default: the configured
+    zone). Callers in a loop should resolve the zone once and pass it in.
     """
     if not s:
         return None
@@ -185,9 +196,10 @@ def parse_date(s: str) -> datetime | None:
     if not cleaned:
         return None
 
+    zone = tz or _boundary_zone()
     for fmt in DATE_FORMATS:
         try:
-            return datetime.strptime(cleaned, fmt).replace(tzinfo=ET)
+            return datetime.strptime(cleaned, fmt).replace(tzinfo=zone)
         except ValueError:
             continue
     return None
@@ -239,7 +251,7 @@ def discover_kb_files(scout_dir: Path) -> list[Path]:
     return candidates
 
 
-def classify(path: Path, now: datetime, scout_dir: Path) -> tuple[str, dict[str, Any]]:
+def classify(path: Path, now: datetime, scout_dir: Path, tz: ZoneInfo | None = None) -> tuple[str, dict[str, Any]]:
     """Classify a single file as STALE / FRESH / NO_DATE.
 
     Returns (label, details). For STALE/FRESH, details has age_hours,
@@ -255,18 +267,19 @@ def classify(path: Path, now: datetime, scout_dir: Path) -> tuple[str, dict[str,
     if not datestr:
         return ("NO_DATE", {"rel": rel})
 
-    parsed = parse_date(datestr)
+    zone = tz or _boundary_zone()
+    parsed = parse_date(datestr, tz=zone)
     if parsed is None:
         return ("NO_DATE", {"rel": rel})
 
-    # Bash interprets the wall-clock date in ET via `date -j -f` then subtracts
-    # UTC-epoch seconds. We must do the same: parse_date now returns an ET-aware
-    # datetime; attach ET to `now` if naive, then subtract via .timestamp() to
-    # get UTC-elapsed seconds (NOT wall-clock seconds — same-zone aware
-    # subtraction in Python returns wall-clock delta, which drifts 1h across DST
-    # boundaries).
-    now_et = now if now.tzinfo is not None else now.replace(tzinfo=ET)
-    age_seconds = now_et.timestamp() - parsed.timestamp()
+    # Bash interpreted the wall-clock date in the system zone via `date -j -f`
+    # then subtracted UTC-epoch seconds. We do the same in the configured zone:
+    # parse_date returns a zone-aware datetime; attach the zone to `now` if
+    # naive, then subtract via .timestamp() to get UTC-elapsed seconds (NOT
+    # wall-clock seconds — same-zone aware subtraction in Python returns
+    # wall-clock delta, which drifts 1h across DST boundaries).
+    now_aware = now if now.tzinfo is not None else now.replace(tzinfo=zone)
+    age_seconds = now_aware.timestamp() - parsed.timestamp()
     age_hours = int(age_seconds // 3600)
     budget = freshness_hours_for(path, lines=head_lines)
 
@@ -336,9 +349,12 @@ def run(
     if not kb_root.is_dir():
         return None
 
+    # Resolve the configured zone ONCE per run and thread it through — the
+    # classify loop would otherwise re-read the config per KB file.
+    zone = _boundary_zone()
     if now is None:
-        now = datetime.now(ZoneInfo("America/New_York"))
-    now_et = now.strftime("%Y-%m-%d %H:%M ET")
+        now = datetime.now(zone)
+    now_et = now.strftime("%Y-%m-%d %H:%M %Z")
 
     files = discover_kb_files(scout_dir)
     stale: list[dict[str, Any]] = []
@@ -347,7 +363,7 @@ def run(
 
     for f in files:
         try:
-            label, details = classify(f, now, scout_dir)
+            label, details = classify(f, now, scout_dir, tz=zone)
         except Exception:
             # One bad file must not block the rest. Treat as NO_DATE.
             label = "NO_DATE"

--- a/engine/scout/hooks/session_tokens.py
+++ b/engine/scout/hooks/session_tokens.py
@@ -31,9 +31,9 @@ from collections import Counter
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import IO, Any
-from zoneinfo import ZoneInfo
 
 from scout import paths
+from scout.config import resolve_timezone
 from scout.events import Event, now_iso
 from scout.ids import new_ulid
 
@@ -81,9 +81,13 @@ def _utc_ts() -> str:
     return datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
 
 
-def _et_ts() -> str:
-    """ET local timestamp like '2026-04-28 16:00 EDT' (matches bash line 37)."""
-    return datetime.now(ZoneInfo("America/New_York")).strftime("%Y-%m-%d %H:%M %Z")
+def _local_ts() -> str:
+    """Configured-zone timestamp like '2026-04-28 16:00 EDT' (#207).
+
+    The emitted JSONL field stays named ``ts_et`` — it is a persisted schema
+    key that downstream consumers grep for; only the zone became configurable.
+    """
+    return datetime.now(resolve_timezone()).strftime("%Y-%m-%d %H:%M %Z")
 
 
 def _tracker_path() -> Path:
@@ -113,7 +117,7 @@ def _zero_row(
     """
     return {
         "ts": _utc_ts(),
-        "ts_et": _et_ts(),
+        "ts_et": _local_ts(),
         "session_id": session_id,
         "scout_mode": scout_mode,
         "cwd": cwd,
@@ -322,7 +326,7 @@ def run(*, stdin: IO[str] | None = None) -> Event | None:
 
     record = {
         "ts": _utc_ts(),
-        "ts_et": _et_ts(),
+        "ts_et": _local_ts(),
         "session_id": session_id,
         "scout_mode": scout_mode,
         "cwd": cwd,

--- a/engine/scout/hooks/session_tool_log.py
+++ b/engine/scout/hooks/session_tool_log.py
@@ -31,9 +31,9 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import IO, Any
-from zoneinfo import ZoneInfo
 
 from scout import paths
+from scout.config import today as config_today
 from scout.events import Event, now_iso
 from scout.hooks.connector_log import classify
 from scout.ids import new_ulid
@@ -201,8 +201,9 @@ def extract_tool_calls(rows: Iterable[dict[str, Any]]) -> list[ToolCallRecord]:
 # ----- emit JSONL ----------------------------------------------------------
 
 
-def _et_date() -> str:
-    return datetime.now(ZoneInfo("America/New_York")).date().isoformat()
+def _local_date() -> str:
+    """Configured-zone date string YYYY-MM-DD (scout.config.today, #207)."""
+    return config_today().isoformat()
 
 
 def _is_error(tool_response: dict[str, Any]) -> tuple[bool, str]:
@@ -238,7 +239,7 @@ def write_records(
     if not records:
         return 0
     log_dir.mkdir(parents=True, exist_ok=True)
-    out_path = log_dir / f"connector-calls-{_et_date()}.jsonl"
+    out_path = log_dir / f"connector-calls-{_local_date()}.jsonl"
     written = 0
     try:
         with out_path.open("a", encoding="utf-8") as f:

--- a/engine/scout/paths.py
+++ b/engine/scout/paths.py
@@ -79,18 +79,26 @@ def require_data_dir(data: Path | None = None) -> Path:
     return d
 
 
-def _today() -> _dt.date:
-    """Indirection so tests can monkeypatch the date without freezing time."""
-    return _dt.date.today()
+def _today(data: Path | None = None) -> _dt.date:
+    """Today in the configured day-boundary zone (scout.config.today).
+
+    Indirection so tests can monkeypatch the date without freezing time.
+    Imported lazily: scout.config imports scout.paths, so a module-level
+    import here would be circular.
+    """
+    from scout.config import today
+
+    return today(data)
 
 
 def action_items_daily_path(data: Path | None = None, date: _dt.date | None = None) -> Path:
-    """Return the daily action-items markdown path for `date` (default today).
+    """Return the daily action-items markdown path for `date` (default: today
+    in the configured timezone — see scout.config.today, #207).
 
     Filename format matches the existing ~/Scout convention:
     `action-items-YYYY-MM-DD.md` under the data dir's `action-items/`.
     """
-    d = date or _today()
+    d = date or _today(data)
     return action_items_dir(data) / f"action-items-{d.isoformat()}.md"
 
 

--- a/engine/scout/scripts/bootstrap.py
+++ b/engine/scout/scripts/bootstrap.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 import yaml
 
+from scout import config as scout_config
 from scout.scripts.bootstrap_doctor import DoctorReport, run_doctor
 from scout.scripts.bootstrap_lock import (
     acquire_lock_with_wait,
@@ -167,7 +168,10 @@ def _template_vars(cfg: BootstrapConfig) -> dict[str, str]:
         "PLATFORM": cfg.platform,
         "MAX_BUDGET": cfg.connector_inputs.get("max_budget", "5.00"),
         "CLAUDE_BIN": cfg.connector_inputs.get("claude_bin", "/usr/local/bin/claude"),
-        "TODAY_DATE": _dt.date.today().isoformat(),
+        # Today in the timezone being installed (NOT the host clock, and not
+        # config.today(): during a fresh install the vault's scout-config.yaml
+        # does not exist yet, so the merged config cannot answer). #207.
+        "TODAY_DATE": _dt.datetime.now(scout_config.timezone_or_default(cfg.timezone)).date().isoformat(),
         "AUTO_UPDATE_ENABLED": cfg.connector_inputs.get("auto_update_enabled", "false"),
     }
 
@@ -227,7 +231,10 @@ def _unique_backup_path(target: Path) -> Path:
     of the day; on a second same-day run, appends ``-1``, ``-2``, ... so an
     earlier run's backup of a different hand-edit is never clobbered (#62).
     """
-    today = _dt.date.today().isoformat()
+    # Configured-zone date (ambient vault resolution) — cosmetic filename
+    # suffix, but it must not flip a day earlier/later than every other
+    # surface near midnight (#207).
+    today = scout_config.today().isoformat()
     base = target.with_name(f"{target.name}.bak.{today}")
     if not base.exists():
         return base

--- a/engine/scout/scripts/cc_session_cache.py
+++ b/engine/scout/scripts/cc_session_cache.py
@@ -29,10 +29,13 @@ from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
 
+from scout import config as scout_config
 from scout import paths
 
 DEFAULT_HOURS_LOOKBACK = 24
-DEFAULT_TZ = "America/New_York"
+# Kept as a named export for back-compat; the runtime default is the
+# CONFIGURED zone (tz_name=None -> scout.config.resolve_timezone, #207).
+DEFAULT_TZ = scout_config.DEFAULT_TIMEZONE
 CACHE_FILENAME = "cc-sessions.cache.json"
 OUTPUT_FILENAME = "cc-sessions.md"
 
@@ -313,7 +316,7 @@ def run(
     *,
     hours: int = DEFAULT_HOURS_LOOKBACK,
     instance_name: str = "Scout",
-    tz_name: str = DEFAULT_TZ,
+    tz_name: str | None = None,
     extra_exclude_suffixes: Iterable[str] = (),
     data_dir: Path | None = None,
     cc_projects_dir: Path | None = None,
@@ -330,7 +333,9 @@ def run(
     cache_dir = paths.cache_dir(target)
     cache_dir.mkdir(parents=True, exist_ok=True)
 
-    tz = ZoneInfo(tz_name)
+    # Explicit tz_name wins (invalid names fall back inside the resolver);
+    # None means "the vault's configured zone" (#207).
+    tz = scout_config.timezone_or_default(tz_name) if tz_name else scout_config.resolve_timezone(target)
     now_dt = now or datetime.now(tz=tz)
     cutoff_ts = (now_dt - timedelta(hours=hours)).timestamp()
 
@@ -379,7 +384,7 @@ def main(
     *,
     hours: int = DEFAULT_HOURS_LOOKBACK,
     instance_name: str = "Scout",
-    tz_name: str = DEFAULT_TZ,
+    tz_name: str | None = None,
 ) -> int:
     """CLI entry — never raises. Prints the summary path so runner logs show
     where the cache landed."""

--- a/engine/scout/scripts/connector_health_report.py
+++ b/engine/scout/scripts/connector_health_report.py
@@ -11,10 +11,9 @@ Direct port of ``~/Scout/scripts/connector-health-report.sh``. Rules preserved:
 Connector roster sourced from :mod:`scout.connectors` (Task 1) — replaces the
 hardcoded CRITICAL / OPTIONAL / REQUIRED_IN / REMEDIATION dicts in the bash.
 
-Note on timezone: the bash original hardcoded ``-4`` (EDT only). This port uses
-``zoneinfo.ZoneInfo("America/New_York")`` which auto-handles DST. The displayed
-abbreviations match in EDT and become correct in EST (the bash silently rendered
-"ET" with the wrong offset in winter). This is a behavioral upgrade.
+Note on timezone: the bash original hardcoded ``-4`` (EDT only); an earlier
+port hardcoded ``America/New_York``. Timestamps now render in the CONFIGURED
+zone (scout.config.resolve_timezone, #207) with the real ``%Z`` abbreviation.
 """
 
 from __future__ import annotations
@@ -31,12 +30,18 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 from scout import paths
+from scout.config import resolve_timezone
 from scout.connectors import Capability, Connector, ConnectorRegistry, load_registry
 from scout.events import Event, now_iso
 from scout.ids import new_ulid
 from scout.schedule import SlotType
 
-ET = ZoneInfo("America/New_York")
+
+def _zone() -> ZoneInfo:
+    """Configured display/day-boundary zone (was hardcoded ET; #207)."""
+    return resolve_timezone()
+
+
 DEFAULT_WINDOW_DAYS = 14
 DEFAULT_RETAIN_DAYS = 30
 DEFAULT_MATRIX_DEPTH = 10
@@ -290,7 +295,7 @@ def recent_error_sample(records: list[dict[str, Any]], c: str, limit: int = 140)
 def fmt_ts(ts: datetime | None) -> str:
     if not ts:
         return "never"
-    return ts.astimezone(ET).strftime("%b %-d %H:%M ET")
+    return ts.astimezone(_zone()).strftime("%b %-d %H:%M %Z")
 
 
 def compute_critical_alerts(
@@ -435,7 +440,7 @@ def render_health_md(
         "",
         "Parent: [[knowledge-base]]",
         "",
-        f"**Last updated:** {now.astimezone(ET).strftime('%Y-%m-%d %H:%M ET')}",
+        f"**Last updated:** {now.astimezone(_zone()).strftime('%Y-%m-%d %H:%M %Z')}",
         f"**Window:** last 14 days, scheduled scout runs only (`{len(recent)}` of `{len(session_list)}` shown).",
         "",
     ]
@@ -470,7 +475,7 @@ def render_health_md(
 
     headers: list[str] = []
     for sid in recent_ids:
-        ts = sessions_by_id[sid][0]["_ts"].astimezone(ET)
+        ts = sessions_by_id[sid][0]["_ts"].astimezone(_zone())
         mode = sessions_by_id[sid][0].get("mode", "?")
         headers.append(f"{ts.strftime('%m-%d %H%M')}<br/>{_compact_mode(mode)}")
 
@@ -534,7 +539,7 @@ def render_pending_alerts_md(
 ) -> str:
     lines = [
         f"🔴 **Connector alerts** (from scout run `{current_mode}` at "
-        f"{now.astimezone(ET).strftime('%b %-d %H:%M ET')}):"
+        f"{now.astimezone(_zone()).strftime('%b %-d %H:%M %Z')}):"
     ]
     for a in alerts:
         icon = "🔴" if a.level == "CRITICAL" else "⚠️"
@@ -651,7 +656,7 @@ def run(
 
     pending_path.parent.mkdir(parents=True, exist_ok=True)
     if alerts:
-        ts_str = n.astimezone(ET).strftime("%Y-%m-%d %H:%M:%S ET")
+        ts_str = n.astimezone(_zone()).strftime("%Y-%m-%d %H:%M:%S %Z")
         try:
             with alerts_path.open("a", encoding="utf-8") as f:
                 for a in alerts:

--- a/engine/scout/scripts/heartbeat.py
+++ b/engine/scout/scripts/heartbeat.py
@@ -395,12 +395,18 @@ def launch_runner(runner: Path, *, vault: Path, log_path: Path) -> int:
 # ----- driver -------------------------------------------------------------
 
 
-def _log_line(log_path: Path, reason: str, tz_name: str = "America/New_York") -> None:
-    """Append a timestamped reason line to the heartbeat log."""
-    try:
-        from zoneinfo import ZoneInfo
+def _log_line(log_path: Path, reason: str, tz_name: str | None = None) -> None:
+    """Append a timestamped reason line to the heartbeat log.
 
-        ts = datetime.now(tz=ZoneInfo(tz_name))
+    ``tz_name=None`` resolves the configured zone (#207). Imported lazily so
+    pyyaml stays off this module's import path (see module docstring on cold
+    starts) and is only paid when a line is actually logged.
+    """
+    try:
+        from scout.config import resolve_timezone, timezone_or_default
+
+        zone = timezone_or_default(tz_name) if tz_name else resolve_timezone()
+        ts = datetime.now(tz=zone)
         stamp = ts.strftime("%Y-%m-%d %H:%M %Z")
     except Exception:
         stamp = datetime.now().isoformat(timespec="minutes")
@@ -429,6 +435,12 @@ def run(
     config_path = target / _CONFIG_FILENAME
     log_path = paths.logs_dir(target) / "heartbeat.log"
 
+    # Resolve the vault's configured zone once for every log stamp this tick
+    # (lazy import — keeps pyyaml off the module import path; #207).
+    from scout.config import resolve_timezone as _resolve_tz
+
+    log_tz = _resolve_tz(target).key
+
     config = load_config(config_path)
     n = now or datetime.now(UTC)
     stats = read_tracker_stats(tracker_path, now=n)
@@ -449,22 +461,22 @@ def run(
     )
 
     if decision.action == "skip":
-        _log_line(log_path, f"skipped: {decision.reason}")
+        _log_line(log_path, f"skipped: {decision.reason}", tz_name=log_tz)
         return EXIT_SKIPPED
 
     runner = decision.runner
     assert runner is not None  # "launch" always has a runner
     if dry_run:
-        _log_line(log_path, f"dry_run: would launch {decision.session_type} ({decision.reason})")
+        _log_line(log_path, f"dry_run: would launch {decision.session_type} ({decision.reason})", tz_name=log_tz)
         print(f"would_launch {runner}")
         return EXIT_LAUNCHED
 
     try:
         pid = launch_runner(runner, vault=target, log_path=log_path)
     except OSError as exc:
-        _log_line(log_path, f"launch_failed: {exc}")
+        _log_line(log_path, f"launch_failed: {exc}", tz_name=log_tz)
         return EXIT_ERROR
-    _log_line(log_path, f"launched {decision.session_type} PID={pid} ({decision.reason})")
+    _log_line(log_path, f"launched {decision.session_type} PID={pid} ({decision.reason})", tz_name=log_tz)
     return EXIT_LAUNCHED
 
 

--- a/engine/scout/scripts/install_cron.py
+++ b/engine/scout/scripts/install_cron.py
@@ -8,11 +8,12 @@ the user's crontab. Atomic rewrite via NamedTemporaryFile so a failed
 
 from __future__ import annotations
 
-import datetime as _dt
 import os
 import subprocess
 import tempfile
 from pathlib import Path
+
+from scout import config as scout_config
 
 TEMPLATE = Path(__file__).parent.parent / "defaults" / "cron-managed-block.tmpl"
 BLOCK_OPEN = "# >>> scout-managed >>>"
@@ -96,7 +97,9 @@ def _backup(previous: str, backup_dir: Path) -> None:
     """
     try:
         backup_dir.mkdir(parents=True, exist_ok=True)
-        today = _dt.date.today().isoformat()
+        # Configured-zone date (scout.config.today) so the backup suffix
+        # agrees with every other daily stamp (#207).
+        today = scout_config.today().isoformat()
         (backup_dir / f".crontab.scout-bak.{today}").write_text(previous, encoding="utf-8")
     except OSError as e:
         # Best-effort — don't mask the successful crontab apply.

--- a/engine/scout/scripts/migrate_perfile.py
+++ b/engine/scout/scripts/migrate_perfile.py
@@ -8,11 +8,12 @@ is safe to run on every upgrade.
 
 from __future__ import annotations
 
-import datetime as _dt
 import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+
+from scout import config as scout_config
 
 DATE_RE = re.compile(r"\b(\d{4}-\d{2}-\d{2})\b")
 
@@ -315,7 +316,8 @@ def migrate_perfile(vault: Path, default_date: str | None = None) -> dict:
     if not needs_migration(vault):
         return {"migrated": False}
 
-    default_date = default_date or _dt.date.today().isoformat()
+    # Configured-zone today for this vault (scout.config.today, #207).
+    default_date = default_date or scout_config.today(vault).isoformat()
 
     docs = vault / "docs"
     wishlist_out = docs / "wishlist"

--- a/engine/scout/scripts/pre_session_data.py
+++ b/engine/scout/scripts/pre_session_data.py
@@ -23,13 +23,15 @@ from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
-from zoneinfo import ZoneInfo
 
+from scout import config as scout_config
 from scout import paths
 
 OUTPUT_FILENAME = "session-context.json"
 KB_DATES_CACHE_FILENAME = "kb-dates.cache.json"
-DEFAULT_TZ = "America/New_York"
+# Kept as a named export for back-compat; the runtime default is the
+# CONFIGURED zone (tz_name=None -> scout.config.resolve_timezone, #207).
+DEFAULT_TZ = scout_config.DEFAULT_TIMEZONE
 DEFAULT_GIT_LOG_LOOKBACK = "12 hours ago"
 PR_LIST_LIMIT = 10
 KB_HEAD_SCAN_LINES = 5
@@ -262,7 +264,7 @@ def gather(
     session_type: str,
     *,
     scout_dir: Path | None = None,
-    tz_name: str = DEFAULT_TZ,
+    tz_name: str | None = None,
     now: datetime | None = None,
 ) -> SessionContext:
     """Collect all routine pre-session data into a :class:`SessionContext`.
@@ -271,7 +273,9 @@ def gather(
     ontology parser. Each upstream call is wrapped to never raise.
     """
     target = scout_dir or paths.data_dir()
-    tz = ZoneInfo(tz_name)
+    # Explicit tz_name wins (invalid names fall back inside the resolver);
+    # None means "the vault's configured zone" (#207).
+    tz = scout_config.timezone_or_default(tz_name) if tz_name else scout_config.resolve_timezone(target)
     now_dt = now or datetime.now(tz=tz)
     generated_at = now_dt.astimezone(tz).strftime("%Y-%m-%dT%H:%M:%S")
 

--- a/engine/scout/triggers/dedup.py
+++ b/engine/scout/triggers/dedup.py
@@ -13,8 +13,10 @@ Backing file: ``.scout-cache/trigger-fires.json``, keyed by trigger id::
       }
     }
 
-``fires_today_date`` is the ET date (America/New_York) — daily caps reset at
-00:00 ET, NOT 00:00 UTC, matching the rest of Scout's day-boundary semantics.
+``fires_today_date`` is the date in the CONFIGURED timezone
+(scout.config.resolve_timezone) — daily caps reset at the user's local
+midnight, NOT 00:00 UTC, matching the rest of Scout's day-boundary
+semantics (#207).
 
 ``is_new`` consults both ``last_seen_event_id`` and a sliding window of the
 100 most recent fired event ids, so non-monotonic event ids can't re-fire.
@@ -32,8 +34,15 @@ from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
 
+from scout.config import resolve_timezone
+
 DEFAULT_RECENT_WINDOW = 100
-DAY_BOUNDARY_ZONE = ZoneInfo("America/New_York")
+
+
+def day_boundary_zone() -> ZoneInfo:
+    """The configured day-boundary zone (resolved per call, not at import,
+    so env/config changes and hermetic tests see the current value)."""
+    return resolve_timezone()
 
 
 def _parse_iso_z(ts: str) -> dt.datetime:
@@ -127,7 +136,7 @@ class DedupStore:
     # ----- internals -------------------------------------------------------
 
     def _day(self, now: dt.datetime) -> str:
-        return now.astimezone(DAY_BOUNDARY_ZONE).date().isoformat()
+        return now.astimezone(day_boundary_zone()).date().isoformat()
 
     def _save(self) -> None:
         """Atomic write (tmp + rename). Best-effort — never raises."""

--- a/engine/scout/tui/config.py
+++ b/engine/scout/tui/config.py
@@ -10,9 +10,12 @@ ACTION_ITEMS_DIR = SCOUT_DIR / "action-items"
 
 
 def action_items_path(date: datetime.date | None = None) -> Path:
-    """Return the action items file path for a given date (defaults to today)."""
+    """Return the action items file path for a given date (defaults to today
+    in the configured timezone — scout.config.today, #207)."""
     if date is None:
-        date = datetime.date.today()
+        from scout.config import today
+
+        date = today()
     filename = f"action-items-{date.isoformat()}.md"
     return ACTION_ITEMS_DIR / filename
 

--- a/engine/scout/tui/screens/dashboard.py
+++ b/engine/scout/tui/screens/dashboard.py
@@ -35,16 +35,16 @@ FILTER_OPTIONS = ["all", "🔴", "🟡", "🟢", "open", "done"]
 def _make_tui_note_line(note_text: str) -> str:
     """Format a TUI note line with a local timestamp.
 
-    Preserves the same format that the old tui/writer.py add_note used:
-      - **[TUI note, YYYY-MM-DD HH:MM AM/PM ET]:** <text>
-    Uses ZoneInfo("America/New_York") so DST transitions track correctly
-    (the source script's hardcoded UTC-4 silently drifted by one hour
-    November–March).
+    Preserves the same shape the old tui/writer.py add_note used:
+      - **[TUI note, YYYY-MM-DD HH:MM AM/PM <zone>]:** <text>
+    The zone is the CONFIGURED one (scout.config.resolve_timezone, #207) and
+    the label is the real %Z abbreviation (the old hardcoded "ET" + UTC-4
+    silently drifted by one hour November–March).
     """
-    from zoneinfo import ZoneInfo
+    from scout.config import resolve_timezone
 
-    now = _dt.datetime.now(ZoneInfo("America/New_York"))
-    timestamp = now.strftime("%Y-%m-%d %I:%M %p ET")
+    now = _dt.datetime.now(resolve_timezone())
+    timestamp = now.strftime("%Y-%m-%d %I:%M %p %Z")
     return f"  - **[TUI note, {timestamp}]:** {note_text}"
 
 

--- a/engine/tests/unit/test_action_items_add_comment.py
+++ b/engine/tests/unit/test_action_items_add_comment.py
@@ -37,7 +37,7 @@ def test_add_comment_by_id_inserts_subbullet(fake_data_dir: Path, monkeypatch: p
     daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
     daily.parent.mkdir(parents=True, exist_ok=True)
     daily.write_text("## In Progress\n\n- [ ] [#A3F7] 🔴 Submit Lever feedback\n- [ ] 🟡 Other unrelated task\n")
-    monkeypatch.setattr("scout.action_items.add_comment._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.add_comment._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     event = add_comment(by_id="A3F7", comment="Hiring manager confirmed", data_dir=fake_data_dir)
 
@@ -60,7 +60,7 @@ def test_add_comment_custom_author_prefix(fake_data_dir: Path, monkeypatch: pyte
     daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
     daily.parent.mkdir(parents=True, exist_ok=True)
     daily.write_text("## To Do\n\n- [ ] 🔴 Followup with vendor on contract\n")
-    monkeypatch.setattr("scout.action_items.add_comment._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.add_comment._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     event = add_comment(by_subject="vendor", comment="test", author="Vaclav Nosek", data_dir=fake_data_dir)
     assert "  - Vaclav Nosek: test" in daily.read_text()
@@ -71,7 +71,7 @@ def test_add_comment_by_subject_fallback(fake_data_dir: Path, monkeypatch: pytes
     daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
     daily.parent.mkdir(parents=True, exist_ok=True)
     daily.write_text("## To Do\n\n- [ ] 🔴 Followup with vendor on contract\n")
-    monkeypatch.setattr("scout.action_items.add_comment._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.add_comment._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     event = add_comment(by_subject="vendor", comment="Email sent 4/26", data_dir=fake_data_dir)
     assert "  - scout: Email sent 4/26" in daily.read_text()
@@ -83,7 +83,7 @@ def test_add_comment_by_id_unknown_prefix_raises(fake_data_dir: Path, monkeypatc
     daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
     daily.parent.mkdir(parents=True, exist_ok=True)
     daily.write_text("- [ ] x\n")
-    monkeypatch.setattr("scout.action_items.add_comment._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.add_comment._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     with pytest.raises(ActionItemError, match="prefix.*not found"):
         add_comment(by_id="ZZZZ", comment="x", data_dir=fake_data_dir)
@@ -96,7 +96,7 @@ def test_add_comment_event_id_and_ts_well_formed(fake_data_dir: Path, monkeypatc
     daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
     daily.parent.mkdir(parents=True, exist_ok=True)
     daily.write_text("- [ ] [#A3F7] task\n")
-    monkeypatch.setattr("scout.action_items.add_comment._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.add_comment._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     event = add_comment(by_id="A3F7", comment="x", data_dir=fake_data_dir)
     assert len(event.id) == 26

--- a/engine/tests/unit/test_action_items_delete_comment.py
+++ b/engine/tests/unit/test_action_items_delete_comment.py
@@ -37,7 +37,7 @@ def test_delete_comment_by_index(fake_data_dir: Path, monkeypatch: pytest.Monkey
         "  - alex: third\n"
         "- [ ] another task\n",
     )
-    monkeypatch.setattr("scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.delete_comment._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     event = delete_comment(by_id="A3F7", index=2, data_dir=fake_data_dir)
 
@@ -58,7 +58,7 @@ def test_delete_comment_by_text_substring(fake_data_dir: Path, monkeypatch: pyte
         fake_data_dir,
         "## In Progress\n\n- [ ] [#A3F7] task\n  - alex: vendor confirmed\n  - alex: legal review needed\n",
     )
-    monkeypatch.setattr("scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.delete_comment._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     delete_comment(by_id="A3F7", text="legal", data_dir=fake_data_dir)
 
@@ -75,7 +75,7 @@ def test_delete_comment_ignores_snoozed_until_marker(fake_data_dir: Path, monkey
         fake_data_dir,
         "## In Progress\n\n- [ ] [#A3F7] task\n  - snoozed-until: 2026-05-01\n  - alex: real comment\n",
     )
-    monkeypatch.setattr("scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.delete_comment._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     delete_comment(by_id="A3F7", index=1, data_dir=fake_data_dir)
 
@@ -90,7 +90,7 @@ def test_delete_comment_index_out_of_range(fake_data_dir: Path, monkeypatch: pyt
         fake_data_dir,
         "- [ ] [#A3F7] task\n  - alex: only one\n",
     )
-    monkeypatch.setattr("scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.delete_comment._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     with pytest.raises(ActionItemError, match="--index 5 out of range"):
         delete_comment(by_id="A3F7", index=5, data_dir=fake_data_dir)
@@ -102,7 +102,7 @@ def test_delete_comment_ambiguous_text(fake_data_dir: Path, monkeypatch: pytest.
         fake_data_dir,
         "- [ ] [#A3F7] task\n  - alex: vendor ping\n  - alex: vendor confirmed\n",
     )
-    monkeypatch.setattr("scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.delete_comment._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     with pytest.raises(ActionItemError, match="ambiguous"):
         delete_comment(by_id="A3F7", text="vendor", data_dir=fake_data_dir)
@@ -111,7 +111,7 @@ def test_delete_comment_ambiguous_text(fake_data_dir: Path, monkeypatch: pytest.
 def test_delete_comment_requires_exactly_one_selector(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _register_prefix(fake_data_dir)
     _make_daily(fake_data_dir, "- [ ] [#A3F7] task\n  - alex: hi\n")
-    monkeypatch.setattr("scout.action_items.delete_comment._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.delete_comment._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     with pytest.raises(ActionItemError, match="exactly one of --index or --text"):
         delete_comment(by_id="A3F7", data_dir=fake_data_dir)

--- a/engine/tests/unit/test_action_items_edit_comment.py
+++ b/engine/tests/unit/test_action_items_edit_comment.py
@@ -32,7 +32,7 @@ def test_edit_comment_by_index_replaces_body_only(fake_data_dir: Path, monkeypat
         fake_data_dir,
         "- [ ] [#A3F7] task\n  - alex: first draft\n  - alex: second draft\n",
     )
-    monkeypatch.setattr("scout.action_items.edit_comment._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.edit_comment._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     event = edit_comment(
         by_id="A3F7",
@@ -59,7 +59,7 @@ def test_edit_comment_preserves_original_indent(fake_data_dir: Path, monkeypatch
         fake_data_dir,
         "- [ ] [#A3F7] task\n    - alice: nested note\n",
     )
-    monkeypatch.setattr("scout.action_items.edit_comment._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.edit_comment._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     edit_comment(
         by_id="A3F7",
@@ -74,7 +74,7 @@ def test_edit_comment_preserves_original_indent(fake_data_dir: Path, monkeypatch
 def test_edit_comment_rejects_empty_text(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _register_prefix(fake_data_dir)
     _make_daily(fake_data_dir, "- [ ] [#A3F7] task\n  - alex: original\n")
-    monkeypatch.setattr("scout.action_items.edit_comment._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.edit_comment._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     with pytest.raises(ActionItemError, match="new-text must not be empty"):
         edit_comment(by_id="A3F7", index=1, new_text="   ", data_dir=fake_data_dir)
@@ -86,7 +86,7 @@ def test_edit_comment_by_text_substring(fake_data_dir: Path, monkeypatch: pytest
         fake_data_dir,
         "- [ ] [#A3F7] task\n  - alex: ping vendor\n  - alex: legal sign-off\n",
     )
-    monkeypatch.setattr("scout.action_items.edit_comment._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.edit_comment._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     edit_comment(
         by_id="A3F7",

--- a/engine/tests/unit/test_action_items_mark_done.py
+++ b/engine/tests/unit/test_action_items_mark_done.py
@@ -32,7 +32,7 @@ def _seed_daily(data_dir: Path, body: str, *, date: dt.date) -> Path:
 
 def test_marks_open_task_done_by_subject(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     today = dt.date(2026, 4, 15)
-    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: today)
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda *a, **kw: today)
     f = _seed_daily(
         fake_data_dir,
         "- [ ] Submit Lever feedback\n- [ ] Other task\n",
@@ -45,7 +45,7 @@ def test_marks_open_task_done_by_subject(fake_data_dir: Path, monkeypatch: pytes
 
 def test_no_match_raises(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     today = dt.date(2026, 4, 15)
-    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: today)
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda *a, **kw: today)
     _seed_daily(fake_data_dir, "- [ ] Existing task\n", date=today)
     with pytest.raises(ActionItemError, match="no open task matched"):
         mark_done(by_subject="missing keyword", data_dir=fake_data_dir)
@@ -53,7 +53,7 @@ def test_no_match_raises(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -
 
 def test_ambiguous_match_raises_listing_candidates(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     today = dt.date(2026, 4, 15)
-    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: today)
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda *a, **kw: today)
     _seed_daily(
         fake_data_dir,
         "- [ ] Lever feedback A\n- [ ] Lever feedback B\n",
@@ -70,7 +70,7 @@ def test_resolves_today_when_data_dir_via_env(tmp_path: Path, monkeypatch: pytes
     """No `data_dir` argument resolves via SCOUT_DATA_DIR env var."""
     monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
     today = dt.date(2026, 4, 15)
-    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: today)
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda *a, **kw: today)
     f = _seed_daily(tmp_path, "- [ ] task X\n", date=today)
     mark_done(by_subject="task X")
     assert "- [x] task X" in f.read_text()
@@ -102,7 +102,7 @@ def test_mark_done_by_id_flips_correct_line(fake_data_dir, monkeypatch):
         "- [ ] [#A3F7] 🔴 Submit Lever feedback\n"
         "- [ ] 🟡 Other unrelated task\n"
     )
-    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     from scout.action_items.mark_done import mark_done
 
@@ -121,7 +121,7 @@ def test_mark_done_by_subject_fallback_for_unprefixed_line(fake_data_dir, monkey
     daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
     daily.parent.mkdir(parents=True, exist_ok=True)
     daily.write_text("## In Progress\n\n- [ ] 🔴 Followup with vendor on contract\n")
-    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     from scout.action_items.mark_done import mark_done
 
@@ -133,7 +133,7 @@ def test_mark_done_by_subject_fallback_for_unprefixed_line(fake_data_dir, monkey
 
 
 def test_mark_done_by_id_unknown_prefix_raises(fake_data_dir, monkeypatch):
-    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda *a, **kw: dt.date(2026, 4, 26))
     from scout.action_items.mark_done import mark_done
     from scout.errors import ActionItemError
 
@@ -148,7 +148,7 @@ def test_mark_done_event_id_and_ts_well_formed(fake_data_dir, monkeypatch):
     daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
     daily.parent.mkdir(parents=True, exist_ok=True)
     daily.write_text("- [ ] [#A3F7] task\n")
-    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     from scout.action_items.mark_done import mark_done
 
@@ -170,7 +170,7 @@ def test_mark_done_uses_parser_line_number_even_under_external_edit(fake_data_di
     no longer valid) rather than silently flipping a different line
     that happens to match by content (the old find_line_number behavior)."""
     today = dt.date(2026, 4, 26)
-    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: today)
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda *a, **kw: today)
 
     # Initial file: target task is at line 3.
     daily = fake_data_dir / "action-items" / f"action-items-{today.isoformat()}.md"
@@ -219,7 +219,7 @@ def test_mark_done_uses_parser_line_number_even_under_external_edit(fake_data_di
 
 def test_undo_reopens_done_task_by_subject(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     today = dt.date(2026, 4, 15)
-    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: today)
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda *a, **kw: today)
     f = _seed_daily(
         fake_data_dir,
         "- [x] Submit Lever feedback\n- [ ] Other task\n",
@@ -233,7 +233,7 @@ def test_undo_reopens_done_task_by_subject(fake_data_dir: Path, monkeypatch: pyt
 def test_undo_reopens_uppercase_done_task(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """#56: a task completed as `[X]` must still be reopenable."""
     today = dt.date(2026, 4, 15)
-    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: today)
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda *a, **kw: today)
     f = _seed_daily(fake_data_dir, "- [X] Shipped thing\n", date=today)
     mark_done(by_subject="Shipped thing", data_dir=fake_data_dir, undo=True)
     assert "- [ ] Shipped thing" in f.read_text()
@@ -241,7 +241,7 @@ def test_undo_reopens_uppercase_done_task(fake_data_dir: Path, monkeypatch: pyte
 
 def test_undo_by_subject_does_not_match_open_tasks(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     today = dt.date(2026, 4, 15)
-    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: today)
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda *a, **kw: today)
     _seed_daily(fake_data_dir, "- [ ] Still open task\n", date=today)
     with pytest.raises(ActionItemError, match="no done task matched"):
         mark_done(by_subject="Still open", data_dir=fake_data_dir, undo=True)
@@ -250,7 +250,7 @@ def test_undo_by_subject_does_not_match_open_tasks(fake_data_dir: Path, monkeypa
 def test_undo_reopens_by_id(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """#116 acceptance: `mark-done --by-id XXXX --undo` reopens a done task."""
     today = dt.date(2026, 4, 15)
-    monkeypatch.setattr("scout.action_items.mark_done._today", lambda: today)
+    monkeypatch.setattr("scout.action_items.mark_done._today", lambda *a, **kw: today)
     f = _seed_daily(fake_data_dir, "- [x] [#AB30] Ship the fix\n", date=today)
     event = mark_done(by_id="AB30", data_dir=fake_data_dir, undo=True)
     assert "- [ ] [#AB30] Ship the fix" in f.read_text()

--- a/engine/tests/unit/test_action_items_render.py
+++ b/engine/tests/unit/test_action_items_render.py
@@ -123,7 +123,7 @@ def test_add_comment_render_round_trip(tmp_path: Path, monkeypatch: pytest.Monke
     daily = data_dir / "action-items" / "action-items-2026-04-26.md"
     daily.parent.mkdir(parents=True, exist_ok=True)
     daily.write_text("# Action Items\n\n## To Do\n\n- [ ] 🔴 Followup with vendor\n")
-    monkeypatch.setattr("scout.action_items.add_comment._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.add_comment._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     add_comment(by_subject="vendor", comment="left a voicemail", data_dir=data_dir)
 

--- a/engine/tests/unit/test_action_items_snooze.py
+++ b/engine/tests/unit/test_action_items_snooze.py
@@ -41,7 +41,7 @@ def test_snooze_by_id_inserts_until_subbullet(fake_data_dir: Path, monkeypatch: 
     daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
     daily.parent.mkdir(parents=True, exist_ok=True)
     daily.write_text("## In Progress\n\n- [ ] [#A3F7] 🔴 Submit Lever feedback\n- [ ] 🟡 Other unrelated task\n")
-    monkeypatch.setattr("scout.action_items.snooze._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.snooze._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     event = snooze(by_id="A3F7", until=dt.date(2026, 5, 1), data_dir=fake_data_dir)
 
@@ -60,7 +60,7 @@ def test_snooze_by_subject_fallback(fake_data_dir: Path, monkeypatch: pytest.Mon
     daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
     daily.parent.mkdir(parents=True, exist_ok=True)
     daily.write_text("## To Do\n\n- [ ] 🔴 Followup with vendor on contract\n")
-    monkeypatch.setattr("scout.action_items.snooze._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.snooze._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     event = snooze(by_subject="vendor", until=dt.date(2026, 5, 1), data_dir=fake_data_dir)
     assert "- snoozed-until: 2026-05-01" in daily.read_text()
@@ -72,7 +72,7 @@ def test_snooze_by_id_unknown_prefix_raises(fake_data_dir: Path, monkeypatch: py
     daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
     daily.parent.mkdir(parents=True, exist_ok=True)
     daily.write_text("- [ ] x\n")
-    monkeypatch.setattr("scout.action_items.snooze._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.snooze._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     with pytest.raises(ActionItemError, match="prefix.*not found"):
         snooze(by_id="ZZZZ", until=dt.date(2026, 5, 1), data_dir=fake_data_dir)
@@ -85,7 +85,7 @@ def test_snooze_event_id_and_ts_well_formed(fake_data_dir: Path, monkeypatch: py
     daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
     daily.parent.mkdir(parents=True, exist_ok=True)
     daily.write_text("- [ ] [#A3F7] task\n")
-    monkeypatch.setattr("scout.action_items.snooze._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.snooze._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     event = snooze(by_id="A3F7", until=dt.date(2026, 5, 1), data_dir=fake_data_dir)
     assert len(event.id) == 26
@@ -102,7 +102,7 @@ def test_snooze_records_from_kind_in_marker(fake_data_dir: Path, monkeypatch: py
     daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
     daily.parent.mkdir(parents=True, exist_ok=True)
     daily.write_text("## 🔴 Urgent\n\n- [ ] [#A3F7] 🔴 task\n")
-    monkeypatch.setattr("scout.action_items.snooze._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.snooze._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     event = snooze(
         by_id="A3F7",
@@ -123,7 +123,7 @@ def test_snooze_omits_from_kind_when_not_provided(fake_data_dir: Path, monkeypat
     daily = fake_data_dir / "action-items" / "action-items-2026-04-26.md"
     daily.parent.mkdir(parents=True, exist_ok=True)
     daily.write_text("- [ ] [#A3F7] task\n")
-    monkeypatch.setattr("scout.action_items.snooze._today", lambda: dt.date(2026, 4, 26))
+    monkeypatch.setattr("scout.action_items.snooze._today", lambda *a, **kw: dt.date(2026, 4, 26))
 
     event = snooze(by_id="A3F7", until=dt.date(2026, 5, 1), data_dir=fake_data_dir)
 

--- a/engine/tests/unit/test_bootstrap_upgrade.py
+++ b/engine/tests/unit/test_bootstrap_upgrade.py
@@ -262,12 +262,8 @@ def test_unique_backup_path_never_clobbers_same_day(tmp_path, monkeypatch):
     distinct paths, so the first hand-edit's backup is never overwritten."""
     import scout.scripts.bootstrap as bs
 
-    class _FixedDate(_dt.date):
-        @classmethod
-        def today(cls):
-            return cls(2026, 6, 15)
-
-    monkeypatch.setattr(bs._dt, "date", _FixedDate)
+    # Backup names come from the configured-zone day boundary now (#207).
+    monkeypatch.setattr(bs.scout_config, "today", lambda *a, **kw: _dt.date(2026, 6, 15))
 
     target = tmp_path / "run-scout.sh"
 

--- a/engine/tests/unit/test_day_boundary.py
+++ b/engine/tests/unit/test_day_boundary.py
@@ -1,0 +1,186 @@
+"""Day-boundary unification regression tests (#207).
+
+Every surface that derives a daily date — the materialize backstop, the five
+action-items mutators, the daily-path default, trigger daily caps, hook
+day-stamps, and bootstrap's template date — must take "today" from the
+CONFIGURED timezone via scout.config.today / resolve_timezone, never from the
+host clock and never from a hardcoded zone.
+
+Probe technique: the two zones below sit at the opposite extremes of the tz
+database — their civil dates are 26 hours apart and therefore NEVER agree.
+Whatever zone the host machine runs in, its date can coincide with at most
+one of them; a code path that follows the host clock (or a hardcoded third
+zone) fails the assertion under at least one probe zone at any time of day,
+while a path that follows the configured zone passes under both.
+
+The env override (SCOUT_USER_TIMEZONE) is the highest-precedence config layer
+and is used here so the tests exercise the same merged-config resolution that
+a vault scout-config.yaml goes through.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from scout import config, paths
+from scout.action_items.add_comment import add_comment
+from scout.action_items.delete_comment import delete_comment
+from scout.action_items.edit_comment import edit_comment
+from scout.action_items.mark_done import mark_done
+from scout.action_items.materialize import materialize
+from scout.action_items.snooze import snooze
+from scout.triggers.dedup import DedupStore
+
+ZONE_EAST = "Pacific/Kiritimati"  # UTC+14 — the first zone to flip dates
+ZONE_WEST = "Etc/GMT+12"  # UTC-12 — the last zone to flip dates
+PROBE_ZONES = (ZONE_EAST, ZONE_WEST)
+
+
+def _date_in(zone: str) -> dt.date:
+    return dt.datetime.now(ZoneInfo(zone)).date()
+
+
+def _run_boundary_safe(zone: str, fn):
+    """Call fn() and return (result, acceptable_dates) — the configured-zone
+    date sampled immediately before and after, so a midnight flip mid-test
+    cannot produce a false failure."""
+    before = _date_in(zone)
+    result = fn()
+    after = _date_in(zone)
+    return result, {before, after}
+
+
+def test_probe_zones_never_share_a_date() -> None:
+    """Lemma for every test below: the two probe dates always differ, so the
+    host date can match at most one of them."""
+    assert _date_in(ZONE_EAST) != _date_in(ZONE_WEST)
+
+
+@pytest.mark.parametrize("zone", PROBE_ZONES)
+def test_config_today_follows_configured_zone(zone: str, fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SCOUT_USER_TIMEZONE", zone)
+    result, ok = _run_boundary_safe(zone, lambda: config.today(fake_data_dir))
+    assert result in ok
+
+
+def test_resolve_timezone_falls_back_inside_the_resolver(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A malformed zone must degrade to the packaged default INSIDE the
+    resolver — never raise — so every surface shifts together (#207)."""
+    assert config.resolve_timezone(fake_data_dir).key == config.DEFAULT_TIMEZONE
+
+    monkeypatch.setenv("SCOUT_USER_TIMEZONE", "Not/AZone")
+    assert config.resolve_timezone(fake_data_dir).key == config.DEFAULT_TIMEZONE
+    # today() keeps working off the fallback rather than raising.
+    result, ok = _run_boundary_safe(config.DEFAULT_TIMEZONE, lambda: config.today(fake_data_dir))
+    assert result in ok
+
+
+@pytest.mark.parametrize("zone", PROBE_ZONES)
+def test_daily_path_default_follows_configured_zone(
+    zone: str, fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SCOUT_USER_TIMEZONE", zone)
+    result, ok = _run_boundary_safe(zone, lambda: paths.action_items_daily_path(fake_data_dir))
+    assert result.name in {f"action-items-{d.isoformat()}.md" for d in ok}
+
+
+@pytest.mark.parametrize("zone", PROBE_ZONES)
+def test_all_action_items_writers_share_one_day_boundary(
+    zone: str, fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#207's headline defect: materialize() took the daily date from the
+    configured zone while every mutator took the host clock. Under a probe
+    zone whose date differs from the host's, the mutators then target a file
+    that materialize never created. All six writers must agree."""
+    monkeypatch.setenv("SCOUT_USER_TIMEZONE", zone)
+
+    today = config.today(fake_data_dir)
+    yesterday = today - dt.timedelta(days=1)
+    prev = fake_data_dir / "action-items" / f"action-items-{yesterday.isoformat()}.md"
+    prev.write_text(
+        f"# Action Items — {yesterday.isoformat()}\n\n## 🔴 Urgent\n- [ ] [#AAAA] 🔴 call the bank\n",
+        encoding="utf-8",
+    )
+
+    created = materialize(data_dir=fake_data_dir)
+    assert created is not None, "materialize found nothing to do"
+    daily = fake_data_dir / "action-items" / f"action-items-{today.isoformat()}.md"
+    assert created == daily
+
+    # Every mutator must resolve the SAME daily file materialize just wrote.
+    # (Comment ops run before snooze/mark_done: the snooze marker would count
+    # as comment #1, and by_subject matches open items only.)
+    add_comment(by_subject="call the bank", comment="left a voicemail", data_dir=fake_data_dir)
+    edit_comment(by_subject="call the bank", index=1, new_text="reached them", data_dir=fake_data_dir)
+    delete_comment(by_subject="call the bank", index=1, data_dir=fake_data_dir)
+    snooze(by_subject="call the bank", until=today + dt.timedelta(days=3), data_dir=fake_data_dir)
+    mark_done(by_subject="call the bank", data_dir=fake_data_dir)
+
+    text = daily.read_text(encoding="utf-8")
+    assert "- [x] [#AAAA] 🔴 call the bank" in text
+    assert f"snoozed-until: {(today + dt.timedelta(days=3)).isoformat()}" in text
+    assert "reached them" not in text  # deleted again by delete_comment
+    # And nothing leaked into a host-dated file (the seeded carry-forward
+    # source may legitimately sit on the host date — exclude it).
+    host_file = fake_data_dir / "action-items" / f"action-items-{dt.date.today().isoformat()}.md"
+    if host_file not in (daily, prev):
+        assert not host_file.exists()
+
+
+def test_dedup_daily_cap_resets_on_configured_midnight(
+    fake_data_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """fires_today_date must be the configured-zone date of the fire instant,
+    so daily caps reset at the user's local midnight (#207)."""
+    instant = dt.datetime(2026, 8, 24, 1, 0, tzinfo=dt.UTC)
+    expected = {
+        ZONE_EAST: "2026-08-24",  # 15:00 local, same day
+        ZONE_WEST: "2026-08-23",  # 13:00 local, previous day
+    }
+    for zone, day in expected.items():
+        monkeypatch.setenv("SCOUT_USER_TIMEZONE", zone)
+        store = DedupStore(tmp_path / f"trigger-fires-{zone.replace('/', '-')}.json")
+        store.record_fire("t", "evt-1", instant)
+        assert store.state("t")["fires_today_date"] == day, zone
+
+
+@pytest.mark.parametrize("zone", PROBE_ZONES)
+def test_hook_day_stamps_follow_configured_zone(
+    zone: str, fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The connector-log JSONL filename date and the session-tool-log filename
+    date bucket rows by day; both must use the configured zone (#207)."""
+    from scout.hooks.connector_log import _local_date as connector_log_date
+    from scout.hooks.session_tool_log import _local_date as tool_log_date
+
+    monkeypatch.setenv("SCOUT_USER_TIMEZONE", zone)
+    for stamp_fn in (connector_log_date, tool_log_date):
+        result, ok = _run_boundary_safe(zone, stamp_fn)
+        assert result in {d.isoformat() for d in ok}
+
+
+@pytest.mark.parametrize("zone", PROBE_ZONES)
+def test_bootstrap_template_date_uses_installed_timezone(zone: str, tmp_path: Path) -> None:
+    """TODAY_DATE is rendered before the vault config exists, so it must come
+    from the timezone being installed (cfg.timezone), not the host clock."""
+    from scout.scripts.bootstrap import BootstrapConfig, _template_vars
+
+    cfg = BootstrapConfig(
+        vault=tmp_path / "Scout",
+        plugin_root=tmp_path,
+        instance_name="TestScout",
+        instance_name_lower="testscout",
+        user_name="Alex Example",
+        user_email="alex@example.com",
+        timezone=zone,
+        platform="macos",
+        plugin_version="0.0.0",
+        enabled_connectors=set(),
+        connector_inputs={},
+    )
+    result, ok = _run_boundary_safe(zone, lambda: _template_vars(cfg)["TODAY_DATE"])
+    assert result in {d.isoformat() for d in ok}

--- a/engine/tests/unit/test_hooks_kb_pre_filter.py
+++ b/engine/tests/unit/test_hooks_kb_pre_filter.py
@@ -526,15 +526,20 @@ def test_main_default_session_type(tmp_path, monkeypatch):
 # -- #53 fixes ----------------------------------------------------------------
 
 
-def test_parse_date_returns_tz_aware_et():
-    """#53: parse_date must return an ET-aware datetime so callers can't drift
-    across DST by forgetting to attach tzinfo."""
-    from scout.hooks.kb_pre_filter import ET, parse_date
+def test_parse_date_returns_tz_aware():
+    """#53: parse_date must return a zone-aware datetime so callers can't drift
+    across DST by forgetting to attach tzinfo. Default zone is the configured
+    one, which in a hermetic test env is the packaged default (#207)."""
+    from zoneinfo import ZoneInfo
 
+    from scout.config import DEFAULT_TIMEZONE
+    from scout.hooks.kb_pre_filter import parse_date
+
+    default_zone = ZoneInfo(DEFAULT_TIMEZONE)
     dt = parse_date("2026-06-15")
     assert dt is not None
     assert dt.tzinfo is not None
-    assert dt.utcoffset() == ET.utcoffset(dt.replace(tzinfo=None))
+    assert dt.utcoffset() == default_zone.utcoffset(dt.replace(tzinfo=None))
 
 
 def test_classify_reads_file_only_once_per_call(tmp_path):

--- a/engine/tests/unit/test_paths.py
+++ b/engine/tests/unit/test_paths.py
@@ -87,7 +87,7 @@ def test_derived_paths_under_data_dir(tmp_path: Path) -> None:
 
 def test_action_items_daily_path_default_today(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     today = dt.date(2026, 4, 24)
-    monkeypatch.setattr(paths, "_today", lambda: today)
+    monkeypatch.setattr(paths, "_today", lambda *a, **kw: today)
     p = paths.action_items_daily_path(data=fake_data_dir)
     assert p.name == "action-items-2026-04-24.md"
     assert p.parent == fake_data_dir / "action-items"


### PR DESCRIPTION
Part 1 of #207 (part 2: the activating config-read fix, stacked on this PR). **Deliberately inert on an ET host** — this is the "unify the day boundary first" commit the #207 thread's landing-order discussion asked for, so that fixing the config read can't split the day boundary.

## What

One configured-zone authority for "today" in `engine/scout/config.py`:

```python
DEFAULT_TIMEZONE = "America/New_York"
def timezone_or_default(tz_name) -> ZoneInfo   # fallback lives INSIDE the resolver
def resolve_timezone(data_dir=None) -> ZoneInfo
def now(data_dir=None) / today(data_dir=None)
```

- **Set A — all 11 bare `date.today()` sites routed**: `paths._today` (lazy-imports `config.today` to avoid the config→paths cycle), the five action-items mutators (`mark_done`/`snooze`/`add_comment`/`edit_comment`/`delete_comment` — `_today(data_dir)` now takes the vault), `tui/config.py`, `bootstrap.py` TODAY_DATE (uses `cfg.timezone`, not `config.today()` — the vault config doesn't exist yet mid-install), `bootstrap._unique_backup_path`, `install_cron.py`, `migrate_perfile.py`.
- **Set B — all 12 hardcoded-ET sites in 11 files routed**: `materialize` (DEFAULT_TZ + `_configured_tz` deleted), `triggers/dedup.DAY_BOUNDARY_ZONE` → call-time `day_boundary_zone()` (import-time capture would leak the dev's real vault zone into tests), `kb_pre_filter` (zone resolved once per run, threaded through `classify`/`parse_date`), `connector_health_report`, `connector_log`/`session_tool_log` `_et_date` → `_local_date`, `session_tokens` (persisted JSONL field stays `ts_et`), `cc_session_cache`/`pre_session_data` tz defaults (None → configured; explicit still wins), `heartbeat._log_line`, TUI dashboard note. `cli.py` `session cc-cache --timezone` default → None.
- `cli.py`'s setup-prompt ET literals intentionally untouched — packaged-default answers, not day-boundary reads.
- Converges with the shell authority: `scout-tz.sh` reads the undotted file's `timezone:`; the Python side now resolves the same field.

## Tests

New `tests/unit/test_day_boundary.py` (13 tests) probes every surface under **Pacific/Kiritimati (UTC+14)** and **Etc/GMT+12 (UTC−12)** — their civil dates never agree, so a host-clock path fails under ≥1 probe zone at any time of day, on any host TZ. **10/13 fail on main** (verified via stash), including the writers-agreement test failing under both zones — the exact #207 split (materialize honored the env zone; mutators didn't).

## Validation

pytest **1016/10/0** at this commit vs main 1003/10/0 (same env); ruff check + format, mypy (86 files), shellcheck, version guard, snapshot checks, manifests all clean.

## One visible diff on an ET host (review call)

Timestamps that hardcoded a literal `"ET"` suffix now render `%Z` (`EDT`/`EST`, or the configured zone's abbrev) — connector-health.md, kb-filter.md header, TUI note lines. Strictly more honest; revertable per-site if "no behavior change" must be absolute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
