### PR TITLE
fix(heartbeat): guard empty-array expansion for macOS bash 3.2 under set -u

### DIFF
--- a/templates/scripts/heartbeat.sh.tmpl
+++ b/templates/scripts/heartbeat.sh.tmpl
@@ -36,4 +36,4 @@ if [[ "${1:-}" == "--dry-run" ]]; then
     DRY_RUN_FLAG=("--dry-run")
 fi
 
-exec "$SCOUTCTL_BIN" heartbeat run "${DRY_RUN_FLAG[@]}"
+exec "$SCOUTCTL_BIN" heartbeat run ${DRY_RUN_FLAG[@]+"${DRY_RUN_FLAG[@]}"}


### PR DESCRIPTION
**The gap.** Heartbeat is dead on arrival on any Mac using the stock `/bin/bash`: every launchd fire exits 1 at line 39 before doing anything, and it fails silently — the only trace is the repeating line in the heartbeat log.

**Evidence.** `templates/scripts/heartbeat.sh.tmpl:18` (`set -euo pipefail`) plus `:34`/`:39` (empty-array expansion). Log signature on bash 3.2.57: `heartbeat.sh: line 39: DRY_RUN_FLAG[@]: unbound variable`, once per fire. Full analysis in #219.

**The change.** One line: guard the expansion with the bash-3.2-safe `${arr[@]+"${arr[@]}"}` idiom. Behavior is identical on newer bash; `--dry-run` still passes through.

**Tested.** Reproduced the failure and verified the fix on macOS `/bin/bash` 3.2.57: the old pattern exits 1 with the exact log signature; the fixed script was rendered into a live vault and exercised both ways — no args (previously fatal, now exits 0) and `--dry-run` (flag still forwarded, exits 0).

**What it deliberately does not do.** No shebang change, no bash-version gate, no regeneration of rendered copies in existing vaults — those need `/scout-update` (or the same one-line patch in place), noted in the issue.

Fixes #219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
