### PR TITLE
fix(schedule): plist placeholders in XML comments break rendering on double-hyphen paths

### DIFF
--- a/engine/scout/defaults/com.scout.heartbeat.plist
+++ b/engine/scout/defaults/com.scout.heartbeat.plist
@@ -3,8 +3,13 @@
 <!--
   com.scout.heartbeat.plist — runs ~/Scout/scripts/heartbeat.sh every 30 min.
 
-  Installed by `scoutctl schedule install-heartbeat-plist`, which fills
-  __USER_HOME__ at install time. Mirrors the schedule-tick plist pattern.
+  Installed by `scoutctl schedule install-heartbeat-plist`, which fills the
+  USER_HOME placeholder (spelled with surrounding double underscores in the
+  values below) at install time. Mirrors the schedule-tick plist pattern.
+
+  Never write the placeholder token verbatim in this comment: install-time
+  substitution is a whole-file replace, and a substituted path containing a
+  double hyphen is illegal inside an XML comment no matter how it is escaped.
 -->
 <plist version="1.0">
 <dict>

--- a/engine/scout/defaults/com.scout.schedule-tick.plist
+++ b/engine/scout/defaults/com.scout.schedule-tick.plist
@@ -3,11 +3,18 @@
 <!--
   com.scout.schedule-tick.plist — runs `scoutctl schedule tick` every 5 min.
 
-  Installed by `scoutctl schedule install-plist`, which fills __USER_HOME__
-  and __SCOUTCTL_BIN__ at install time. __SCOUTCTL_BIN__ defaults to
-  ~/scout-plugin/.venv/bin/scoutctl (canonical layout) but falls back to
-  the venv that ran the install command so non-canonical layouts work too.
+  Installed by `scoutctl schedule install-plist`, which fills the USER_HOME
+  and SCOUTCTL_BIN placeholders (spelled with surrounding double underscores
+  in the values below) at install time. SCOUTCTL_BIN resolves to
+  .venv/bin/scoutctl under the running engine's plugin root, so canonical
+  clones, dev trees, and marketplace installs all work.
   Replaces the 7 per-slot legacy plists deleted in Task 11.
+
+  Never write the placeholder tokens verbatim in this comment: install-time
+  substitution is a whole-file replace, and a substituted path containing a
+  double hyphen (e.g. a marketplace install under an "owner"+"repo" dir
+  joined by two hyphens) is illegal inside an XML comment no matter how it
+  is escaped.
 -->
 <plist version="1.0">
 <dict>

--- a/engine/scout/docs/connectors/com.scout.whatsapp-bridge.plist.template
+++ b/engine/scout/docs/connectors/com.scout.whatsapp-bridge.plist.template
@@ -6,18 +6,21 @@
   and fill in the placeholders below before loading with:
     launchctl load -w ~/Library/LaunchAgents/com.scout.whatsapp-bridge.plist
 
-  Placeholders to replace:
-    __WHATSAPP_MCP_DIR__   Absolute path to the cloned whatsapp-mcp repo.
-                           Recommended default:
-                             /Users/<you>/.local/share/whatsapp-mcp
-                           This must be the parent of the whatsapp-bridge/
-                           directory and must be an absolute path
-                           (`~` does NOT expand inside plists).
-    __USER_HOME__          Output of `echo $HOME`, e.g. /Users/yourname.
-                           Used as a sane fallback for $HOME inside the
-                           launched process; LaunchAgents already inherit
-                           the user but some Go libraries read $HOME
-                           explicitly.
+  Placeholders to replace — spelled with surrounding double underscores in
+  the XML below, written without them here so a global find-and-replace
+  never edits this comment (a path containing a double hyphen would be
+  illegal inside an XML comment):
+    WHATSAPP_MCP_DIR   Absolute path to the cloned whatsapp-mcp repo.
+                       Recommended default:
+                         /Users/<you>/.local/share/whatsapp-mcp
+                       This must be the parent of the whatsapp-bridge/
+                       directory and must be an absolute path
+                       (`~` does NOT expand inside plists).
+    USER_HOME          Output of `echo $HOME`, e.g. /Users/yourname.
+                       Used as a sane fallback for $HOME inside the
+                       launched process; LaunchAgents already inherit
+                       the user but some Go libraries read $HOME
+                       explicitly.
 
   Notes:
     - The bridge binary is `whatsapp-bridge` in the whatsapp-bridge/

