### PR TITLE
release: v0.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "scout",
       "source": "./",
       "description": "Autonomous knowledge management and daily briefing system for Claude Code",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "author": {
         "name": "Jordan Burger"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scout",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Autonomous knowledge management and daily briefing system. Monitors your work tools (Slack, Calendar, Linear, GitHub, etc.), synthesizes findings into a persistent knowledge base with a formal ontology, and delivers daily action items — all running unattended via scheduled Claude Code sessions. Six session types: Morning Briefing, Consolidation, Dreaming, Research, interactive Work sessions, and Meta Review. Pre-session hooks pre-compute KB staleness, recent git activity, PR state, and Claude Code session summaries before each run, trading a few seconds of shell work for large token savings inside the session.",
   "author": {
     "name": "Jordan Burger"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-09-02
+
+
 
 ### Changed
 - **The vault's `scout-config.yaml` is actually read** (`engine/scout/config.py`, `engine/scout/paths.py`) — `paths.config_path()` resolved to `.scout-config.yaml`, a dotfile no code path has ever written, so the entire user-override layer was silently dead for every vault. It now resolves to the undotted file `/scout-setup` and bootstrap write. **Configured budgets, thresholds and timezone reach their consumers for the first time**, so a legacy or hand-calibrated vault will see enforcement move off the silent 50/5h/80 defaults onto whatever its `plan:`/`thresholds:` block says. Legacy key shapes are normalized on read (top-level `timezone` → `user.timezone`; `connectors.inputs.github_username`/`user_slack_id` → `user.*`) and the vault file is never rewritten. The layer is read tolerantly: unreadable YAML, a non-mapping, a permission error or non-UTF-8 degrades to packaged defaults with a one-line stderr warning instead of killing an unattended run, and a scalar where the defaults define a mapping is ignored rather than clobbering the subtree. Budget knobs are bounds-checked — an out-of-range value (`rate_limit_window_hours: 0` or negative, `skip_threshold_pct` outside 0–100) falls back to its default with a warning rather than silently disabling the governor; `daily_budget_estimate_usd: 0` remains legal. Both hot-path config readers now share one section-aware scanner (`engine/scout/scripts/_config_scan.py`), so a key only counts under its own parent. (#207, #202)

--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scout-engine"
-version = "0.8.0"
+version = "0.9.0"
 description = "Scout engine: CLI, hooks, runners, and Python library for the Scout productivity system."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/engine/scout/__init__.py
+++ b/engine/scout/__init__.py
@@ -1,3 +1,3 @@
 """Scout engine package."""
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"


### PR DESCRIPTION
Automated release prep for v0.9.0. Review, ensure CI is green, and merge — then run `scripts/release.sh --finalize v0.9.0` to tag and publish the GitHub Release.