### PR TITLE
fix(config): read the vault's scout-config.yaml (#207)

### DIFF
--- a/engine/scout/config.py
+++ b/engine/scout/config.py
@@ -2,14 +2,25 @@
 
 Precedence (low → high, later overrides earlier):
   1. Engine defaults (scout/defaults/scout-config.yaml, shipped with package)
-  2. User overrides ($SCOUT_DATA_DIR/.scout-config.yaml)
+  2. The vault's scout-config.yaml ($SCOUT_DATA_DIR/scout-config.yaml — the
+     file /scout-setup and bootstrap write; NO dot, see #207/#202)
   3. SCOUT_* environment variables (whitelisted keys)
+
+The vault file doubles as bootstrap state (version stamps, connectors,
+schedule, plan) and predates the canonical schema, so layer 2 is read
+tolerantly: legacy key shapes are normalized on read (never rewritten on
+disk), unreadable YAML degrades to defaults with a stderr warning, and a
+scalar where the defaults define a mapping is ignored with a warning instead
+of clobbering the subtree. This layer was silently dead for every existing
+vault until #207 — tolerance keeps switching it on from turning a stale or
+hand-mangled file into a crash.
 """
 
 from __future__ import annotations
 
 import datetime as _dt
 import os
+import sys
 from importlib.resources import as_file, files
 from pathlib import Path
 from typing import Any
@@ -72,14 +83,79 @@ def _read_packaged_defaults() -> dict[str, Any]:
         return _read_yaml(path)
 
 
+def _warn(msg: str) -> None:
+    """One-line stderr warning. The silent-defaults fallback is what kept
+    #202 invisible for so long — degradation must be loud enough to spot in
+    --verbose output and run logs, but must never raise."""
+    print(f"scout-config: {msg}", file=sys.stderr)
+
+
+def _normalize_legacy_keys(overrides: dict[str, Any]) -> dict[str, Any]:
+    """Map the key shapes bootstrap actually writes onto the canonical schema
+    (#207 §2). Read-side only — the vault file is never rewritten, so
+    existing vaults need no migration. Explicit canonical ``user.*`` keys
+    always win; legacy keys only fill gaps.
+
+      timezone (top level)               → user.timezone
+      connectors.inputs.github_username  → user.github_username
+      connectors.inputs.user_slack_id    → user.slack_user_id
+    """
+    out = dict(overrides)
+    raw_user = out.get("user")
+    user: dict[str, Any] = dict(raw_user) if isinstance(raw_user, dict) else {}
+
+    def fill(canonical: str, value: object) -> None:
+        if isinstance(value, str) and value and not user.get(canonical):
+            user[canonical] = value
+
+    fill("timezone", out.get("timezone"))
+    connectors = out.get("connectors")
+    inputs = connectors.get("inputs") if isinstance(connectors, dict) else None
+    if isinstance(inputs, dict):
+        fill("github_username", inputs.get("github_username"))
+        fill("slack_user_id", inputs.get("user_slack_id"))
+
+    if user:
+        out["user"] = user
+    return out
+
+
+def _merge_user_layer(defaults: dict[str, Any], overrides: dict[str, Any], _path: str = "") -> dict[str, Any]:
+    """Deep merge with a guard: where the DEFAULTS define a mapping, a
+    non-mapping override is ignored with a warning instead of replacing the
+    subtree (a stale ``user: oops`` must not take user.timezone down with
+    it). Keys unknown to the defaults — bootstrap state like ``plugin`` or
+    ``schedule`` — merge through silently."""
+    result = dict(defaults)
+    for key, value in overrides.items():
+        where = f"{_path}{key}"
+        if key in result and isinstance(result[key], dict):
+            if isinstance(value, dict):
+                result[key] = _merge_user_layer(result[key], value, f"{where}.")
+            else:
+                _warn(f"ignoring '{where}': expected a mapping, got {type(value).__name__} — using defaults")
+        else:
+            result[key] = value
+    return result
+
+
 def load_config(data_dir: Path | None = None) -> dict[str, Any]:
-    """Load the three-layer merged config."""
+    """Load the three-layer merged config.
+
+    Never raises on a bad VAULT file — the packaged defaults must scream
+    (a broken wheel is a bug), but the user layer warns and degrades so a
+    stale or hand-mangled scout-config.yaml cannot block a run.
+    """
     defaults = _read_packaged_defaults()
     user_path = paths.config_path(data_dir)
-    user_overrides = _read_yaml(user_path)
+    try:
+        user_overrides = _read_yaml(user_path)
+    except ConfigError as e:
+        _warn(f"ignoring unreadable {user_path.name}: {e} — running on packaged defaults")
+        user_overrides = {}
     env_overrides = _env_overrides()
 
-    merged = _deep_merge(defaults, user_overrides)
+    merged = _merge_user_layer(defaults, _normalize_legacy_keys(user_overrides))
     merged = _deep_merge(merged, env_overrides)
     return merged
 

--- a/engine/scout/config.py
+++ b/engine/scout/config.py
@@ -150,7 +150,8 @@ def load_config(data_dir: Path | None = None) -> dict[str, Any]:
     user_path = paths.config_path(data_dir)
     try:
         user_overrides = _read_yaml(user_path)
-    except ConfigError as e:
+    except (ConfigError, OSError, UnicodeDecodeError) as e:
+        # OSError: permissions/races; UnicodeDecodeError: binary corruption.
         _warn(f"ignoring unreadable {user_path.name}: {e} — running on packaged defaults")
         user_overrides = {}
     env_overrides = _env_overrides()

--- a/engine/scout/paths.py
+++ b/engine/scout/paths.py
@@ -52,7 +52,16 @@ def state_dir(data: Path | None = None) -> Path:
 
 
 def config_path(data: Path | None = None) -> Path:
-    return (data or data_dir()) / ".scout-config.yaml"
+    """The vault's config file — ``scout-config.yaml``, NO dot.
+
+    This is the file /scout-setup and bootstrap actually write. The loader
+    historically pointed at ``.scout-config.yaml``, a dotfile no code path
+    ever wrote, which silently disabled the whole user-override layer
+    (#207/#202). The undotted file holds bootstrap state (version stamps,
+    connectors, schedule) alongside user overrides; scout.config.load_config
+    normalizes its legacy key shapes on read.
+    """
+    return (data or data_dir()) / "scout-config.yaml"
 
 
 def kb_dir(data: Path | None = None) -> Path:

--- a/engine/scout/scripts/_config_scan.py
+++ b/engine/scout/scripts/_config_scan.py
@@ -1,0 +1,78 @@
+"""Shared two-level scanner for the vault's ``scout-config.yaml``.
+
+Both :mod:`scout.scripts.budget_check` and :mod:`scout.scripts.heartbeat` read a
+handful of scalar knobs out of the vault config on a hot path where importing
+pyyaml is not worth the startup cost, so each carried its own ``grep``-shaped
+line scanner. Keeping two copies let them drift: heartbeat learned the nested
+``off_peak: {start, end}`` shape the template writes while budget_check stayed
+flat, and a flat scanner is **parent-blind** — it matches ``key: value`` at any
+indentation under any parent, so an unrelated subtree can set the budget and a
+duplicate key silently wins by being last.
+
+That blindness matters because ``scout-config.yaml`` is not a single-purpose
+override file: it doubles as bootstrap state (version stamps, connectors,
+schedule, plan), written by several producers, with many subtrees.
+
+So the rule here is explicit about parentage:
+
+* **nested keys** match only as ``(section, key)`` — the key indented directly
+  under its expected top-level section. ``plan.rate_limit_window_hours`` is set
+  by ``plan:`` and by nothing else.
+* **flat keys** match only at top level (no indent), for hand-written override
+  files that predate the nested shape.
+
+An indented key under the wrong parent matches nothing, which is the whole
+point. Values are returned as raw strings; each caller casts and validates.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+
+# Captures indent, key, and an OPTIONAL value — a key with no value is a
+# section header, which is how the section context is tracked.
+_CONFIG_LINE_RE = re.compile(r"^(\s*)([A-Za-z_][A-Za-z0-9_]*)\s*:\s*([^#\s][^#]*?)?\s*(?:#.*)?$")
+
+
+def scan_overrides(
+    text: str,
+    *,
+    flat_keys: Mapping[str, str] | None = None,
+    nested_keys: Mapping[tuple[str, str], str] | None = None,
+) -> dict[str, str]:
+    """Map config text to ``{field_name: raw_value}``.
+
+    ``flat_keys`` maps a top-level ``yaml_key`` to a field name; ``nested_keys``
+    maps ``(section, yaml_key)`` to a field name. Keys that match neither rule —
+    including a nested key found under the wrong parent — are ignored.
+    """
+    flat = flat_keys or {}
+    nested = nested_keys or {}
+    out: dict[str, str] = {}
+    section: str | None = None
+
+    for line in text.splitlines():
+        m = _CONFIG_LINE_RE.match(line)
+        if not m:
+            continue
+        indent, yaml_key, raw_value = m.group(1), m.group(2), m.group(3)
+
+        if raw_value is None:
+            # `key:` with no value. Only a top-level one opens a section; a
+            # nested one closes the context so its children can't be mistaken
+            # for direct children of the enclosing section.
+            section = yaml_key if not indent else None
+            continue
+
+        if not indent:
+            section = None
+            field_name = flat.get(yaml_key)
+        else:
+            field_name = nested.get((section, yaml_key)) if section else None
+
+        if field_name is None:
+            continue
+        out[field_name] = raw_value.strip().strip("\"'")
+
+    return out

--- a/engine/scout/scripts/budget_check.py
+++ b/engine/scout/scripts/budget_check.py
@@ -17,7 +17,7 @@ unparseable rows are silently skipped (same as the bash original).
 from __future__ import annotations
 
 import json
-import re
+import sys
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import Any
 
 from scout import paths
+from scout.scripts._config_scan import scan_overrides
 
 # Defaults — mirror budget-check.sh defaults so behavior is preserved when no
 # scout-config.yaml is present.
@@ -54,6 +55,21 @@ class BudgetConfig:
         return round(self.window_budget_usd * self.skip_threshold_pct / 100, 2)
 
 
+# Ranges a knob must fall in to be usable. These went live for the first time
+# when the loader was repointed at the vault's scout-config.yaml, so a value
+# that makes the governor nonsensical must be refused rather than enforced:
+# `rate_limit_window_hours: 0` — a plausible spelling of "no window" — yields a
+# $0 window budget and a $0 skip threshold, which silently skips every session
+# from then on, and a negative value yields a negative budget. Out-of-range
+# values fall back to the default with a warning instead.
+_CONFIG_BOUNDS: dict[str, tuple[float, float]] = {
+    "daily_budget_usd": (0.0, float("inf")),  # 0 is a real choice: spend nothing
+    "window_hours": (1, float("inf")),  # a 0-hour rolling window is not a window
+    "skip_threshold_pct": (0.0, 100.0),
+    "failure_backoff_min": (0, float("inf")),
+}
+
+
 @dataclass(frozen=True)
 class BudgetDecision:
     exit_code: int
@@ -67,6 +83,20 @@ class BudgetDecision:
 # Lightweight YAML reader for the four flat scalar keys this script needs.
 # Avoids importing pyyaml on the hot path — and the bash version uses grep+awk
 # for parity reasons. Anything more structured falls through to the default.
+# The parents these keys live under in scout-config.yaml. Matching on
+# (section, key) rather than on the bare key keeps an unrelated subtree from
+# setting the budget: scout-config.yaml doubles as bootstrap state written by
+# several producers, so a bare-key scan would let any `daily_budget_estimate_usd`
+# anywhere in the file win — and, being last-wins, let a stale duplicate quietly
+# override the live one.
+_NESTED_CONFIG_KEYS = {
+    ("plan", "daily_budget_estimate_usd"): ("daily_budget_usd", float),
+    ("plan", "rate_limit_window_hours"): ("window_hours", int),
+    ("thresholds", "skip_threshold_pct"): ("skip_threshold_pct", float),
+    ("thresholds", "failure_backoff_minutes"): ("failure_backoff_min", int),
+}
+
+# Flat top-level spellings — back-compat with hand-made override files.
 _CONFIG_KEYS = {
     "daily_budget_estimate_usd": ("daily_budget_usd", float),
     "rate_limit_window_hours": ("window_hours", int),
@@ -74,14 +104,15 @@ _CONFIG_KEYS = {
     "failure_backoff_minutes": ("failure_backoff_min", int),
 }
 
-_CONFIG_LINE_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*([^#\s][^#]*?)\s*(?:#.*)?$")
-
 
 def load_config(config_path: Path) -> BudgetConfig:
     """Parse the four scalar keys this check cares about from scout-config.yaml.
 
     Missing file or unparseable rows fall back to defaults — matches the bash
-    `grep ... | awk` pattern which silently no-ops on missing keys.
+    `grep ... | awk` pattern which silently no-ops on missing keys. The scan is
+    the shared two-level reader, so each key is only honoured under its own
+    section (or spelled flat at top level), and a value outside
+    :data:`_CONFIG_BOUNDS` falls back to its default with a warning.
     """
     overrides: dict[str, Any] = {}
     if not config_path.exists():
@@ -90,19 +121,25 @@ def load_config(config_path: Path) -> BudgetConfig:
         text = config_path.read_text(encoding="utf-8")
     except OSError:
         return BudgetConfig()
-    for line in text.splitlines():
-        m = _CONFIG_LINE_RE.match(line)
-        if not m:
-            continue
-        yaml_key, raw_value = m.group(1), m.group(2).strip().strip("\"'")
-        mapping = _CONFIG_KEYS.get(yaml_key)
-        if mapping is None:
-            continue
-        field_name, caster = mapping
+
+    flat = {k: v[0] for k, v in _CONFIG_KEYS.items()}
+    nested = {k: v[0] for k, v in _NESTED_CONFIG_KEYS.items()}
+    casters = {v[0]: v[1] for v in _CONFIG_KEYS.values()}
+
+    for field_name, raw_value in scan_overrides(text, flat_keys=flat, nested_keys=nested).items():
         try:
-            overrides[field_name] = caster(raw_value)
+            value = casters[field_name](raw_value)
         except (TypeError, ValueError):
             continue
+        low, high = _CONFIG_BOUNDS[field_name]
+        if not (low <= value <= high):
+            print(
+                f"[budget-check] ignoring {field_name}={value}: outside the usable range "
+                f"[{low}, {high}] — using the default",
+                file=sys.stderr,
+            )
+            continue
+        overrides[field_name] = value
     return BudgetConfig(**overrides)
 
 

--- a/engine/scout/scripts/budget_check.py
+++ b/engine/scout/scripts/budget_check.py
@@ -27,7 +27,7 @@ from typing import Any
 from scout import paths
 
 # Defaults — mirror budget-check.sh defaults so behavior is preserved when no
-# .scout-config.yaml is present.
+# scout-config.yaml is present.
 DEFAULT_WINDOW_HOURS = 5
 DEFAULT_DAILY_BUDGET_USD = 50.0
 DEFAULT_SKIP_THRESHOLD_PCT = 80.0
@@ -78,7 +78,7 @@ _CONFIG_LINE_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*([^#\s][^#]*?)
 
 
 def load_config(config_path: Path) -> BudgetConfig:
-    """Parse the four scalar keys this check cares about from .scout-config.yaml.
+    """Parse the four scalar keys this check cares about from scout-config.yaml.
 
     Missing file or unparseable rows fall back to defaults — matches the bash
     `grep ... | awk` pattern which silently no-ops on missing keys.
@@ -216,9 +216,14 @@ def run(*, verbose: bool = False, data_dir: Path | None = None) -> int:
     """
     target = data_dir or paths.data_dir()
     tracker_path = paths.logs_dir(target) / "usage-tracker.jsonl"
-    config = load_config(paths.config_path(target))
+    config_path = paths.config_path(target)
+    config = load_config(config_path)
     decision = decide(tracker_path, config)
     if verbose:
+        # Say WHICH file supplied the numbers — the silent-defaults fallback
+        # is what kept #202 invisible for months.
+        state = "" if config_path.exists() else " (missing — using engine defaults)"
+        print(f"[budget-check] config: {config_path}{state}")
         print(f"[budget-check] {decision.reason}")
         print(
             f"[budget-check] window: {config.window_hours}h, "

--- a/engine/scout/scripts/heartbeat.py
+++ b/engine/scout/scripts/heartbeat.py
@@ -36,6 +36,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from scout import paths
+from scout.scripts._config_scan import scan_overrides
 
 # Defaults mirror heartbeat.sh constants so behavior is preserved when no
 # scout-config.yaml is present.
@@ -53,8 +54,6 @@ EXIT_ERROR = 1
 _TRACKER_FILENAME = "usage-tracker.jsonl"
 _RESEARCH_QUEUE_REL = "knowledge-base/research-queue.md"
 _RESEARCH_QUEUE_DIR_REL = "knowledge-base/research-queue"
-
-_CONFIG_LINE_RE = re.compile(r"^(\s*)([A-Za-z_][A-Za-z0-9_]*)\s*:\s*([^#\s][^#]*?)?\s*(?:#.*)?$")
 
 # Flat spellings — back-compat with hand-made override files.
 _CONFIG_KEYS = {
@@ -89,10 +88,10 @@ def load_config(config_path: Path) -> HeartbeatConfig:
     """Parse only the off-peak keys heartbeat cares about from scout-config.yaml.
 
     Missing file or unparseable values silently fall back to defaults, matching
-    the bash original's tolerant ``grep | awk`` pattern. The scan is a
-    lightweight two-level reader (still no pyyaml on this hot path): it
-    understands both the nested ``off_peak: {start, end}`` shape /scout-setup
-    writes and the flat ``off_peak_start/off_peak_end`` spellings.
+    the bash original's tolerant ``grep | awk`` pattern. The scan is the shared
+    two-level reader (still no pyyaml on this hot path): it understands both the
+    nested ``off_peak: {start, end}`` shape /scout-setup writes and the flat
+    ``off_peak_start/off_peak_end`` spellings.
     """
     if not config_path.exists():
         return HeartbeatConfig()
@@ -101,26 +100,7 @@ def load_config(config_path: Path) -> HeartbeatConfig:
     except OSError:
         return HeartbeatConfig()
     overrides: dict[str, int] = {}
-    section: str | None = None
-    for line in text.splitlines():
-        m = _CONFIG_LINE_RE.match(line)
-        if not m:
-            continue
-        indent, yaml_key, raw_value = m.group(1), m.group(2), m.group(3)
-        if raw_value is None:
-            # `key:` with no value — a section header at top level.
-            section = yaml_key if not indent else None
-            continue
-        raw_value = raw_value.strip().strip("\"'")
-        if not indent:
-            section = None
-            field_name = _CONFIG_KEYS.get(yaml_key)
-        else:
-            field_name = _NESTED_CONFIG_KEYS.get((section, yaml_key)) if section else None
-            # Indented flat spellings keep working too (hand-made files).
-            field_name = field_name or _CONFIG_KEYS.get(yaml_key)
-        if field_name is None:
-            continue
+    for field_name, raw_value in scan_overrides(text, flat_keys=_CONFIG_KEYS, nested_keys=_NESTED_CONFIG_KEYS).items():
         try:
             overrides[field_name] = int(raw_value)
         except (TypeError, ValueError):

--- a/engine/scout/scripts/heartbeat.py
+++ b/engine/scout/scripts/heartbeat.py
@@ -9,7 +9,7 @@ all three derived values plus the pgrep / git-status side checks.
 
 Gating order (preserved from bash):
   1. Another ``claude .*scout-`` process already running → skip
-  2. Off-peak detection from ``.scout-config.yaml`` (used by gate 5)
+  2. Off-peak detection from ``scout-config.yaml`` (used by gate 5)
   3. Budget check (delegates to ``scoutctl budget check`` so its tracker
      parse is shared with #87's optimization)
   4. Minimum gap since last session (default 120 min)
@@ -38,7 +38,7 @@ from pathlib import Path
 from scout import paths
 
 # Defaults mirror heartbeat.sh constants so behavior is preserved when no
-# .scout-config.yaml is present.
+# scout-config.yaml is present.
 DEFAULT_OFF_PEAK_START = 23
 DEFAULT_OFF_PEAK_END = 6
 DEFAULT_MIN_GAP_MINUTES = 120
@@ -51,15 +51,24 @@ EXIT_SKIPPED = 0  # bash returns 0 on intentional skip too
 EXIT_ERROR = 1
 
 _TRACKER_FILENAME = "usage-tracker.jsonl"
-_CONFIG_FILENAME = ".scout-config.yaml"
 _RESEARCH_QUEUE_REL = "knowledge-base/research-queue.md"
 _RESEARCH_QUEUE_DIR_REL = "knowledge-base/research-queue"
 
-_CONFIG_LINE_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*([^#\s][^#]*?)\s*(?:#.*)?$")
+_CONFIG_LINE_RE = re.compile(r"^(\s*)([A-Za-z_][A-Za-z0-9_]*)\s*:\s*([^#\s][^#]*?)?\s*(?:#.*)?$")
 
+# Flat spellings — back-compat with hand-made override files.
 _CONFIG_KEYS = {
     "off_peak_start": "off_peak_start",
     "off_peak_end": "off_peak_end",
+}
+
+# The shape /scout-setup actually writes (templates/scout-config.yaml.tmpl):
+#   off_peak:
+#     start: 23
+#     end: 6
+_NESTED_CONFIG_KEYS = {
+    ("off_peak", "start"): "off_peak_start",
+    ("off_peak", "end"): "off_peak_end",
 }
 
 
@@ -77,10 +86,13 @@ class HeartbeatConfig:
 
 
 def load_config(config_path: Path) -> HeartbeatConfig:
-    """Parse only the two scalar keys heartbeat cares about from .scout-config.yaml.
+    """Parse only the off-peak keys heartbeat cares about from scout-config.yaml.
 
     Missing file or unparseable values silently fall back to defaults, matching
-    the bash original's tolerant ``grep | awk`` pattern.
+    the bash original's tolerant ``grep | awk`` pattern. The scan is a
+    lightweight two-level reader (still no pyyaml on this hot path): it
+    understands both the nested ``off_peak: {start, end}`` shape /scout-setup
+    writes and the flat ``off_peak_start/off_peak_end`` spellings.
     """
     if not config_path.exists():
         return HeartbeatConfig()
@@ -89,12 +101,24 @@ def load_config(config_path: Path) -> HeartbeatConfig:
     except OSError:
         return HeartbeatConfig()
     overrides: dict[str, int] = {}
+    section: str | None = None
     for line in text.splitlines():
         m = _CONFIG_LINE_RE.match(line)
         if not m:
             continue
-        yaml_key, raw_value = m.group(1), m.group(2).strip().strip("\"'")
-        field_name = _CONFIG_KEYS.get(yaml_key)
+        indent, yaml_key, raw_value = m.group(1), m.group(2), m.group(3)
+        if raw_value is None:
+            # `key:` with no value — a section header at top level.
+            section = yaml_key if not indent else None
+            continue
+        raw_value = raw_value.strip().strip("\"'")
+        if not indent:
+            section = None
+            field_name = _CONFIG_KEYS.get(yaml_key)
+        else:
+            field_name = _NESTED_CONFIG_KEYS.get((section, yaml_key)) if section else None
+            # Indented flat spellings keep working too (hand-made files).
+            field_name = field_name or _CONFIG_KEYS.get(yaml_key)
         if field_name is None:
             continue
         try:
@@ -432,7 +456,9 @@ def run(
     """
     target = data_dir or paths.data_dir()
     tracker_path = paths.logs_dir(target) / _TRACKER_FILENAME
-    config_path = target / _CONFIG_FILENAME
+    # Through paths.config_path — heartbeat's own hardcoded dotted filename
+    # was the file-that-nothing-writes half of #207 (comment thread).
+    config_path = paths.config_path(target)
     log_path = paths.logs_dir(target) / "heartbeat.log"
 
     # Resolve the vault's configured zone once for every log stamp this tick

--- a/engine/tests/unit/test_config.py
+++ b/engine/tests/unit/test_config.py
@@ -24,7 +24,7 @@ def test_load_config_returns_defaults_when_no_user_override(clean_env: None, fak
 
 def test_user_config_overrides_defaults(clean_env: None, fake_data_dir: Path) -> None:
     _write(
-        fake_data_dir / ".scout-config.yaml",
+        fake_data_dir / "scout-config.yaml",
         {"budgets": {"daily_budget_estimate_usd": 999}},
     )
     cfg = config.load_config(fake_data_dir)
@@ -35,7 +35,7 @@ def test_user_config_overrides_defaults(clean_env: None, fake_data_dir: Path) ->
 
 def test_deep_merge_preserves_sibling_keys(clean_env: None, fake_data_dir: Path) -> None:
     _write(
-        fake_data_dir / ".scout-config.yaml",
+        fake_data_dir / "scout-config.yaml",
         {"user": {"email": "test@example.com"}},
     )
     cfg = config.load_config(fake_data_dir)
@@ -46,7 +46,7 @@ def test_deep_merge_preserves_sibling_keys(clean_env: None, fake_data_dir: Path)
 
 def test_env_var_overrides_user_config(clean_env: None, fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _write(
-        fake_data_dir / ".scout-config.yaml",
+        fake_data_dir / "scout-config.yaml",
         {"user": {"email": "user@example.com"}},
     )
     monkeypatch.setenv("SCOUT_USER_EMAIL", "env@example.com")
@@ -54,13 +54,26 @@ def test_env_var_overrides_user_config(clean_env: None, fake_data_dir: Path, mon
     assert cfg["user"]["email"] == "env@example.com"
 
 
-def test_invalid_yaml_raises_config_error(clean_env: None, fake_data_dir: Path) -> None:
-    (fake_data_dir / ".scout-config.yaml").write_text("key: [unclosed")
+def test_invalid_yaml_degrades_to_defaults(
+    clean_env: None, fake_data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """#207: the vault layer warns and degrades instead of raising — a stale
+    file must not block a run now that the layer is actually live. (_read_yaml
+    itself still raises ConfigError; see test_config_vault_file.py.)"""
+    (fake_data_dir / "scout-config.yaml").write_text("key: [unclosed")
+    cfg = config.load_config(fake_data_dir)
+    assert cfg["schema_version"] == 1
+    assert "Invalid YAML" in capsys.readouterr().err
     with pytest.raises(ConfigError, match="Invalid YAML"):
-        config.load_config(fake_data_dir)
+        config._read_yaml(fake_data_dir / "scout-config.yaml")
 
 
-def test_non_mapping_yaml_raises_config_error(clean_env: None, fake_data_dir: Path) -> None:
-    (fake_data_dir / ".scout-config.yaml").write_text("- a\n- b\n")
+def test_non_mapping_yaml_degrades_to_defaults(
+    clean_env: None, fake_data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (fake_data_dir / "scout-config.yaml").write_text("- a\n- b\n")
+    cfg = config.load_config(fake_data_dir)
+    assert cfg["schema_version"] == 1
+    assert "YAML mapping" in capsys.readouterr().err
     with pytest.raises(ConfigError, match="YAML mapping"):
-        config.load_config(fake_data_dir)
+        config._read_yaml(fake_data_dir / "scout-config.yaml")

--- a/engine/tests/unit/test_config_vault_file.py
+++ b/engine/tests/unit/test_config_vault_file.py
@@ -1,0 +1,290 @@
+"""Regression tests for the config-read fix (#207 part 2, closes #202).
+
+The user-override layer must read the file /scout-setup actually writes —
+``<vault>/scout-config.yaml`` (no dot) — and must understand the key shapes
+bootstrap writes into it (top-level ``timezone``, identity under
+``connectors.inputs``), normalizing them onto the canonical schema on read
+without rewriting the file. Explicit canonical ``user.*`` keys always win.
+
+The undotted file legitimately holds bootstrap state (version stamps,
+connectors, schedule) alongside user overrides — those keys must pass
+through untouched and never warn.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scout import config, paths
+from scout.scripts import budget_check, heartbeat
+
+
+def _write_vault_config(vault: Path, data: dict) -> Path:
+    p = vault / "scout-config.yaml"
+    p.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    return p
+
+
+# ----- filename: the layer must read the undotted file ----------------------
+
+
+def test_config_path_is_the_undotted_vault_file(tmp_path: Path) -> None:
+    assert paths.config_path(tmp_path) == tmp_path / "scout-config.yaml"
+
+
+def test_load_config_reads_vault_scout_config(clean_env: None, fake_data_dir: Path) -> None:
+    """#207 part 1: the override layer pointed at a dotfile no code path
+    writes, so every scoutctl caller ran on packaged defaults."""
+    _write_vault_config(fake_data_dir, {"user": {"timezone": "Europe/Prague"}})
+    cfg = config.load_config(fake_data_dir)
+    assert cfg["user"]["timezone"] == "Europe/Prague"
+    assert config.resolve_timezone(fake_data_dir).key == "Europe/Prague"
+
+
+# ----- key shape: normalize what bootstrap actually writes ------------------
+
+
+def test_legacy_top_level_timezone_reaches_user_timezone(clean_env: None, fake_data_dir: Path) -> None:
+    """bootstrap._stage_version_stamp persists ``timezone`` at the TOP level;
+    consumers read ``user.timezone``. Deep-merge alone leaves the packaged
+    zone in place (#207 §2) — the loader must normalize on read."""
+    _write_vault_config(fake_data_dir, {"timezone": "Europe/Prague", "user": {"name": "Alex"}})
+    cfg = config.load_config(fake_data_dir)
+    assert cfg["user"]["timezone"] == "Europe/Prague"
+    # The legacy key is not erased — the file is bootstrap state too.
+    assert cfg["timezone"] == "Europe/Prague"
+
+
+def test_explicit_user_timezone_wins_over_legacy_top_level(clean_env: None, fake_data_dir: Path) -> None:
+    _write_vault_config(
+        fake_data_dir,
+        {"timezone": "America/New_York", "user": {"timezone": "Europe/Prague"}},
+    )
+    assert config.load_config(fake_data_dir)["user"]["timezone"] == "Europe/Prague"
+
+
+def test_connector_inputs_identity_normalized(clean_env: None, fake_data_dir: Path) -> None:
+    _write_vault_config(
+        fake_data_dir,
+        {
+            "connectors": {
+                "enabled": ["github", "slack"],
+                "inputs": {"github_username": "alex-example", "user_slack_id": "U0123456789"},
+            }
+        },
+    )
+    cfg = config.load_config(fake_data_dir)
+    assert cfg["user"]["github_username"] == "alex-example"
+    assert cfg["user"]["slack_user_id"] == "U0123456789"
+    # Bootstrap state passes through untouched.
+    assert cfg["connectors"]["enabled"] == ["github", "slack"]
+
+
+def test_env_override_still_beats_vault_file(
+    clean_env: None, fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_vault_config(fake_data_dir, {"timezone": "Europe/Prague"})
+    monkeypatch.setenv("SCOUT_USER_TIMEZONE", "Pacific/Auckland")
+    assert config.load_config(fake_data_dir)["user"]["timezone"] == "Pacific/Auckland"
+
+
+# ----- #202: the budget governor must see the configured budget -------------
+
+
+def test_budget_governor_reads_configured_budget(clean_env: None, fake_data_dir: Path) -> None:
+    """#202's repro: /scout-setup renders the budget block into
+    scout-config.yaml, but budget_check read the dotted file — so every
+    configured budget was silently ignored and the governor enforced
+    50 USD / 5 h / 80% regardless."""
+    _write_vault_config(
+        fake_data_dir,
+        {
+            "plan": {"type": "claude-max", "daily_budget_estimate_usd": 999, "rate_limit_window_hours": 7},
+            "thresholds": {"skip_threshold_pct": 55, "failure_backoff_minutes": 11},
+        },
+    )
+    cfg = budget_check.load_config(paths.config_path(fake_data_dir))
+    assert cfg.daily_budget_usd == 999.0
+    assert cfg.window_hours == 7
+    assert cfg.skip_threshold_pct == 55.0
+    assert cfg.failure_backoff_min == 11
+    assert cfg.window_budget_usd == 291.38
+    assert cfg.skip_threshold_usd == 160.26
+
+
+def test_bootstrap_install_config_reaches_governor_and_loader(tmp_path: Path) -> None:
+    """#202's asked-for integration test, against what bootstrap ACTUALLY
+    writes: the Python install pipeline stamps scout-config.yaml via
+    _stage_version_stamp (identity + timezone + connectors + versions) and
+    does NOT render the budget template — only legacy bash-installed vaults
+    carry a plan/thresholds block. So: a fresh vault must resolve its
+    configured timezone through the loader, and a vault whose file carries
+    the budget block (legacy render or hand calibration, as the template
+    header instructs) must have the governor see those exact numbers."""
+    from scout.scripts.bootstrap import BootstrapConfig, install
+
+    plugin_root = Path(__file__).parent.parent.parent.parent  # repo root
+    vault = tmp_path / "Scout"
+    install(
+        BootstrapConfig(
+            vault=vault,
+            plugin_root=plugin_root,
+            instance_name="TestScout",
+            instance_name_lower="testscout",
+            user_name="Alex Example",
+            user_email="alex@example.com",
+            timezone="Europe/Prague",
+            platform="macos",
+            plugin_version="0.0.0",
+            enabled_connectors=set(),
+            connector_inputs={"max_budget": "5.00"},
+            skip_jobs=True,
+            skip_claude=True,
+        )
+    )
+
+    # The stamp's top-level `timezone` reaches user.timezone via read-side
+    # normalization — the activation every real vault gets from #207.
+    assert config.resolve_timezone(vault).key == "Europe/Prague"
+
+    # Fresh Python-bootstrap vaults carry no budget block: engine defaults.
+    fresh = budget_check.load_config(paths.config_path(vault))
+    assert fresh.daily_budget_usd == budget_check.DEFAULT_DAILY_BUDGET_USD
+
+    # A vault whose file carries the template's budget block (legacy installs;
+    # calibrated vaults): the governor must see the configured numbers.
+    cfg_file = paths.config_path(vault)
+    cfg_file.write_text(
+        cfg_file.read_text(encoding="utf-8")
+        + (
+            "plan:\n"
+            "  type: claude-max\n"
+            "  daily_budget_estimate_usd: 150\n"
+            "  rate_limit_window_hours: 3\n"
+            "thresholds:\n"
+            "  skip_threshold_pct: 90\n"
+            "  failure_backoff_minutes: 30\n"
+        ),
+        encoding="utf-8",
+    )
+    calibrated = budget_check.load_config(cfg_file)
+    assert calibrated.daily_budget_usd == 150.0
+    assert calibrated.window_hours == 3
+    assert calibrated.skip_threshold_pct == 90.0
+    assert calibrated.failure_backoff_min == 30
+
+
+def test_budget_check_verbose_names_the_config_file(
+    clean_env: None, fake_data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """#202: the silent-defaults fallback is what made this invisible —
+    --verbose must say which file it read and whether it existed."""
+    budget_check.run(verbose=True, data_dir=fake_data_dir)
+    out = capsys.readouterr().out
+    assert str(paths.config_path(fake_data_dir)) in out
+    assert "missing" in out
+
+    _write_vault_config(fake_data_dir, {"plan": {"daily_budget_estimate_usd": 999}})
+    budget_check.run(verbose=True, data_dir=fake_data_dir)
+    out = capsys.readouterr().out
+    assert str(paths.config_path(fake_data_dir)) in out
+    assert "missing" not in out
+
+
+# ----- heartbeat: its own hardcoded filename (#207 thread) ------------------
+
+
+def test_heartbeat_reads_vault_config_off_peak(clean_env: None, fake_data_dir: Path) -> None:
+    """heartbeat.py carried its own hardcoded '.scout-config.yaml' literal, so
+    a paths.py-only fix would have left it behind (#207 comment thread). It
+    must read the vault file — including the template's NESTED off_peak
+    shape, which its flat line-scan never matched."""
+    _write_vault_config(fake_data_dir, {"off_peak": {"start": 22, "end": 5}})
+    cfg = heartbeat.load_config(paths.config_path(fake_data_dir))
+    assert cfg.off_peak_start == 22
+    assert cfg.off_peak_end == 5
+
+
+def test_heartbeat_flat_keys_still_parse(tmp_path: Path) -> None:
+    """Hand-made flat keys (the shape the old dotted workaround used) keep
+    working."""
+    p = tmp_path / "scout-config.yaml"
+    p.write_text("off_peak_start: 21\noff_peak_end: 4\n", encoding="utf-8")
+    cfg = heartbeat.load_config(p)
+    assert cfg.off_peak_start == 21
+    assert cfg.off_peak_end == 4
+
+
+def test_heartbeat_run_uses_paths_config_path(fake_data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[Path] = []
+    real_load = heartbeat.load_config
+
+    def spy(config_path: Path) -> heartbeat.HeartbeatConfig:
+        seen.append(config_path)
+        return real_load(config_path)
+
+    monkeypatch.setattr(heartbeat, "load_config", spy)
+    monkeypatch.setattr(heartbeat, "scout_session_running", lambda *_, **__: False)
+    monkeypatch.setattr(heartbeat, "vault_has_uncommitted_changes", lambda *_: False)
+    monkeypatch.setattr(heartbeat, "run_budget_check", lambda *_, **__: 0)
+    assert heartbeat.run(data_dir=fake_data_dir, dry_run=True) == 0
+    assert seen == [paths.config_path(fake_data_dir)]
+
+
+# ----- graceful degradation: this layer was dead, now it is live ------------
+
+
+def test_invalid_yaml_warns_and_falls_back(
+    clean_env: None, fake_data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Turning on a config layer that was dead for every existing vault must
+    not convert a stale/corrupt file into a crash: warn and run on defaults."""
+    (fake_data_dir / "scout-config.yaml").write_text("key: [unclosed", encoding="utf-8")
+    cfg = config.load_config(fake_data_dir)
+    assert cfg["user"]["timezone"] == config.DEFAULT_TIMEZONE
+    assert "scout-config" in capsys.readouterr().err
+
+
+def test_non_mapping_yaml_warns_and_falls_back(
+    clean_env: None, fake_data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (fake_data_dir / "scout-config.yaml").write_text("- a\n- b\n", encoding="utf-8")
+    cfg = config.load_config(fake_data_dir)
+    assert cfg["schema_version"] == 1
+    assert "scout-config" in capsys.readouterr().err
+
+
+def test_type_mismatched_section_warns_and_keeps_defaults(
+    clean_env: None, fake_data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A scalar where the defaults define a mapping (e.g. ``user: oops``)
+    would otherwise clobber the whole subtree for every consumer."""
+    _write_vault_config(fake_data_dir, {"user": "oops", "budgets": 5})
+    cfg = config.load_config(fake_data_dir)
+    assert cfg["user"]["timezone"] == config.DEFAULT_TIMEZONE
+    assert cfg["budgets"]["daily_budget_estimate_usd"] == 150
+    err = capsys.readouterr().err
+    assert "user" in err and "budgets" in err
+
+
+def test_unknown_bootstrap_keys_pass_through_silently(
+    clean_env: None, fake_data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The undotted file legitimately holds bootstrap state (#202) — version
+    stamps, schedule, plan — which must merge through without noise."""
+    _write_vault_config(
+        fake_data_dir,
+        {
+            "instance": {"name": "TestScout"},
+            "plugin": {"version_at_last_setup": "0.8.0"},
+            "schedule": {"briefing": "07:30"},
+            "plan": {"daily_budget_estimate_usd": 150},
+        },
+    )
+    cfg = config.load_config(fake_data_dir)
+    assert cfg["plugin"]["version_at_last_setup"] == "0.8.0"
+    assert cfg["schedule"]["briefing"] == "07:30"
+    assert capsys.readouterr().err == ""

--- a/engine/tests/unit/test_config_vault_file.py
+++ b/engine/tests/unit/test_config_vault_file.py
@@ -257,6 +257,16 @@ def test_non_mapping_yaml_warns_and_falls_back(
     assert "scout-config" in capsys.readouterr().err
 
 
+def test_binary_corrupted_file_warns_and_falls_back(
+    clean_env: None, fake_data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Invalid UTF-8 (disk corruption, wrong file) must degrade, not raise."""
+    (fake_data_dir / "scout-config.yaml").write_bytes(b"\xff\xfe\x00\x01 not yaml")
+    cfg = config.load_config(fake_data_dir)
+    assert cfg["user"]["timezone"] == config.DEFAULT_TIMEZONE
+    assert "scout-config" in capsys.readouterr().err
+
+
 def test_type_mismatched_section_warns_and_keeps_defaults(
     clean_env: None, fake_data_dir: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/engine/tests/unit/test_paths.py
+++ b/engine/tests/unit/test_paths.py
@@ -80,7 +80,8 @@ def test_derived_paths_under_data_dir(tmp_path: Path) -> None:
     assert paths.logs_dir(tmp_path) == tmp_path / ".scout-logs"
     assert paths.cache_dir(tmp_path) == tmp_path / ".scout-cache"
     assert paths.state_dir(tmp_path) == tmp_path / ".scout-state"
-    assert paths.config_path(tmp_path) == tmp_path / ".scout-config.yaml"
+    # The UNDOTTED file — the one /scout-setup and bootstrap write (#207/#202).
+    assert paths.config_path(tmp_path) == tmp_path / "scout-config.yaml"
     assert paths.kb_dir(tmp_path) == tmp_path / "knowledge-base"
     assert paths.action_items_dir(tmp_path) == tmp_path / "action-items"
 


### PR DESCRIPTION
Fixes #207. Closes #202. **Part 2, stacked on the day-boundary unification PR** — retarget to `main` and rebase after that one lands. This is the small activating commit: with the boundary already unified, repointing the config read can't split it.

## What

**The read fix.** `paths.config_path()` now resolves to `scout-config.yaml` — the file `/scout-setup` actually writes — instead of `.scout-config.yaml`, a dotfile no code path has ever written. The user-override layer works for the first time: configured budgets/thresholds reach the governor (the #202 repro is now a regression test).

**Both gaps from the #207 thread:**
- **heartbeat**: `_CONFIG_FILENAME` deleted; `run()` goes through `paths.config_path(target)` (spy-tested). Its no-pyyaml line scan now also understands the **nested `off_peak: {start, end}` shape the template writes** — the flat keys it looked for never existed in any real file (same silent-knob class as #202; scope-extension, flagged for review).
- **Key-shape normalization, read-side only**, exactly the issue's three mappings: top-level `timezone` → `user.timezone`, `connectors.inputs.github_username` → `user.github_username`, `connectors.inputs.user_slack_id` → `user.slack_user_id`. Explicit `user.*` wins; the vault file is never rewritten. (Not added: a `user.slack_id` mapping — the issue didn't list it and `connectors.inputs.user_slack_id` carries the same value; possible follow-up.)

**#202's caveat honored:** bootstrap state (`instance`, `plugin`, `schedule`, `plan`, `connectors`, …) merges through untouched, never warns.

**From review (`af6ccfa`) — one scanner, and bounds on the knobs.** The heartbeat scope-extension above fixed the nested-shape blindness in *one* of the two hand-rolled readers; `budget_check` kept the byte-identical flat original. A flat scan is parent-blind — it matches `key: value` at any indentation under any parent and resolves duplicates last-wins — which matters precisely because `scout-config.yaml` doubles as multi-producer bootstrap state. Extracted `scout/scripts/_config_scan.py` and put both readers on it: nested keys match only under their own section, flat keys only at top level. Verified that `daily_budget_estimate_usd: 999` under an unrelated parent used to set the budget and now sets nothing, and that a stale duplicate under a second parent used to win and now loses to the real `plan:` entry — while template values, flat top-level spellings, and the nested `off_peak` shape all still read as before. Same commit adds `_CONFIG_BOUNDS` so the newly-live knobs can't be set to values that silently disable the governor.

**Graceful degradation (new):** unreadable YAML / non-mapping / permission error / non-UTF-8 → one-line stderr warning + packaged defaults, never raises; a scalar where defaults define a mapping warns and keeps the defaults subtree. `_read_yaml` stays strict for packaged defaults. This deliberately changes two existing tests' contract (they asserted `load_config` raises on bad YAML) — updated to assert warn-and-degrade. Rationale: this loader now runs unattended in every scheduled session (and is what a future auto-updater will trust); a typo'd vault file must degrade, not kill the run.

**#202's verbose ask:** `budget check --verbose` prints `[budget-check] config: <path>` (+ `(missing — using engine defaults)`).

## Tests

New `tests/unit/test_config_vault_file.py` (17 tests): undotted read, all three normalizations, canonical-wins, env-wins, the **#202 governor repro** (999/7h/55/11 → window $291.38, skip $160.26), bootstrap-install integration, heartbeat nested+flat off_peak + run()-path spy, `--verbose` naming, four degradation cases. **13/16 failed pre-fix** (verified), including the #202 repro.

## Validation (full branch vs origin/main @ 4d92967, same venv)

pytest **1033 passed / 10 skipped / 0 failed** vs 1003/10/0 on main; ruff check + format, mypy (86 files), shellcheck, version guard, snapshot checks, manifests all clean.

## Blast radius — keys that go LIVE for existing vaults

| Key | Reader | Effect when live |
|---|---|---|
| `timezone` (stamped into every vault) | all day-boundary surfaces | The intended activation: boundary flips host/ET → configured zone atomically. Invalid zone → silent ET fallback (parity with scout-tz.sh). |
| `plan.daily_budget_estimate_usd` | budget governor | Legacy/calibrated vaults: enforcement moves from silent 50/5h/80 to the configured block (template 150/3h/90 → skip threshold $8.34 → $16.88: sessions run more, spend more). |
| `plan.rate_limit_window_hours`, `thresholds.skip_threshold_pct`, `thresholds.failure_backoff_minutes` | budget governor | Enforced as written **within a usable range** (see the bounds commit below). An out-of-range value — `rate_limit_window_hours: 0` or negative, `skip_threshold_pct` outside 0–100 — falls back to its default with a stderr warning rather than being enforced. `daily_budget_estimate_usd: 0` stays legal: "spend nothing" is a real choice. |
| `off_peak.start/end` | heartbeat | Template values equal engine defaults → no change unless user-edited. |
| `user.*`, `auto_update.enabled` | no runtime consumer yet | Inert; #195 stands alone. |

**Discovery for the maintainer:** Python `bootstrap install` never renders `templates/scout-config.yaml.tmpl` — fresh 0.8.x vaults have no `plan:`/`thresholds:` block at all; only legacy bash-installed or hand-calibrated vaults do. The wiring now provably works (bootstrap-install integration test), but "configured budgets take effect" applies where the block exists. If fresh installs should get one, that's a bootstrap/scout-setup follow-up, not this fix.

**Still-dead knobs worth follow-up issues** (same class as #195): `sessions.min_session_gap_minutes` (template says 30; heartbeat hardcodes 120), `thresholds.extra_session_threshold_pct`, defaults-schema `budgets.*`, `rate_limit_warn/block_pct`, `connector_staleness_hours`, `features.*`.

> Live-install note: when this reaches a real vault, day boundary, budget enforcement, and log stamps all shift to the configured zone in one update — worth one supervised run after upgrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