--- a/engine/scout/scripts/install_heartbeat_plist.py
+++ b/engine/scout/scripts/install_heartbeat_plist.py
@@ -8,6 +8,7 @@ install_schedule_plist.py for com.scout.heartbeat.plist.
 from __future__ import annotations
 
 import os
+import plistlib
 import subprocess
 from html import escape
 from pathlib import Path
@@ -32,7 +33,16 @@ def install_plist(
     # XML-escape __USER_HOME__: it lands inside <string> elements, and a path
     # with `&`, `<`, `>`, `"` (legal on macOS) would otherwise produce
     # malformed XML that launchd silently refuses to load. (#49)
+    # Escaping only covers <string> content: the replace is whole-file, so the
+    # template must keep the placeholder token out of its XML comment — a
+    # substituted path containing `--` is illegal there however it is escaped.
     rendered = TEMPLATE.read_text(encoding="utf-8").replace("__USER_HOME__", escape(str(home), quote=True))
+    # Fail loudly at install time rather than let launchd silently drop the
+    # job on malformed output (#49).
+    try:
+        plistlib.loads(rendered.encode("utf-8"))
+    except Exception as exc:
+        raise ValueError(f"rendered {PLIST_NAME} is not well-formed XML: {exc}") from exc
     target.write_text(rendered, encoding="utf-8")
     if bootstrap:
         uid = os.getuid()

--- a/engine/scout/scripts/install_schedule_plist.py
+++ b/engine/scout/scripts/install_schedule_plist.py
@@ -8,6 +8,7 @@ not at runtime, because launchd's plist parser doesn't expand env vars in
 from __future__ import annotations
 
 import os
+import plistlib
 import subprocess
 from html import escape
 from pathlib import Path
@@ -56,11 +57,21 @@ def install_plist(
     # path with `&`, `<`, `>`, `"` (all legal on macOS, e.g. ~/R&D) would
     # otherwise produce malformed XML that launchd silently refuses to load,
     # stopping every scheduled run with no error. (#49)
+    # Escaping only covers <string> content: the replace is whole-file, so the
+    # template must keep the placeholder tokens out of its XML comment — a
+    # substituted path containing `--` (e.g. a marketplace engine install
+    # under an `<owner>--<repo>` dir) is illegal there however it is escaped.
     rendered = (
         TEMPLATE.read_text(encoding="utf-8")
         .replace("__USER_HOME__", escape(str(home), quote=True))
         .replace("__SCOUTCTL_BIN__", escape(str(resolve_scoutctl_bin()), quote=True))
     )
+    # Fail loudly at install time rather than let launchd silently drop the
+    # job on malformed output (#49).
+    try:
+        plistlib.loads(rendered.encode("utf-8"))
+    except Exception as exc:
+        raise ValueError(f"rendered {PLIST_NAME} is not well-formed XML: {exc}") from exc
     target.write_text(rendered, encoding="utf-8")
     if bootstrap:
         uid = os.getuid()

--- a/engine/tests/unit/test_install_heartbeat_plist.py
+++ b/engine/tests/unit/test_install_heartbeat_plist.py
@@ -74,6 +74,23 @@ def test_install_heartbeat_plist_escapes_xml_metacharacters(tmp_path):
     assert data["EnvironmentVariables"]["HOME"] == str(home)
 
 
+def test_install_plist_tolerates_double_hyphen_paths(tmp_path):
+    """A home path containing `--` must still render a well-formed plist:
+    XML escaping can't protect values substituted into the template's XML
+    comment, where `--` is illegal no matter how it is escaped."""
+    import plistlib
+
+    home = tmp_path / "home--with--hyphens"
+    home.mkdir()
+    agents = tmp_path / "LaunchAgents"
+    agents.mkdir()
+    target = install_plist(home=home, agents_dir=agents)
+
+    with target.open("rb") as f:
+        data = plistlib.load(f)
+    assert data["EnvironmentVariables"]["HOME"] == str(home)
+
+
 def test_install_plist_bootstrap_boots_out_first(tmp_path, monkeypatch):
     """Re-install must bootout the loaded job before bootstrap: launchctl
     bootstrap EIOs on an already-loaded label and has no --force (#48, #23)."""

--- a/engine/tests/unit/test_install_schedule_plist.py
+++ b/engine/tests/unit/test_install_schedule_plist.py
@@ -101,6 +101,28 @@ def test_install_plist_escapes_xml_metacharacters(tmp_path):
     assert data["EnvironmentVariables"]["HOME"] == str(home)
 
 
+def test_install_plist_tolerates_double_hyphen_paths(tmp_path, monkeypatch):
+    """Paths containing `--` (e.g. a marketplace engine install under the
+    `<owner>--<repo>` layout) must still render a well-formed plist. XML
+    escaping alone can't guarantee this: values substituted into the
+    template's XML comment would make `--` illegal there no matter how they
+    are escaped, so the template must keep placeholders out of comments."""
+    import plistlib
+
+    scoutctl = tmp_path / "repos" / "example-org--scout-plugin" / ".venv" / "bin" / "scoutctl"
+    monkeypatch.setattr("scout.scripts.install_schedule_plist.resolve_scoutctl_bin", lambda: scoutctl)
+    home = tmp_path / "home--with--hyphens"
+    home.mkdir()
+    agents = tmp_path / "LaunchAgents"
+    agents.mkdir()
+    target = install_plist(home=home, agents_dir=agents)
+
+    with target.open("rb") as f:
+        data = plistlib.load(f)
+    assert data["ProgramArguments"][0] == str(scoutctl)
+    assert data["EnvironmentVariables"]["HOME"] == str(home)
+
+
 def test_install_plist_bootstrap_boots_out_first(tmp_path, monkeypatch):
     """Re-install must bootout the loaded job before bootstrap: launchctl
     bootstrap EIOs on an already-loaded label and has no --force (#48, #23)."""


### PR DESCRIPTION
## The bug

`test_install_plist_escapes_xml_metacharacters` fails locally with `xml.parsers.expat.ExpatError: not well-formed (invalid token): line 7, column 61` while CI stays green on the same commit. This is a **real escaping bug that CI masks**, not an environment artifact:

- `install_plist` fills `__USER_HOME__` / `__SCOUTCTL_BIN__` with a **whole-file** `.replace()`, so the values also land inside the templates' XML *comments* (lines 6–7 of `com.scout.schedule-tick.plist`).
- `html.escape` cannot make a value safe there: `--` is illegal inside an XML comment no matter how it's escaped.
- `resolve_scoutctl_bin()` derives its path from the running engine's package location. An engine that lives under a directory containing `--` — the plugin-install `<owner>--<repo>` layout (`Raven-Scout--scout-plugin`), or any user path with a double hyphen — renders a malformed plist. Rendering `.../Raven-Scout--scout-plugin/.venv/bin/scoutctl` into the template reproduces the reported error **exactly**, down to line 7, column 61.
- CI checkout paths (`/Users/runner/work/...`, `/home/runner/...`) contain no `--`, so CI never exercises the failure.

Consequence beyond the test: launchd **silently refuses** to load a malformed plist, so on an affected install every scheduled run stops with no error — the exact failure mode #49 was meant to close.

## The fix

- **Templates** (`com.scout.schedule-tick.plist`, `com.scout.heartbeat.plist`, and the manually-filled `com.scout.whatsapp-bridge.plist.template` in docs): reword the header comments so the literal placeholder tokens never appear inside an XML comment, and leave a warning explaining why. Values now only ever land inside `<string>` elements, where XML-escaping is sufficient.
- **Installers**: validate the rendered output with `plistlib.loads` before writing, so any future template regression fails loudly at install time instead of silently killing the schedule.
- **Regression tests**: installs with home / scoutctl paths containing `--` must produce a plist that `plistlib` can load and that round-trips the real paths.

## Verification

- New tests fail on `main` with the exact reported error (`ExpatError ... line 7`), pass with the fix.
- Full engine suite: 1022 passed, 10 skipped (Python 3.12.10, macOS); `ruff check` and `ruff format --check` clean.
- Verified from a checkout whose own path contains `--`: before the fix the *existing* `test_install_plist_escapes_xml_metacharacters` fails there exactly as reported; after the fix it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)