### PR TITLE
fix(runner): export SCOUT_MODE so connector telemetry activates (#192, #121)

### DIFF
--- a/engine/tests/integration/test_run_scout_mode_export.py
+++ b/engine/tests/integration/test_run_scout_mode_export.py
@@ -1,0 +1,237 @@
+"""Integration test: the rendered runners hand SCOUT_MODE to the telemetry hooks.
+
+Renders each runner template (run-scout / run-dreaming / run-research) with a
+stubbed ``scripts/claude-with-retry.sh`` that stands in for the ``claude`` child
+process. The stub records the ``SCOUT_MODE`` it inherited and then drives the
+real hooks exactly as Claude Code would from inside the session:
+
+  - ``session-tool-log`` — the Stop hook registered in hooks/hooks.json — against
+    a two-row session transcript, and
+  - ``connector-log`` — the PostToolUse-shaped hook it replaced (#72), still
+    exposed as ``scoutctl hook connector-log`` and the repro used in #192 —
+    against one synthetic tool call.
+
+Both gate on ``SCOUT_MODE``. The assertions are on the telemetry rows the hooks
+write, not on the shell text.
+
+Regression context (#192, #121): the runners set a *local* ``MODE`` and exported
+only ``SCOUT_DATA_DIR``. The hooks short-circuit when ``SCOUT_MODE`` is unset
+(interactive sessions must stay silent), so every scheduled run since the Plan
+4/5 port looked interactive: no ``connector-calls-*.jsonl`` rows, therefore no
+``connector-health-report`` data, therefore the outage alerter could never fire.
+A connector was dark for 20 consecutive runs with exit code 0 and an empty
+failures.log before anyone noticed. On the pre-fix templates the "mode seen" file
+below reads ``<unset>`` and zero rows are written.
+
+The static counterpart (export line ordering) lives in
+``tests/unit/test_runner_exports_scout_mode.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]  # …/scout-plugin
+ENGINE_ROOT = REPO_ROOT / "engine"
+TEMPLATES = REPO_ROOT / "templates"
+
+RUN_TIMEOUT_S = 60
+
+# (template, a dispatcher slot key that routes to this runner, default MODE when
+#  SCOUT_FORCE_MODE is unset — i.e. an operator firing the runner by hand)
+RUNNERS = [
+    ("run-scout.sh.tmpl", "morning-briefing", "manual"),
+    ("run-dreaming.sh.tmpl", "dreaming-nightly", "dreaming-manual"),
+    ("run-research.sh.tmpl", "research", "research-manual"),
+]
+
+SESSION_ID = "sess-0001"
+
+# One synthetic PostToolUse payload for connector-log — shape matches what Claude
+# Code hands the hook. Anonymized per CLAUDE.md (stand-in Slack channel id).
+MCP_TOOL = "mcp__plugin_slack_slack__slack_send_message"
+TOOL_CALL = json.dumps(
+    {
+        "session_id": SESSION_ID,
+        "tool_name": MCP_TOOL,
+        "tool_input": {"channel": "C0123456789", "text": "hello"},
+        "tool_response": {"isError": False},
+    }
+)
+
+# A minimal session transcript for session-tool-log: one Bash tool_use paired
+# with its tool_result. `gh` is a connector binary, so the row classifies as
+# ``github`` — exercising the same labeller the health alerter reads.
+TRANSCRIPT_ROWS = [
+    {
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "gh pr list"}}],
+        }
+    },
+    {
+        "message": {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "no open pull requests"}],
+        }
+    },
+]
+
+EXPECTED_ROWS = {MCP_TOOL: "mcp:plugin_slack_slack", "Bash": "github"}  # tool -> connector key
+
+UNSET_SENTINEL = "<unset>"
+
+
+def _render(tmpl: Path, scout_dir: Path) -> Path:
+    text = tmpl.read_text(encoding="utf-8")
+    for placeholder, value in {
+        "{{SCOUT_DIR}}": str(scout_dir),
+        "{{CLAUDE_BIN}}": "/usr/bin/true",  # never reached — the retry wrapper is stubbed
+        "{{INSTANCE_NAME_LOWER}}": "scout",
+        "{{INSTANCE_NAME}}": "Scout",
+        "{{MAX_BUDGET}}": "25",
+        "{{USER_NAME}}": "Alex",
+        "{{USER_SLACK_ID}}": "U0123456789",
+    }.items():
+        text = text.replace(placeholder, value)
+    assert "{{" not in text, f"unrendered placeholder left in {tmpl.name}"
+    out = scout_dir / tmpl.name.removesuffix(".tmpl")
+    out.write_text(text, encoding="utf-8")
+    out.chmod(0o755)
+    return out
+
+
+def _stub_claude(scout_dir: Path) -> Path:
+    """Stand-in for scripts/claude-with-retry.sh (and thereby the claude child).
+
+    Writes the inherited SCOUT_MODE (or a sentinel) to ``scout-mode.seen``, then
+    drives both real hooks: connector-log with one tool call, session-tool-log
+    with a Stop payload pointing at a transcript. Runs them with the test's own
+    interpreter and the in-tree engine on PYTHONPATH so the package under test
+    is what gets exercised.
+    """
+    seen = scout_dir / "scout-mode.seen"
+    transcript = scout_dir / "transcript.jsonl"
+    transcript.write_text("".join(json.dumps(row) + "\n" for row in TRANSCRIPT_ROWS), encoding="utf-8")
+    stop_payload = json.dumps({"transcript_path": str(transcript), "session_id": SESSION_ID})
+
+    py = sys.executable
+    post_tool_use_hook = "import sys; from scout.hooks.connector_log import run; run(stdin=sys.stdin)"
+    stop_hook = "import sys; from scout.hooks.session_tool_log import run; run(stdin=sys.stdin)"
+
+    stub = scout_dir / "scripts" / "claude-with-retry.sh"
+    stub.parent.mkdir(parents=True, exist_ok=True)
+    stub.write_text(
+        "#!/bin/bash\n"
+        'LOG_FILE="$1"\n'
+        f'printf \'%s\\n\' "${{SCOUT_MODE-{UNSET_SENTINEL}}}" > "{seen}"\n'
+        f'export PYTHONPATH="{ENGINE_ROOT}${{PYTHONPATH:+:$PYTHONPATH}}"\n'
+        f'printf \'%s\' \'{TOOL_CALL}\' | "{py}" -c "{post_tool_use_hook}" >> "$LOG_FILE" 2>&1\n'
+        f'printf \'%s\' \'{stop_payload}\' | "{py}" -c "{stop_hook}" >> "$LOG_FILE" 2>&1\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    return seen
+
+
+def _run(script: Path, *, force_mode: str | None) -> subprocess.CompletedProcess:
+    # Start from a clean slate for the three variables under test: the test
+    # process itself may be running inside a Scout session.
+    env = {k: v for k, v in os.environ.items() if k not in ("SCOUT_MODE", "SCOUT_FORCE_MODE", "SCOUT_DATA_DIR")}
+    if force_mode is not None:
+        env["SCOUT_FORCE_MODE"] = force_mode  # what schedule_tick / run_skill set
+    return subprocess.run(
+        [str(script)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=RUN_TIMEOUT_S,
+    )
+
+
+def _run_log(scout_dir: Path) -> str:
+    logs = sorted((scout_dir / ".scout-logs").glob("*.log"))
+    return "\n".join(log.read_text(encoding="utf-8") for log in logs)
+
+
+def _telemetry_rows(scout_dir: Path) -> list[dict]:
+    files = sorted((scout_dir / ".scout-logs").glob("connector-calls-*.jsonl"))
+    return [json.loads(line) for f in files for line in f.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _assert_both_hooks_wrote_rows(scout_dir: Path, *, mode: str) -> None:
+    rows = _telemetry_rows(scout_dir)
+    by_tool = {row["tool"]: row for row in rows}
+    assert set(by_tool) == set(EXPECTED_ROWS), (
+        f"expected one row from each hook (0 rows == they short-circuited); got {rows!r}; log:\n{_run_log(scout_dir)}"
+    )
+    assert len(rows) == len(EXPECTED_ROWS), f"each hook writes exactly one row; got {rows!r}"
+    for tool, connector in EXPECTED_ROWS.items():
+        row = by_tool[tool]
+        assert row["mode"] == mode, f"{tool}: row must carry {mode!r}, got {row['mode']!r}"
+        assert row["connector"] == connector
+        assert row["session_id"] == SESSION_ID
+        assert row["error"] is False
+
+
+@pytest.mark.parametrize(("name", "slot_key", "_default_mode"), RUNNERS)
+def test_dispatched_run_tags_telemetry_with_slot_key(
+    tmp_path: Path, name: str, slot_key: str, _default_mode: str
+) -> None:
+    """Scheduler path: SCOUT_FORCE_MODE=<slot key> must surface to the hooks as SCOUT_MODE."""
+    scout_dir = tmp_path / "Scout"
+    scout_dir.mkdir()
+    script = _render(TEMPLATES / name, scout_dir)
+    seen = _stub_claude(scout_dir)
+
+    result = _run(script, force_mode=slot_key)
+
+    assert result.returncode == 0, result.stderr + _run_log(scout_dir)
+    assert seen.read_text(encoding="utf-8").strip() == slot_key, "claude child must inherit SCOUT_MODE"
+    _assert_both_hooks_wrote_rows(scout_dir, mode=slot_key)
+
+
+@pytest.mark.parametrize(("name", "_slot_key", "default_mode"), RUNNERS)
+def test_manual_run_tags_telemetry_with_runner_default(
+    tmp_path: Path, name: str, _slot_key: str, default_mode: str
+) -> None:
+    """Operator path (no SCOUT_FORCE_MODE): the runner's own default mode is exported.
+
+    Manual runs are still scheduled-style sessions — the skills launch them with
+    ``nohup bash ~/Scout/run-*.sh`` — so they must be accounted for too, under the
+    per-runner default the prompt and cost tracker already use.
+    """
+    scout_dir = tmp_path / "Scout"
+    scout_dir.mkdir()
+    script = _render(TEMPLATES / name, scout_dir)
+    seen = _stub_claude(scout_dir)
+
+    result = _run(script, force_mode=None)
+
+    assert result.returncode == 0, result.stderr + _run_log(scout_dir)
+    assert seen.read_text(encoding="utf-8").strip() == default_mode
+    _assert_both_hooks_wrote_rows(scout_dir, mode=default_mode)
+
+
+@pytest.mark.parametrize(("name", "slot_key", "_default_mode"), RUNNERS)
+def test_data_dir_export_points_hooks_at_the_vault(
+    tmp_path: Path, name: str, slot_key: str, _default_mode: str
+) -> None:
+    """Rows land under <vault>/.scout-logs — the runner's SCOUT_DATA_DIR export, not ~/Scout."""
+    scout_dir = tmp_path / "Scout"
+    scout_dir.mkdir()
+    script = _render(TEMPLATES / name, scout_dir)
+    _stub_claude(scout_dir)
+
+    result = _run(script, force_mode=slot_key)
+
+    assert result.returncode == 0, result.stderr + _run_log(scout_dir)
+    files = list((scout_dir / ".scout-logs").glob("connector-calls-*.jsonl"))
+    assert len(files) == 1, "both hooks must write into the rendered vault's day-file, not the default data dir"

--- a/engine/tests/unit/test_runner_exports_scout_mode.py
+++ b/engine/tests/unit/test_runner_exports_scout_mode.py
@@ -1,0 +1,61 @@
+"""Static guard: every runner template exports SCOUT_MODE before launching claude.
+
+Regression context (#192, #121): the runners resolved the dispatcher's slot key
+into a *local* ``MODE`` shell variable and exported only ``SCOUT_DATA_DIR``. The
+plugin's Stop hooks (hooks/hooks.json -> session-tool-log, session-tokens) read
+``SCOUT_MODE`` from the claude child's environment and deliberately short-circuit
+when it is unset (interactive sessions must stay silent) — so every scheduled run
+looked interactive, no ``connector-calls-*.jsonl`` row was ever written, and the
+whole outage-detection chain built on that telemetry (``connector-health-report``,
+``connector-alerts.log``, the macOS notification, ``connector-health.md``) never
+activated. The export was present in the pre-port bash runner and dropped in the
+Plan 4/5 migration; this test pins it so it cannot be dropped silently again.
+
+The end-to-end counterpart (rendered runner -> stubbed claude -> real hook) lives
+in ``tests/integration/test_run_scout_mode_export.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]  # …/scout-plugin
+TEMPLATES = REPO_ROOT / "templates"
+
+# (template, default MODE when the dispatcher's SCOUT_FORCE_MODE is unset)
+RUNNERS = [
+    ("run-scout.sh.tmpl", "manual"),
+    ("run-dreaming.sh.tmpl", "dreaming-manual"),
+    ("run-research.sh.tmpl", "research-manual"),
+]
+
+EXPORT_LINE = 'export SCOUT_MODE="$MODE"'
+CLAUDE_LAUNCH = '"$SCOUT_DIR/scripts/claude-with-retry.sh"'
+
+
+@pytest.mark.parametrize(("name", "default_mode"), RUNNERS)
+def test_runner_exports_scout_mode_between_mode_resolution_and_claude_launch(name: str, default_mode: str) -> None:
+    """MODE is resolved, then exported as SCOUT_MODE, then claude is launched — in that order.
+
+    Order matters: an export before the assignment exports an empty string (which
+    the hooks treat as unset), and an export after the launch never reaches the
+    child at all.
+    """
+    text = (TEMPLATES / name).read_text(encoding="utf-8")
+
+    mode_assign = text.index(f'MODE="${{SCOUT_FORCE_MODE:-{default_mode}}}"')
+    export = text.index(EXPORT_LINE)
+    launch = text.index(CLAUDE_LAUNCH)
+
+    assert mode_assign < export, f"{name}: SCOUT_MODE must be exported after MODE is resolved"
+    assert export < launch, f"{name}: SCOUT_MODE must be exported before claude is launched"
+    assert text.count(EXPORT_LINE) == 1, f"{name}: exactly one SCOUT_MODE export expected"
+
+
+@pytest.mark.parametrize(("name", "_default_mode"), RUNNERS)
+def test_runner_still_exports_data_dir(name: str, _default_mode: str) -> None:
+    """Guard: the engine-package vault resolution export (Plan 5+) stays in place."""
+    text = (TEMPLATES / name).read_text(encoding="utf-8")
+    assert 'export SCOUT_DATA_DIR="$SCOUT_DIR"' in text

--- a/templates/run-dreaming.sh.tmpl
+++ b/templates/run-dreaming.sh.tmpl
@@ -111,6 +111,12 @@ fi
 # Mode is set by the dispatcher (SCOUT_FORCE_MODE). For manual invocations
 # without SCOUT_FORCE_MODE set, default to "dreaming-manual".
 MODE="${SCOUT_FORCE_MODE:-dreaming-manual}"
+# Exported as SCOUT_MODE so the plugin's Stop hooks (session-tool-log,
+# session-tokens — see hooks/hooks.json) see it inside the claude child
+# process. The hooks deliberately short-circuit when it is unset so that
+# interactive sessions stay silent; without this export every scheduled run
+# looks interactive and no connector telemetry is ever written (#192, #121).
+export SCOUT_MODE="$MODE"
 
 START_TIME=$(date +%s)
 

--- a/templates/run-research.sh.tmpl
+++ b/templates/run-research.sh.tmpl
@@ -97,6 +97,12 @@ fi
 # Mode is set by the dispatcher (SCOUT_FORCE_MODE). For manual invocations
 # without SCOUT_FORCE_MODE set, default to "research-manual".
 MODE="${SCOUT_FORCE_MODE:-research-manual}"
+# Exported as SCOUT_MODE so the plugin's Stop hooks (session-tool-log,
+# session-tokens — see hooks/hooks.json) see it inside the claude child
+# process. The hooks deliberately short-circuit when it is unset so that
+# interactive sessions stay silent; without this export every scheduled run
+# looks interactive and no connector telemetry is ever written (#192, #121).
+export SCOUT_MODE="$MODE"
 
 START_TIME=$(date +%s)
 

--- a/templates/run-scout.sh.tmpl
+++ b/templates/run-scout.sh.tmpl
@@ -69,6 +69,12 @@ trap 'rm -f "$LOCK_FILE"' EXIT
 # fire the runner directly for debugging, and the Run Modes table tells the
 # model to fall back to a day-of-week + hour derivation in that case.
 MODE="${SCOUT_FORCE_MODE:-manual}"
+# Exported as SCOUT_MODE so the plugin's Stop hooks (session-tool-log,
+# session-tokens — see hooks/hooks.json) see it inside the claude child
+# process. The hooks deliberately short-circuit when it is unset so that
+# interactive sessions stay silent; without this export every scheduled run
+# looks interactive and no connector telemetry is ever written (#192, #121).
+export SCOUT_MODE="$MODE"
 
 # The prompt instructs Claude to read SKILL.md and execute it
 PROMPT="You are {{INSTANCE_NAME}}, an autonomous knowledge management system. Your working directory is {{SCOUT_DIR}}.


### PR DESCRIPTION
Fixes #192. Refs #121 (its §1 — the export — is this PR; §2–§4 are called out below as follow-ups).

## What

The three runner templates (`run-scout`, `run-dreaming`, `run-research`) set `MODE=` but never exported it, so the plugin's Stop hooks (`session-tool-log`, `session-tokens` — see `hooks/hooks.json`) never saw `SCOUT_MODE` inside the `claude` child process. The hooks deliberately short-circuit when it is unset so interactive sessions stay silent — which meant **every scheduled run looked interactive and no connector telemetry was ever written**. The whole outage-detection feature (`dark_runs()`, `connector-alerts.log`, the macOS notification, `knowledge-base/connector-health.md`) has been built-but-dark since June; one reporter's Linear connector was dark for 20 consecutive runs with nothing alerting.

Fix: `export SCOUT_MODE="$MODE"` right after `MODE=` in each runner (identical 6-line block incl. comment). The value is exactly what the hooks and `connector_health_report` already key on: the dispatcher slot key (`SCOUT_FORCE_MODE`, set by `schedule_tick.py` / `run_skill.py`) or the per-runner manual default (`manual` / `dreaming-manual` / `research-manual`). No new mode strings. `session_tokens.py`'s mislabelling of scheduled runs as `manual` is fixed by the same export.

## Tests (+15, all fail on main's templates)

- `tests/unit/test_runner_exports_scout_mode.py` — static guard over the 3 templates: `MODE=` precedes `export SCOUT_MODE="$MODE"` precedes the claude launch, exactly one export line, `export SCOUT_DATA_DIR` still present.
- `tests/integration/test_run_scout_mode_export.py` — renders each template, stubs `claude-with-retry.sh` to record the inherited `$SCOUT_MODE` and drive **both real hooks** (`connector_log.run` — the #192 repro — and `session_tool_log.run`, the registered Stop hook) with synthetic payloads. Asserts: dispatcher path carries the slot key (`morning-briefing` / `dreaming-nightly` / `research`), operator path carries the manual default, rows land in the rendered vault's `.scout-logs`. On main: 12 of 15 fail (the 3 passing are the SCOUT_DATA_DIR guard).

Fixtures anonymized (Alex, `C0123456789`, `U0123456789`).

## Validation (same venv; branch vs origin/main @ 98c14aa)

pytest **1035 passed / 10 skipped / 0 failed** vs 1020/10/0 on main; ruff check + format, mypy (86 files), shellcheck `-S error` over all templates, version guard, manifests, connectors + schedule snapshot drift: all clean.

## Migration for existing vaults

No separate migration: `bootstrap._stage_cat1b_runners` re-renders all three installed runners unconditionally on `scoutctl bootstrap upgrade` (`/scout-update`), backing up hand-edited ones as `.bak.<date>`. **Run `/scout-update` on live vaults after merge** — until then the installed runners keep the old behavior.

## Findings worth the maintainer's attention

1. **`connector_health_report` is never invoked post-run.** Only the `scoutctl connector-health-report` CLI and a one-shot dev tool call it — nothing in templates/phases/skills/hooks does. After this lands, telemetry rows will accumulate, but `connector-health.md`, `connector-alerts.log`, and the notification still won't regenerate until something wires the report in (#121 §4). That is the next blocker for the feature; its natural home is connector-resilience Layer 1b (the part of the design gated on #121).
2. **No dreaming/research telemetry row has ever existed.** Those slots couldn't fire before #198 (08-22) and were unexported after; the first rows appear after this + a vault upgrade. `mode_baseline` needs ≥2 prior same-mode runs before alerting, so dreaming/research alerts stay quiet for the first couple of runs by design.
3. Not implemented (follow-ups, optional): #121 §2 hook-side `SCOUT_FORCE_MODE` fallback (covers only the dispatcher path; tests now pin the contract instead), §3 zero-rows liveness alert (fits Layer 1b), a `bootstrap doctor` check that installed runners export `SCOUT_MODE` (would catch un-upgraded vaults — cheap).

Unlocks connector-resilience Phase 2 (PR #187's follow-on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
