### PR TITLE
fix(release): --finalize could never succeed (SIGPIPE + pipefail)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **`release.sh --finalize` could never succeed** (`scripts/release.sh`) — the "is this version on origin/main yet?" guard piped `git show origin/main:CHANGELOG.md` into `grep -q`. `grep -q` exits the instant it matches, closing the pipe while `git show` is still writing, so `git show` dies of SIGPIPE with status 141; `set -euo pipefail` then makes 141 the *pipeline's* status, and `!` inverts that failure into the error branch. Both outcomes therefore printed `origin/main CHANGELOG has no [X.Y.Z] section — merge the release PR first`: no match → exit 1 (right answer, wrong reason), match → exit 141 (wrong answer). The bug is position-dependent — a match late in the file lets `git show` finish inside the pipe buffer — so it fires hardest on exactly the case that matters, a freshly promoted section at the top of the file. v0.9.0 had to be tagged by hand as a result. The guard now reads the blob into a variable and matches it with a herestring, so there is no pipeline for `pipefail` to poison. (#225)
+- **Transient API failures skipped their retry on a chatty run** (`templates/scripts/claude-with-retry.sh.tmpl`) — same SIGPIPE-under-`pipefail` shape: `tail -50 "$LOG_FILE" | grep -qE "$TRANSIENT_PATTERNS"` returns 141 rather than 0 when the match lands early and the 50-line tail outgrows the pipe buffer, so `! …` reclassified a retryable error as "not classified as transient — no retry", defeating the wrapper. The tail is now snapshotted once and matched from a variable (which also drops a duplicate `tail`). (#225)
+- **Hardened the first-match extraction in rate-limit detection** (`templates/scripts/rate-limit-detect.sh.tmpl`) — `echo "$MATCHES" | head -1 | cut` has the same unbounded-writer/early-reader shape; a 141 there would propagate through `set -e` and be read by the runner as "no rate limit detected". Not reproduced in practice (bash's builtin `echo` usually survives the EPIPE), so this is a latent hardening rather than an observed failure. (#225)
+
 ## [0.9.0] - 2026-09-02
 
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -28,7 +28,14 @@ if [ "${1:-}" = "--finalize" ]; then
     VER="${TAG#v}"
     git fetch -q origin
     # The release PR must be merged first: origin/main's CHANGELOG carries this version.
-    if ! git show "origin/main:CHANGELOG.md" | grep -q "## \[$VER\]"; then
+    #
+    # No pipeline here, deliberately. `git show … | grep -q` kills the writer with
+    # SIGPIPE (141) the instant grep matches, and `pipefail` promotes that 141 to the
+    # pipeline's status — so `!` inverted a *match* into the error branch and
+    # --finalize could never succeed. Feeding grep from a herestring removes the pipe
+    # (and the writer) entirely, so pipefail has nothing to promote.
+    CHANGELOG_MAIN="$(git show "origin/main:CHANGELOG.md" 2>/dev/null || true)"
+    if ! grep -q "## \[$VER\]" <<<"$CHANGELOG_MAIN"; then
         echo "error: origin/main CHANGELOG has no [$VER] section — merge the release PR first" >&2
         exit 1
     fi

--- a/templates/scripts/claude-with-retry.sh.tmpl
+++ b/templates/scripts/claude-with-retry.sh.tmpl
@@ -77,8 +77,16 @@ while :; do
         exit "$exit_code"
     fi
 
-    if ! tail -50 "$LOG_FILE" | grep -qE "$TRANSIENT_PATTERNS"; then
-        if tail -50 "$LOG_FILE" | grep -qE "$AUTH_PATTERNS"; then
+    # Snapshot the tail once, then match against the variable. `tail … | grep -q`
+    # SIGPIPEs the writer (141) as soon as grep matches, and `pipefail` makes 141 the
+    # pipeline's status — which would silently reclassify a transient failure as
+    # "not transient" and skip the retry this wrapper exists for. A 50-line tail is
+    # bounded in lines, not bytes, so it can outgrow the pipe buffer on a chatty run.
+    # `|| true` keeps an unreadable log from aborting the wrapper under `set -e`,
+    # so the real claude exit code still reaches the caller (prior behavior).
+    LOG_TAIL="$(tail -50 "$LOG_FILE" 2>/dev/null || true)"
+    if ! grep -qE "$TRANSIENT_PATTERNS" <<<"$LOG_TAIL"; then
+        if grep -qE "$AUTH_PATTERNS" <<<"$LOG_TAIL"; then
             {
                 echo "=== Authentication failure (HTTP 401/403) — no retry (exit $exit_code) ==="
                 echo "    Claude Code's API credentials were rejected. This blocks every scheduled {{INSTANCE_NAME}} run until re-authenticated."

--- a/templates/scripts/rate-limit-detect.sh.tmpl
+++ b/templates/scripts/rate-limit-detect.sh.tmpl
@@ -52,8 +52,12 @@ if [ -z "$MATCHES" ]; then
     exit 1
 fi
 
-# Rate limit detected — extract the first matching line for context
-FIRST_MATCH=$(echo "$MATCHES" | head -1 | cut -c1-200)
+# Rate limit detected — extract the first matching line for context.
+# No pipe into `head`: it exits after one line and SIGPIPEs the writer (141), which
+# `pipefail` would promote to the assignment's status and `set -e` would turn into a
+# 141 exit — read by the caller as "no rate limit". $MATCHES is unbounded (every
+# matching line in a 100-line tail), so it can outgrow the pipe buffer.
+FIRST_MATCH=$(head -1 <<<"$MATCHES" | cut -c1-200)
 
 if [ "$WRITE_TRACKER" = "--write-tracker" ]; then
     TIMESTAMP=$(TZ=UTC date '+%Y-%m-%dT%H:%M:%SZ')


### PR DESCRIPTION
## The bug

`scripts/release.sh --finalize vX.Y.Z` can never succeed. It always exits with:

```
error: origin/main CHANGELOG has no [0.9.0] section — merge the release PR first
```

even when the section is plainly there. **v0.9.0 had to be tagged by hand because of this.**

The guard:

```bash
if ! git show "origin/main:CHANGELOG.md" | grep -q "## \[$VER\]"; then
    echo "error: origin/main CHANGELOG has no [$VER] section — merge the release PR first" >&2
    exit 1
fi
```

`grep -q` exits `0` the instant it matches. The freshly promoted section sits at **line 9** of a 139-line / **29,613-byte** `CHANGELOG.md`, so grep matches almost immediately and closes the pipe **while `git show` is still writing**. `git show` is killed by `SIGPIPE` and exits **141**. The script runs under `set -euo pipefail` (line 17), so `pipefail` makes 141 the *pipeline's* status, and `!` inverts that failure into the error branch.

### PIPESTATUS evidence (on `origin/main`, before the fix)

```
$ git show "origin/main:CHANGELOG.md" | grep -q "## \[0.9.0\]"

# pipefail OFF:  exit=0    PIPESTATUS=(141 0)   <- git show SIGPIPEd, grep matched
# pipefail ON :  exit=141                       <- `!` flips this into the error branch
```

So **both** branches were broken:

| CHANGELOG state | pipeline status | `!` result | outcome |
|---|---|---|---|
| section absent | 1 (grep no-match) | true | error — *right answer, wrong reason* |
| section present | **141** (SIGPIPE) | true | error — **wrong** |

The guard could only ever produce the error.

### Why it wasn't caught earlier

The failure is **position-dependent**: a match late in the file lets `git show` finish writing inside the pipe buffer, so no SIGPIPE. Checking the same CHANGELOG for a *past* version passes, while the *current* one fails:

```
== version 0.9.0 (line 9)      BEFORE: error (rc=1)      AFTER: passes (rc=0)
== version 0.8.0 (line ~87)    BEFORE: passes (rc=0)     AFTER: passes (rc=0)
== version 99.99.99 (absent)   BEFORE: error (rc=1)      AFTER: error (rc=1)
```

It breaks hardest on exactly the case the script exists for — a newly promoted section at the top of the file.

## The fix

Read the blob into a variable and match it with a herestring, so there is **no pipeline** for `pipefail` to poison:

```bash
CHANGELOG_MAIN="$(git show "origin/main:CHANGELOG.md" 2>/dev/null || true)"
if ! grep -q "## \[$VER\]" <<<"$CHANGELOG_MAIN"; then
```

(`2>/dev/null || true` keeps a genuinely missing blob on the friendly-error path instead of aborting via `set -e`.)

> **Worth flagging:** the obvious `printf '%s\n' "$CHANGELOG_MAIN" | grep -q …` rewrite does **not** fix this. It is still a pipeline with an early-exiting reader, and it reproduces the same 141 at larger payloads — `printf`'s builtin subshell took SIGPIPE in **5/5 runs at a 2 MB payload**. It only survives the 29 KB case by winning a race. Removing the pipeline outright is the only shape that is correct under `pipefail` regardless of input size.

## Audit of the rest of the repo's shell

Every pipeline in `scripts/*.sh`, `install.sh`, `engine/tests/**/*.sh` and `templates/**/*.sh.tmpl` was checked for the same `pipefail` + early-exiting-consumer shape. All of these files set `set -euo pipefail` except `pre-session-data.sh.tmpl` and `cc-session-cache.sh.tmpl`.

### Real — fixed

**`templates/scripts/claude-with-retry.sh.tmpl:80-81`**

```bash
if ! tail -50 "$LOG_FILE" | grep -qE "$TRANSIENT_PATTERNS"; then
    if tail -50 "$LOG_FILE" | grep -qE "$AUTH_PATTERNS"; then
```

Same shape, same consequence. **Reproduced**: with a log whose 50-line tail is 100,454 bytes and whose transient signal is on the first tailed line, the wrapper skipped the retry entirely and logged `Failure not classified as transient — no retry`:

```
=== claude-with-retry.sh: transient error should be RETRIED ===
  old: exit=7  -> NO RETRY (bug: transient error misclassified)
  new: exit=7  -> RETRIED (correct)
```

`tail -50` is bounded in *lines*, not bytes, so a chatty run reaches this. Today's real vault logs are ~3.3–6.5 KB per 50-line tail and do **not** trip it, so this has most likely not fired in production yet — but it silently defeats the entire purpose of the retry wrapper when it does. Fixed by snapshotting the tail once and matching from the variable (which also drops a duplicate `tail`). The 6 existing tests in `tests/integration/test_claude_with_retry.py` still pass.

### Latent — hardened, honestly not reproduced

**`templates/scripts/rate-limit-detect.sh.tmpl:56`**

```bash
FIRST_MATCH=$(echo "$MATCHES" | head -1 | cut -c1-200)
```

`head -1` exits after one line; `$MATCHES` is unbounded (every matching line in a 100-line tail). A 141 here propagates through `set -e` (bare assignment), and the runner reads the script's exit code directly — `if "$RATE_DETECT" "$LOG_FILE" --write-tracker` — so 141 would be silently read as "no rate limit detected".

**I could not reproduce it.** bash's builtin `echo` survived the EPIPE at every size tested up to 16 MB, unlike `printf` in the same shape. Since it is the same construct as one that *does* reliably fail at 2 MB, and the fix is a zero-risk one-character-class change, it is hardened rather than left alone — but it is listed as latent, not as an observed failure.

### Audited and deliberately left alone — safe, not merely similar

| Location | Why it is safe |
|---|---|
| `install.sh:37` | `claude plugin list --json \| python3 -c "…json.load(sys.stdin)…"` — `json.load` drains stdin completely before returning, so the writer never sees EPIPE. Also wrapped in `\|\| true`. |
| `templates/scripts/rate-limit-detect.sh.tmpl:49` | `tail -100 \| grep -iE` — no `-q`, grep drains the stream. Also `\|\| true`. |
| `templates/scripts/rate-limit-detect.sh.tmpl:67` | `echo \| sed \| tr` — both drain, and the input is already `cut` to ≤200 chars. |
| `templates/scripts/scout-tz.sh.tmpl:68` | `awk '…{print; exit}' "$config" \| sed …` — awk's early `exit` is on a **file** read, not a pipe, and the downstream `sed` drains. |
| `templates/action-items/watch.sh.tmpl:63` | `fswatch -o \| while read` — the reader never exits early; that's the intended long-running shape. |
| `engine/tests/integration/test_bootstrap_smoke.sh:51` | `grep -q … "$file"` — reads a file, no pipe at all. |

`.github/workflows/*.yml` contain no pipelines of this shape.

## Verification

- Guard logic exercised directly under `set -euo pipefail` against real `origin/main` — passes for `0.9.0` and `0.8.0`, still errors for an absent `99.99.99` (table above).
- `templates/scripts/claude-with-retry.sh.tmpl` old-vs-new rendered and run against a 100 KB tail — old misclassifies, new retries.
- `engine/`: `.venv/bin/ruff check scout tests` → **All checks passed**; `.venv/bin/ruff format --check scout tests` → **190 files already formatted**; `.venv/bin/mypy scout` → **Success: no issues found in 87 source files**.
- `shellcheck` (available locally, `/opt/homebrew/bin/shellcheck`) → **clean, rc=0** on all three changed files (templates linted with `{{VARS}}` substituted).
- `pytest tests/integration/test_claude_with_retry.py` → **6 passed**.

No real `--finalize` was run. **No git tags were created, moved or deleted**; nothing was pushed to `main`; no version numbers or existing CHANGELOG version sections were touched (the entry is added under `[Unreleased]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
