### PR TITLE
test(engine): raise coverage 80% → 99% and gate it in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,28 @@ jobs:
         # here checks the canonical file is in sync with the YAML — drift =
         # someone edited schedule.yaml and forgot to regenerate.
         run: .venv/bin/python -m scout.scripts.schedule_snapshot --check --target scout/schedule.snapshot.json
+
+  # Coverage runs once, not across the matrix, for two reasons:
+  #   1. The `[full]` extra is required. Every scout/tui test is gated on
+  #      `pytest.importorskip("textual")`, so a `[dev]`-only install skips the
+  #      whole TUI package and the total drops ~3 points below the gate.
+  #   2. Coverage's tracer skews tests/perf/, which measures scoutctl's cold
+  #      -start latency. Keeping the matrix job coverage-free leaves those
+  #      timings honest.
+  # The threshold itself lives in [tool.coverage.report] fail_under.
+  coverage:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: engine
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - name: Setup Python
+        run: uv python install 3.12
+      - name: Create venv
+        run: uv venv --python 3.12
+      - name: Install
+        run: uv pip install -e ".[dev,full]"
+      - name: Pytest with coverage
+        run: .venv/bin/pytest tests/ --cov --cov-report=term-missing

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ __pycache__/
 .pytest_cache/
 .ruff_cache/
 .mypy_cache/
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
 
 # Virtual envs
 .venv/

--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -89,3 +89,32 @@ markers = [
     "concurrency: tests involving multiple processes/threads",
     "slow: tests taking > 1 second",
 ]
+
+# Coverage is opt-in per-invocation (`pytest --cov=scout`), not wired into
+# addopts — the perf tests measure cold-start latency and coverage's tracer
+# skews those numbers. CI runs a dedicated coverage job; see
+# .github/workflows/test.yml.
+[tool.coverage.run]
+source = ["scout"]
+branch = true
+omit = [
+    # Trivial `python -m scout` shim; its one branch is the __main__ guard.
+    "scout/__main__.py",
+]
+
+[tool.coverage.report]
+# The engine ships as a scheduled, unattended runner: an uncovered failure
+# path is one that first executes at 03:00 with no one watching. The suite
+# currently sits at ~99% statement+branch; the floor is set just under that so
+# a genuinely-untestable line doesn't fail a build, while a new module landing
+# without tests does. Raise it as gaps close — never lower it to make a build
+# pass.
+fail_under = 98
+show_missing = true
+skip_covered = true
+exclude_also = [
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "@(typing\\.)?overload",
+]

--- a/engine/tests/unit/test_action_items_cli_commands.py
+++ b/engine/tests/unit/test_action_items_cli_commands.py
@@ -1,0 +1,443 @@
+"""Per-command coverage of the `scoutctl action-items` Typer sub-app.
+
+`test_action_items_cli.py` pins two help/validation behaviours and the
+integration suite drives a handful of commands through a subprocess. Neither
+exercises the sub-app's own argument plumbing — the `--subject`/`--by-id`
+exclusivity guards, the legacy "path argument implies data_dir + date"
+back-compat branch, and each command's stdout contract. Those branches are
+where a regression is silent (a mis-derived data_dir writes to the wrong
+vault), so drive them in-process via CliRunner.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from scout.action_items.cli import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A vault whose 2026-04-15 daily file holds one prefixed open task."""
+    data_dir = tmp_path / "Scout"
+    (data_dir / "action-items").mkdir(parents=True)
+    (data_dir / ".scout-state").mkdir(parents=True)
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(data_dir))
+    return data_dir
+
+
+def _daily(vault: Path, date: str = "2026-04-15") -> Path:
+    return vault / "action-items" / f"action-items-{date}.md"
+
+
+def _seed(vault: Path, body: str, date: str = "2026-04-15") -> Path:
+    target = _daily(vault, date)
+    target.write_text(body, encoding="utf-8")
+    return target
+
+
+def _seed_id_map(vault: Path, prefix: str, title: str, file: str, line: int) -> None:
+    ulid = "01HXAAA0000000000000000000"
+    (vault / ".scout-state" / "id-map.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "entries": {
+                    ulid: {
+                        "ulid": ulid,
+                        "short_prefix": prefix,
+                        "last_title": title,
+                        "last_file": file,
+                        "last_line": line,
+                    }
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _err(result) -> str:
+    """Error text regardless of whether Typer raised or printed."""
+    return ((str(result.exception) if result.exception else "") + result.output).lower()
+
+
+# --------------------------------------------------------------------------
+# --subject / --by-id exclusivity
+#
+# Every mutating command guards "exactly one of". Both-given and neither-given
+# must fail identically; a command that silently preferred one selector would
+# mutate a task the caller never named.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("command", "extra"),
+    [
+        ("mark-done", []),
+        ("snooze", ["--until", "2026-04-20"]),
+        ("add-comment", ["--comment", "hi"]),
+        ("delete-comment", ["--index", "1"]),
+        ("edit-comment", ["--new-text", "hi", "--index", "1"]),
+    ],
+)
+@pytest.mark.parametrize("selectors", [[], ["--subject", "x", "--by-id", "A3F7"]])
+@pytest.mark.usefixtures("vault")
+def test_selector_must_be_exactly_one(command: str, extra: list[str], selectors: list[str]) -> None:
+    result = runner.invoke(app, [command, *extra, *selectors])
+    assert result.exit_code != 0
+    assert "exactly one of --subject or --by-id" in _err(result)
+
+
+@pytest.mark.parametrize(
+    ("command", "extra"),
+    [
+        ("delete-comment", []),
+        ("edit-comment", ["--new-text", "hi"]),
+    ],
+)
+@pytest.mark.parametrize("locators", [[], ["--index", "1", "--text", "hi"]])
+@pytest.mark.usefixtures("vault")
+def test_comment_locator_must_be_exactly_one(command: str, extra: list[str], locators: list[str]) -> None:
+    """--index and --text are equally exclusive, and checked after the
+    selector guard — so pass a valid --subject to reach it."""
+    result = runner.invoke(app, [command, *extra, "--subject", "x", *locators])
+    assert result.exit_code != 0
+    assert "exactly one of --index or --text" in _err(result)
+
+
+# --------------------------------------------------------------------------
+# Legacy positional path → data_dir + date
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("command", "extra"),
+    [
+        ("mark-done", []),
+        ("snooze", ["--until", "2026-04-20"]),
+        ("add-comment", ["--comment", "hi"]),
+        ("delete-comment", ["--index", "1"]),
+        ("edit-comment", ["--new-text", "hi", "--index", "1"]),
+    ],
+)
+def test_unparseable_daily_filename_is_rejected(vault: Path, command: str, extra: list[str]) -> None:
+    """The path argument's stem must be `action-items-YYYY-MM-DD`; the date is
+    what pins which day is edited, so a stem we cannot parse must not fall
+    back to "today" silently."""
+    bogus = vault / "action-items" / "notes.md"
+    bogus.write_text("- [ ] sample task\n", encoding="utf-8")
+
+    result = runner.invoke(app, [command, *extra, "--subject", "sample", str(bogus)])
+    assert result.exit_code != 0
+    assert "unrecognized daily filename: notes.md" in _err(result)
+
+
+def test_mark_done_derives_data_dir_from_path_grandparent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """With SCOUT_DATA_DIR pointing elsewhere, the positional path still wins:
+    its grandparent is the vault. This is the back-compat contract scout-app
+    relies on when it passes absolute file paths."""
+    decoy = tmp_path / "decoy"
+    (decoy / "action-items").mkdir(parents=True)
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(decoy))
+
+    real = tmp_path / "Real"
+    (real / "action-items").mkdir(parents=True)
+    (real / ".scout-state").mkdir(parents=True)
+    target = real / "action-items" / "action-items-2026-04-15.md"
+    target.write_text("- [ ] sample task\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["mark-done", "--subject", "sample", str(target)])
+    assert result.exit_code == 0, result.output
+    assert "- [x] sample task" in target.read_text()
+
+
+# --------------------------------------------------------------------------
+# Individual command happy paths
+# --------------------------------------------------------------------------
+
+
+def test_mark_done_undo_reopens(vault: Path) -> None:
+    target = _seed(vault, "- [x] sample task\n")
+    result = runner.invoke(app, ["mark-done", "--subject", "sample", "--undo", str(target)])
+    assert result.exit_code == 0, result.output
+    assert "- [ ] sample task" in target.read_text()
+
+
+def test_mark_done_by_id(vault: Path) -> None:
+    target = _seed(vault, "## To Do\n\n- [ ] [#A3F7] sample task\n")
+    _seed_id_map(vault, "A3F7", "sample task", target.name, 3)
+    result = runner.invoke(app, ["mark-done", "--by-id", "A3F7", str(target)])
+    assert result.exit_code == 0, result.output
+    assert "- [x] [#A3F7] sample task" in target.read_text()
+
+
+def test_snooze_writes_marker(vault: Path) -> None:
+    target = _seed(vault, "- [ ] sample task\n")
+    result = runner.invoke(
+        app, ["snooze", "--until", "2026-04-20", "--subject", "sample", "--from-kind", "urgent", str(target)]
+    )
+    assert result.exit_code == 0, result.output
+    assert "2026-04-20" in target.read_text()
+
+
+@pytest.mark.usefixtures("vault")
+def test_snooze_rejects_non_iso_until() -> None:
+    result = runner.invoke(app, ["snooze", "--until", "next tuesday", "--subject", "sample"])
+    assert result.exit_code != 0
+    assert "--until: invalid date" in _err(result)
+
+
+def test_add_comment_appends_with_author(vault: Path) -> None:
+    target = _seed(vault, "- [ ] sample task\n")
+    result = runner.invoke(
+        app, ["add-comment", "--comment", "looked into it", "--subject", "sample", "--author", "priya", str(target)]
+    )
+    assert result.exit_code == 0, result.output
+    text = target.read_text()
+    assert "looked into it" in text
+    assert "priya" in text
+
+
+def test_delete_comment_by_index(vault: Path) -> None:
+    target = _seed(vault, "- [ ] sample task\n")
+    runner.invoke(app, ["add-comment", "--comment", "first note", "--subject", "sample", str(target)])
+    assert "first note" in target.read_text()
+
+    result = runner.invoke(app, ["delete-comment", "--subject", "sample", "--index", "1", str(target)])
+    assert result.exit_code == 0, result.output
+    assert "first note" not in target.read_text()
+
+
+def test_delete_comment_by_text(vault: Path) -> None:
+    target = _seed(vault, "- [ ] sample task\n")
+    runner.invoke(app, ["add-comment", "--comment", "first note", "--subject", "sample", str(target)])
+
+    result = runner.invoke(app, ["delete-comment", "--subject", "sample", "--text", "FIRST", str(target)])
+    assert result.exit_code == 0, result.output
+    assert "first note" not in target.read_text()
+
+
+def test_edit_comment_replaces_body(vault: Path) -> None:
+    target = _seed(vault, "- [ ] sample task\n")
+    runner.invoke(app, ["add-comment", "--comment", "old body", "--subject", "sample", str(target)])
+
+    result = runner.invoke(
+        app, ["edit-comment", "--new-text", "new body", "--subject", "sample", "--index", "1", str(target)]
+    )
+    assert result.exit_code == 0, result.output
+    text = target.read_text()
+    assert "new body" in text
+    assert "old body" not in text
+
+
+def test_render_emits_html_for_explicit_path(vault: Path) -> None:
+    target = _seed(vault, "# Action Items — 2026-04-15\n\n## To Do\n\n- [ ] [#A3F7] sample task\n")
+    result = runner.invoke(app, ["render", str(target)])
+    assert result.exit_code == 0, result.output
+    assert "<!DOCTYPE html>" in result.stdout or "<html" in result.stdout
+    assert "sample task" in result.stdout
+
+
+@pytest.mark.usefixtures("vault")
+def test_render_defaults_to_todays_daily_file() -> None:
+    """With no path argument, render resolves via paths.action_items_daily_path()."""
+    from scout import paths
+
+    target = paths.action_items_daily_path()
+    target.write_text("# Action Items\n\n## To Do\n\n- [ ] todays task\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["render"])
+    assert result.exit_code == 0, result.output
+    assert "todays task" in result.stdout
+
+
+def test_list_json_payload_shape(vault: Path) -> None:
+    target = _seed(
+        vault,
+        "# Action Items\n\n## To Do\n\n- [ ] [#A3F7] 🔴 sample task\n- [x] [#B5K2] done task\n",
+    )
+    result = runner.invoke(app, ["list", str(target), "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert [row["title"] for row in payload] == ["sample task"]
+    assert set(payload[0]) == {"title", "priority", "status", "section", "short_prefix"}
+    assert payload[0]["short_prefix"] == "A3F7"
+    assert payload[0]["status"] == "open"
+
+
+def test_list_include_done_and_filters(vault: Path) -> None:
+    target = _seed(
+        vault,
+        "# Action Items\n\n## To Do\n\n- [ ] [#A3F7] 🔴 red task\n- [ ] 🟢 green task\n- [x] done task\n",
+    )
+
+    with_done = json.loads(runner.invoke(app, ["list", str(target), "--json", "--include-done"]).stdout)
+    assert {row["status"] for row in with_done} == {"open", "done"}
+
+    only_red = json.loads(runner.invoke(app, ["list", str(target), "--json", "--priority", "high"]).stdout)
+    assert [row["title"] for row in only_red] == ["red task"]
+
+    # The glyph itself is an accepted alias for the same filter.
+    by_glyph = json.loads(runner.invoke(app, ["list", str(target), "--json", "--priority", "🔴"]).stdout)
+    assert [row["title"] for row in by_glyph] == ["red task"]
+
+    by_section = json.loads(runner.invoke(app, ["list", str(target), "--json", "--section", "To Do"]).stdout)
+    assert len(by_section) == 2
+
+    no_match = json.loads(runner.invoke(app, ["list", str(target), "--json", "--section", "Nonexistent"]).stdout)
+    assert no_match == []
+
+
+def test_list_rejects_unknown_priority(vault: Path) -> None:
+    target = _seed(vault, "# Action Items\n\n## To Do\n\n- [ ] 🔴 red task\n")
+    result = runner.invoke(app, ["list", str(target), "--priority", "urgent"])
+    assert result.exit_code != 0
+    assert "unknown priority" in _err(result)
+
+
+def test_list_plain_output_is_the_formatter(vault: Path) -> None:
+    target = _seed(vault, "# Action Items\n\n## To Do\n\n- [ ] [#A3F7] sample task\n")
+    result = runner.invoke(app, ["list", str(target)])
+    assert result.exit_code == 0, result.output
+    assert "[#A3F7]" in result.stdout
+    assert "sample task" in result.stdout
+
+
+def test_new_prefix_is_bare_and_avoids_collisions(vault: Path) -> None:
+    _seed_id_map(vault, "A3F7", "sample task", "action-items-2026-04-15.md", 3)
+    result = runner.invoke(app, ["new-prefix"])
+    assert result.exit_code == 0, result.output
+    prefix = result.stdout.strip()
+    # Bare: callers interpolate it straight into `[#${prefix}]`.
+    assert "[#" not in prefix
+    assert prefix != "A3F7"
+    assert 2 <= len(prefix) <= 8
+
+
+def test_new_prefix_honours_positional_path(vault: Path) -> None:
+    """The path argument's grandparent is the vault whose id-map is consulted."""
+    target = _daily(vault)
+    _seed_id_map(vault, "A3F7", "sample task", target.name, 3)
+    result = runner.invoke(app, ["new-prefix", str(target)])
+    assert result.exit_code == 0, result.output
+    assert result.stdout.strip() != "A3F7"
+
+
+def test_materialize_creates_from_prior_day(vault: Path) -> None:
+    _seed(vault, "# Action Items — Tuesday, Apr 14, 2026\n\n## To Do\n\n- [ ] carried task\n", date="2026-04-14")
+
+    result = runner.invoke(app, ["materialize", "--date", "2026-04-15"])
+    assert result.exit_code == 0, result.output
+    assert "materialize: created" in result.stdout
+    assert "carried task" in _daily(vault).read_text()
+
+
+def test_materialize_is_idempotent(vault: Path) -> None:
+    _seed(vault, "# Action Items\n\n- [ ] carried task\n", date="2026-04-14")
+    runner.invoke(app, ["materialize", "--date", "2026-04-15"])
+
+    again = runner.invoke(app, ["materialize", "--date", "2026-04-15"])
+    assert again.exit_code == 0, again.output
+    assert "nothing to do" in again.stdout
+
+
+@pytest.mark.usefixtures("vault")
+def test_materialize_reports_nothing_to_do_with_no_prior_file() -> None:
+    result = runner.invoke(app, ["materialize", "--date", "2026-04-15"])
+    assert result.exit_code == 0, result.output
+    assert "nothing to do" in result.stdout
+
+
+def test_materialize_honours_explicit_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    decoy = tmp_path / "decoy"
+    (decoy / "action-items").mkdir(parents=True)
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(decoy))
+
+    real = tmp_path / "Real"
+    (real / "action-items").mkdir(parents=True)
+    (real / "action-items" / "action-items-2026-04-14.md").write_text("# A\n\n- [ ] carried\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["materialize", "--date", "2026-04-15", "--data-dir", str(real)])
+    assert result.exit_code == 0, result.output
+    assert (real / "action-items" / "action-items-2026-04-15.md").exists()
+    assert not (decoy / "action-items" / "action-items-2026-04-15.md").exists()
+
+
+@pytest.mark.usefixtures("vault")
+def test_materialize_rejects_non_iso_date() -> None:
+    result = runner.invoke(app, ["materialize", "--date", "04/15/2026"])
+    assert result.exit_code != 0
+    assert "--date: invalid date" in _err(result)
+
+
+def test_backfill_prefixes_dry_run_does_not_write(vault: Path) -> None:
+    target = _seed(vault, "# Action Items\n\n## To Do\n\n- [ ] unprefixed task\n")
+    before = target.read_text()
+
+    result = runner.invoke(app, ["backfill-prefixes", str(target), "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "would add 1 prefix(es):" in result.stdout
+    assert "unprefixed task" in result.stdout
+    assert target.read_text() == before
+
+
+def test_backfill_prefixes_writes(vault: Path) -> None:
+    target = _seed(vault, "# Action Items\n\n## To Do\n\n- [ ] unprefixed task\n")
+
+    result = runner.invoke(app, ["backfill-prefixes", str(target)])
+    assert result.exit_code == 0, result.output
+    assert "added 1 prefix(es):" in result.stdout
+    assert "[#" in target.read_text()
+
+
+def test_backfill_prefixes_reports_no_op(vault: Path) -> None:
+    target = _seed(vault, "# Action Items\n\n## To Do\n\n- [ ] [#A3F7] already prefixed\n")
+    result = runner.invoke(app, ["backfill-prefixes", str(target)])
+    assert result.exit_code == 0, result.output
+    assert "no unprefixed open tasks found" in result.stdout
+
+
+# --------------------------------------------------------------------------
+# watch — target resolution (the loop itself is stubbed; it blocks forever)
+# --------------------------------------------------------------------------
+
+
+def test_watch_accepts_bare_date(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = _seed(vault, "- [ ] sample task\n")
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(
+        "scout.action_items.watch.run_watch_loop",
+        lambda path, *, color: seen.update(path=path, color=color),
+    )
+
+    result = runner.invoke(app, ["watch", "2026-04-15"])
+    assert result.exit_code == 0, result.output
+    assert seen["path"] == target
+
+
+def test_watch_accepts_explicit_path_and_no_color(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = _seed(vault, "- [ ] sample task\n")
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(
+        "scout.action_items.watch.run_watch_loop",
+        lambda path, *, color: seen.update(path=path, color=color),
+    )
+
+    result = runner.invoke(app, ["watch", str(target), "--no-color"])
+    assert result.exit_code == 0, result.output
+    assert seen["path"] == target.resolve()
+    assert seen["color"] is False
+
+
+def test_watch_rejects_missing_explicit_path(vault: Path) -> None:
+    result = runner.invoke(app, ["watch", str(vault / "action-items" / "nope.md")])
+    assert result.exit_code != 0
+    assert "does not exist" in _err(result)

--- a/engine/tests/unit/test_action_items_parser_inference.py
+++ b/engine/tests/unit/test_action_items_parser_inference.py
@@ -1,0 +1,287 @@
+"""Status/priority inference and helper coverage for the action-items parser.
+
+`test_action_items_parser.py` and the corpus contract test
+(`test_parser_contract.py`) cover the checkbox/prefix/priority happy paths.
+What's left is the inference cascade in `_infer_status` — the legacy formats a
+mature vault still contains (`✅`/`🔄` prefixes, `~~strike~~`, `— Done`
+suffixes, and section/subsection defaults) — plus `### ` subsection handling,
+TUI note attachment, and the two public grouping helpers.
+
+Those matter because a mis-inferred status hides an open item from
+`filter_actionable`, which is what the briefing prompt reads.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scout.action_items.parser import (
+    ActionItem,
+    filter_actionable,
+    items_by_priority,
+    parse_action_items,
+    parse_lines,
+)
+
+
+def _lines(text: str) -> list[str]:
+    """splitlines() with an explicit list[str] type (parse_lines is invariant)."""
+    return list(text.splitlines())
+
+
+def _items(text: str) -> list[ActionItem]:
+    return parse_lines(_lines(text))
+
+
+def _one(text: str) -> ActionItem:
+    items = _items(text)
+    assert len(items) == 1, items
+    return items[0]
+
+
+# ---------------------------------------------------------------------------
+# parse_action_items — file-level
+# ---------------------------------------------------------------------------
+
+
+def test_parse_action_items_returns_empty_for_a_missing_file(tmp_path: Path) -> None:
+    """The daily file legitimately doesn't exist before the first briefing;
+    callers read the result as "no items", not an error."""
+    assert parse_action_items(tmp_path / "action-items-2026-04-15.md") == []
+
+
+def test_parse_action_items_reads_a_real_file(tmp_path: Path) -> None:
+    p = tmp_path / "action-items-2026-04-15.md"
+    p.write_text("## To Do\n\n- [ ] 🔴 a task\n", encoding="utf-8")
+    items = parse_action_items(p)
+    assert [i.title for i in items] == ["a task"]
+
+
+# ---------------------------------------------------------------------------
+# _infer_status cascade
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        ("- [x] explicit done", "done"),
+        ("- [X] explicit done upper", "done"),
+        ("- [ ] explicit open", "open"),
+        # Legacy status-emoji prefixes, before checkboxes were adopted.
+        ("- ✅ finished item", "done"),
+        ("- 🔄 in flight", "in_progress"),
+        ("- ~~dropped item~~", "done"),
+        ("- Ship the thing — Done", "done"),
+        ("- Ship the thing — Completed", "done"),
+        ("- Ship the thing ✅ Done", "done"),
+        # Nothing to infer from -> open.
+        ("- a plain bullet", "open"),
+    ],
+)
+def test_infer_status_from_the_line_itself(line: str, expected: str) -> None:
+    assert _one(f"## Notes\n\n{line}\n").status == expected
+
+
+def test_a_checkbox_beats_a_done_looking_section() -> None:
+    """An explicit `- [ ]` under "## Completed Today" is still open — the
+    checkbox is the author's intent and must win over the section default."""
+    items = _items("## Completed Today\n\n- [ ] actually still open\n- [x] really done\n")
+    by_title = {i.title: i.status for i in items}
+    assert by_title == {"actually still open": "open", "really done": "done"}
+
+
+@pytest.mark.parametrize(
+    ("section", "expected"),
+    [
+        ("Completed Today", "done"),
+        ("Completed", "done"),
+        ("Done", "done"),
+        ("In Progress", "in_progress"),
+        ("To Do", "open"),
+        ("Todo", "open"),
+        ("Watching", "watching"),
+        ("Upcoming", "open"),
+        ("Something Else", "open"),  # no mapping -> open
+    ],
+)
+def test_infer_status_from_the_section_header(section: str, expected: str) -> None:
+    assert _one(f"## {section}\n\n- a plain bullet\n").status == expected
+
+
+def test_infer_status_from_the_section_is_case_insensitive() -> None:
+    assert _one("## COMPLETED TODAY\n\n- a plain bullet\n").status == "done"
+
+
+@pytest.mark.parametrize("subsection", ["✅ Security Plugin", "Rollout — Done", "done work"])
+def test_infer_status_from_a_done_marking_subsection(subsection: str) -> None:
+    """`### ✅ …` / `### … — Done` are status markers: bullets under them are
+    complete even without a checkbox."""
+    assert _one(f"## To Do\n\n### {subsection}\n\n- a plain bullet\n").status == "done"
+
+
+def test_a_subsection_beats_the_parent_section_for_status() -> None:
+    item = _one("## Watching\n\n### ✅ Shipped\n\n- a plain bullet\n")
+    assert item.status == "done"
+
+
+# ---------------------------------------------------------------------------
+# Priority inference
+# ---------------------------------------------------------------------------
+
+
+def test_priority_comes_from_the_line_when_present() -> None:
+    assert _one("## 🟢 Watching\n\n- [ ] 🔴 urgent despite the section\n").priority == "🔴"
+
+
+def test_priority_falls_back_to_the_subsection() -> None:
+    item = _one("## To Do\n\n### 🟡 Medium bucket\n\n- [ ] no glyph on the line\n")
+    assert item.priority == "🟡"
+
+
+def test_priority_falls_back_to_the_section() -> None:
+    assert _one("## 🔴 Urgent\n\n- [ ] no glyph on the line\n").priority == "🔴"
+
+
+def test_the_subsection_beats_the_section_for_priority() -> None:
+    item = _one("## 🔴 Urgent\n\n### 🟢 Low bucket\n\n- [ ] no glyph on the line\n")
+    assert item.priority == "🟢"
+
+
+def test_priority_is_empty_when_nothing_declares_one() -> None:
+    assert _one("## To Do\n\n- [ ] no glyph anywhere\n").priority == ""
+
+
+# ---------------------------------------------------------------------------
+# Sections, subsections and attachment
+# ---------------------------------------------------------------------------
+
+
+def test_the_subsection_becomes_the_reported_section_label() -> None:
+    assert _one("## To Do\n\n### Q2 budget\n\n- [ ] a task\n").section == "Q2 budget"
+
+
+def test_the_section_label_falls_back_to_the_h2() -> None:
+    assert _one("## To Do\n\n- [ ] a task\n").section == "To Do"
+
+
+def test_a_new_subsection_detaches_the_previous_item() -> None:
+    """A sub-bullet after a `###` must not be appended to the item above the
+    heading — it belongs to whatever comes next."""
+    items = _items("## To Do\n\n- [ ] first task\n\n### Later\n\n  - orphan sub-bullet\n- [ ] second task\n")
+    first = next(i for i in items if i.title == "first task")
+    assert first.details == []
+
+
+def test_a_new_section_detaches_the_previous_item() -> None:
+    items = _items("## To Do\n\n- [ ] first task\n\n## Watching\n\n  - orphan sub-bullet\n")
+    assert next(i for i in items if i.title == "first task").details == []
+
+
+def test_tui_notes_attach_to_the_preceding_item() -> None:
+    item = _one("## To Do\n\n- [ ] a task\n  - **[TUI note 2026-04-15]** looked into it\n")
+    assert item.notes == ["- **[TUI note 2026-04-15]** looked into it"]
+    # A note is not a detail sub-bullet.
+    assert item.details == []
+
+
+def test_sub_bullets_collect_details_and_context_links() -> None:
+    item = _one(
+        "## To Do\n\n- [ ] a task\n  - Source: https://example.com/thread\n  - See [[knowledge-base/rollout-plan]]\n"
+    )
+    assert item.context_links == ["https://example.com/thread", "kb://knowledge-base/rollout-plan"]
+    assert len(item.details) == 2
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "| Time | Meeting |",  # a table row
+        "> a blockquote",
+        "",
+        "   ",
+        "Just a paragraph of prose.",
+    ],
+)
+def test_non_content_lines_never_become_items(line: str) -> None:
+    assert _items(f"## To Do\n\n{line}\n") == []
+
+
+@pytest.mark.parametrize("fence", ["```", "~~~", "```markdown"])
+def test_fenced_blocks_are_not_parsed(fence: str) -> None:
+    """Documentation examples inside a fence must not be mistaken for real
+    items — backfill would otherwise rewrite the docs (#40)."""
+    text = f"## To Do\n\n{fence}\n- [ ] example task from the docs\n## Not a heading\n```\n\n- [ ] real task\n"
+    items = parse_lines(_lines(text))
+    assert [i.title for i in items] == ["real task"]
+    # The `## Not a heading` inside the fence must not have changed the section.
+    assert items[0].section == "To Do"
+
+
+# ---------------------------------------------------------------------------
+# Sorting
+# ---------------------------------------------------------------------------
+
+
+def test_items_sort_by_status_then_priority() -> None:
+    # An explicit `- [ ]` forces "open" regardless of section (see
+    # test_a_checkbox_beats_a_done_looking_section), so the in_progress rows
+    # here are bare bullets under "## In Progress".
+    items = _items(
+        "## In Progress\n\n- 🟢 wip low\n- 🔴 wip urgent\n"
+        "## To Do\n\n- [ ] 🔴 open urgent\n- [ ] 🟡 open medium\n"
+        "## Watching\n\n- 🟢 watching low\n"
+        "## Completed Today\n\n- [x] 🔴 done urgent\n"
+    )
+    assert [i.title for i in items] == [
+        "wip urgent",
+        "wip low",
+        "open urgent",
+        "open medium",
+        "watching low",
+        "done urgent",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# filter_actionable / items_by_priority
+# ---------------------------------------------------------------------------
+
+
+def test_filter_actionable_drops_done_items() -> None:
+    items = _items("## To Do\n\n- [ ] open task\n- [x] done task\n")
+    assert [i.title for i in filter_actionable(items)] == ["open task"]
+
+
+def test_filter_actionable_drops_calendar_sections() -> None:
+    """Calendar rows are informational; surfacing them as actionable made the
+    briefing's "what to do" list unreadable."""
+    items = _items("## To Do\n\n- [ ] open task\n## Calendar\n\n- [ ] 09:00 standup\n")
+    assert [i.title for i in filter_actionable(items)] == ["open task"]
+
+
+def test_filter_actionable_matches_calendar_case_insensitively() -> None:
+    items = _items("## Today's CALENDAR\n\n- [ ] 09:00 standup\n")
+    assert filter_actionable(items) == []
+
+
+def test_items_by_priority_always_returns_the_four_known_buckets() -> None:
+    items = _items("## To Do\n\n- [ ] 🔴 urgent\n- [ ] no glyph\n")
+    groups = items_by_priority(items)
+    assert set(groups) == {"🔴", "🟡", "🟢", ""}
+    assert [i.title for i in groups["🔴"]] == ["urgent"]
+    assert [i.title for i in groups[""]] == ["no glyph"]
+    assert groups["🟡"] == [] and groups["🟢"] == []
+
+
+def test_items_by_priority_adds_a_bucket_for_an_unexpected_glyph() -> None:
+    """A future priority glyph must land in its own bucket rather than being
+    dropped on the floor."""
+    groups = items_by_priority([ActionItem(priority="🔵", title="new glyph", status="open", section="To Do")])
+    assert [i.title for i in groups["🔵"]] == ["new glyph"]
+
+
+def test_items_by_priority_on_an_empty_list() -> None:
+    assert items_by_priority([]) == {"🔴": [], "🟡": [], "🟢": [], "": []}

--- a/engine/tests/unit/test_action_items_render_sections.py
+++ b/engine/tests/unit/test_action_items_render_sections.py
@@ -1,0 +1,471 @@
+"""Per-section-kind coverage of the action-items HTML renderer.
+
+`test_action_items_render.py` covers the happy path over the shared fixture
+plus comment binding. The renderer's other half — one specialized emitter per
+section emoji (`💡` focus, `📅` meetings, `✅` completed, `📋` digest), the
+deep-link scanner, the markdown-aware subject splitter and the inline
+formatter — is only reachable from richer markdown, so this file drives each
+of those from a purpose-built document.
+
+Fixture content is anonymized per CLAUDE.md: `PROJ-`/`OPS-` Linear prefixes,
+`example-org` repos, `acme-co.slack.com` links, Alex/Priya/Sam.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scout.action_items.render import (
+    SECTION_STYLES,
+    _plain_subject,
+    _render_task_links,
+    _section_kind,
+    _split_subject,
+    parse,
+    render,
+)
+
+# One document exercising every section kind and inline construct.
+FULL_DOC = """# Action Items — Wednesday, Apr 15, 2026
+**Morning briefing** — Last updated 08:12 ET
+
+Preamble paragraph one.
+Preamble paragraph two.
+
+---
+
+## 💡 Today's Focus
+
+- Ship the parser fix
+- Reply to Priya about the rollout
+
+## 🔴 Urgent / Time-sensitive
+
+- [ ] [#A3F7] **Land PROJ-1234** — blocked on review, see PROJ-1234 again
+  - Source: standup
+  > Alex (2026-04-15 09:00 ET): taking a look
+- [ ] Review https://github.com/example-org/widgets/pull/42 — and the same PR https://github.com/example-org/widgets/pull/42
+- [ ] Follow the thread https://acme-co.slack.com/archives/C0123456789/p1700000000000000
+- [x] [#B5K2] Already handled — nothing to do
+
+## 🟡 To Do
+
+- [ ] Draft the `scoutctl` migration note — uses ~~old~~ new flags and *emphasis*
+- [ ] Read [[knowledge-base/rollout-plan|the rollout plan]] and [[bare-wikilink]]
+- [ ] Check [the changelog](https://example.com/changelog)
+
+## 🟢 Watching
+
+- [ ] Watch for the vendor reply
+
+## 🏡 Personal errands
+
+- [ ] Book the dentist
+
+## 📅 Today's Meetings
+
+| Time | Meeting | Attendees |
+| :--- | :------ | --------: |
+| 09:00 | Standup | Alex, Priya |
+| 14:00 | Review | Sam |
+
+### Tentative
+
+| Time | Meeting |
+| --- | --- |
+| 16:00 | Coffee |
+
+## ✅ Completed Today
+
+- [x] **Sent the weekly status** — to the whole team
+- [x] Filed OPS-77
+- [ ] Not actually done
+
+## 📋 Scout Digest
+
+**Rollout**
+
+The rollout is on track.
+Second paragraph of the same block.
+
+**Risks**
+
+One risk remains.
+
+## Uncategorized bucket
+
+- [ ] A task in a section with no emoji
+"""
+
+
+@pytest.fixture
+def doc(tmp_path: Path) -> Path:
+    p = tmp_path / "action-items-2026-04-15.md"
+    p.write_text(FULL_DOC, encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def out(doc: Path) -> str:
+    return render(doc)
+
+
+# ---------------------------------------------------------------------------
+# parse()
+# ---------------------------------------------------------------------------
+
+
+def test_parse_captures_title_preamble_and_every_section(doc: Path) -> None:
+    title, preamble, sections = parse(doc)
+    assert title == "Action Items — Wednesday, Apr 15, 2026"
+    # The bold "**Morning briefing** …" line and both paragraphs precede the
+    # first `##`, so all three are preamble.
+    assert "Preamble paragraph one." in preamble
+    assert "Preamble paragraph two." in preamble
+    assert [s.title for s in sections] == [
+        "Today's Focus",
+        "Urgent / Time-sensitive",
+        "To Do",
+        "Watching",
+        "Personal errands",
+        "Today's Meetings",
+        "Completed Today",
+        "Scout Digest",
+        "Uncategorized bucket",
+    ]
+
+
+def test_parse_collects_focus_bullets_not_tasks(doc: Path) -> None:
+    _, _, sections = parse(doc)
+    focus = next(s for s in sections if s.title == "Today's Focus")
+    assert focus.tasks == []
+    assert [b.text for b in focus.bullets] == [
+        "Ship the parser fix",
+        "Reply to Priya about the rollout",
+    ]
+
+
+def test_parse_reads_tables_and_subheads(doc: Path) -> None:
+    _, _, sections = parse(doc)
+    meetings = next(s for s in sections if s.title == "Today's Meetings")
+    assert len(meetings.tables) == 2
+    assert meetings.tables[0].headers == ["Time", "Meeting", "Attendees"]
+    # The `| :--- | :---: |` alignment row is dropped, not read as data.
+    assert meetings.tables[0].rows == [["09:00", "Standup", "Alex, Priya"], ["14:00", "Review", "Sam"]]
+    assert meetings.subheads == ["Tentative"]
+    assert meetings.tables[1].rows == [["16:00", "Coffee"]]
+
+
+def test_parse_treats_bare_paragraphs_inside_a_section_as_bullets(doc: Path) -> None:
+    """The digest's prose lines aren't bullets in the markdown; the parser
+    still collects them so `_render_digest` can wrap them in <p>."""
+    _, _, sections = parse(doc)
+    digest = next(s for s in sections if s.title == "Scout Digest")
+    texts = [b.text for b in digest.bullets]
+    assert "The rollout is on track." in texts
+    assert "**Rollout**" in texts
+
+
+def test_parse_of_a_file_with_no_h1_starts_at_line_zero(tmp_path: Path) -> None:
+    p = tmp_path / "no-title.md"
+    p.write_text("## 🔴 Urgent\n\n- [ ] a task\n", encoding="utf-8")
+    title, preamble, sections = parse(p)
+    assert title == ""
+    assert preamble == []
+    assert [s.title for s in sections] == ["Urgent"]
+
+
+def test_parse_section_whose_first_token_is_not_an_emoji_keeps_the_full_title(tmp_path: Path) -> None:
+    p = tmp_path / "d.md"
+    p.write_text("# T\n\n## Q2 budget review\n\n- [ ] a task\n", encoding="utf-8")
+    _, _, sections = parse(p)
+    assert sections[0].emoji == ""
+    assert sections[0].title == "Q2 budget review"
+
+
+def test_parse_ignores_subheads_and_hrules_before_the_first_section(tmp_path: Path) -> None:
+    p = tmp_path / "d.md"
+    p.write_text("# T\n\n***\n\n### orphan subhead\n\n## 🔴 Urgent\n\n- [ ] a task\n", encoding="utf-8")
+    _, preamble, sections = parse(p)
+    assert len(sections) == 1
+    assert sections[0].subheads == []
+    # "### orphan subhead" arrives with current=None, so it lands in preamble.
+    assert any("orphan subhead" in p_ for p_ in preamble)
+
+
+# ---------------------------------------------------------------------------
+# _section_kind
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("emoji", "expected"), [(e, v[0]) for e, v in SECTION_STYLES.items()])
+def test_section_kind_maps_every_known_emoji(emoji: str, expected: str) -> None:
+    from scout.action_items.render import Section
+
+    assert _section_kind(Section(emoji=emoji, title="whatever")) == expected
+
+
+def test_section_kind_falls_back_to_personal_by_title() -> None:
+    from scout.action_items.render import Section
+
+    assert _section_kind(Section(emoji="🏡", title="Personal errands")) == "personal"
+    assert _section_kind(Section(emoji="", title="PERSONAL stuff")) == "personal"
+
+
+def test_section_kind_defaults_to_neutral() -> None:
+    from scout.action_items.render import Section
+
+    assert _section_kind(Section(emoji="", title="Uncategorized bucket")) == "neutral"
+
+
+# ---------------------------------------------------------------------------
+# _split_subject — the separator must not land inside a markdown token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("line", "subject", "body"),
+    [
+        ("**Land it** — blocked on review", "**Land it**", "blocked on review"),
+        ("Plain subject – en dash body", "Plain subject", "en dash body"),
+        ("Plain subject - hyphen body", "Plain subject", "hyphen body"),
+        # A dash inside each token type must be skipped over.
+        ("`a - b` — real body", "`a - b`", "real body"),
+        ("~~a - b~~ — real body", "~~a - b~~", "real body"),
+        ("**a - b** — real body", "**a - b**", "real body"),
+        ("[[note - draft]] — real body", "[[note - draft]]", "real body"),
+        ("[label - x](https://example.com/a-b) — real body", "[label - x](https://example.com/a-b)", "real body"),
+        # No separator at all: the whole line is the subject.
+        ("No separator here", "No separator here", ""),
+    ],
+)
+def test_split_subject_respects_markdown_tokens(line: str, subject: str, body: str) -> None:
+    assert _split_subject(line) == (subject, body)
+
+
+def test_split_subject_uses_the_first_separator_outside_tokens() -> None:
+    assert _split_subject("subject — body — trailing") == ("subject", "body — trailing")
+
+
+@pytest.mark.parametrize(
+    ("line", "subject", "body"),
+    [
+        # With no dash separator, a ": " outside tokens splits instead.
+        ("Budget review: reply to Priya", "Budget review", "reply to Priya"),
+        # ...and the same token-awareness applies to that fallback.
+        ("`ratio: 3` is fine", "`ratio: 3` is fine", ""),
+        ("**stage: two** shipped", "**stage: two** shipped", ""),
+        ("~~stage: two~~ dropped", "~~stage: two~~ dropped", ""),
+        ("**Bold head**: the body", "**Bold head**", "the body"),
+        # A colon with no following space is not a separator.
+        ("ratio:3 unchanged", "ratio:3 unchanged", ""),
+    ],
+)
+def test_split_subject_colon_fallback(line: str, subject: str, body: str) -> None:
+    assert _split_subject(line) == (subject, body)
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        # A bare `[` ... `]` with no `(` after it: bracket_depth must reset so a
+        # later dash is still found.
+        "[tag] — real body",
+        # Unbalanced parens must not swallow the rest of the line.
+        "[label](https://example.com/x) — real body",
+    ],
+)
+def test_split_subject_handles_bracket_forms_without_swallowing_the_body(line: str) -> None:
+    subject, body = _split_subject(line)
+    assert body == "real body"
+    assert subject == line.split(" — ")[0]
+
+
+def test_plain_subject_strips_markdown_for_the_cli_needle() -> None:
+    """The rendered mark-done command must carry the same stripped needle the
+    CLI compares against."""
+    assert _plain_subject("**Land** `PROJ-1234` ~~old~~ [[note]] [text](https://example.com)") == (
+        "Land PROJ-1234 old note text"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Deep links
+# ---------------------------------------------------------------------------
+
+
+def _task(subject: str, body: str = ""):
+    from scout.action_items.render import Task
+
+    return Task(done=False, subject=subject, body=body, raw=subject)
+
+
+def test_task_links_deduplicate_repeated_linear_ids() -> None:
+    html_out = _render_task_links(_task("Land PROJ-1234", "still PROJ-1234 and PROJ-1234"))
+    assert html_out.count("Linear PROJ-1234") == 1
+    assert "linear.app/" in html_out
+
+
+def test_task_links_uses_the_configured_linear_workspace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The workspace slug is env-driven so no real workspace is baked in."""
+    import importlib
+
+    monkeypatch.setenv("SCOUT_LINEAR_WORKSPACE", "acme-co")
+    mod = importlib.reload(importlib.import_module("scout.action_items.render"))
+    try:
+        assert "linear.app/acme-co/issue/PROJ-1234" in mod._render_task_links(_task("Land PROJ-1234"))
+    finally:
+        monkeypatch.delenv("SCOUT_LINEAR_WORKSPACE", raising=False)
+        importlib.reload(mod)
+
+
+def test_task_links_deduplicate_github_prs_and_slack_threads() -> None:
+    pr = "https://github.com/example-org/widgets/pull/42"
+    slack = "https://acme-co.slack.com/archives/C0123456789/p1700000000000000"
+    html_out = _render_task_links(_task(f"Review {pr}", f"{pr} and {slack} and {slack}"))
+    assert html_out.count("PR example-org/widgets#42") == 1
+    assert html_out.count("Slack thread") == 1
+
+
+def test_task_links_are_empty_when_nothing_matches() -> None:
+    assert _render_task_links(_task("Book the dentist")) == ""
+
+
+def test_task_links_open_safely_in_a_new_tab() -> None:
+    html_out = _render_task_links(_task("Land PROJ-1234"))
+    assert 'target="_blank"' in html_out
+    assert 'rel="noopener noreferrer"' in html_out
+
+
+# ---------------------------------------------------------------------------
+# render() — the per-kind emitters
+# ---------------------------------------------------------------------------
+
+
+def test_render_emits_a_focus_box(out: str) -> None:
+    assert 'class="focus-box"' in out
+    assert "<li>Ship the parser fix</li>" in out
+
+
+def test_render_emits_the_meetings_table_with_its_subhead(out: str) -> None:
+    assert 'class="section section-meetings"' in out
+    assert '<table class="mtg">' in out
+    assert "<th>Time</th>" in out
+    assert "<td>Standup</td>" in out
+    assert "<h3>Tentative</h3>" in out
+    assert "<td>Coffee</td>" in out
+
+
+def test_render_completed_section_counts_only_done_tasks(out: str) -> None:
+    assert 'class="completed"' in out
+    assert "Sent the weekly status" in out
+    assert "Filed OPS-77" in out
+    # The open task inside ✅ is excluded, so the count is 2, not 3.
+    assert '<span class="count">(2)</span>' in out
+    assert "Not actually done" not in out
+
+
+def test_render_digest_splits_blocks_on_bold_subheads(out: str) -> None:
+    assert 'class="digest"' in out
+    assert "<h3><strong>Rollout</strong></h3>" in out
+    assert "<h3><strong>Risks</strong></h3>" in out
+    assert out.count('class="digest-block"') == 2
+    assert "<p>The rollout is on track.</p>" in out
+
+
+def test_render_emoji_less_section_falls_back_to_cards(out: str) -> None:
+    assert "A task in a section with no emoji" in out
+
+
+def test_render_summary_counts_open_tasks_per_kind(out: str) -> None:
+    """The stat row is the first thing a reader looks at; a mis-bucketed count
+    is worse than no count. Urgent has 3 open + 1 done."""
+    summary = out.split('<section class="summary">', 1)[1].split("</section>", 1)[0]
+    assert '<div class="stat urgent"><div class="num">3</div>' in summary
+    assert '<div class="stat warn"><div class="num">3</div>' in summary
+    assert '<div class="stat info"><div class="num">1</div>' in summary
+    assert '<div class="stat muted"><div class="num">1</div>' in summary
+    assert '<div class="stat ok"><div class="num">2</div>' in summary
+
+
+def test_render_names_the_source_file_in_the_footer(out: str) -> None:
+    assert "<code>action-items-2026-04-15.md</code>" in out
+
+
+def test_render_carries_preamble_paragraphs_into_the_header(out: str) -> None:
+    assert "<p>Preamble paragraph one.</p>" in out
+
+
+# ---------------------------------------------------------------------------
+# _inline
+# ---------------------------------------------------------------------------
+
+
+def test_inline_renders_every_markdown_token(out: str) -> None:
+    assert "<code>scoutctl</code>" in out
+    assert "<s>old</s>" in out
+    assert "<em>emphasis</em>" in out
+    assert "<strong>Land PROJ-1234</strong>" in out
+
+
+def test_inline_renders_wikilinks_as_pills_using_the_label(out: str) -> None:
+    assert '<span class="wiki">the rollout plan</span>' in out
+    # A bare wikilink falls back to the last path segment.
+    assert '<span class="wiki">bare-wikilink</span>' in out
+
+
+def test_inline_renders_markdown_links_as_anchors(out: str) -> None:
+    assert '<a href="https://example.com/changelog" target="_blank" rel="noopener">the changelog</a>' in out
+
+
+def test_render_escapes_html_in_task_text(tmp_path: Path) -> None:
+    p = tmp_path / "action-items-2026-04-15.md"
+    p.write_text(
+        '# T\n\n## 🔴 Urgent\n\n- [ ] Fix <script>alert("x")</script> in the parser\n',
+        encoding="utf-8",
+    )
+    out = render(p)
+    assert "<script>alert" not in out
+    assert "&lt;script&gt;" in out
+
+
+def test_render_escapes_html_in_the_title(tmp_path: Path) -> None:
+    p = tmp_path / "action-items-2026-04-15.md"
+    p.write_text("# Action <b>Items</b>\n\n## 🔴 Urgent\n\n- [ ] a task\n", encoding="utf-8")
+    out = render(p)
+    assert "<title>Action &lt;b&gt;Items&lt;/b&gt;</title>" in out
+
+
+def test_render_task_actions_truncate_a_long_needle(tmp_path: Path) -> None:
+    """The copy-to-clipboard command embeds a subject substring; over ~40 chars
+    it is trimmed so the command stays readable."""
+    long_subject = "A very long action item subject that keeps going well past forty characters"
+    p = tmp_path / "action-items-2026-04-15.md"
+    p.write_text(f"# T\n\n## 🔴 Urgent\n\n- [ ] {long_subject}\n", encoding="utf-8")
+    out = render(p)
+    # 40 chars then rstrip: "…that kee" (the 41st char is the 'p' of "keeps").
+    assert "--subject &quot;A very long action item subject that kee&quot;" in out
+    # The date is threaded in from the filename stem.
+    assert "mark_done.py 2026-04-15 --subject" in out
+    # ...and the untruncated subject appears only in the card body, never in a
+    # copy-command payload.
+    for chunk in out.split('data-cmd="')[1:]:
+        assert long_subject not in chunk.split('"', 1)[0]
+
+
+def test_render_offers_no_actions_for_completed_tasks(tmp_path: Path) -> None:
+    p = tmp_path / "action-items-2026-04-15.md"
+    p.write_text("# T\n\n## 🔴 Urgent\n\n- [x] done already\n", encoding="utf-8")
+    out = render(p)
+    assert 'class="task-actions"' not in out
+
+
+def test_render_escapes_quotes_in_the_copy_command(tmp_path: Path) -> None:
+    p = tmp_path / "action-items-2026-04-15.md"
+    p.write_text('# T\n\n## 🔴 Urgent\n\n- [ ] Reply to the "budget" thread\n', encoding="utf-8")
+    out = render(p)
+    # The needle is embedded inside a double-quoted shell argument, so an inner
+    # quote must be backslash-escaped before HTML escaping.
+    assert "&quot;budget&quot;" in out or "\\&quot;budget\\&quot;" in out

--- a/engine/tests/unit/test_action_items_watch_loop.py
+++ b/engine/tests/unit/test_action_items_watch_loop.py
@@ -1,0 +1,248 @@
+"""Coverage of `run_watch_loop` — the watchdog wiring behind
+`scoutctl action-items watch`.
+
+`test_action_items_watch.py` covers `process_change`, the pure text→text→lines
+core. The loop around it is untested and holds all the fiddly bits: the
+bytes-vs-str `src_path` from watchdog, the "some other file in the directory
+changed" filter, the mid-rename `FileNotFoundError` (atomic writes replace the
+daily file, so the watcher *will* see a vanished path), the no-op guard when
+content is unchanged, and the state advance that keeps the next diff correct.
+
+The loop blocks on `observer.join()` forever, so these tests substitute a fake
+Observer and invoke the captured handler directly.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("watchdog")
+
+from scout.action_items.watch import run_watch_loop  # noqa: E402
+
+
+class _FakeObserver:
+    """Records what the loop schedules, and returns from join() immediately."""
+
+    instances: list[_FakeObserver] = []
+
+    def __init__(self) -> None:
+        self.handler = None
+        self.watched_path: str | None = None
+        self.recursive: bool | None = None
+        self.started = False
+        self.stopped = False
+        self.joined = 0
+        _FakeObserver.instances.append(self)
+
+    def schedule(self, handler, path: str, recursive: bool = False) -> None:
+        self.handler = handler
+        self.watched_path = path
+        self.recursive = recursive
+
+    def start(self) -> None:
+        self.started = True
+
+    def join(self) -> None:
+        self.joined += 1
+
+    def stop(self) -> None:
+        self.stopped = True
+
+
+class _Event:
+    def __init__(self, src_path: str | bytes) -> None:
+        self.src_path = src_path
+
+
+@pytest.fixture
+def observed(monkeypatch: pytest.MonkeyPatch) -> type[_FakeObserver]:
+    _FakeObserver.instances = []
+    monkeypatch.setattr("watchdog.observers.Observer", _FakeObserver)
+    return _FakeObserver
+
+
+@pytest.fixture
+def daily(tmp_path: Path) -> Path:
+    p = tmp_path / "action-items-2026-04-15.md"
+    p.write_text("## To Do\n\n- [ ] first task\n", encoding="utf-8")
+    return p
+
+
+def _handler(observed: type[_FakeObserver]):
+    obs = observed.instances[-1]
+    assert obs.handler is not None
+    return obs.handler
+
+
+def test_missing_target_raises_before_any_watcher_is_started(tmp_path: Path, observed: type[_FakeObserver]) -> None:
+    with pytest.raises(FileNotFoundError):
+        run_watch_loop(tmp_path / "nope.md", color=False)
+    assert observed.instances == []
+
+
+def test_loop_watches_the_parent_directory_non_recursively(
+    daily: Path, observed: type[_FakeObserver], capsys: pytest.CaptureFixture[str]
+) -> None:
+    """watchdog watches directories, not files — atomic renames would break a
+    file-level watch. Recursion is off so a big vault stays cheap."""
+    run_watch_loop(daily, color=False)
+    obs = observed.instances[-1]
+    assert obs.watched_path == str(daily.parent)
+    assert obs.recursive is False
+    assert obs.started is True
+    assert obs.joined == 1
+    # The "how to stop" hint goes to stderr so stdout stays a pure change stream.
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert f"Watching {daily.name} for changes" in captured.err
+
+
+def test_a_change_prints_one_line_per_detected_event(
+    daily: Path, observed: type[_FakeObserver], capsys: pytest.CaptureFixture[str]
+) -> None:
+    run_watch_loop(daily, color=False)
+    capsys.readouterr()  # drop the startup banner
+
+    daily.write_text("## To Do\n\n- [x] first task\n", encoding="utf-8")
+    _handler(observed).on_modified(_Event(str(daily)))
+
+    out = capsys.readouterr().out
+    assert out.strip(), "a completed task should emit a change line"
+    assert "first task" in out
+
+
+def test_a_bytes_src_path_is_decoded(
+    daily: Path, observed: type[_FakeObserver], capsys: pytest.CaptureFixture[str]
+) -> None:
+    """watchdog's inotify backend hands back bytes paths; comparing those to a
+    str Path silently matches nothing and the watcher goes deaf."""
+    run_watch_loop(daily, color=False)
+    capsys.readouterr()
+
+    daily.write_text("## To Do\n\n- [x] first task\n", encoding="utf-8")
+    _handler(observed).on_modified(_Event(str(daily).encode()))
+
+    assert capsys.readouterr().out.strip()
+
+
+def test_a_change_to_a_different_file_is_ignored(
+    daily: Path, observed: type[_FakeObserver], capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The watch is directory-wide, so every sibling file's events arrive here
+    too — including the `.tmp` files the writers create."""
+    sibling = daily.parent / "action-items-2026-04-14.md"
+    sibling.write_text("## To Do\n\n- [ ] yesterday\n", encoding="utf-8")
+
+    run_watch_loop(daily, color=False)
+    capsys.readouterr()
+
+    daily.write_text("## To Do\n\n- [x] first task\n", encoding="utf-8")
+    _handler(observed).on_modified(_Event(str(sibling)))
+
+    assert capsys.readouterr().out == ""
+
+
+def test_an_unchanged_file_emits_nothing(
+    daily: Path, observed: type[_FakeObserver], capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A touch or a rewrite with identical bytes must not print an empty diff."""
+    run_watch_loop(daily, color=False)
+    capsys.readouterr()
+
+    daily.write_text(daily.read_text(), encoding="utf-8")
+    _handler(observed).on_modified(_Event(str(daily)))
+
+    assert capsys.readouterr().out == ""
+
+
+def test_a_vanished_file_mid_rename_is_skipped(
+    daily: Path, observed: type[_FakeObserver], capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The writers use write-tmp-then-replace, so the watcher can observe the
+    path between unlink and rename. That must be a no-op, not a crash — the
+    next event delivers the new contents."""
+    run_watch_loop(daily, color=False)
+    capsys.readouterr()
+
+    handler = _handler(observed)
+    daily.unlink()
+    handler.on_modified(_Event(str(daily)))  # must not raise
+    assert capsys.readouterr().out == ""
+
+    daily.write_text("## To Do\n\n- [x] first task\n", encoding="utf-8")
+    handler.on_modified(_Event(str(daily)))
+    assert capsys.readouterr().out.strip()
+
+
+def test_state_advances_so_each_change_diffs_against_the_previous_one(
+    daily: Path, observed: type[_FakeObserver], capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Without the state advance, every event re-reports the whole history."""
+    run_watch_loop(daily, color=False)
+    capsys.readouterr()
+    handler = _handler(observed)
+
+    daily.write_text("## To Do\n\n- [ ] first task\n- [ ] second task\n", encoding="utf-8")
+    handler.on_modified(_Event(str(daily)))
+    first_out = capsys.readouterr().out
+    assert "second task" in first_out
+
+    daily.write_text("## To Do\n\n- [ ] first task\n- [ ] second task\n- [ ] third task\n", encoding="utf-8")
+    handler.on_modified(_Event(str(daily)))
+    second_out = capsys.readouterr().out
+    assert "third task" in second_out
+    # "second task" was already reported; it must not repeat.
+    assert "second task" not in second_out
+
+
+def test_color_flag_reaches_the_renderer(
+    daily: Path, observed: type[_FakeObserver], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen: list[bool] = []
+    monkeypatch.setattr(
+        "scout.action_items.watch.process_change",
+        lambda *, prev_text, curr_text, now, color: seen.append(color) or [],
+    )
+    run_watch_loop(daily, color=True)
+    daily.write_text("## To Do\n\n- [x] first task\n", encoding="utf-8")
+    _handler(observed).on_modified(_Event(str(daily)))
+    assert seen == [True]
+
+
+def test_keyboard_interrupt_stops_and_drains_the_observer(
+    daily: Path, observed: type[_FakeObserver], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ctrl-C is the documented way to stop this command, so it must shut the
+    observer thread down rather than leaving it running."""
+    calls: list[str] = []
+
+    class InterruptingObserver(_FakeObserver):
+        def join(self) -> None:
+            calls.append("join")
+            if len(calls) == 1:
+                raise KeyboardInterrupt
+
+        def stop(self) -> None:
+            calls.append("stop")
+
+    monkeypatch.setattr("watchdog.observers.Observer", InterruptingObserver)
+    run_watch_loop(daily, color=False)
+    assert calls == ["join", "stop", "join"]
+
+
+def test_process_change_uses_a_real_timestamp(
+    daily: Path, observed: type[_FakeObserver], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen: list[dt.datetime] = []
+    monkeypatch.setattr(
+        "scout.action_items.watch.process_change",
+        lambda *, prev_text, curr_text, now, color: seen.append(now) or [],
+    )
+    run_watch_loop(daily, color=False)
+    daily.write_text("## To Do\n\n- [x] first task\n", encoding="utf-8")
+    _handler(observed).on_modified(_Event(str(daily)))
+    assert len(seen) == 1 and isinstance(seen[0], dt.datetime)

--- a/engine/tests/unit/test_bootstrap_degraded.py
+++ b/engine/tests/unit/test_bootstrap_degraded.py
@@ -1,0 +1,321 @@
+"""Bootstrap's degraded-input and job-installation branches.
+
+`test_bootstrap_install.py` / `_upgrade.py` / `_migrate_legacy.py` drive the
+pipeline against the real plugin checkout, where every template and phase file
+is present. This file drives it against a *pruned* plugin root — the shape a
+partial checkout, a failed plugin update, or a future template rename produces
+— plus the two stages the other files necessarily skip (`skip_jobs=True`
+everywhere, so launchd/cron/shim installation is never exercised).
+
+The pipeline is what renders a user's vault. Silently writing a placeholder
+where a runner should be, or dropping a whole phase from the assembled
+SKILL.md, produces a vault that looks installed and doesn't work.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from scout.scripts import bootstrap
+from scout.scripts.bootstrap import BootstrapConfig, install, upgrade
+
+PLUGIN_ROOT = Path(bootstrap.__file__).parent.parent.parent.parent
+
+
+def _config(vault: Path, plugin_root: Path, **overrides) -> BootstrapConfig:
+    base = {
+        "vault": vault,
+        "plugin_root": plugin_root,
+        "instance_name": "TestScout",
+        "instance_name_lower": "testscout",
+        "user_name": "Alex",
+        "user_email": "alex@example.com",
+        "timezone": "America/New_York",
+        "platform": "macos",
+        "plugin_version": "0.8.0",
+        "enabled_connectors": set(),
+        "connector_inputs": {},
+        "skip_jobs": True,
+        "skip_claude": True,
+    }
+    base.update(overrides)
+    return BootstrapConfig(**base)  # type: ignore[arg-type]
+
+
+@pytest.fixture
+def bare_plugin(tmp_path: Path) -> Path:
+    """A plugin root with none of the cat-1 sources or templates present."""
+    root = tmp_path / "bare-plugin"
+    root.mkdir()
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Missing cat-1 sources / templates
+# ---------------------------------------------------------------------------
+
+
+def test_a_missing_cat1_source_writes_a_named_placeholder(tmp_path: Path, bare_plugin: Path) -> None:
+    """A placeholder is a deliberate, visible failure marker: the vault renders,
+    the doctor's non-empty-content check still passes, and the file says which
+    plugin path was missing."""
+    vault = tmp_path / "Scout"
+    install(_config(vault, bare_plugin))
+
+    for vault_rel, plugin_rel in bootstrap._CAT1_FILES_FROM_PLUGIN.items():
+        body = (vault / vault_rel).read_text()
+        assert body == f"# placeholder: {plugin_rel}\n"
+
+
+def test_a_missing_cat1_template_writes_a_named_placeholder(tmp_path: Path, bare_plugin: Path) -> None:
+    vault = tmp_path / "Scout"
+    install(_config(vault, bare_plugin))
+
+    for vault_rel, tmpl_rel in bootstrap._CAT1_TEMPLATES:
+        body = (vault / vault_rel).read_text()
+        assert body == f"# placeholder: {tmpl_rel}\n"
+
+
+def test_a_missing_install_only_template_is_skipped_silently(tmp_path: Path, bare_plugin: Path) -> None:
+    """Install-only templates are seeds, not required files — absence leaves no
+    file rather than a placeholder."""
+    vault = tmp_path / "Scout"
+    install(_config(vault, bare_plugin))
+    for vault_rel, _tmpl_rel in bootstrap._INSTALL_ONLY_TEMPLATES:
+        assert not (vault / vault_rel).exists()
+
+
+def test_an_existing_install_only_file_is_never_overwritten(tmp_path: Path) -> None:
+    """These hold the user's own content (mistake audit, review queue, inbox);
+    re-seeding over them would destroy real work."""
+    vault = tmp_path / "Scout"
+    cfg = _config(vault, PLUGIN_ROOT)
+    install(cfg)
+
+    vault_rel = next(rel for rel, _tmpl in bootstrap._INSTALL_ONLY_TEMPLATES if (vault / rel).exists())
+    target = vault / vault_rel
+    target.write_text("MY OWN CONTENT\n", encoding="utf-8")
+
+    # Re-run the seed stage directly: `install` refuses an existing vault, and
+    # `upgrade` doesn't re-seed, so this is the only way to reach the guard.
+    bootstrap._stage_install_only_seeds(cfg)
+    assert target.read_text() == "MY OWN CONTENT\n"
+
+
+def test_a_missing_schedule_default_falls_back_to_an_empty_schedule(tmp_path: Path, bare_plugin: Path) -> None:
+    """A vault with no schedule.yaml fails the doctor outright; an empty but
+    valid one at least loads."""
+    vault = tmp_path / "Scout"
+    install(_config(vault, bare_plugin))
+    body = (vault / ".scout-state" / "schedule.yaml").read_text()
+    assert body == "schema_version: 1\nslots: {}\n"
+
+
+def test_a_missing_cat_merge_source_is_skipped_on_install_and_upgrade(tmp_path: Path, bare_plugin: Path) -> None:
+    vault = tmp_path / "Scout"
+    install(_config(vault, bare_plugin))
+    for vault_rel in bootstrap._CAT_MERGE_FILES:
+        assert not (vault / vault_rel).exists()
+
+    (vault / "scout-config.yaml").write_text("instance:\n  name: TestScout\n", encoding="utf-8")
+    upgrade(_config(vault, bare_plugin))  # must not raise
+    for vault_rel in bootstrap._CAT_MERGE_FILES:
+        assert not (vault / vault_rel).exists()
+
+
+# ---------------------------------------------------------------------------
+# Phase assembly degradation
+# ---------------------------------------------------------------------------
+
+
+def test_a_missing_phase_dir_yields_an_assembled_file_anyway(tmp_path: Path, bare_plugin: Path) -> None:
+    vault = tmp_path / "Scout"
+    install(_config(vault, bare_plugin))
+    for kind in ("SKILL", "DREAMING", "RESEARCH"):
+        assert (vault / f"{kind}.md").exists()
+
+
+def test_an_unparseable_phase_file_is_skipped_with_a_loud_warning(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The bundled phase files all parse today; this guard exists so a future
+    regression surfaces on stderr instead of silently dropping a whole phase
+    from the assembled brain file."""
+    plugin = tmp_path / "plugin"
+    shutil.copytree(PLUGIN_ROOT / "phases", plugin / "phases")
+    broken = next(iter(sorted((plugin / "phases").rglob("*.md"))))
+    broken.write_text("no frontmatter fence at all\n", encoding="utf-8")
+
+    vault = tmp_path / "Scout"
+    install(_config(vault, plugin))
+
+    err = capsys.readouterr().err
+    assert "warning: skipping unparseable phase file" in err
+    assert broken.name in err
+    # The rest of the assembly still happened.
+    assert (vault / "SKILL.md").read_text().strip()
+
+
+# ---------------------------------------------------------------------------
+# Backup-name collision
+# ---------------------------------------------------------------------------
+
+
+def test_backup_names_disambiguate_within_a_day(tmp_path: Path) -> None:
+    """Two upgrades on the same date must not have the second's backup
+    overwrite the first's — that would lose the older hand-edits."""
+    target = tmp_path / "run-scout.sh"
+    target.write_text("v1\n", encoding="utf-8")
+
+    import datetime as dt
+
+    today = dt.date.today().isoformat()
+
+    first = bootstrap._unique_backup_path(target)
+    assert first.name == f"run-scout.sh.bak.{today}"
+    first.write_text("v1\n", encoding="utf-8")
+
+    second = bootstrap._unique_backup_path(target)
+    assert second.name == f"run-scout.sh.bak.{today}-1"
+    second.write_text("v2\n", encoding="utf-8")
+
+    third = bootstrap._unique_backup_path(target)
+    assert third.name == f"run-scout.sh.bak.{today}-2"
+
+
+# ---------------------------------------------------------------------------
+# Job / shim installation stages
+# ---------------------------------------------------------------------------
+
+
+def test_installing_jobs_on_macos_writes_both_launchd_plists(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "scout.scripts.install_schedule_plist.install_plist",
+        lambda **_k: calls.append("tick") or tmp_path / "t.plist",
+    )
+    monkeypatch.setattr(
+        "scout.scripts.install_heartbeat_plist.install_plist",
+        lambda **_k: calls.append("heartbeat") or tmp_path / "h.plist",
+    )
+    monkeypatch.setattr("scout.scripts.install_scoutctl_shim.install_scoutctl_shim", lambda **_k: None)
+
+    vault = tmp_path / "Scout"
+    install(_config(vault, PLUGIN_ROOT, platform="macos", skip_jobs=False))
+    assert calls == ["tick", "heartbeat"]
+
+
+def test_installing_jobs_on_linux_writes_the_cron_block(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr("scout.scripts.install_cron.install_cron", lambda **_k: calls.append("cron"))
+    monkeypatch.setattr("scout.scripts.install_scoutctl_shim.install_scoutctl_shim", lambda **_k: None)
+
+    vault = tmp_path / "Scout"
+    install(_config(vault, PLUGIN_ROOT, platform="linux", skip_jobs=False))
+    assert calls == ["cron"]
+
+
+def test_an_unknown_platform_installs_no_jobs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail(**_k: object):
+        raise AssertionError("no scheduler should be installed for an unknown platform")
+
+    monkeypatch.setattr("scout.scripts.install_schedule_plist.install_plist", fail)
+    monkeypatch.setattr("scout.scripts.install_cron.install_cron", fail)
+    monkeypatch.setattr("scout.scripts.install_scoutctl_shim.install_scoutctl_shim", lambda **_k: None)
+
+    vault = tmp_path / "Scout"
+    install(_config(vault, PLUGIN_ROOT, platform="freebsd", skip_jobs=False))
+    assert vault.is_dir()
+
+
+def test_installing_jobs_also_writes_the_scoutctl_shim(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The SKILL-driven session resolves bare `scoutctl` through this shim
+    (#99); without it the session hand-mints action-item prefixes."""
+    calls: list[str] = []
+    monkeypatch.setattr("scout.scripts.install_schedule_plist.install_plist", lambda **_k: tmp_path / "t")
+    monkeypatch.setattr("scout.scripts.install_heartbeat_plist.install_plist", lambda **_k: tmp_path / "h")
+    monkeypatch.setattr("scout.scripts.install_scoutctl_shim.install_scoutctl_shim", lambda **_k: calls.append("shim"))
+
+    vault = tmp_path / "Scout"
+    install(_config(vault, PLUGIN_ROOT, skip_jobs=False))
+    assert calls == ["shim"]
+
+
+def test_skip_jobs_installs_neither_a_scheduler_nor_a_shim(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail(**_k: object):
+        raise AssertionError("skip_jobs must touch neither launchd/cron nor the shim")
+
+    monkeypatch.setattr("scout.scripts.install_schedule_plist.install_plist", fail)
+    monkeypatch.setattr("scout.scripts.install_cron.install_cron", fail)
+    monkeypatch.setattr("scout.scripts.install_scoutctl_shim.install_scoutctl_shim", fail)
+
+    vault = tmp_path / "Scout"
+    install(_config(vault, PLUGIN_ROOT, skip_jobs=True))
+    assert vault.is_dir()
+
+
+# ---------------------------------------------------------------------------
+# Three-way merge: clean merge
+# ---------------------------------------------------------------------------
+
+
+def test_a_clean_three_way_merge_of_a_brain_file_keeps_both_sides(tmp_path: Path) -> None:
+    """SKILL.md is assembled from phases/ but users hand-edit it. When the user
+    and the plugin change *different* regions, the upgrade must merge rather
+    than pick a winner — dropping either side loses real content."""
+    plugin = tmp_path / "plugin"
+    shutil.copytree(PLUGIN_ROOT / "phases", plugin / "phases")
+
+    vault = tmp_path / "Scout"
+    install(_config(vault, plugin))
+
+    live = vault / "SKILL.md"
+    snap = vault / ".scout-state" / "last-assembled" / "SKILL.md"
+    assert live.exists() and snap.exists()
+
+    # The user appends their own section at the very end...
+    live.write_text(live.read_text() + "\n## My own section\n\nUSER EDIT\n", encoding="utf-8")
+
+    # ...and the plugin changes a phase fragment that the SKILL assembly
+    # actually includes (the connectors/ fragments are mode-gated out).
+    fragment = plugin / "phases" / "core" / "action-items.md"
+    fragment.write_text(fragment.read_text().rstrip("\n") + "\n\nPLUGIN EDIT\n", encoding="utf-8")
+
+    (vault / "scout-config.yaml").write_text("instance:\n  name: TestScout\n", encoding="utf-8")
+    result = upgrade(_config(vault, plugin))
+
+    merged = live.read_text()
+    assert "USER EDIT" in merged, "the user's hand-edit must survive the upgrade"
+    assert "PLUGIN EDIT" in merged, "the new plugin content must land"
+    assert "SKILL.md.proposed-merge" not in result.conflicts
+    # The snapshot advances to the plugin's assembly so the next upgrade diffs
+    # the user's edits against *this* render, not the original one.
+    assert "PLUGIN EDIT" in snap.read_text()
+
+
+# ---------------------------------------------------------------------------
+# migrate_legacy snapshot establishment
+# ---------------------------------------------------------------------------
+
+
+def test_migrate_legacy_snapshots_only_the_brain_files_that_exist(tmp_path: Path) -> None:
+    from scout.scripts.bootstrap import migrate_legacy
+
+    vault = tmp_path / "Scout"
+    (vault / ".scout-state").mkdir(parents=True)
+    (vault / "SKILL.md").write_text("# SKILL\n\nlive content\n", encoding="utf-8")
+    (vault / "DREAMING.md").write_text("# DREAMING\n\nlive content\n", encoding="utf-8")
+    # RESEARCH.md deliberately absent.
+
+    result = migrate_legacy(_config(vault, PLUGIN_ROOT))
+
+    snap_dir = vault / ".scout-state" / "last-assembled"
+    assert (snap_dir / "SKILL.md").read_text() == "# SKILL\n\nlive content\n"
+    assert (snap_dir / "DREAMING.md").exists()
+    assert not (snap_dir / "RESEARCH.md").exists()
+    recorded = set(result.snapshots_recorded)
+    assert recorded >= {"SKILL.md", "DREAMING.md"}
+    assert "RESEARCH.md" not in recorded

--- a/engine/tests/unit/test_bootstrap_doctor_checks.py
+++ b/engine/tests/unit/test_bootstrap_doctor_checks.py
@@ -1,0 +1,400 @@
+"""The doctor's host-inspection checks and its config/schedule validation.
+
+`test_bootstrap_doctor.py` covers the vault-shape checks. This file covers the
+ones that read the *host*: the auth-failure log scan, the Linux crontab
+scoutctl-path check, the `~/.local/bin` shim check, and the platform dispatch
+between them — plus the two YAML validations.
+
+These matter because the doctor is the post-install and post-upgrade gate. A
+check that silently returns "no findings" on a broken host is worse than no
+check: `/scout-status` reports green while every scheduled run fails.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scout.scripts import bootstrap_doctor as doc
+from scout.scripts.bootstrap_doctor import run_doctor
+from scout.scripts.install_scoutctl_shim import SHIM_MARKER
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    v = tmp_path / "Scout"
+    (v / ".scout-logs").mkdir(parents=True)
+    return v
+
+
+# ---------------------------------------------------------------------------
+# _tail_text
+# ---------------------------------------------------------------------------
+
+
+def test_the_tail_reader_returns_only_the_trailing_bytes(tmp_path: Path) -> None:
+    """Session logs can be huge; the failure marker and the run-finished line
+    both live at the end, so the check stays cheap by reading only the tail."""
+    log = tmp_path / "run.log"
+    log.write_text("A" * 1000 + "TAIL-MARKER", encoding="utf-8")
+    out = doc._tail_text(log, max_bytes=32)
+    assert len(out) == 32
+    assert out.endswith("TAIL-MARKER")
+
+
+def test_the_tail_reader_returns_a_short_file_whole(tmp_path: Path) -> None:
+    log = tmp_path / "run.log"
+    log.write_text("short\n", encoding="utf-8")
+    assert doc._tail_text(log, max_bytes=65536) == "short\n"
+
+
+def test_the_tail_reader_replaces_undecodable_bytes(tmp_path: Path) -> None:
+    log = tmp_path / "run.log"
+    log.write_bytes(b"prefix \xff\xfe suffix")
+    out = doc._tail_text(log)
+    assert "prefix" in out and "suffix" in out
+
+
+def test_the_tail_reader_is_empty_for_an_unreadable_file(tmp_path: Path) -> None:
+    assert doc._tail_text(tmp_path / "nope.log") == ""
+
+
+# ---------------------------------------------------------------------------
+# _check_recent_auth_failure
+# ---------------------------------------------------------------------------
+
+
+def test_no_logs_dir_yields_no_auth_findings(tmp_path: Path) -> None:
+    assert doc._check_recent_auth_failure(vault=tmp_path) == ([], [])
+
+
+def test_no_run_logs_yields_no_auth_findings(vault: Path) -> None:
+    assert doc._check_recent_auth_failure(vault=vault) == ([], [])
+
+
+def test_a_clean_latest_run_log_yields_no_auth_findings(vault: Path) -> None:
+    (vault / ".scout-logs" / "scout-2026-05-28.log").write_text("all good\n", encoding="utf-8")
+    assert doc._check_recent_auth_failure(vault=vault) == ([], [])
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "=== Authentication failure (HTTP 401/403)",
+        "Failed to authenticate. API Error: 401",
+        "Failed to authenticate. API Error: 403",
+        "Invalid authentication credentials",
+    ],
+)
+def test_an_auth_failure_in_the_latest_run_log_is_an_error(vault: Path, marker: str) -> None:
+    """A 401/403 blocks every scheduled run and leaves no on-disk vault state,
+    so this log scan is the only signal the doctor has."""
+    (vault / ".scout-logs" / "scout-2026-05-28.log").write_text(f"...\n{marker}\n", encoding="utf-8")
+    errors, warnings = doc._check_recent_auth_failure(vault=vault)
+    assert warnings == []
+    assert len(errors) == 1
+    assert "failed to authenticate (HTTP 401/403)" in errors[0]
+    assert "claude setup-token" in errors[0]
+
+
+def test_a_bare_401_in_a_run_log_is_not_an_auth_failure(vault: Path) -> None:
+    """The markers are deliberately specific so a session that merely *writes
+    about* HTTP 401 can't trip the detector."""
+    (vault / ".scout-logs" / "scout-2026-05-28.log").write_text(
+        "The vendor API returned 401 for the old token; noted in the KB.\n", encoding="utf-8"
+    )
+    assert doc._check_recent_auth_failure(vault=vault) == ([], [])
+
+
+def test_only_the_newest_run_log_is_inspected(vault: Path) -> None:
+    """The signal must self-clear: a later successful run writes a newer, clean
+    log and the error disappears."""
+    logs = vault / ".scout-logs"
+    old = logs / "scout-2026-05-28.log"
+    old.write_text("Invalid authentication credentials\n", encoding="utf-8")
+    new = logs / "dreaming-2026-05-28.log"
+    new.write_text("all good\n", encoding="utf-8")
+
+    base = new.stat().st_mtime
+    os.utime(old, (base - 3600, base - 3600))
+
+    assert doc._check_recent_auth_failure(vault=vault) == ([], [])
+
+
+def test_an_unstattable_candidate_yields_no_auth_findings(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    log = vault / ".scout-logs" / "scout-2026-05-28.log"
+    log.write_text("Invalid authentication credentials\n", encoding="utf-8")
+
+    real_stat = Path.stat
+
+    def maybe_boom(self: Path, *a: object, **k: object):
+        if self == log:
+            raise OSError("vanished mid-scan")
+        return real_stat(self, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "stat", maybe_boom)
+    assert doc._check_recent_auth_failure(vault=vault) == ([], [])
+
+
+# ---------------------------------------------------------------------------
+# _check_linux_cron_scoutctl_bin
+# ---------------------------------------------------------------------------
+
+
+class _Proc:
+    def __init__(self, returncode: int = 0, stdout: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = ""
+
+
+def _cron_block(command: str) -> str:
+    return "\n".join(
+        [
+            "# unrelated line",
+            "# >>> scout-managed >>>",
+            command,
+            "# <<< scout-managed <<<",
+            "# also unrelated",
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "exc", [subprocess.SubprocessError("boom"), FileNotFoundError("crontab"), subprocess.TimeoutExpired("crontab", 5)]
+)
+def test_no_findings_when_crontab_cannot_be_read(monkeypatch: pytest.MonkeyPatch, exc: Exception) -> None:
+    def boom(*_a: object, **_k: object):
+        raise exc
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    assert doc._check_linux_cron_scoutctl_bin() == ([], [])
+
+
+def test_no_findings_when_the_user_has_no_crontab(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Proc(1, ""))
+    assert doc._check_linux_cron_scoutctl_bin() == ([], [])
+
+
+def test_no_findings_without_a_scout_managed_block(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Proc(0, "* * * * * something-else\n"))
+    assert doc._check_linux_cron_scoutctl_bin() == ([], [])
+
+
+def test_a_crontab_pointing_at_a_missing_scoutctl_is_an_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    missing = tmp_path / "gone" / ".venv" / "bin" / "scoutctl"
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: _Proc(0, _cron_block(f"*/5 * * * * {missing} schedule tick"))
+    )
+    errors, warnings = doc._check_linux_cron_scoutctl_bin()
+    assert warnings == []
+    assert len(errors) == 1
+    assert "non-existent scoutctl" in errors[0]
+    assert "scoutctl schedule install-cron" in errors[0]
+
+
+def test_a_crontab_pointing_at_a_non_executable_scoutctl_is_an_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """After a plugin update the file can survive with its +x bit lost; cron
+    then fails silently every 5 minutes."""
+    binpath = tmp_path / "scoutctl"
+    binpath.write_text("#!/bin/sh\n", encoding="utf-8")
+    binpath.chmod(0o644)
+
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: _Proc(0, _cron_block(f"*/5 * * * * {binpath} schedule tick"))
+    )
+    errors, _warnings = doc._check_linux_cron_scoutctl_bin()
+    assert len(errors) == 1
+    assert "non-executable scoutctl" in errors[0]
+
+
+def test_a_healthy_crontab_yields_no_findings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    binpath = tmp_path / "scoutctl"
+    binpath.write_text("#!/bin/sh\n", encoding="utf-8")
+    binpath.chmod(0o755)
+
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: _Proc(0, _cron_block(f"*/5 * * * * {binpath} schedule tick"))
+    )
+    assert doc._check_linux_cron_scoutctl_bin() == ([], [])
+
+
+def test_a_hand_edited_cron_shorthand_bails_instead_of_accusing_the_wrong_binary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`@daily <path> schedule tick` has one cron token instead of five, so
+    index 5 would name the wrong word. Better to report nothing than to blame
+    a binary the user never configured."""
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Proc(0, _cron_block("@daily /nope/scoutctl schedule tick")))
+    assert doc._check_linux_cron_scoutctl_bin() == ([], [])
+
+
+def test_lines_outside_the_managed_block_are_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    crontab = "\n".join(
+        [
+            "*/5 * * * * /some/other/scoutctl schedule tick",  # before the block
+            "# >>> scout-managed >>>",
+            "# a comment inside the block",
+            "# <<< scout-managed <<<",
+            "*/5 * * * * /yet/another/scoutctl schedule tick",  # after the block
+        ]
+    )
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Proc(0, crontab))
+    assert doc._check_linux_cron_scoutctl_bin() == ([], [])
+
+
+# ---------------------------------------------------------------------------
+# _check_scheduler_bin_path dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_the_scheduler_check_dispatches_to_launchd_on_darwin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    calls: list[str] = []
+    monkeypatch.setattr(doc, "_check_macos_plist_scoutctl_bin", lambda *, home: calls.append("darwin") or ([], []))
+    assert doc._check_scheduler_bin_path(home=tmp_path) == ([], [])
+    assert calls == ["darwin"]
+
+
+def test_the_scheduler_check_dispatches_to_cron_on_linux(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    calls: list[str] = []
+    monkeypatch.setattr(doc, "_check_linux_cron_scoutctl_bin", lambda: calls.append("linux") or ([], []))
+    assert doc._check_scheduler_bin_path(home=tmp_path) == ([], [])
+    assert calls == ["linux"]
+
+
+def test_the_scheduler_check_is_silent_on_an_unsupported_platform(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    assert doc._check_scheduler_bin_path(home=tmp_path) == ([], [])
+
+
+# ---------------------------------------------------------------------------
+# _check_scoutctl_shim
+# ---------------------------------------------------------------------------
+
+
+def _shim(home: Path, body: str) -> Path:
+    d = home / ".local" / "bin"
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / "scoutctl"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def test_a_missing_shim_is_not_flagged(tmp_path: Path) -> None:
+    """Install and upgrade always (re)write the shim, so absence resolves
+    itself on the next run."""
+    assert doc._check_scoutctl_shim(home=tmp_path) == ([], [])
+
+
+def test_a_dangling_shim_is_a_warning(tmp_path: Path) -> None:
+    """The realistic post-update failure: the shim still points at a venv the
+    update removed, so the session silently hand-mints prefixes (#99)."""
+    _shim(tmp_path, f'#!/bin/sh\n{SHIM_MARKER}\nexec "/gone/scoutctl" "$@"\n')
+    errors, warnings = doc._check_scoutctl_shim(home=tmp_path)
+    assert errors == []
+    assert len(warnings) == 1
+    assert "points at a missing target (/gone/scoutctl)" in warnings[0]
+    assert "scoutctl bootstrap upgrade" in warnings[0]
+
+
+def test_a_healthy_shim_is_not_flagged(tmp_path: Path) -> None:
+    real = tmp_path / "real-scoutctl"
+    real.write_text("#!/bin/sh\n", encoding="utf-8")
+    _shim(tmp_path, f'#!/bin/sh\n{SHIM_MARKER}\nexec "{real}" "$@"\n')
+    assert doc._check_scoutctl_shim(home=tmp_path) == ([], [])
+
+
+def test_a_foreign_scoutctl_is_never_flagged(tmp_path: Path) -> None:
+    """A user-managed scoutctl (pipx, a global venv) carries no marker; the
+    doctor must not comment on it."""
+    _shim(tmp_path, '#!/bin/sh\nexec /somewhere/else/scoutctl "$@"\n')
+    assert doc._check_scoutctl_shim(home=tmp_path) == ([], [])
+
+
+def test_a_marked_shim_with_no_exec_line_is_not_flagged(tmp_path: Path) -> None:
+    _shim(tmp_path, f"#!/bin/sh\n{SHIM_MARKER}\n# nothing to exec\n")
+    assert doc._check_scoutctl_shim(home=tmp_path) == ([], [])
+
+
+def test_an_unreadable_shim_is_not_flagged(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    shim = _shim(tmp_path, f'{SHIM_MARKER}\nexec "/gone/scoutctl" "$@"\n')
+
+    real_read_text = Path.read_text
+
+    def maybe_boom(self: Path, *a: object, **k: object):
+        if self == shim:
+            raise OSError("permission denied")
+        return real_read_text(self, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", maybe_boom)
+    assert doc._check_scoutctl_shim(home=tmp_path) == ([], [])
+
+
+# ---------------------------------------------------------------------------
+# run_doctor — the two YAML validations
+# ---------------------------------------------------------------------------
+
+
+def _seed_vault(vault: Path, *, config: str, schedule: str = "schema_version: 1\nslots: {}\n") -> None:
+    (vault / ".scout-state").mkdir(parents=True, exist_ok=True)
+    (vault / ".scout-state" / "schedule.yaml").write_text(schedule, encoding="utf-8")
+    (vault / "scout-config.yaml").write_text(config, encoding="utf-8")
+
+
+def _messages(report) -> str:
+    return "\n".join(report.errors)
+
+
+def test_a_malformed_schedule_yaml_is_reported(vault: Path, tmp_path: Path) -> None:
+    _seed_vault(vault, config="plugin:\n  version_at_last_setup: '0.8.0'\n", schedule="slots: [unclosed\n")
+    report = run_doctor(vault=vault, check_jobs=False, home=tmp_path / "home")
+    assert "schedule.yaml invalid:" in _messages(report)
+
+
+def test_a_missing_scout_config_is_reported(vault: Path, tmp_path: Path) -> None:
+    (vault / ".scout-state").mkdir(parents=True, exist_ok=True)
+    (vault / ".scout-state" / "schedule.yaml").write_text("schema_version: 1\nslots: {}\n", encoding="utf-8")
+    report = run_doctor(vault=vault, check_jobs=False, home=tmp_path / "home")
+    assert "missing scout-config.yaml" in _messages(report)
+
+
+def test_a_malformed_scout_config_is_reported(vault: Path, tmp_path: Path) -> None:
+    _seed_vault(vault, config="plugin: [unclosed\n")
+    report = run_doctor(vault=vault, check_jobs=False, home=tmp_path / "home")
+    assert "scout-config.yaml invalid:" in _messages(report)
+
+
+def test_missing_version_stamps_are_reported(vault: Path, tmp_path: Path) -> None:
+    """The stamps are how `/scout-status` and the update nudge know which
+    plugin version a vault was rendered against."""
+    _seed_vault(vault, config="plugin: {}\n")
+    messages = _messages(run_doctor(vault=vault, check_jobs=False, home=tmp_path / "home"))
+    assert "plugin.version_at_last_setup missing" in messages
+    assert "plugin.version_at_last_update missing" in messages
+
+
+def test_an_empty_scout_config_reports_both_stamps(vault: Path, tmp_path: Path) -> None:
+    _seed_vault(vault, config="")
+    messages = _messages(run_doctor(vault=vault, check_jobs=False, home=tmp_path / "home"))
+    assert "plugin.version_at_last_setup missing" in messages
+    assert "plugin.version_at_last_update missing" in messages
+
+
+def test_present_version_stamps_are_not_reported(vault: Path, tmp_path: Path) -> None:
+    _seed_vault(
+        vault,
+        config="plugin:\n  version_at_last_setup: '0.8.0'\n  version_at_last_update: '0.8.0'\n",
+    )
+    messages = _messages(run_doctor(vault=vault, check_jobs=False, home=tmp_path / "home"))
+    assert "version_at_last_setup missing" not in messages
+    assert "version_at_last_update missing" not in messages

--- a/engine/tests/unit/test_budget_and_triggers_config_edges.py
+++ b/engine/tests/unit/test_budget_and_triggers_config_edges.py
@@ -1,0 +1,457 @@
+"""Tolerance and validation branches in `budget_check` and `triggers.config`.
+
+Two modules, two opposite contracts, both under-covered at the edges:
+
+* `budget_check` is deliberately *tolerant* — it gates whether a scheduled
+  session runs at all, so a hand-edited config or a torn tracker append must
+  fall back to defaults rather than block the run.
+* `triggers.config` is deliberately *strict* — a trigger is a thing that fires
+  automated actions, so every malformed field must raise a named `ConfigError`
+  the operator can act on, never be silently defaulted.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from scout.errors import ConfigError
+from scout.scripts import budget_check as bc
+from scout.scripts.budget_check import (
+    EXIT_BACKOFF,
+    EXIT_PROCEED,
+    EXIT_SKIP_OVER_BUDGET,
+    BudgetConfig,
+    BudgetDecision,
+    decide,
+    load_config,
+)
+from scout.triggers import config as tcfg
+from scout.triggers.config import load_triggers
+
+NOW = datetime(2026, 5, 28, 14, 0, tzinfo=UTC)
+
+
+def _tracker(path: Path, *rows: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    return path
+
+
+def _row(minutes_ago: int, **fields) -> dict:
+    ts = (NOW - timedelta(minutes=minutes_ago)).isoformat().replace("+00:00", "Z")
+    return {"ts": ts, **fields}
+
+
+# ---------------------------------------------------------------------------
+# BudgetDecision / BudgetConfig
+# ---------------------------------------------------------------------------
+
+
+def test_should_proceed_is_true_only_for_the_proceed_code() -> None:
+    assert BudgetDecision(EXIT_PROCEED, "ok").should_proceed is True
+    assert BudgetDecision(EXIT_SKIP_OVER_BUDGET, "over").should_proceed is False
+    assert BudgetDecision(EXIT_BACKOFF, "backoff").should_proceed is False
+
+
+def test_window_and_threshold_are_derived_from_the_daily_budget() -> None:
+    cfg = BudgetConfig(daily_budget_usd=48.0, window_hours=6, skip_threshold_pct=50.0)
+    assert cfg.window_budget_usd == 12.0  # 48 * 6 / 24
+    assert cfg.skip_threshold_usd == 6.0  # 12 * 50%
+
+
+# ---------------------------------------------------------------------------
+# load_config
+# ---------------------------------------------------------------------------
+
+
+def test_config_defaults_when_the_file_is_absent(tmp_path: Path) -> None:
+    assert load_config(tmp_path / "nope.yaml") == BudgetConfig()
+
+
+def test_config_defaults_when_the_file_is_unreadable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = tmp_path / "scout-config.yaml"
+    cfg.write_text("daily_budget_estimate_usd: 10\n", encoding="utf-8")
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "read_text", boom)
+    assert load_config(cfg) == BudgetConfig()
+
+
+def test_config_reads_all_four_keys(tmp_path: Path) -> None:
+    cfg = tmp_path / "scout-config.yaml"
+    cfg.write_text(
+        "daily_budget_estimate_usd: 12.5\n"
+        "rate_limit_window_hours: 3\n"
+        "skip_threshold_pct: 60\n"
+        "failure_backoff_minutes: 15\n",
+        encoding="utf-8",
+    )
+    assert load_config(cfg) == BudgetConfig(
+        daily_budget_usd=12.5, window_hours=3, skip_threshold_pct=60.0, failure_backoff_min=15
+    )
+
+
+def test_config_skips_unparseable_and_irrelevant_lines(tmp_path: Path) -> None:
+    """A `scout-config.yaml` is hand-edited and holds far more than these four
+    keys — every other shape must be ignored, not crash the gate."""
+    cfg = tmp_path / "scout-config.yaml"
+    cfg.write_text(
+        "# a comment\n"
+        "\n"
+        "instance:\n"  # key with no scalar value
+        "  name: Scout\n"  # nested, and not one of our keys
+        "timezone: America/New_York\n"  # unknown key
+        "daily_budget_estimate_usd: not-a-number\n"  # right key, bad cast
+        "rate_limit_window_hours: 3  # trailing comment\n",
+        encoding="utf-8",
+    )
+    cfgv = load_config(cfg)
+    assert cfgv.window_hours == 3
+    assert cfgv.daily_budget_usd == bc.DEFAULT_DAILY_BUDGET_USD
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "field"),
+    [
+        ("skip_threshold_pct", "150", "skip_threshold_pct"),  # > 100%
+        ("skip_threshold_pct", "-5", "skip_threshold_pct"),
+        ("rate_limit_window_hours", "0", "window_hours"),  # a 0h window prices nothing
+        ("daily_budget_estimate_usd", "-1", "daily_budget_usd"),
+    ],
+)
+def test_an_out_of_range_override_falls_back_with_a_warning(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], key: str, value: str, field: str
+) -> None:
+    """scout-config.yaml is hand-editable and doubles as bootstrap state. A
+    nonsense bound (a 0-hour window, a 150% threshold) would silently mis-gate
+    every scheduled run, so it's refused *loudly* and the default stands."""
+    cfg = tmp_path / "scout-config.yaml"
+    cfg.write_text(f"{key}: {value}\n", encoding="utf-8")
+
+    loaded = load_config(cfg)
+    assert getattr(loaded, field) == getattr(BudgetConfig(), field)
+    err = capsys.readouterr().err
+    assert f"ignoring {field}=" in err
+    assert "outside the usable range" in err
+
+
+def test_an_in_range_override_is_honoured(tmp_path: Path) -> None:
+    cfg = tmp_path / "scout-config.yaml"
+    cfg.write_text("skip_threshold_pct: 100\nrate_limit_window_hours: 1\n", encoding="utf-8")
+    loaded = load_config(cfg)
+    assert loaded.skip_threshold_pct == 100.0
+    assert loaded.window_hours == 1
+
+
+def test_a_nested_override_is_honoured_under_its_own_section(tmp_path: Path) -> None:
+    """Keys are matched on (section, key) so an unrelated subtree can't set the
+    budget — scout-config.yaml has several producers, and a bare-key scan would
+    let a stale duplicate quietly win."""
+    cfg = tmp_path / "scout-config.yaml"
+    cfg.write_text("plan:\n  rate_limit_window_hours: 3\nthresholds:\n  skip_threshold_pct: 60\n", encoding="utf-8")
+    loaded = load_config(cfg)
+    assert loaded.window_hours == 3
+    assert loaded.skip_threshold_pct == 60.0
+
+
+def test_config_strips_quotes_around_a_value(tmp_path: Path) -> None:
+    cfg = tmp_path / "scout-config.yaml"
+    cfg.write_text('daily_budget_estimate_usd: "7.50"\n', encoding="utf-8")
+    assert load_config(cfg).daily_budget_usd == 7.5
+
+
+# ---------------------------------------------------------------------------
+# decide
+# ---------------------------------------------------------------------------
+
+
+def test_decide_proceeds_on_a_first_run(tmp_path: Path) -> None:
+    d = decide(tmp_path / "usage-tracker.jsonl", BudgetConfig(), now=NOW)
+    assert d.exit_code == EXIT_PROCEED
+    assert "first run" in d.reason
+
+
+def test_decide_backs_off_after_a_recent_rate_limit(tmp_path: Path) -> None:
+    """The rate-limit gate uses double the failure-backoff window — a 429 means
+    the account is throttled, not just that one session failed."""
+    cfg = BudgetConfig(failure_backoff_min=30)
+    tracker = _tracker(tmp_path / "usage-tracker.jsonl", _row(50, type="rate_limit"))
+    d = decide(tracker, cfg, now=NOW)
+    assert d.exit_code == EXIT_BACKOFF
+    assert "rate_limit event in last 60m" in d.reason
+
+
+def test_decide_ignores_a_rate_limit_outside_the_doubled_window(tmp_path: Path) -> None:
+    cfg = BudgetConfig(failure_backoff_min=30)
+    tracker = _tracker(tmp_path / "usage-tracker.jsonl", _row(90, type="rate_limit"))
+    assert decide(tracker, cfg, now=NOW).exit_code == EXIT_PROCEED
+
+
+def test_decide_backs_off_after_a_recent_nonzero_exit(tmp_path: Path) -> None:
+    cfg = BudgetConfig(failure_backoff_min=60)
+    tracker = _tracker(tmp_path / "usage-tracker.jsonl", _row(10, exit_code=1, budget_spent=0.1))
+    d = decide(tracker, cfg, now=NOW)
+    assert d.exit_code == EXIT_BACKOFF
+    assert "recent failure 10m ago" in d.reason
+
+
+def test_decide_proceeds_once_the_failure_backoff_has_elapsed(tmp_path: Path) -> None:
+    cfg = BudgetConfig(failure_backoff_min=30)
+    tracker = _tracker(tmp_path / "usage-tracker.jsonl", _row(45, exit_code=1, budget_spent=0.1))
+    assert decide(tracker, cfg, now=NOW).exit_code == EXIT_PROCEED
+
+
+def test_decide_skips_when_the_window_cost_reaches_the_threshold(tmp_path: Path) -> None:
+    cfg = BudgetConfig(daily_budget_usd=24.0, window_hours=6, skip_threshold_pct=50.0)
+    # window budget = 6.00, threshold = 3.00
+    tracker = _tracker(
+        tmp_path / "usage-tracker.jsonl",
+        _row(30, exit_code=0, budget_spent=1.5),
+        _row(20, exit_code=0, budget_spent=1.5),
+    )
+    d = decide(tracker, cfg, now=NOW)
+    assert d.exit_code == EXIT_SKIP_OVER_BUDGET
+    assert "$3.00 >= skip threshold $3.00" in d.reason
+
+
+def test_decide_excludes_spend_from_before_the_window(tmp_path: Path) -> None:
+    cfg = BudgetConfig(daily_budget_usd=24.0, window_hours=1, skip_threshold_pct=50.0)
+    tracker = _tracker(
+        tmp_path / "usage-tracker.jsonl",
+        _row(600, exit_code=0, budget_spent=99.0),  # long outside the window
+        _row(10, exit_code=0, budget_spent=0.1),
+    )
+    d = decide(tracker, cfg, now=NOW)
+    assert d.exit_code == EXIT_PROCEED
+    assert "$0.10 spent" in d.reason
+
+
+def test_decide_tolerates_a_naive_timestamp(tmp_path: Path) -> None:
+    """Older tracker rows were written without an offset; reading them as local
+    time would shift the whole window."""
+    naive = (NOW - timedelta(minutes=10)).replace(tzinfo=None).isoformat()
+    tracker = _tracker(tmp_path / "usage-tracker.jsonl", {"ts": naive, "exit_code": 0, "budget_spent": 0.25})
+    d = decide(tracker, BudgetConfig(), now=NOW)
+    assert "$0.25 spent" in d.reason
+
+
+def test_decide_skips_rows_with_no_usable_timestamp(tmp_path: Path) -> None:
+    tracker = _tracker(
+        tmp_path / "usage-tracker.jsonl",
+        {"budget_spent": 99.0},  # no ts
+        {"ts": "", "budget_spent": 99.0},
+        {"ts": 1700000000, "budget_spent": 99.0},  # not a string
+        {"ts": "not-a-date", "budget_spent": 99.0},
+        _row(10, exit_code=0, budget_spent=0.25),
+    )
+    d = decide(tracker, BudgetConfig(), now=NOW)
+    assert "$0.25 spent" in d.reason
+
+
+def test_decide_tolerates_uncastable_cost_and_exit_fields(tmp_path: Path) -> None:
+    tracker = _tracker(
+        tmp_path / "usage-tracker.jsonl",
+        _row(10, exit_code="fine", budget_spent="a lot"),
+        _row(5, exit_code=0, budget_spent=None),
+    )
+    d = decide(tracker, BudgetConfig(), now=NOW)
+    assert d.exit_code == EXIT_PROCEED
+    assert "$0.00 spent" in d.reason
+
+
+def test_decide_skips_blank_and_malformed_tracker_lines(tmp_path: Path) -> None:
+    tracker = tmp_path / "usage-tracker.jsonl"
+    tracker.write_text(
+        "\n".join(
+            [
+                "",
+                "   ",
+                "{torn",
+                '"a bare string"',
+                "[1, 2]",
+                json.dumps(_row(10, exit_code=0, budget_spent=0.25)),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    assert "$0.25 spent" in decide(tracker, BudgetConfig(), now=NOW).reason
+
+
+def test_decide_proceeds_when_the_tracker_becomes_unreadable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A permission problem must not read as "budget exhausted" — that would
+    silently stop every session."""
+    tracker = _tracker(tmp_path / "usage-tracker.jsonl", _row(10, exit_code=1, budget_spent=99.0))
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "open", boom)
+    assert decide(tracker, BudgetConfig(), now=NOW).exit_code == EXIT_PROCEED
+
+
+def test_run_wires_the_vault_paths_and_prints_when_verbose(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    vault = tmp_path / "Scout"
+    (vault / ".scout-logs").mkdir(parents=True)
+    (vault / "scout-config.yaml").write_text("rate_limit_window_hours: 3\n", encoding="utf-8")
+
+    assert bc.run(verbose=True, data_dir=vault) == EXIT_PROCEED
+    out = capsys.readouterr().out
+    assert "[budget-check] no tracker — first run" in out
+    assert "window: 3h" in out
+
+
+def test_run_is_quiet_by_default(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    vault = tmp_path / "Scout"
+    (vault / ".scout-logs").mkdir(parents=True)
+    assert bc.run(data_dir=vault) == EXIT_PROCEED
+    assert capsys.readouterr().out == ""
+
+
+def test_run_resolves_the_vault_from_the_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    vault = tmp_path / "Scout"
+    (vault / ".scout-logs").mkdir(parents=True)
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(vault))
+    assert bc.run() == EXIT_PROCEED
+
+
+# ---------------------------------------------------------------------------
+# triggers.config — default_installed_skills
+# ---------------------------------------------------------------------------
+
+
+def test_installed_skills_lists_the_plugins_skill_dirs(tmp_path: Path) -> None:
+    skills = tmp_path / "skills"
+    (skills / "scout-work").mkdir(parents=True)
+    (skills / "scout-status").mkdir()
+    (skills / "README.md").write_text("not a skill\n", encoding="utf-8")
+
+    assert tcfg.default_installed_skills(tmp_path) == {"scout-work", "scout-status"}
+
+
+def test_installed_skills_is_empty_without_a_skills_dir(tmp_path: Path) -> None:
+    assert tcfg.default_installed_skills(tmp_path) == set()
+
+
+def test_installed_skills_defaults_to_this_checkout() -> None:
+    """No plugin_root argument resolves to the running checkout — the roster a
+    `run_skill` action is validated against."""
+    assert tcfg.default_installed_skills()
+
+
+# ---------------------------------------------------------------------------
+# triggers.config — load_triggers file-level validation
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "triggers.yaml"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def test_load_triggers_reports_a_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(ConfigError, match="not found"):
+        load_triggers(tmp_path / "nope.yaml")
+
+
+def test_load_triggers_reports_malformed_yaml(tmp_path: Path) -> None:
+    with pytest.raises(ConfigError, match="is malformed"):
+        load_triggers(_write(tmp_path, "triggers: [unclosed\n"))
+
+
+def test_an_empty_file_is_zero_triggers(tmp_path: Path) -> None:
+    """An empty triggers.yaml is a legitimate "nothing configured" state, not
+    an error — `scoutctl trigger validate` must pass on it."""
+    assert load_triggers(_write(tmp_path, ""), installed_skills=set()) == []
+
+
+@pytest.mark.parametrize("body", ["- a\n- list\n", "just a string\n", "42\n"])
+def test_a_non_mapping_file_is_rejected(tmp_path: Path, body: str) -> None:
+    with pytest.raises(ConfigError, match="is not a mapping"):
+        load_triggers(_write(tmp_path, body), installed_skills=set())
+
+
+def test_an_unsupported_schema_version_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ConfigError, match="schema_version 99; engine supports 1"):
+        load_triggers(_write(tmp_path, "schema_version: 99\ntriggers: []\n"), installed_skills=set())
+
+
+@pytest.mark.parametrize("value", ["a string", "{a: mapping}", "42"])
+def test_a_non_list_triggers_key_is_rejected(tmp_path: Path, value: str) -> None:
+    with pytest.raises(ConfigError, match="'triggers' must be a list"):
+        load_triggers(_write(tmp_path, f"triggers: {value}\n"), installed_skills=set())
+
+
+def test_a_non_mapping_trigger_entry_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ConfigError, match=r"trigger\[0\]: expected a mapping, got str"):
+        load_triggers(_write(tmp_path, "triggers:\n  - just a string\n"), installed_skills=set())
+
+
+# ---------------------------------------------------------------------------
+# triggers.config — per-trigger field validation
+# ---------------------------------------------------------------------------
+
+_VALID = """schema_version: 1
+triggers:
+  - id: t1
+    source: scout_internal
+    match: {type: slot.fire_failed}
+    action: {kind: notify, tier: info, body: hi}
+    daily_fire_cap: 3
+"""
+
+
+def test_a_valid_trigger_loads(tmp_path: Path) -> None:
+    triggers = load_triggers(_write(tmp_path, _VALID), installed_skills=set())
+    assert [t.id for t in triggers] == ["t1"]
+    assert triggers[0].match_type == "slot.fire_failed"
+    assert triggers[0].daily_fire_cap == 3
+    assert triggers[0].cooldown_seconds == 0
+    assert triggers[0].allow_cycle is False
+    assert triggers[0].enabled is True
+
+
+def test_an_action_with_no_kind_is_rejected(tmp_path: Path) -> None:
+    body = _VALID.replace("action: {kind: notify, tier: info, body: hi}", "action: {tier: info}")
+    with pytest.raises(ConfigError, match="action.kind is required"):
+        load_triggers(_write(tmp_path, body), installed_skills=set())
+
+
+def test_a_non_mapping_action_is_rejected(tmp_path: Path) -> None:
+    body = _VALID.replace("action: {kind: notify, tier: info, body: hi}", "action: notify")
+    with pytest.raises(ConfigError, match="action.kind is required"):
+        load_triggers(_write(tmp_path, body), installed_skills=set())
+
+
+@pytest.mark.parametrize("value", ["not-a-number", "[1, 2]", "{a: b}", "null"])
+def test_a_non_integer_daily_fire_cap_is_rejected(tmp_path: Path, value: str) -> None:
+    """The cap is the blast radius on an automated action; a silently-defaulted
+    one is unlimited firing."""
+    body = _VALID.replace("daily_fire_cap: 3", f"daily_fire_cap: {value}")
+    with pytest.raises(ConfigError, match="daily_fire_cap must be an integer"):
+        load_triggers(_write(tmp_path, body), installed_skills=set())
+
+
+@pytest.mark.parametrize("value", ["not-a-number", "[1, 2]", "{a: b}", "null"])
+def test_a_non_integer_cooldown_is_rejected(tmp_path: Path, value: str) -> None:
+    body = _VALID.replace("daily_fire_cap: 3", f"daily_fire_cap: 3\n    cooldown_seconds: {value}")
+    with pytest.raises(ConfigError, match="cooldown_seconds must be an integer"):
+        load_triggers(_write(tmp_path, body), installed_skills=set())
+
+
+def test_a_negative_cooldown_is_rejected(tmp_path: Path) -> None:
+    body = _VALID.replace("daily_fire_cap: 3", "daily_fire_cap: 3\n    cooldown_seconds: -5")
+    with pytest.raises(ConfigError, match="cooldown_seconds must be >= 0, got -5"):
+        load_triggers(_write(tmp_path, body), installed_skills=set())
+
+
+def test_a_float_cap_is_truncated_not_rejected(tmp_path: Path) -> None:
+    body = _VALID.replace("daily_fire_cap: 3", "daily_fire_cap: 3.9")
+    assert load_triggers(_write(tmp_path, body), installed_skills=set())[0].daily_fire_cap == 3

--- a/engine/tests/unit/test_cc_session_cache_edges.py
+++ b/engine/tests/unit/test_cc_session_cache_edges.py
@@ -1,0 +1,404 @@
+"""Tolerance branches in the CC-session cache.
+
+`test_cc_session_cache.py` covers discovery, the mtime cache and the markdown
+render. What's left is every path that must degrade quietly: a session JSONL
+that vanishes or can't be read mid-walk, a corrupt cache file, a failed atomic
+write, the "no user message found" sentinels, and `main()`'s
+never-break-the-preamble contract.
+
+This module runs in the preamble of every scheduled session over
+`~/.claude/projects`, a directory another process is actively writing — so
+"tolerant" is the whole design, and an untested tolerance branch is one that
+first executes at 03:00.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scout.scripts import cc_session_cache as ccc
+from scout.scripts.cc_session_cache import SessionEntry
+
+
+@pytest.fixture
+def projects(tmp_path: Path) -> Path:
+    d = tmp_path / "projects"
+    d.mkdir()
+    return d
+
+
+def _session(projects: Path, project_dir: str, session_id: str, *rows: dict) -> Path:
+    d = projects / project_dir
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / f"{session_id}.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    return p
+
+
+def _entry(path: str = "/p/s.jsonl", **overrides) -> SessionEntry:
+    base = {
+        "jsonl_path": path,
+        "project_path": "/Users/alex/work",
+        "session_id": "s",
+        "mtime_ns": 1,
+        "size_bytes": 2,
+        "first_msg": "hello",
+        "files_touched": ["~/work/a.py"],
+    }
+    base.update(overrides)
+    return SessionEntry(**base)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# iter_session_jsonls
+# ---------------------------------------------------------------------------
+
+
+def test_discovery_yields_nothing_when_the_projects_dir_is_absent(tmp_path: Path) -> None:
+    assert list(ccc.iter_session_jsonls(tmp_path / "nope", cutoff_ts=0, exclude_suffixes=())) == []
+
+
+def test_discovery_skips_loose_files_in_the_projects_dir(projects: Path) -> None:
+    (projects / "stray.jsonl").write_text("{}\n", encoding="utf-8")
+    _session(projects, "-Users-alex-work", "s1", {"type": "user", "content": "hi"})
+    found = [p.name for p, _st in ccc.iter_session_jsonls(projects, cutoff_ts=0, exclude_suffixes=())]
+    assert found == ["s1.jsonl"]
+
+
+def test_discovery_skips_a_file_it_cannot_stat(projects: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Claude Code rotates these files while we walk; a vanished one must be
+    skipped, not abort the whole scan."""
+    gone = _session(projects, "-Users-alex-work", "gone", {"type": "user", "content": "hi"})
+    _session(projects, "-Users-alex-work", "kept", {"type": "user", "content": "hi"})
+
+    real_stat = Path.stat
+
+    def maybe_boom(self: Path, *a: object, **k: object):
+        if self == gone:
+            raise OSError("vanished mid-walk")
+        return real_stat(self, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "stat", maybe_boom)
+    found = [p.stem for p, _st in ccc.iter_session_jsonls(projects, cutoff_ts=0, exclude_suffixes=())]
+    assert found == ["kept"]
+
+
+def test_discovery_excludes_scouts_own_project_dirs(projects: Path) -> None:
+    _session(projects, "-Users-alex-Scout", "own", {"type": "user", "content": "hi"})
+    _session(projects, "-Users-alex-work", "other", {"type": "user", "content": "hi"})
+    found = [
+        p.stem for p, _st in ccc.iter_session_jsonls(projects, cutoff_ts=0, exclude_suffixes=ccc._excluded_suffixes())
+    ]
+    assert found == ["other"]
+
+
+def test_discovery_honours_the_cutoff(projects: Path) -> None:
+    old = _session(projects, "-Users-alex-work", "old", {"type": "user", "content": "hi"})
+    os.utime(old, (0, 0))
+    _session(projects, "-Users-alex-work", "new", {"type": "user", "content": "hi"})
+
+    found = [p.stem for p, _st in ccc.iter_session_jsonls(projects, cutoff_ts=1, exclude_suffixes=())]
+    assert found == ["new"]
+
+
+def test_project_path_decoding() -> None:
+    assert ccc._project_path_from_dirname("-Users-alex-work") == "/Users/alex/work"
+    # A name that isn't dash-encoded passes through untouched.
+    assert ccc._project_path_from_dirname("plain-name") == "plain-name"
+
+
+# ---------------------------------------------------------------------------
+# extract_first_message
+# ---------------------------------------------------------------------------
+
+
+def test_first_message_reads_a_nested_text_block(tmp_path: Path) -> None:
+    p = tmp_path / "s.jsonl"
+    p.write_text(
+        json.dumps({"type": "user", "message": {"content": [{"type": "text", "text": "review PROJ-1234"}]}}) + "\n",
+        encoding="utf-8",
+    )
+    assert ccc.extract_first_message(p) == "review PROJ-1234"
+
+
+def test_first_message_reads_a_top_level_string_content(tmp_path: Path) -> None:
+    p = tmp_path / "s.jsonl"
+    p.write_text(json.dumps({"role": "human", "content": "hello there"}) + "\n", encoding="utf-8")
+    assert ccc.extract_first_message(p) == "hello there"
+
+
+def test_first_message_skips_blank_malformed_and_non_user_rows(tmp_path: Path) -> None:
+    p = tmp_path / "s.jsonl"
+    p.write_text(
+        "\n".join(
+            [
+                "",
+                "   ",
+                "{torn",
+                '"a bare string"',
+                json.dumps({"type": "assistant", "content": "not the user"}),
+                json.dumps({"type": "user", "content": "   "}),  # blank -> keep looking
+                json.dumps({"type": "user", "message": {"content": [{"type": "image"}]}}),  # no text
+                json.dumps({"type": "user", "message": {"content": [{"type": "text", "text": ""}]}}),
+                json.dumps({"type": "user", "content": "the real first message"}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    assert ccc.extract_first_message(p) == "the real first message"
+
+
+def test_first_message_only_scans_the_head_of_the_file(tmp_path: Path) -> None:
+    """Bash used `head -50`; a session's first prompt is always near the top,
+    and scanning a 100 MB transcript per file would blow the preamble budget."""
+    p = tmp_path / "s.jsonl"
+    filler = [json.dumps({"type": "assistant", "content": "x"})] * 60
+    p.write_text("\n".join([*filler, json.dumps({"type": "user", "content": "too late"})]) + "\n", encoding="utf-8")
+    assert ccc.extract_first_message(p) == "(could not extract first message)"
+
+
+def test_first_message_is_truncated(tmp_path: Path) -> None:
+    p = tmp_path / "s.jsonl"
+    p.write_text(json.dumps({"type": "user", "content": "x" * 900}) + "\n", encoding="utf-8")
+    assert len(ccc.extract_first_message(p)) == ccc._FIRST_MSG_MAX_CHARS
+
+
+def test_first_message_reports_a_parse_error_for_an_unreadable_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    p = tmp_path / "s.jsonl"
+    p.write_text(json.dumps({"type": "user", "content": "hi"}) + "\n", encoding="utf-8")
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "open", boom)
+    assert ccc.extract_first_message(p) == "(parse error)"
+
+
+def test_first_message_sentinel_for_a_session_with_no_user_row(tmp_path: Path) -> None:
+    p = tmp_path / "s.jsonl"
+    p.write_text(json.dumps({"type": "assistant", "content": "hello"}) + "\n", encoding="utf-8")
+    assert ccc.extract_first_message(p) == "(could not extract first message)"
+
+
+# ---------------------------------------------------------------------------
+# extract_files_touched
+# ---------------------------------------------------------------------------
+
+
+def test_files_touched_collapses_home_and_dedupes(tmp_path: Path) -> None:
+    p = tmp_path / "s.jsonl"
+    p.write_text(
+        "\n".join(
+            [
+                json.dumps({"tool_input": {"file_path": "/Users/alex/work/a.py"}}),
+                json.dumps({"tool_input": {"file_path": "/Users/alex/work/a.py"}}),
+                json.dumps({"tool_input": {"file_path": "/etc/hosts"}}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    assert ccc.extract_files_touched(p, home=Path("/Users/alex")) == ["/etc/hosts", "~/work/a.py"]
+
+
+@pytest.mark.parametrize(
+    "noisy",
+    [
+        "/Users/alex/.claude/projects/-x/tool-results/r.json",
+        "/Users/alex/.claude/projects/-x/tasks/t.json",
+        "/Users/alex/.claude/plugins/cache/p.js",
+        "/Users/alex/work/node_modules/dep/index.js",
+        "/private/tmp/claude-501/scratch.txt",
+        "/Users/alex/.claude/projects/-x/memory/m.md",
+    ],
+)
+def test_files_touched_drops_agent_internal_noise(tmp_path: Path, noisy: str) -> None:
+    """These are the agent's own scratch files; surfacing them buries the
+    user-meaningful edits the briefing is supposed to notice."""
+    p = tmp_path / "s.jsonl"
+    p.write_text(json.dumps({"tool_input": {"file_path": noisy}}) + "\n", encoding="utf-8")
+    assert ccc.extract_files_touched(p, home=Path("/Users/alex")) == []
+
+
+def test_files_touched_is_capped(tmp_path: Path) -> None:
+    p = tmp_path / "s.jsonl"
+    p.write_text(
+        "\n".join(json.dumps({"tool_input": {"file_path": f"/w/f{n:03d}.py"}}) for n in range(25)) + "\n",
+        encoding="utf-8",
+    )
+    assert len(ccc.extract_files_touched(p, home=Path("/Users/alex"))) == ccc._MAX_FILES_TOUCHED
+
+
+def test_files_touched_is_empty_for_an_unreadable_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    p = tmp_path / "s.jsonl"
+    p.write_text(json.dumps({"tool_input": {"file_path": "/w/a.py"}}) + "\n", encoding="utf-8")
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "open", boom)
+    assert ccc.extract_files_touched(p) == []
+
+
+# ---------------------------------------------------------------------------
+# cache load / write
+# ---------------------------------------------------------------------------
+
+
+def test_cache_load_is_empty_when_absent(tmp_path: Path) -> None:
+    assert ccc._load_cache(tmp_path / "nope.json") == {}
+
+
+@pytest.mark.parametrize("body", ["{torn", '["a", "list"]', "null", "42"])
+def test_cache_load_rejects_a_corrupt_file(tmp_path: Path, body: str) -> None:
+    """A corrupt cache costs one slow run, not a crashed preamble."""
+    cache = tmp_path / "cc-sessions.cache.json"
+    cache.write_text(body, encoding="utf-8")
+    assert ccc._load_cache(cache) == {}
+
+
+def test_cache_load_skips_individual_bad_entries(tmp_path: Path) -> None:
+    cache = tmp_path / "cc-sessions.cache.json"
+    from dataclasses import asdict
+
+    cache.write_text(
+        json.dumps(
+            {
+                "/p/good.jsonl": asdict(_entry("/p/good.jsonl")),
+                "/p/not-a-dict.jsonl": "oops",
+                "/p/missing-keys.jsonl": {"jsonl_path": "/p/missing-keys.jsonl"},
+                "/p/bad-mtime.jsonl": {**asdict(_entry("/p/bad-mtime.jsonl")), "mtime_ns": "soon"},
+                "/p/null-files.jsonl": {**asdict(_entry("/p/null-files.jsonl")), "files_touched": None},
+            }
+        ),
+        encoding="utf-8",
+    )
+    loaded = ccc._load_cache(cache)
+    assert set(loaded) == {"/p/good.jsonl", "/p/null-files.jsonl"}
+    assert loaded["/p/null-files.jsonl"].files_touched == []
+
+
+def test_cache_write_round_trips(tmp_path: Path) -> None:
+    cache = tmp_path / "nested" / "cc-sessions.cache.json"
+    ccc._write_cache(cache, {"/p/s.jsonl": _entry()})
+    assert ccc._load_cache(cache) == {"/p/s.jsonl": _entry()}
+
+
+def test_cache_write_cleans_up_after_a_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cache = tmp_path / "cc-sessions.cache.json"
+    real_open = Path.open
+
+    def maybe_boom(self: Path, *a: object, **k: object):
+        if self.name.endswith(".json.tmp"):
+            raise OSError("disk full")
+        return real_open(self, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "open", maybe_boom)
+    ccc._write_cache(cache, {"/p/s.jsonl": _entry()})  # must not raise
+    assert not cache.exists()
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+# ---------------------------------------------------------------------------
+# run() / main()
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    d = tmp_path / "Scout"
+    (d / ".scout-cache").mkdir(parents=True)
+    return d
+
+
+def test_run_writes_an_empty_summary_when_there_are_no_sessions(vault: Path, tmp_path: Path) -> None:
+    """The function is total: downstream consumers rely on the file existing."""
+    out, count = ccc.run(data_dir=vault, cc_projects_dir=tmp_path / "no-projects")
+    assert count == 0
+    assert out == vault / ".scout-cache" / ccc.OUTPUT_FILENAME
+    text = out.read_text()
+    assert "No non-Scout CC sessions found" in text
+    assert "**Total:** 0 session(s) found." in text
+
+
+def test_run_reuses_a_cached_entry_when_the_mtime_is_unchanged(
+    vault: Path, projects: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The whole point of the cache: a second run must not re-open an unchanged
+    transcript."""
+    _session(projects, "-Users-alex-work", "s1", {"type": "user", "content": "first prompt"})
+    ccc.run(data_dir=vault, cc_projects_dir=projects)
+
+    def fail(*_a: object, **_k: object):
+        raise AssertionError("an unchanged transcript must not be re-extracted")
+
+    monkeypatch.setattr(ccc, "build_session_entry", fail)
+    _out, count = ccc.run(data_dir=vault, cc_projects_dir=projects)
+    assert count == 1
+
+
+def test_run_re_extracts_after_an_mtime_bump(vault: Path, projects: Path) -> None:
+    p = _session(projects, "-Users-alex-work", "s1", {"type": "user", "content": "first prompt"})
+    out, _count = ccc.run(data_dir=vault, cc_projects_dir=projects)
+    assert "first prompt" in out.read_text()
+
+    p.write_text(json.dumps({"type": "user", "content": "second prompt"}) + "\n", encoding="utf-8")
+    os.utime(p, ns=(p.stat().st_mtime_ns + 1_000_000_000, p.stat().st_mtime_ns + 1_000_000_000))
+    out, _count = ccc.run(data_dir=vault, cc_projects_dir=projects)
+    assert "second prompt" in out.read_text()
+
+
+def test_run_sorts_sessions_newest_first(vault: Path, projects: Path) -> None:
+    older = _session(projects, "-Users-alex-work", "older", {"type": "user", "content": "older prompt"})
+    newer = _session(projects, "-Users-alex-work", "newer", {"type": "user", "content": "newer prompt"})
+    base = newer.stat().st_mtime_ns
+    os.utime(older, ns=(base - 60_000_000_000, base - 60_000_000_000))
+
+    out, count = ccc.run(data_dir=vault, cc_projects_dir=projects)
+    assert count == 2
+    text = out.read_text()
+    assert text.index("newer prompt") < text.index("older prompt")
+
+
+def test_run_honours_extra_exclude_suffixes(vault: Path, projects: Path) -> None:
+    _session(projects, "-Users-alex-sandbox", "sandboxed", {"type": "user", "content": "sandbox prompt"})
+    _session(projects, "-Users-alex-work", "kept", {"type": "user", "content": "work prompt"})
+
+    _out, count = ccc.run(data_dir=vault, cc_projects_dir=projects, extra_exclude_suffixes=("-sandbox",))
+    assert count == 1
+
+
+def test_run_excludes_a_custom_instance_name(vault: Path, projects: Path) -> None:
+    _session(projects, "-Users-alex-Nightly", "own", {"type": "user", "content": "own prompt"})
+    _session(projects, "-Users-alex-work", "other", {"type": "user", "content": "work prompt"})
+
+    _out, count = ccc.run(data_dir=vault, cc_projects_dir=projects, instance_name="Nightly")
+    assert count == 1
+
+
+def test_main_prints_the_summary_and_returns_zero(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(vault))
+    assert ccc.main(hours=6) == 0
+    out = capsys.readouterr().out
+    assert "CC session cache written to" in out
+    assert "6h lookback" in out
+
+
+def test_main_returns_zero_even_when_run_blows_up(monkeypatch: pytest.MonkeyPatch) -> None:
+    """This runs in every scheduled session's preamble; a crash here must not
+    be the reason a session doesn't start."""
+
+    def boom(**_k: object):
+        raise RuntimeError("unreachable state")
+
+    monkeypatch.setattr(ccc, "run", boom)
+    assert ccc.main() == 0

--- a/engine/tests/unit/test_cli_surface.py
+++ b/engine/tests/unit/test_cli_surface.py
@@ -1,0 +1,1269 @@
+"""Coverage of the `scoutctl` command surface that the other cli tests skip.
+
+`test_cli.py` covers version/manifest/main(); the three `test_cli_*_subapp.py`
+files cover the read paths of connectors/schedule/trigger. What is left — and
+what this file drives — is:
+
+* the hook/script shims (`scoutctl hook …`, `budget check`, `session cc-cache`,
+  `heartbeat run`, `pre-session data`, `connector-health-report`). Each is a
+  one-line forward whose only contract is "call that module's main() with these
+  arguments and exit with its return code". A silently dropped flag here is
+  invisible until a scheduled run misbehaves, so pin the forwarding.
+* the installer commands (`schedule install-plist`, `install-wake-schedule`,
+  `install-heartbeat-plist`, `install-cron`, `install-all`), whose real bodies
+  touch `~/Library/LaunchAgents` and `crontab` — stubbed here, with the CLI's
+  own branching (uninstall / FileExistsError / unsupported platform) asserted.
+* the snapshot commands' check/write/drift branches.
+* `bootstrap {install,upgrade,doctor,migrate-legacy}`, `phases backport`,
+  `self-update check` and `tui`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from scout import cli
+from scout.errors import ConfigError
+from scout.events import Event, now_iso
+
+runner = CliRunner()
+
+PLUGIN_ROOT = Path(cli.__file__).parent.parent.parent
+
+
+@pytest.fixture
+def vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    d = tmp_path / "Scout"
+    for sub in (".scout-logs", ".scout-cache", ".scout-state", "knowledge-base", "action-items"):
+        (d / sub).mkdir(parents=True)
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(d))
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Shims: `scoutctl <cmd>` -> `<module>.main(...)`, exit code = return value
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("argv", "module"),
+    [
+        (["hook", "connector-log"], "scout.hooks.connector_log"),
+        (["hook", "session-tokens"], "scout.hooks.session_tokens"),
+        (["hook", "session-tool-log"], "scout.hooks.session_tool_log"),
+        (["connector-health-report"], "scout.scripts.connector_health_report"),
+    ],
+)
+@pytest.mark.parametrize("rc", [0, 1, 2])
+def test_zero_arg_shim_forwards_exit_code(
+    monkeypatch: pytest.MonkeyPatch, argv: list[str], module: str, rc: int
+) -> None:
+    monkeypatch.setattr(f"{module}.main", lambda: rc)
+    assert runner.invoke(cli.app, argv).exit_code == rc
+
+
+def test_hook_kb_pre_filter_forwards_session_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[list[str]] = []
+    monkeypatch.setattr("scout.hooks.kb_pre_filter.main", lambda argv: seen.append(argv) or 0)
+
+    assert runner.invoke(cli.app, ["hook", "kb-pre-filter"]).exit_code == 0
+    assert seen[-1] == ["dreaming"]  # documented default
+
+    assert runner.invoke(cli.app, ["hook", "kb-pre-filter", "-s", "briefing"]).exit_code == 0
+    assert seen[-1] == ["briefing"]
+
+
+def test_budget_check_forwards_verbose_and_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[bool] = []
+
+    def fake_run(*, verbose: bool) -> int:
+        seen.append(verbose)
+        return 2  # documented "backoff"
+
+    monkeypatch.setattr("scout.scripts.budget_check.run", fake_run)
+
+    assert runner.invoke(cli.app, ["budget", "check"]).exit_code == 2
+    assert seen[-1] is False
+    runner.invoke(cli.app, ["budget", "check", "--verbose"])
+    assert seen[-1] is True
+
+
+def test_session_cc_cache_forwards_all_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_main(*, hours: int, instance_name: str, tz_name: str) -> int:
+        seen.update(hours=hours, instance_name=instance_name, tz_name=tz_name)
+        return 0
+
+    monkeypatch.setattr("scout.scripts.cc_session_cache.main", fake_main)
+
+    assert runner.invoke(cli.app, ["session", "cc-cache"]).exit_code == 0
+    # tz_name defaults to None: since the TZ-localization work the zone is
+    # resolved from the vault's configured timezone at runtime rather than
+    # baked in as a literal default here.
+    assert seen == {"hours": 24, "instance_name": "Scout", "tz_name": None}
+
+    runner.invoke(
+        cli.app,
+        ["session", "cc-cache", "--hours", "6", "--instance-name", "Nightly", "--timezone", "UTC"],
+    )
+    assert seen == {"hours": 6, "instance_name": "Nightly", "tz_name": "UTC"}
+
+
+def test_heartbeat_run_forwards_dry_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[bool] = []
+    monkeypatch.setattr("scout.scripts.heartbeat.main", lambda *, dry_run: seen.append(dry_run) or 0)
+
+    assert runner.invoke(cli.app, ["heartbeat", "run"]).exit_code == 0
+    assert seen[-1] is False
+    runner.invoke(cli.app, ["heartbeat", "run", "--dry-run"])
+    assert seen[-1] is True
+
+
+def test_pre_session_data_forwards_session_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[str] = []
+    monkeypatch.setattr("scout.scripts.pre_session_data.main", lambda st: seen.append(st) or 0)
+
+    assert runner.invoke(cli.app, ["pre-session", "data"]).exit_code == 0
+    assert seen[-1] == "unknown"  # documented default
+    runner.invoke(cli.app, ["pre-session", "data", "research"])
+    assert seen[-1] == "research"
+
+
+def test_schedule_tick_forwards_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("scout.scripts.schedule_tick.main", lambda: 3)
+    assert runner.invoke(cli.app, ["schedule", "tick"]).exit_code == 3
+
+
+# ---------------------------------------------------------------------------
+# connectors list / show / reload
+# ---------------------------------------------------------------------------
+
+
+def test_connectors_list_is_tab_separated_and_sorted() -> None:
+    result = runner.invoke(cli.app, ["connectors", "list"])
+    assert result.exit_code == 0, result.output
+    rows = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    assert rows, "roster is empty"
+    keys = [ln.split("\t")[0] for ln in rows]
+    assert keys == sorted(keys)
+    assert all(len(ln.split("\t")) == 3 for ln in rows)
+
+
+def test_connectors_show_emits_the_full_record() -> None:
+    key = runner.invoke(cli.app, ["connectors", "list"]).stdout.splitlines()[0].split("\t")[0]
+    result = runner.invoke(cli.app, ["connectors", "show", key])
+    assert result.exit_code == 0, result.output
+    record = json.loads(result.stdout)
+    assert record["key"] == key
+    assert set(record) == {
+        "key",
+        "display_name",
+        "tier",
+        "capabilities",
+        "required_in",
+        "required_in_types",
+        "remediation",
+        "notes",
+    }
+    assert set(record["remediation"]) == {"first_fix", "detail"}
+
+
+def test_connectors_show_unknown_key_is_a_config_error() -> None:
+    result = runner.invoke(cli.app, ["connectors", "show", "not-a-connector"])
+    assert result.exit_code != 0
+    assert isinstance(result.exception, ConfigError)
+    assert "unknown connector: not-a-connector" in str(result.exception)
+
+
+def test_connectors_reload_reports_success() -> None:
+    result = runner.invoke(cli.app, ["connectors", "reload"])
+    assert result.exit_code == 0, result.output
+    assert result.stdout.strip() == "reloaded"
+
+
+# ---------------------------------------------------------------------------
+# connectors / schedule snapshot
+#
+# Both commands share one shape: --check compares, no --check writes, and the
+# best-effort scout-app dual-write warns rather than failing when that repo
+# isn't checked out. HOME is a tmp dir here (conftest), so the app fixture path
+# never exists — which is exactly the warn branch.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("group", ["connectors", "schedule"])
+def test_snapshot_check_passes_against_a_freshly_written_file(group: str, tmp_path: Path) -> None:
+    target = tmp_path / f"{group}.snapshot.json"
+    write = runner.invoke(cli.app, [group, "snapshot", "--target", str(target), "--no-also-write-app-fixture"])
+    assert write.exit_code == 0, write.output
+    assert f"Wrote: {target}" in write.stdout
+
+    check = runner.invoke(cli.app, [group, "snapshot", "--target", str(target), "--check"])
+    assert check.exit_code == 0, check.output
+    assert "snapshot OK" in check.stdout
+
+
+@pytest.mark.parametrize("group", ["connectors", "schedule"])
+def test_snapshot_check_detects_drift(group: str, tmp_path: Path) -> None:
+    target = tmp_path / f"{group}.snapshot.json"
+    runner.invoke(cli.app, [group, "snapshot", "--target", str(target), "--no-also-write-app-fixture"])
+    payload = json.loads(target.read_text())
+    payload["schema_version"] = 999
+    target.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = runner.invoke(cli.app, [group, "snapshot", "--target", str(target), "--check"])
+    assert result.exit_code == 1
+    assert "Drift detected" in result.output
+
+
+@pytest.mark.parametrize("group", ["connectors", "schedule"])
+def test_snapshot_warns_when_app_fixture_repo_is_absent(group: str, tmp_path: Path) -> None:
+    """Default is a dual-write; on a machine without ~/scout-app checked out it
+    must warn and still exit 0 — a build agent has no second repo."""
+    target = tmp_path / f"{group}.snapshot.json"
+    result = runner.invoke(cli.app, [group, "snapshot", "--target", str(target)])
+    assert result.exit_code == 0, result.output
+    assert "skipped scout-app fixture write" in result.output
+
+
+@pytest.mark.parametrize("group", ["connectors", "schedule"])
+def test_snapshot_target_pointed_at_app_fixture_writes_once(
+    group: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """--target == the app fixture path must not double-write (nor warn)."""
+    target = tmp_path / "fixture.snapshot.json"
+    module = "scout.scripts.connectors_snapshot" if group == "connectors" else "scout.scripts.schedule_snapshot"
+    monkeypatch.setattr(f"{module}.app_fixture_snapshot_path", lambda: target)
+
+    result = runner.invoke(cli.app, [group, "snapshot", "--target", str(target)])
+    assert result.exit_code == 0, result.output
+    assert result.stdout.count("Wrote:") == 1
+    assert "skipped scout-app fixture write" not in result.output
+
+
+@pytest.mark.parametrize("group", ["connectors", "schedule"])
+def test_snapshot_dual_writes_when_app_fixture_dir_exists(
+    group: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fixture_dir = tmp_path / "scout-app" / "ScoutTests" / "Fixtures"
+    fixture_dir.mkdir(parents=True)
+    fixture = fixture_dir / "snapshot.json"
+    module = "scout.scripts.connectors_snapshot" if group == "connectors" else "scout.scripts.schedule_snapshot"
+    monkeypatch.setattr(f"{module}.app_fixture_snapshot_path", lambda: fixture)
+
+    target = tmp_path / "canonical.json"
+    result = runner.invoke(cli.app, [group, "snapshot", "--target", str(target)])
+    assert result.exit_code == 0, result.output
+    assert fixture.exists()
+    assert result.stdout.count("Wrote:") == 2
+
+
+# ---------------------------------------------------------------------------
+# schedule fire-now
+# ---------------------------------------------------------------------------
+
+
+def _event(kind: str, payload: dict[str, object] | None = None) -> Event:
+    return Event(id="01HXAAA0000000000000000000", ts=now_iso(), kind=kind, source="test", payload=payload or {})
+
+
+def test_schedule_fire_now_reports_the_fired_slot(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "scout.scripts.schedule_tick.fire_now",
+        lambda key: _event("slot.fired", {"slot_key": key}),
+    )
+    result = runner.invoke(cli.app, ["schedule", "fire-now", "morning-briefing"])
+    assert result.exit_code == 0, result.output
+    assert "fired: morning-briefing" in result.stdout
+
+
+def test_schedule_fire_now_surfaces_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "scout.scripts.schedule_tick.fire_now",
+        lambda key: _event("slot.fire_failed", {"slot_key": key, "error": "runner missing"}),
+    )
+    result = runner.invoke(cli.app, ["schedule", "fire-now", "morning-briefing"])
+    assert result.exit_code == 1
+    assert "failed: runner missing" in result.output
+
+
+def test_schedule_fire_now_failure_without_error_key_says_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "scout.scripts.schedule_tick.fire_now",
+        lambda key: _event("slot.fire_failed"),
+    )
+    result = runner.invoke(cli.app, ["schedule", "fire-now", "morning-briefing"])
+    assert result.exit_code == 1
+    assert "failed: unknown" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Installer commands
+#
+# The bodies shell out to launchctl / pmset / crontab, so stub the script-level
+# entry points and assert only the CLI's own branching and messages.
+# ---------------------------------------------------------------------------
+
+
+def test_install_plist_reports_installed_target(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_install(*, home: Path, force: bool, bootstrap: bool) -> Path:
+        seen.update(force=force, bootstrap=bootstrap)
+        return tmp_path / "com.scout.schedule-tick.plist"
+
+    monkeypatch.setattr("scout.scripts.install_schedule_plist.install_plist", fake_install)
+
+    result = runner.invoke(cli.app, ["schedule", "install-plist", "--force", "--no-bootstrap"])
+    assert result.exit_code == 0, result.output
+    assert "installed:" in result.stdout
+    assert seen == {"force": True, "bootstrap": False}
+
+
+def test_install_plist_existing_file_asks_for_force(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(**_kwargs: object) -> Path:
+        raise FileExistsError("/Users/x/Library/LaunchAgents/com.scout.schedule-tick.plist")
+
+    monkeypatch.setattr("scout.scripts.install_schedule_plist.install_plist", boom)
+
+    result = runner.invoke(cli.app, ["schedule", "install-plist"])
+    assert result.exit_code == 1
+    assert "use --force to overwrite" in result.output
+
+
+def test_install_plist_uninstall_passes_bootout(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[bool] = []
+    monkeypatch.setattr(
+        "scout.scripts.install_schedule_plist.uninstall_plist",
+        lambda *, bootout: seen.append(bootout),
+    )
+    result = runner.invoke(cli.app, ["schedule", "install-plist", "--uninstall"])
+    assert result.exit_code == 0, result.output
+    assert "uninstalled com.scout.schedule-tick.plist" in result.stdout
+    assert seen == [True]
+
+
+def test_install_heartbeat_plist_all_three_branches(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        "scout.scripts.install_heartbeat_plist.install_plist",
+        lambda **_k: tmp_path / "com.scout.heartbeat.plist",
+    )
+    ok = runner.invoke(cli.app, ["schedule", "install-heartbeat-plist"])
+    assert ok.exit_code == 0, ok.output
+    assert "installed:" in ok.stdout
+
+    seen: list[bool] = []
+    monkeypatch.setattr(
+        "scout.scripts.install_heartbeat_plist.uninstall_plist",
+        lambda *, bootout: seen.append(bootout),
+    )
+    gone = runner.invoke(cli.app, ["schedule", "install-heartbeat-plist", "--uninstall", "--no-bootstrap"])
+    assert gone.exit_code == 0, gone.output
+    assert "uninstalled com.scout.heartbeat.plist" in gone.stdout
+    assert seen == [False]
+
+    def boom(**_k: object) -> Path:
+        raise FileExistsError("/Users/x/Library/LaunchAgents/com.scout.heartbeat.plist")
+
+    monkeypatch.setattr("scout.scripts.install_heartbeat_plist.install_plist", boom)
+    clash = runner.invoke(cli.app, ["schedule", "install-heartbeat-plist"])
+    assert clash.exit_code == 1
+    assert "use --force to overwrite" in clash.output
+
+
+def test_install_wake_schedule_prints_ac_only_note(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "scout.scripts.install_wake_schedule.install_wake_schedule",
+        lambda sched, *, dry_run: f"would-wake dry_run={dry_run} slots={len(sched.keys())}",
+    )
+    result = runner.invoke(cli.app, ["schedule", "install-wake-schedule", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    # The AC-only caveat is a real operational footgun; keep it in the output.
+    assert "AC-only" in result.stdout
+    assert "would-wake dry_run=True" in result.stdout
+
+
+def test_install_wake_schedule_uninstall_skips_the_note(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "scout.scripts.install_wake_schedule.uninstall_wake_schedule",
+        lambda *, dry_run: f"removed dry_run={dry_run}",
+    )
+    result = runner.invoke(cli.app, ["schedule", "install-wake-schedule", "--uninstall"])
+    assert result.exit_code == 0, result.output
+    assert "removed dry_run=False" in result.stdout
+    assert "AC-only" not in result.stdout
+
+
+def test_install_wake_schedule_prefers_the_vault_schedule(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A vault schedule.yaml overrides the plugin defaults."""
+    runner.invoke(cli.app, ["schedule", "init"])
+    assert (vault / ".scout-state" / "schedule.yaml").exists()
+
+    keys: list[list[str]] = []
+    monkeypatch.setattr(
+        "scout.scripts.install_wake_schedule.install_wake_schedule",
+        lambda sched, *, dry_run: keys.append(sorted(sched)) or "ok",
+    )
+    result = runner.invoke(cli.app, ["schedule", "install-wake-schedule", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert keys and keys[0]
+
+
+def test_install_cron_install_and_uninstall(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("scout.scripts.install_cron.install_cron", lambda *, home: None)
+    monkeypatch.setattr("scout.scripts.install_cron.uninstall_cron", lambda *, home: None)
+
+    added = runner.invoke(cli.app, ["schedule", "install-cron"])
+    assert added.exit_code == 0, added.output
+    assert "installed scout-managed crontab block" in added.stdout
+
+    removed = runner.invoke(cli.app, ["schedule", "install-cron", "--uninstall"])
+    assert removed.exit_code == 0, removed.output
+    assert "removed scout-managed crontab block" in removed.stdout
+
+
+def test_install_cron_surfaces_apply_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scout.scripts.install_cron import CrontabApplyError
+
+    def boom(*, home: Path) -> None:
+        raise CrontabApplyError("crontab: no crontab for user")
+
+    monkeypatch.setattr("scout.scripts.install_cron.install_cron", boom)
+    result = runner.invoke(cli.app, ["schedule", "install-cron"])
+    assert result.exit_code == 1
+    assert "crontab apply failed: crontab: no crontab for user" in result.output
+
+
+def test_install_all_on_darwin_installs_both_plists(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "scout.scripts.install_schedule_plist.install_plist",
+        lambda **_k: calls.append("tick") or tmp_path / "t.plist",
+    )
+    monkeypatch.setattr(
+        "scout.scripts.install_heartbeat_plist.install_plist",
+        lambda **_k: calls.append("heartbeat") or tmp_path / "h.plist",
+    )
+
+    result = runner.invoke(cli.app, ["schedule", "install-all"])
+    assert result.exit_code == 0, result.output
+    assert "installed launchd plists" in result.stdout
+    assert calls == ["tick", "heartbeat"]
+
+
+def test_install_all_on_darwin_uninstalls_both_plists(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "scout.scripts.install_schedule_plist.uninstall_plist",
+        lambda *, bootout: calls.append(f"tick:{bootout}"),
+    )
+    monkeypatch.setattr(
+        "scout.scripts.install_heartbeat_plist.uninstall_plist",
+        lambda *, bootout: calls.append(f"heartbeat:{bootout}"),
+    )
+
+    result = runner.invoke(cli.app, ["schedule", "install-all", "--uninstall"])
+    assert result.exit_code == 0, result.output
+    assert "uninstalled launchd plists" in result.stdout
+    assert calls == ["tick:True", "heartbeat:True"]
+
+
+def test_install_all_on_linux_uses_cron(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    calls: list[str] = []
+    monkeypatch.setattr("scout.scripts.install_cron.install_cron", lambda *, home: calls.append("install"))
+    monkeypatch.setattr("scout.scripts.install_cron.uninstall_cron", lambda *, home: calls.append("uninstall"))
+
+    added = runner.invoke(cli.app, ["schedule", "install-all"])
+    assert added.exit_code == 0, added.output
+    assert "installed scout-managed crontab block" in added.stdout
+
+    removed = runner.invoke(cli.app, ["schedule", "install-all", "--uninstall"])
+    assert removed.exit_code == 0, removed.output
+    assert "uninstalled scout-managed crontab block" in removed.stdout
+    assert calls == ["install", "uninstall"]
+
+
+def test_install_all_rejects_unsupported_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("platform.system", lambda: "Windows")
+    result = runner.invoke(cli.app, ["schedule", "install-all"])
+    assert result.exit_code == 2
+    assert "unsupported platform: Windows" in result.output
+
+
+# ---------------------------------------------------------------------------
+# trigger — the error/edge branches the subapp test file doesn't reach
+# ---------------------------------------------------------------------------
+
+
+def test_trigger_validate_target_ok(vault: Path, tmp_path: Path) -> None:
+    target = tmp_path / "triggers.yaml"
+    target.write_text("schema_version: 1\ntriggers: []\n", encoding="utf-8")
+    result = runner.invoke(cli.app, ["trigger", "validate", "--target", str(target)])
+    assert result.exit_code == 0, result.output
+    assert f"triggers OK: {target}" in result.stdout
+
+
+def test_trigger_validate_target_missing_exits_one(vault: Path, tmp_path: Path) -> None:
+    result = runner.invoke(cli.app, ["trigger", "validate", "--target", str(tmp_path / "nope.yaml")])
+    assert result.exit_code == 1
+    assert "target does not exist" in result.output
+
+
+def test_trigger_validate_target_invalid_exits_one(vault: Path, tmp_path: Path) -> None:
+    target = tmp_path / "triggers.yaml"
+    target.write_text("schema_version: 1\ntriggers: [{id: x}]\n", encoding="utf-8")
+    result = runner.invoke(cli.app, ["trigger", "validate", "--target", str(target)])
+    assert result.exit_code == 1
+
+
+def test_trigger_validate_vault_file_invalid_exits_one(vault: Path) -> None:
+    (vault / ".scout-state" / "triggers.yaml").write_text("schema_version: 99\ntriggers: []\n", encoding="utf-8")
+    result = runner.invoke(cli.app, ["trigger", "validate"])
+    assert result.exit_code == 1
+
+
+def test_trigger_stats_json_and_empty_text(vault: Path) -> None:
+    empty_json = runner.invoke(cli.app, ["trigger", "stats", "--json"])
+    assert empty_json.exit_code == 0, empty_json.output
+    assert json.loads(empty_json.stdout) == {"days": 7, "by_trigger": {}, "by_day": {}}
+
+    empty_text = runner.invoke(cli.app, ["trigger", "stats", "--days", "3"])
+    assert empty_text.exit_code == 0, empty_text.output
+    assert "no trigger fires in the last 3 day(s)" in empty_text.stdout
+
+
+def test_trigger_stats_skips_blank_and_unparseable_log_lines(vault: Path) -> None:
+    """Fire logs are append-only JSONL written by a live dispatcher; a torn
+    write must degrade to "skip that line", never crash the roll-up."""
+    import datetime as dt
+
+    from scout.triggers.dispatcher import FIRE_LOG_PREFIX
+
+    today = dt.datetime.now(tz=dt.UTC).date().isoformat()
+    log = vault / ".scout-logs" / f"{FIRE_LOG_PREFIX}{today}.jsonl"
+    log.write_text(
+        "\n".join(
+            [
+                json.dumps({"trigger_id": "t1", "status": "ok"}),
+                "",
+                "   ",
+                "{not json",
+                json.dumps({"trigger_id": "t1", "status": "error"}),
+                json.dumps({"status": "ok"}),  # no trigger_id -> "?"
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(cli.app, ["trigger", "stats", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["by_trigger"]["t1"] == {"total": 2, "ok": 1, "error": 1}
+    assert payload["by_trigger"]["?"] == {"total": 1, "ok": 1, "error": 0}
+    assert payload["by_day"][today] == 3
+
+    text = runner.invoke(cli.app, ["trigger", "stats"])
+    assert "t1\ttotal=2\tok=1\terror=1" in text.stdout
+    assert f"{today}\t3" in text.stdout
+
+
+def test_trigger_test_rejects_unhealthy_source(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (vault / ".scout-state" / "triggers.yaml").write_text(
+        "schema_version: 1\n"
+        "triggers:\n"
+        "  - id: t1\n"
+        "    source: scout_internal\n"
+        "    match: {type: slot.fire_failed}\n"
+        "    action: {kind: notify, tier: info, body: hi}\n"
+        "    daily_fire_cap: 3\n",
+        encoding="utf-8",
+    )
+
+    class Unhealthy:
+        def health_check(self) -> tuple[bool, str]:
+            return False, "log dir missing"
+
+    monkeypatch.setattr("scout.triggers.sources.get_source", lambda name, *, vault: Unhealthy())
+
+    result = runner.invoke(cli.app, ["trigger", "test", "t1"])
+    assert result.exit_code == 1
+    assert "is not healthy: log dir missing" in result.output
+
+
+# ---------------------------------------------------------------------------
+# notify telegram — the error-mapping branches (the point of the command)
+# ---------------------------------------------------------------------------
+
+
+def test_notify_telegram_emits_event_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "scout.scripts.notify_telegram.send",
+        lambda *, tier, body, dry_run: _event("notify.sent", {"tier": tier, "dry_run": dry_run}),
+    )
+    result = runner.invoke(cli.app, ["notify", "telegram", "--body", "hello", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["kind"] == "notify.sent"
+    assert payload["payload"] == {"tier": "info", "dry_run": True}
+
+
+def test_notify_telegram_missing_secrets_uses_configerror_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The runner keys off this exit code to know secrets are missing."""
+
+    def boom(**_k: object):
+        raise ConfigError("Secret file is empty: ~/.scout/telegram-token")
+
+    monkeypatch.setattr("scout.scripts.notify_telegram.send", boom)
+    result = runner.invoke(cli.app, ["notify", "telegram", "--body", "hi"])
+    assert result.exit_code == ConfigError.exit_code
+    assert "scoutctl notify telegram: Secret file is empty" in result.output
+
+
+def test_notify_telegram_bad_tier_exits_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(**_k: object):
+        raise ValueError("unknown tier 'shout'")
+
+    monkeypatch.setattr("scout.scripts.notify_telegram.send", boom)
+    result = runner.invoke(cli.app, ["notify", "telegram", "--body", "hi", "--tier", "shout"])
+    assert result.exit_code == 1
+    assert "unknown tier 'shout'" in result.output
+
+
+def test_notify_telegram_http_error_redacts_the_bot_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`str(HTTPError)` embeds the request URL, and the Telegram URL carries the
+    bot token in its path. A 401 must not print it."""
+    import requests
+
+    class FakeResponse:
+        status_code = 401
+        reason = "Unauthorized"
+
+    def boom(**_k: object):
+        raise requests.HTTPError(
+            "401 Client Error: Unauthorized for url: https://api.telegram.org/botSUPERSECRET123/sendMessage",
+            response=FakeResponse(),  # type: ignore[arg-type]
+        )
+
+    monkeypatch.setattr("scout.scripts.notify_telegram.send", boom)
+    result = runner.invoke(cli.app, ["notify", "telegram", "--body", "hi"])
+    assert result.exit_code == 2
+    assert "HTTP 401 Unauthorized (token redacted in URL)" in result.output
+    assert "SUPERSECRET123" not in result.output
+
+
+def test_notify_telegram_http_error_without_response_degrades_gracefully(monkeypatch: pytest.MonkeyPatch) -> None:
+    import requests
+
+    monkeypatch.setattr(
+        "scout.scripts.notify_telegram.send",
+        lambda **_k: (_ for _ in ()).throw(requests.HTTPError("boom", response=None)),  # type: ignore[arg-type]
+    )
+    result = runner.invoke(cli.app, ["notify", "telegram", "--body", "hi"])
+    assert result.exit_code == 2
+    assert "HTTP ? Unknown" in result.output
+
+
+def test_notify_telegram_transport_error_exits_two(monkeypatch: pytest.MonkeyPatch) -> None:
+    import requests
+
+    monkeypatch.setattr(
+        "scout.scripts.notify_telegram.send",
+        lambda **_k: (_ for _ in ()).throw(requests.ConnectTimeout("connect timed out")),
+    )
+    result = runner.invoke(cli.app, ["notify", "telegram", "--body", "hi"])
+    assert result.exit_code == 2
+    assert "HTTP error: connect timed out" in result.output
+
+
+# ---------------------------------------------------------------------------
+# bootstrap
+# ---------------------------------------------------------------------------
+
+
+def _install_argv(*extra: str) -> list[str]:
+    return [
+        "bootstrap",
+        "install",
+        "--user-name",
+        "Alex",
+        "--user-email",
+        "alex@example.com",
+        "--instance-name",
+        "TestScout",
+        "--no-jobs",
+        "--skip-claude",
+        *extra,
+    ]
+
+
+def test_bootstrap_install_creates_the_vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """install() refuses a pre-existing vault, so point SCOUT_DATA_DIR at a
+    path it gets to create."""
+    target = tmp_path / "FreshScout"
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(target))
+
+    result = runner.invoke(cli.app, _install_argv("--connectors", "github, slack ,"))
+    # Exit code is the doctor's — a fresh test vault may legitimately warn.
+    assert result.exit_code in (0, 1), result.output
+    assert f"installed: {target}" in result.stdout
+    assert "doctor:" in result.stdout
+
+    config = (target / "scout-config.yaml").read_text()
+    assert "TestScout" in config
+    # Comma-separated connectors are split and stripped, blanks dropped.
+    assert "github" in config and "slack" in config
+
+
+def test_bootstrap_install_forwards_connector_inputs(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The "regen ships placeholders" bug was a dropped connector_inputs dict —
+    assert every flag lands in the BootstrapConfig."""
+    seen: dict[str, object] = {}
+
+    def fake_install(cfg):
+        seen["inputs"] = dict(cfg.connector_inputs)
+        seen["instance_name_lower"] = cfg.instance_name_lower
+        seen["plugin_root"] = cfg.plugin_root
+
+        class R:
+            vault = cfg.vault
+
+            class doctor:
+                class severity:
+                    value = "ok"
+
+                warnings: list[str] = []
+                errors: list[str] = []
+                exit_code = 0
+
+        return R()
+
+    monkeypatch.setattr("scout.scripts.bootstrap.install", fake_install)
+
+    result = runner.invoke(
+        cli.app,
+        _install_argv(
+            "--user-slack-id",
+            "U123",
+            "--github-username",
+            "alex",
+            "--github-repos",
+            "example-org/repo",
+            "--claude-bin",
+            "/opt/claude",
+            "--max-budget",
+            "9.50",
+        ),
+    )
+    assert result.exit_code == 0, result.output
+    assert seen["inputs"] == {
+        "user_slack_id": "U123",
+        "github_username": "alex",
+        "github_repos": "example-org/repo",
+        "claude_bin": "/opt/claude",
+        "max_budget": "9.50",
+    }
+    # "TestScout" -> "testscout"; spaces become dashes.
+    assert seen["instance_name_lower"] == "testscout"
+    assert seen["plugin_root"] == PLUGIN_ROOT
+
+
+def test_bootstrap_install_reports_doctor_warnings_and_errors(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_install(cfg):
+        class R:
+            vault = cfg.vault
+
+            class doctor:
+                class severity:
+                    value = "error"
+
+                warnings = ["schedule.yaml not seeded"]
+                errors = ["claude binary not found"]
+                exit_code = 1
+
+        return R()
+
+    monkeypatch.setattr("scout.scripts.bootstrap.install", fake_install)
+    result = runner.invoke(cli.app, _install_argv())
+    assert result.exit_code == 1
+    assert "warning: schedule.yaml not seeded" in result.output
+    assert "error: claude binary not found" in result.output
+
+
+def test_bootstrap_upgrade_reads_existing_config(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (vault / "scout-config.yaml").write_text(
+        "instance:\n"
+        "  name: TestScout\n"
+        "  name_lower: testscout\n"
+        "user:\n"
+        "  name: Alex\n"
+        "  email: alex@example.com\n"
+        "timezone: Europe/Prague\n"
+        "platform: linux\n"
+        "connectors:\n"
+        "  enabled: [github]\n"
+        "  inputs: {github_username: alex}\n",
+        encoding="utf-8",
+    )
+    seen: dict[str, object] = {}
+
+    def fake_upgrade(cfg):
+        seen.update(
+            instance_name=cfg.instance_name,
+            timezone=cfg.timezone,
+            platform=cfg.platform,
+            connectors=set(cfg.enabled_connectors),
+            inputs=dict(cfg.connector_inputs),
+            skip_jobs=cfg.skip_jobs,
+            skip_claude=cfg.skip_claude,
+        )
+
+        class R:
+            vault = cfg.vault
+            conflicts = ["SKILL.md"]
+            backups = ["SKILL.md.bak.2026-04-15"]
+
+            class doctor:
+                class severity:
+                    value = "warn"
+
+                exit_code = 0
+
+        return R()
+
+    monkeypatch.setattr("scout.scripts.bootstrap.upgrade", fake_upgrade)
+
+    result = runner.invoke(cli.app, ["bootstrap", "upgrade", "--no-jobs", "--skip-claude"])
+    assert result.exit_code == 0, result.output
+    assert f"upgraded: {vault}" in result.stdout
+    assert "conflict (sidecar): SKILL.md" in result.output
+    assert "backup: SKILL.md.bak.2026-04-15" in result.output
+    assert "doctor: warn" in result.stdout
+    assert seen["timezone"] == "Europe/Prague"
+    assert seen["platform"] == "linux"
+    assert seen["connectors"] == {"github"}
+    assert seen["inputs"] == {"github_username": "alex"}
+    assert seen["skip_jobs"] is True and seen["skip_claude"] is True
+
+
+def test_bootstrap_upgrade_without_a_vault_exits_two(vault: Path) -> None:
+    result = runner.invoke(cli.app, ["bootstrap", "upgrade"])
+    assert result.exit_code == 2
+    assert "run /scout-setup" in result.output
+
+
+def test_bootstrap_upgrade_empty_config_falls_back_to_defaults(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty (but parseable) scout-config.yaml must not crash — `or {}`."""
+    (vault / "scout-config.yaml").write_text("", encoding="utf-8")
+    seen: dict[str, object] = {}
+
+    def fake_upgrade(cfg):
+        seen.update(instance_name=cfg.instance_name, user_name=cfg.user_name, timezone=cfg.timezone)
+
+        class R:
+            vault = cfg.vault
+            conflicts: list[str] = []
+            backups: list[str] = []
+
+            class doctor:
+                class severity:
+                    value = "ok"
+
+                exit_code = 0
+
+        return R()
+
+    monkeypatch.setattr("scout.scripts.bootstrap.upgrade", fake_upgrade)
+    result = runner.invoke(cli.app, ["bootstrap", "upgrade"])
+    assert result.exit_code == 0, result.output
+    assert seen == {"instance_name": "Scout", "user_name": "", "timezone": "America/New_York"}
+
+
+def test_bootstrap_doctor_reports_severity_and_findings(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_run_doctor(*, vault: Path, check_jobs: bool):
+        seen.update(vault=vault, check_jobs=check_jobs)
+
+        class R:
+            class severity:
+                value = "warn"
+
+            warnings = ["no recent session"]
+            errors = ["missing knowledge-base/"]
+            exit_code = 0
+
+        return R()
+
+    monkeypatch.setattr("scout.scripts.bootstrap_doctor.run_doctor", fake_run_doctor)
+
+    result = runner.invoke(cli.app, ["bootstrap", "doctor"])
+    assert result.exit_code == 0, result.output
+    assert "severity: warn" in result.stdout
+    assert "warning: no recent session" in result.stdout
+    assert "error: missing knowledge-base/" in result.output
+    assert seen["check_jobs"] is True
+
+    runner.invoke(cli.app, ["bootstrap", "doctor", "--no-jobs"])
+    assert seen["check_jobs"] is False
+
+
+def test_bootstrap_migrate_legacy_reports_snapshots_and_backups(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_migrate(cfg):
+        seen.update(skip_jobs=cfg.skip_jobs, skip_claude=cfg.skip_claude, inputs=dict(cfg.connector_inputs))
+
+        class R:
+            vault = cfg.vault
+            snapshots_recorded = ["SKILL", "DREAMING"]
+            backups = ["run-briefing.sh.bak.2026-04-15"]
+
+            class doctor:
+                class severity:
+                    value = "ok"
+
+                warnings = ["legacy runner backed up"]
+                errors: list[str] = []
+                exit_code = 0
+
+        return R()
+
+    monkeypatch.setattr("scout.scripts.bootstrap.migrate_legacy", fake_migrate)
+
+    result = runner.invoke(
+        cli.app,
+        ["bootstrap", "migrate-legacy", "--user-name", "Alex", "--user-email", "alex@example.com"],
+    )
+    assert result.exit_code == 0, result.output
+    assert f"migrated: {vault}" in result.stdout
+    assert "snapshots recorded: SKILL, DREAMING" in result.stdout
+    assert "backup: run-briefing.sh.bak.2026-04-15" in result.stdout
+    assert "warning: legacy runner backed up" in result.output
+    # migrate-legacy defaults to --no-jobs and never runs Claude.
+    assert seen["skip_jobs"] is True
+    assert seen["skip_claude"] is True
+
+
+def test_bootstrap_migrate_legacy_rebootstrap_jobs_flips_skip_jobs(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_migrate(cfg):
+        seen["skip_jobs"] = cfg.skip_jobs
+
+        class R:
+            vault = cfg.vault
+            snapshots_recorded: list[str] = []
+            backups: list[str] = []
+
+            class doctor:
+                class severity:
+                    value = "ok"
+
+                warnings: list[str] = []
+                errors: list[str] = []
+                exit_code = 0
+
+        return R()
+
+    monkeypatch.setattr("scout.scripts.bootstrap.migrate_legacy", fake_migrate)
+    result = runner.invoke(
+        cli.app,
+        [
+            "bootstrap",
+            "migrate-legacy",
+            "--user-name",
+            "Alex",
+            "--user-email",
+            "alex@example.com",
+            "--rebootstrap-jobs",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert seen["skip_jobs"] is False
+    assert "snapshots recorded: none" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# phases backport
+# ---------------------------------------------------------------------------
+
+
+def _write_vault_config(vault: Path) -> None:
+    (vault / "scout-config.yaml").write_text(
+        "instance:\n  name: TestScout\n  name_lower: testscout\n"
+        "user:\n  name: Alex\n  email: alex@example.com\n"
+        "connectors:\n  enabled: []\n  inputs: {}\n",
+        encoding="utf-8",
+    )
+
+
+def test_phases_backport_without_a_vault_exits_two(vault: Path) -> None:
+    result = runner.invoke(cli.app, ["phases", "backport"])
+    assert result.exit_code == 2
+    assert "run /scout-setup" in result.output
+
+
+def test_phases_backport_malformed_config_exits_configerror(vault: Path) -> None:
+    (vault / "scout-config.yaml").write_text("instance: [unclosed\n", encoding="utf-8")
+    result = runner.invoke(cli.app, ["phases", "backport"])
+    assert result.exit_code == ConfigError.exit_code
+    assert "scout-config.yaml is malformed" in result.output
+
+
+def test_phases_backport_skips_kinds_with_no_snapshot(vault: Path) -> None:
+    _write_vault_config(vault)
+    result = runner.invoke(cli.app, ["phases", "backport", "--kind", "SKILL"])
+    assert result.exit_code == 0, result.output
+    assert "SKILL: skip — missing snapshot file" in result.output
+    assert "dry-run" in result.stdout
+
+
+def test_phases_backport_skips_when_only_the_live_file_is_missing(vault: Path) -> None:
+    _write_vault_config(vault)
+    snap_dir = vault / ".scout-state" / "last-assembled"
+    snap_dir.mkdir(parents=True)
+    (snap_dir / "SKILL.md").write_text("# SKILL\n", encoding="utf-8")
+
+    result = runner.invoke(cli.app, ["phases", "backport", "--kind", "skill"])
+    assert result.exit_code == 0, result.output
+    assert "SKILL: skip — missing live file" in result.output
+
+
+def test_phases_backport_all_visits_three_kinds(vault: Path) -> None:
+    _write_vault_config(vault)
+    result = runner.invoke(cli.app, ["phases", "backport"])
+    assert result.exit_code == 0, result.output
+    for kind in ("SKILL", "DREAMING", "RESEARCH"):
+        assert f"{kind}: skip" in result.output
+
+
+def test_phases_backport_reports_unchanged_files(vault: Path) -> None:
+    """Snapshot == live means zero hunks: a clean 0-hunk report, not a crash."""
+    _write_vault_config(vault)
+    snap_dir = vault / ".scout-state" / "last-assembled"
+    snap_dir.mkdir(parents=True)
+    body = "# SKILL\n\nunchanged body\n"
+    (snap_dir / "SKILL.md").write_text(body, encoding="utf-8")
+    (vault / "SKILL.md").write_text(body, encoding="utf-8")
+
+    result = runner.invoke(cli.app, ["phases", "backport", "--kind", "SKILL"])
+    assert result.exit_code == 0, result.output
+    assert "phases backport — SKILL (0 hunk(s)" in result.stdout
+
+
+def test_phases_backport_honours_explicit_vault_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    decoy = tmp_path / "decoy"
+    decoy.mkdir()
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(decoy))
+
+    real = tmp_path / "Real"
+    (real / ".scout-state").mkdir(parents=True)
+    _write_vault_config(real)
+
+    result = runner.invoke(cli.app, ["phases", "backport", "--vault", str(real), "--kind", "SKILL"])
+    assert result.exit_code == 0, result.output
+    assert "SKILL: skip" in result.output
+
+
+def test_phases_backport_apply_writes_the_applied_hunks(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """--apply must round-trip each applied hunk back into its phase fragment.
+    The planner is stubbed so the test pins the CLI's write loop, not the
+    re-templatizer (covered by test_phase_backport.py)."""
+    _write_vault_config(vault)
+    snap_dir = vault / ".scout-state" / "last-assembled"
+    snap_dir.mkdir(parents=True)
+    (snap_dir / "SKILL.md").write_text("# SKILL\n\nold\n", encoding="utf-8")
+    (vault / "SKILL.md").write_text("# SKILL\n\nnew\n", encoding="utf-8")
+
+    fragment = vault / "fragment.md"
+    fragment.write_text("## Section\n\nRAW BODY\n", encoding="utf-8")
+
+    class Section:
+        phase_file = fragment
+        section_name = "Section"
+        raw_body = "RAW BODY"
+        rendered_body = "RAW BODY"
+
+    class Result:
+        status = "applied"
+        phase_file = fragment
+        section_name = "Section"
+        added = ["new"]
+        anchor = "old"
+        retemplatized = "new"
+        reason = ""
+        risky_hits: list[str] = []
+
+    monkeypatch.setattr("scout.scripts.phase_backport.build_rendered_sections", lambda *a, **k: [Section()])
+    monkeypatch.setattr("scout.scripts.phase_backport.plan_backport", lambda *a, **k: [Result()])
+    monkeypatch.setattr("scout.scripts.phase_backport.apply_section_edits", lambda raw, rendered, edits: "EDITED BODY")
+    monkeypatch.setattr(
+        "scout.scripts.phase_backport.apply_to_phase_text",
+        lambda text, raw, edited: text.replace(raw, edited),
+    )
+
+    result = runner.invoke(cli.app, ["phases", "backport", "--kind", "SKILL", "--apply"])
+    assert result.exit_code == 0, result.output
+    assert "✓ applied" in result.stdout
+    assert f"→ wrote {fragment}" in result.stdout
+    assert "Applied 1 hunk(s) to phases/." in result.stdout
+    assert "EDITED BODY" in fragment.read_text()
+
+
+def test_phases_backport_renders_needs_review_and_unmapped_rows(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_vault_config(vault)
+    snap_dir = vault / ".scout-state" / "last-assembled"
+    snap_dir.mkdir(parents=True)
+    (snap_dir / "SKILL.md").write_text("# SKILL\n\nold\n", encoding="utf-8")
+    (vault / "SKILL.md").write_text("# SKILL\n\nnew\n", encoding="utf-8")
+
+    class Review:
+        status = "needs-review"
+        phase_file = Path("phases/skill/10-intro.md")
+        section_name = "Intro"
+        reason = "anchor ambiguous"
+        risky_hits = ["hardcoded path"]
+        added: list[str] = []
+
+    class ReviewNoFile:
+        status = "needs-review"
+        phase_file = None
+        section_name = ""
+        reason = "no matching section"
+        risky_hits: list[str] = []
+        added: list[str] = []
+
+    class Unmapped:
+        status = "unmapped"
+        phase_file = None
+        section_name = ""
+        reason = "no fragment owns this text"
+        risky_hits: list[str] = []
+        added = ["x" * 80]
+
+    monkeypatch.setattr("scout.scripts.phase_backport.build_rendered_sections", lambda *a, **k: [])
+    monkeypatch.setattr(
+        "scout.scripts.phase_backport.plan_backport",
+        lambda *a, **k: [Review(), ReviewNoFile(), Unmapped()],
+    )
+
+    result = runner.invoke(cli.app, ["phases", "backport", "--kind", "SKILL"])
+    assert result.exit_code == 0, result.output
+    assert "⚠ needs-review phases/skill/10-intro.md «Intro» — anchor ambiguous [risky: hardcoded path]" in result.stdout
+    assert "⚠ needs-review — — no matching section" in result.stdout
+    assert "✗ unmapped     no fragment owns this text" in result.stdout
+    # The unmapped snippet is truncated to 60 chars + ellipsis.
+    assert "x" * 60 + "…" in result.stdout
+
+
+def test_phases_backport_apply_with_no_applied_hunks_writes_nothing(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_vault_config(vault)
+    snap_dir = vault / ".scout-state" / "last-assembled"
+    snap_dir.mkdir(parents=True)
+    (snap_dir / "SKILL.md").write_text("# SKILL\n\nold\n", encoding="utf-8")
+    (vault / "SKILL.md").write_text("# SKILL\n\nnew\n", encoding="utf-8")
+
+    monkeypatch.setattr("scout.scripts.phase_backport.build_rendered_sections", lambda *a, **k: [])
+    monkeypatch.setattr("scout.scripts.phase_backport.plan_backport", lambda *a, **k: [])
+
+    result = runner.invoke(cli.app, ["phases", "backport", "--kind", "SKILL", "--apply"])
+    assert result.exit_code == 0, result.output
+    assert "Applied 0 hunk(s) to phases/." in result.stdout
+    assert "→ wrote" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# self-update check / tui
+# ---------------------------------------------------------------------------
+
+
+def test_self_update_check_text_when_update_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scout.scripts.self_update import UpdateStatus
+
+    monkeypatch.setattr(
+        "scout.scripts.self_update.check",
+        lambda: UpdateStatus(installed="0.8.0", available="0.9.0", update_available=True),
+    )
+    result = runner.invoke(cli.app, ["self-update", "check"])
+    assert result.exit_code == 0, result.output
+    assert result.stdout.strip() == "update available: 0.8.0 -> 0.9.0"
+
+
+def test_self_update_check_text_when_up_to_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scout.scripts.self_update import UpdateStatus
+
+    monkeypatch.setattr(
+        "scout.scripts.self_update.check",
+        lambda: UpdateStatus(installed="0.8.0", available="0.8.0", update_available=False),
+    )
+    result = runner.invoke(cli.app, ["self-update", "check"])
+    assert result.exit_code == 0, result.output
+    assert result.stdout.strip() == "up to date (0.8.0)"
+
+
+def test_self_update_check_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scout.scripts.self_update import UpdateStatus
+
+    monkeypatch.setattr(
+        "scout.scripts.self_update.check",
+        lambda: UpdateStatus(installed="0.8.0", available="0.9.0", update_available=True),
+    )
+    result = runner.invoke(cli.app, ["self-update", "check", "--json"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {
+        "installed": "0.8.0",
+        "available": "0.9.0",
+        "update_available": True,
+    }
+
+
+def test_tui_runs_the_textual_app(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Patching scout.tui.app imports it, and that needs textual — which lives
+    # in the [full] extra, not [dev]. The no-textual path is covered by
+    # test_tui_without_textual_raises_actionable_error below.
+    pytest.importorskip("textual")
+
+    runs: list[str] = []
+
+    class FakeApp:
+        def run(self) -> None:
+            runs.append("ran")
+
+    monkeypatch.setattr("scout.tui.app.ScoutApp", FakeApp)
+    result = runner.invoke(cli.app, ["tui"])
+    assert result.exit_code == 0, result.output
+    assert runs == ["ran"]
+
+
+def test_tui_without_textual_raises_actionable_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """textual lives in the [full] extra; a [dev]-only install must get an
+    install hint, not a bare ImportError traceback."""
+    import builtins
+
+    from scout.errors import ActionItemError
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object):
+        if name == "scout.tui.app":
+            raise ImportError("No module named 'textual'")
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    result = runner.invoke(cli.app, ["tui"])
+    assert result.exit_code != 0
+    assert isinstance(result.exception, ActionItemError)
+    assert ".[full]" in str(result.exception)

--- a/engine/tests/unit/test_heartbeat_run.py
+++ b/engine/tests/unit/test_heartbeat_run.py
@@ -1,0 +1,585 @@
+"""Coverage of heartbeat's I/O layer: the subprocess probes, the detached
+launch, the log writer, and the `run()`/`main()` driver.
+
+`test_heartbeat.py` covers the pure pieces — `load_config`,
+`read_tracker_stats`, `in_off_peak`, `decide`, and one no-tracker `run()`.
+What is left is everything that shells out or writes: `scout_session_running`
+(pgrep), `vault_has_uncommitted_changes` (git), `run_budget_check`
+(scoutctl), `launch_runner` (detached Popen), `_log_line`, and the driver's
+launch / dry-run / launch-failure branches.
+
+These matter because heartbeat runs unattended every 30 minutes: a probe that
+raises instead of returning a bool turns a routine skip into a launchd
+"configuration error", and a swallowed launch failure means Scout silently
+stops running sessions.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from scout.scripts import heartbeat as hb
+
+
+def _now() -> datetime:
+    return datetime(2026, 5, 28, 14, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    v = tmp_path / "Scout"
+    (v / ".scout-logs").mkdir(parents=True)
+    return v
+
+
+class _Proc:
+    """Stand-in for a CompletedProcess."""
+
+    def __init__(self, returncode: int = 0, stdout: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+# ---------------------------------------------------------------------------
+# scout_session_running
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("returncode", "stdout", "expected"),
+    [
+        (0, "4711\n", True),
+        (1, "", False),  # pgrep's "no match"
+        (0, "   \n", False),  # exit 0 but nothing named — treat as not running
+    ],
+)
+def test_scout_session_running_reads_pgrep(
+    monkeypatch: pytest.MonkeyPatch, returncode: int, stdout: str, expected: bool
+) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Proc(returncode, stdout))
+    assert hb.scout_session_running() is expected
+
+
+@pytest.mark.parametrize("exc", [OSError("no pgrep"), subprocess.TimeoutExpired("pgrep", 2)])
+def test_scout_session_running_treats_a_broken_probe_as_not_running(
+    monkeypatch: pytest.MonkeyPatch, exc: Exception
+) -> None:
+    """A missing or hung pgrep must not block the heartbeat forever — "unknown"
+    resolves to "not running" so a session can still fire."""
+
+    def boom(*_a: object, **_k: object):
+        raise exc
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    assert hb.scout_session_running() is False
+
+
+def test_scout_session_running_passes_the_pattern_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[list[str]] = []
+    monkeypatch.setattr(subprocess, "run", lambda argv, **k: seen.append(argv) or _Proc(1))
+    hb.scout_session_running("claude.*custom-")
+    assert seen == [["pgrep", "-f", "claude.*custom-"]]
+
+
+# ---------------------------------------------------------------------------
+# vault_has_uncommitted_changes
+# ---------------------------------------------------------------------------
+
+
+def test_vault_without_a_git_dir_reports_no_changes(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No .git means git is never invoked — this is the common case for a vault
+    the user hasn't put under version control."""
+
+    def fail(*_a: object, **_k: object):
+        raise AssertionError("git must not run without a .git dir")
+
+    monkeypatch.setattr(subprocess, "run", fail)
+    assert hb.vault_has_uncommitted_changes(vault) is False
+
+
+@pytest.mark.parametrize(
+    ("returncode", "stdout", "expected"),
+    [
+        (0, " M knowledge-base/people.md\n", True),
+        (0, "", False),
+        (128, "", False),  # git error (e.g. corrupt repo) -> no signal
+    ],
+)
+def test_vault_has_uncommitted_changes_reads_git_status(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, returncode: int, stdout: str, expected: bool
+) -> None:
+    (vault / ".git").mkdir()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Proc(returncode, stdout))
+    assert hb.vault_has_uncommitted_changes(vault) is expected
+
+
+@pytest.mark.parametrize("exc", [OSError("no git"), subprocess.TimeoutExpired("git", 5)])
+def test_vault_has_uncommitted_changes_swallows_probe_failures(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, exc: Exception
+) -> None:
+    (vault / ".git").mkdir()
+
+    def boom(*_a: object, **_k: object):
+        raise exc
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    assert hb.vault_has_uncommitted_changes(vault) is False
+
+
+# ---------------------------------------------------------------------------
+# load_config / read_tracker_stats tolerance
+#
+# Both parsers are deliberately forgiving: heartbeat must never fail a tick
+# over a hand-edited config or a torn tracker append.
+# ---------------------------------------------------------------------------
+
+
+def test_load_config_falls_back_when_the_file_is_unreadable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = tmp_path / "scout-config.yaml"
+    config.write_text("off_peak_start: 1\n", encoding="utf-8")
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "read_text", boom)
+    assert hb.load_config(config) == hb.HeartbeatConfig()
+
+
+def test_load_config_ignores_non_scalar_and_unknown_lines(tmp_path: Path) -> None:
+    config = tmp_path / "scout-config.yaml"
+    config.write_text(
+        "# a comment\n"
+        "\n"
+        "instance:\n"  # key with no value -> no match
+        "  name: Scout\n"  # known-shaped but not a heartbeat key
+        "timezone: America/New_York\n"  # unknown key
+        "off_peak_start: 22  # trailing comment\n",
+        encoding="utf-8",
+    )
+    cfg = hb.load_config(config)
+    assert cfg.off_peak_start == 22
+    assert cfg.off_peak_end == hb.DEFAULT_OFF_PEAK_END
+
+
+def test_read_tracker_stats_tolerates_blank_and_non_object_rows(tmp_path: Path) -> None:
+    tracker = tmp_path / "usage-tracker.jsonl"
+    good = _now().replace(hour=12)
+    tracker.write_text(
+        "\n".join(
+            [
+                "",
+                "   ",
+                '"just a string"',  # valid JSON, not a dict
+                "[1, 2, 3]",  # valid JSON, not a dict
+                json.dumps({"type": "dreaming"}),  # no ts
+                json.dumps({"ts": 1700000000, "type": "dreaming"}),  # ts not a string
+                json.dumps({"ts": good.isoformat().replace("+00:00", "Z"), "type": "dreaming"}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    stats = hb.read_tracker_stats(tracker, now=_now())
+    assert stats.minutes_since_last_session == 120
+    assert stats.hours_since_dreaming == 2
+
+
+def test_read_tracker_stats_assumes_utc_for_a_naive_timestamp(tmp_path: Path) -> None:
+    """Older tracker rows were written without an offset; reading them as local
+    time would shift every gap by hours and mis-gate the heartbeat."""
+    tracker = tmp_path / "usage-tracker.jsonl"
+    tracker.write_text(json.dumps({"ts": "2026-05-28T12:00:00", "type": "dreaming"}) + "\n", encoding="utf-8")
+    stats = hb.read_tracker_stats(tracker, now=_now())
+    assert stats.minutes_since_last_session == 120
+
+
+def test_read_tracker_stats_falls_back_when_the_tracker_is_unreadable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tracker = tmp_path / "usage-tracker.jsonl"
+    tracker.write_text(json.dumps({"ts": "2026-05-28T12:00:00Z"}) + "\n", encoding="utf-8")
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "open", boom)
+    assert hb.read_tracker_stats(tracker, now=_now()) == hb.TrackerStats.empty()
+
+
+# ---------------------------------------------------------------------------
+# research_queue_has_unchecked / _item_status edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_research_queue_has_unchecked_survives_an_unreadable_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    queue = tmp_path / "research-queue.md"
+    queue.write_text("- [ ] item\n", encoding="utf-8")
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "open", boom)
+    assert hb.research_queue_has_unchecked(queue) is False
+
+
+def test_item_status_returns_none_for_an_unreadable_item(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    item = tmp_path / "item.md"
+    item.write_text("---\nstatus: open\n---\n", encoding="utf-8")
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "read_text", boom)
+    assert hb._item_status(item) is None
+
+
+def test_item_status_returns_none_without_frontmatter(tmp_path: Path) -> None:
+    item = tmp_path / "item.md"
+    item.write_text("# Just a heading\n\nstatus: open\n", encoding="utf-8")
+    assert hb._item_status(item) is None
+
+
+def test_item_status_returns_none_for_unterminated_frontmatter(tmp_path: Path) -> None:
+    """No closing fence means the block is malformed; a `status:` inside it is
+    not trustworthy, so the item is not counted as open."""
+    item = tmp_path / "item.md"
+    item.write_text("---\ntitle: no closing fence\n", encoding="utf-8")
+    assert hb._item_status(item) is None
+
+
+def test_item_status_returns_none_when_frontmatter_has_no_status(tmp_path: Path) -> None:
+    item = tmp_path / "item.md"
+    item.write_text("---\ntitle: nothing here\n---\n\nbody\n", encoding="utf-8")
+    assert hb._item_status(item) is None
+
+
+def test_item_status_lowercases_the_value(tmp_path: Path) -> None:
+    item = tmp_path / "item.md"
+    item.write_text("---\nstatus: In-Progress\n---\n", encoding="utf-8")
+    assert hb._item_status(item) == "in-progress"
+
+
+def test_research_queue_has_open_survives_an_unlistable_queue_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    queue_dir = tmp_path / "knowledge-base" / "research-queue"
+    queue_dir.mkdir(parents=True)
+    (queue_dir / "topic.md").write_text("---\nstatus: open\n---\n", encoding="utf-8")
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "glob", boom)
+    assert hb.research_queue_has_open(tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# run_budget_check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("rc", [0, 1, 2])
+def test_run_budget_check_forwards_the_exit_code(monkeypatch: pytest.MonkeyPatch, rc: int) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Proc(rc))
+    assert hb.run_budget_check("scoutctl") == rc
+
+
+def test_run_budget_check_resolves_the_binary_from_the_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[list[str]] = []
+    monkeypatch.setenv("SCOUTCTL_BIN", "/opt/scout/bin/scoutctl")
+    monkeypatch.setattr(subprocess, "run", lambda argv, **k: seen.append(argv) or _Proc(0))
+    hb.run_budget_check()
+    assert seen == [["/opt/scout/bin/scoutctl", "budget", "check"]]
+
+
+def test_run_budget_check_defaults_to_scoutctl_on_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[list[str]] = []
+    monkeypatch.delenv("SCOUTCTL_BIN", raising=False)
+    monkeypatch.setattr(subprocess, "run", lambda argv, **k: seen.append(argv) or _Proc(0))
+    hb.run_budget_check()
+    assert seen[0][0] == "scoutctl"
+
+
+@pytest.mark.parametrize("exc", [OSError("not found"), subprocess.TimeoutExpired("scoutctl", 10)])
+def test_run_budget_check_does_not_gate_on_a_missing_scoutctl(monkeypatch: pytest.MonkeyPatch, exc: Exception) -> None:
+    """An unreachable budget check must read as "proceed" (0), not "exhausted" —
+    otherwise a PATH problem silently stops all sessions."""
+
+    def boom(*_a: object, **_k: object):
+        raise exc
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    assert hb.run_budget_check("scoutctl") == 0
+
+
+# ---------------------------------------------------------------------------
+# launch_runner
+# ---------------------------------------------------------------------------
+
+
+def test_launch_runner_detaches_and_redirects_into_the_log(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    log_path = vault / ".scout-logs" / "heartbeat.log"
+    runner = vault / "run-dreaming.sh"
+    runner.write_text("#!/bin/sh\nexit 0\n")
+    runner.chmod(0o755)
+
+    seen: dict[str, object] = {}
+
+    class FakePopen:
+        pid = 4711
+
+        def __init__(self, argv, **kwargs):
+            seen["argv"] = argv
+            seen.update(kwargs)
+
+    monkeypatch.setattr(subprocess, "Popen", FakePopen)
+
+    assert hb.launch_runner(runner, vault=vault, log_path=log_path) == 4711
+    assert seen["argv"] == [str(runner)]
+    assert seen["cwd"] == str(vault)
+    # Detached: a new session so launchd reaping the heartbeat doesn't kill the
+    # child, and no inherited stdin.
+    assert seen["start_new_session"] is True
+    assert seen["stdin"] is subprocess.DEVNULL
+    assert seen["stdout"] is seen["stderr"]
+
+
+def test_launch_runner_creates_the_log_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    log_path = tmp_path / "nested" / "dirs" / "heartbeat.log"
+    runner = tmp_path / "run.sh"
+    runner.write_text("#!/bin/sh\n")
+
+    class FakePopen:
+        pid = 1
+
+        def __init__(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(subprocess, "Popen", FakePopen)
+    hb.launch_runner(runner, vault=tmp_path, log_path=log_path)
+    assert log_path.parent.is_dir()
+
+
+def test_launch_runner_really_runs_a_script(vault: Path) -> None:
+    """One unmocked launch, to prove the Popen wiring works end-to-end."""
+    log_path = vault / ".scout-logs" / "heartbeat.log"
+    runner = vault / "run-dreaming.sh"
+    runner.write_text("#!/bin/sh\necho hello-from-runner\n")
+    runner.chmod(0o755)
+
+    pid = hb.launch_runner(runner, vault=vault, log_path=log_path)
+    assert pid > 0
+    # Reap it so the test doesn't leave a zombie, then read what it wrote.
+    try:
+        import os
+
+        os.waitpid(pid, 0)
+    except (ChildProcessError, OSError):
+        pass
+    assert "hello-from-runner" in log_path.read_text()
+
+
+# ---------------------------------------------------------------------------
+# _log_line
+# ---------------------------------------------------------------------------
+
+
+def test_log_line_appends_a_timestamped_reason(vault: Path) -> None:
+    log_path = vault / ".scout-logs" / "heartbeat.log"
+    hb._log_line(log_path, "skipped: budget_exhausted")
+    hb._log_line(log_path, "launched dreaming PID=1")
+    lines = log_path.read_text().splitlines()
+    assert len(lines) == 2
+    assert lines[0].startswith("[") and "skipped: budget_exhausted" in lines[0]
+    assert "launched dreaming PID=1" in lines[1]
+
+
+def test_log_line_falls_back_when_the_timezone_is_unknown(vault: Path) -> None:
+    log_path = vault / ".scout-logs" / "heartbeat.log"
+    hb._log_line(log_path, "skipped: x", tz_name="Not/AZone")
+    assert "skipped: x" in log_path.read_text()
+
+
+def test_log_line_falls_back_when_zone_resolution_raises(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The stamp is decoration; the *reason* is the signal. A config layer that
+    blows up mid-resolution must still leave a readable log line."""
+    import scout.config as scout_config
+
+    def boom(*_a: object, **_k: object):
+        raise RuntimeError("config layer exploded")
+
+    monkeypatch.setattr(scout_config, "resolve_timezone", boom)
+
+    log_path = vault / ".scout-logs" / "heartbeat.log"
+    hb._log_line(log_path, "skipped: budget_exhausted")
+    assert "skipped: budget_exhausted" in log_path.read_text()
+
+
+def test_log_line_never_raises_on_an_unwritable_log(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Logging is best-effort: an unwritable log must not turn a normal skip
+    into a launchd configuration error."""
+    log_path = vault / ".scout-logs" / "heartbeat.log"
+    real_open = Path.open
+
+    def maybe_boom(self: Path, *a: object, **k: object):
+        if self == log_path:
+            raise OSError("read-only filesystem")
+        return real_open(self, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "open", maybe_boom)
+    hb._log_line(log_path, "skipped: x")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# run() / main()
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def quiet_probes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutral probe results: no session running, budget fine, no git changes."""
+    monkeypatch.setattr(hb, "scout_session_running", lambda *a, **k: False)
+    monkeypatch.setattr(hb, "run_budget_check", lambda *a, **k: 0)
+    monkeypatch.setattr(hb, "vault_has_uncommitted_changes", lambda *a, **k: False)
+
+
+def _seed_runner(vault: Path, name: str) -> Path:
+    runner = vault / name
+    runner.write_text("#!/bin/sh\nexit 0\n")
+    runner.chmod(0o755)
+    return runner
+
+
+def test_run_launches_dreaming_and_logs_the_pid(
+    vault: Path, quiet_probes: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_runner(vault, "run-dreaming.sh")
+    monkeypatch.setattr(hb, "launch_runner", lambda runner, *, vault, log_path: 4711)
+
+    assert hb.run(data_dir=vault, now=_now()) == hb.EXIT_LAUNCHED
+    log = (vault / ".scout-logs" / "heartbeat.log").read_text()
+    assert "launched dreaming PID=4711" in log
+
+
+def test_run_dry_run_reports_without_launching(
+    vault: Path, quiet_probes: None, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    runner = _seed_runner(vault, "run-dreaming.sh")
+
+    def fail(*_a: object, **_k: object):
+        raise AssertionError("dry_run must not launch")
+
+    monkeypatch.setattr(hb, "launch_runner", fail)
+
+    assert hb.run(data_dir=vault, dry_run=True, now=_now()) == hb.EXIT_LAUNCHED
+    assert f"would_launch {runner}" in capsys.readouterr().out
+    assert "dry_run: would launch dreaming" in (vault / ".scout-logs" / "heartbeat.log").read_text()
+
+
+def test_run_returns_error_when_the_launch_fails(
+    vault: Path, quiet_probes: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_runner(vault, "run-dreaming.sh")
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("exec format error")
+
+    monkeypatch.setattr(hb, "launch_runner", boom)
+
+    assert hb.run(data_dir=vault, now=_now()) == hb.EXIT_ERROR
+    assert "launch_failed: exec format error" in (vault / ".scout-logs" / "heartbeat.log").read_text()
+
+
+def test_run_skips_and_logs_when_a_session_is_already_running(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _seed_runner(vault, "run-dreaming.sh")
+    monkeypatch.setattr(hb, "scout_session_running", lambda *a, **k: True)
+    monkeypatch.setattr(hb, "run_budget_check", lambda *a, **k: 0)
+    monkeypatch.setattr(hb, "vault_has_uncommitted_changes", lambda *a, **k: False)
+
+    assert hb.run(data_dir=vault, now=_now()) == hb.EXIT_SKIPPED
+    assert "skipped: session_already_running" in (vault / ".scout-logs" / "heartbeat.log").read_text()
+
+
+def test_run_skips_when_the_budget_check_says_no(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _seed_runner(vault, "run-dreaming.sh")
+    monkeypatch.setattr(hb, "scout_session_running", lambda *a, **k: False)
+    monkeypatch.setattr(hb, "run_budget_check", lambda *a, **k: 1)
+    monkeypatch.setattr(hb, "vault_has_uncommitted_changes", lambda *a, **k: False)
+
+    assert hb.run(data_dir=vault, now=_now()) == hb.EXIT_SKIPPED
+    assert "skipped: budget_exhausted" in (vault / ".scout-logs" / "heartbeat.log").read_text()
+
+
+def test_run_picks_research_when_the_queue_has_an_open_item(
+    vault: Path, quiet_probes: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both runners present and both gaps wide: research wins over dreaming."""
+    research = _seed_runner(vault, "run-research.sh")
+    _seed_runner(vault, "run-dreaming.sh")
+    queue_dir = vault / "knowledge-base" / "research-queue"
+    queue_dir.mkdir(parents=True)
+    (queue_dir / "topic.md").write_text("---\nstatus: open\n---\n", encoding="utf-8")
+
+    launched: list[Path] = []
+    monkeypatch.setattr(hb, "launch_runner", lambda runner, *, vault, log_path: launched.append(runner) or 99)
+
+    assert hb.run(data_dir=vault, now=_now()) == hb.EXIT_LAUNCHED
+    assert launched == [research]
+    assert "launched research PID=99" in (vault / ".scout-logs" / "heartbeat.log").read_text()
+
+
+def test_run_honours_the_vault_off_peak_window(vault: Path, quiet_probes: None) -> None:
+    """A vault scout-config.yaml widening the off-peak window must be picked up
+    by run() (not just load_config in isolation)."""
+    _seed_runner(vault, "run-dreaming.sh")
+    (vault / "scout-config.yaml").write_text("off_peak_start: 0\noff_peak_end: 24\n", encoding="utf-8")
+
+    tracker = vault / ".scout-logs" / "usage-tracker.jsonl"
+    recent = _now().replace(hour=11)  # 180 min before _now(): past min_gap, under off-peak gap
+    tracker.write_text(
+        json.dumps({"ts": recent.isoformat().replace("+00:00", "Z"), "type": "dreaming"}) + "\n",
+        encoding="utf-8",
+    )
+
+    assert hb.run(data_dir=vault, now=_now()) == hb.EXIT_SKIPPED
+    assert "off_peak_conservatism" in (vault / ".scout-logs" / "heartbeat.log").read_text()
+
+
+def test_run_skips_when_no_runner_is_executable(vault: Path, quiet_probes: None) -> None:
+    (vault / "run-dreaming.sh").write_text("#!/bin/sh\n")  # present but not +x
+    assert hb.run(data_dir=vault, now=_now()) == hb.EXIT_SKIPPED
+    assert "skipped: no_runner_executable" in (vault / ".scout-logs" / "heartbeat.log").read_text()
+
+
+def test_run_resolves_the_data_dir_from_the_environment(
+    vault: Path, quiet_probes: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(vault))
+    _seed_runner(vault, "run-dreaming.sh")
+    monkeypatch.setattr(hb, "launch_runner", lambda runner, *, vault, log_path: 1)
+    assert hb.run(now=_now()) == hb.EXIT_LAUNCHED
+
+
+def test_main_forwards_dry_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[bool] = []
+    monkeypatch.setattr(hb, "run", lambda *, dry_run: seen.append(dry_run) or hb.EXIT_LAUNCHED)
+    assert hb.main(dry_run=True) == hb.EXIT_LAUNCHED
+    assert seen == [True]
+
+
+def test_main_converts_an_unexpected_exception_into_exit_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """launchd reads non-zero as a config error, so an unexpected crash must
+    still come back as a clean EXIT_ERROR rather than a traceback."""
+
+    def boom(**_k: object):
+        raise RuntimeError("unreachable state")
+
+    monkeypatch.setattr(hb, "run", boom)
+    assert hb.main() == hb.EXIT_ERROR

--- a/engine/tests/unit/test_hooks_and_loaders_edges.py
+++ b/engine/tests/unit/test_hooks_and_loaders_edges.py
@@ -1,0 +1,653 @@
+"""Last-mile branches across the two Stop-hook helpers, the schedule loader,
+and the phase/probe/cron/plist/merge scripts.
+
+Everything here is a failure or fallback path the mainline test files don't
+reach. Two themes:
+
+* **Hooks must never raise.** `session_tokens` and `kb_pre_filter` run at the
+  end of / start of every session, so an unreadable transcript, an unwritable
+  tracker, or one malformed KB file must degrade to an empty value.
+* **Loaders must fail loudly.** `schedule.py` and the phase/probe parsers gate
+  what the scheduler and the assembled brain files contain, so a malformed
+  YAML has to raise a named error rather than silently yield an empty config.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import subprocess
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from scout.errors import ConfigError
+from scout.hooks import connector_log, kb_pre_filter
+from scout.hooks import session_tokens as stok
+from scout.schedule import load_default_schedule, load_schedule, next_fires
+
+# ---------------------------------------------------------------------------
+# session_tokens helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("model", ["", None])
+def test_an_empty_model_is_not_a_known_family(model: str | None) -> None:
+    assert stok._is_known_model(model or "") is False
+    # ...and prices conservatively as Opus.
+    assert stok._model_family(model) == "claude-opus"
+
+
+def test_an_unknown_model_prices_as_opus() -> None:
+    """Under-charging a session would let it slip past the budget gate, so an
+    unrecognized model falls back to the most expensive family."""
+    assert stok._model_family("claude-experimental-42") == "claude-opus"
+    assert stok._is_known_model("claude-experimental-42") is False
+
+
+def test_the_tracker_path_defaults_to_the_vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SESSION_TOKENS_TRACKER", raising=False)
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    assert stok._tracker_path() == tmp_path / ".scout-logs" / "session-tokens.jsonl"
+
+
+def test_the_tracker_path_honours_the_override_and_expands_a_tilde(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("SESSION_TOKENS_TRACKER", "~/custom-tracker.jsonl")
+    assert stok._tracker_path() == tmp_path / "custom-tracker.jsonl"
+
+
+def test_reading_usage_turns_skips_blank_and_malformed_lines(tmp_path: Path) -> None:
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text(
+        "\n".join(
+            [
+                "",
+                "   ",
+                "{torn",
+                json.dumps({"message": {"role": "assistant"}}),  # no usage
+                json.dumps({"message": {"usage": None}}),  # explicit null usage
+                json.dumps({"message": "not a dict"}),
+                json.dumps({"message": {"model": "claude-opus-4", "usage": {"input_tokens": 5}}}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    turns = stok._read_usage_turns(transcript)
+    assert len(turns) == 1
+    assert turns[0]["message"]["usage"]["input_tokens"] == 5
+
+
+def test_reading_usage_turns_is_empty_for_an_unreadable_transcript(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text(json.dumps({"message": {"usage": {}}}) + "\n", encoding="utf-8")
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "open", boom)
+    assert stok._read_usage_turns(transcript) == []
+
+
+def test_polling_gives_up_after_the_configured_attempts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Claude Code can fire Stop before the final assistant turn lands on disk;
+    the poll gives that write a moment, then reports no usage."""
+    transcript = tmp_path / "missing.jsonl"
+    slept: list[float] = []
+    monkeypatch.setattr(stok.time, "sleep", lambda s: slept.append(s))
+    monkeypatch.setattr(stok, "_POLL_ATTEMPTS", 3)
+    monkeypatch.setattr(stok, "_POLL_INTERVAL_S", 0.05)
+
+    assert stok._poll_for_usage_turns(transcript) == []
+    # Sleeps between attempts only.
+    assert slept == [0.05, 0.05]
+
+
+def test_polling_returns_on_the_first_hit_without_sleeping(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text(
+        json.dumps({"message": {"model": "claude-opus-4", "usage": {"input_tokens": 1}}}) + "\n",
+        encoding="utf-8",
+    )
+
+    def fail(_s: float) -> None:
+        raise AssertionError("the happy path must not sleep")
+
+    monkeypatch.setattr(stok.time, "sleep", fail)
+    assert len(stok._poll_for_usage_turns(transcript)) == 1
+
+
+def test_the_primary_model_is_empty_when_no_turn_names_one() -> None:
+    assert stok._primary_model([]) == ""
+    assert stok._primary_model([{"message": {"usage": {}}}]) == ""
+
+
+def test_the_primary_model_is_the_most_frequent() -> None:
+    turns = [
+        {"message": {"model": "claude-opus-4"}},
+        {"message": {"model": "claude-sonnet-4"}},
+        {"message": {"model": "claude-opus-4"}},
+    ]
+    assert stok._primary_model(turns) == "claude-opus-4"
+
+
+def test_the_first_unknown_model_is_reported_in_transcript_order() -> None:
+    turns = [
+        {"message": {"model": "claude-opus-4"}},
+        {"message": {"model": "claude-experimental-42"}},
+        {"message": {"model": "claude-experimental-99"}},
+    ]
+    assert stok._first_unknown_model(turns) == "claude-experimental-42"
+    assert stok._first_unknown_model([{"message": {"model": "claude-haiku-4-5"}}]) == ""
+
+
+def test_appending_a_row_never_raises_on_an_unwritable_tracker(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SESSION_TOKENS_TRACKER", str(tmp_path / "logs" / "session-tokens.jsonl"))
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(Path, "open", boom)
+    stok._append_row({"ts": "2026-05-28T14:00:00Z"})  # must not raise
+
+
+def test_run_returns_none_for_a_non_object_payload() -> None:
+    import io
+
+    assert stok.run(stdin=io.StringIO('"just a string"')) is None
+    assert stok.run(stdin=io.StringIO("[1, 2]")) is None
+
+
+def test_run_reads_real_stdin_when_none_is_passed(monkeypatch: pytest.MonkeyPatch) -> None:
+    import io
+
+    monkeypatch.setattr("sys.stdin", io.StringIO("not json"))
+    assert stok.run() is None
+
+
+def test_main_returns_zero_even_when_run_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The Stop hook's exit code gates the session; it must always be 0."""
+
+    def boom(**_k: object):
+        raise RuntimeError("unreachable state")
+
+    monkeypatch.setattr(stok, "run", boom)
+    assert stok.main() == 0
+
+
+def test_main_returns_zero_on_the_happy_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import io
+
+    tracker = tmp_path / "session-tokens.jsonl"
+    monkeypatch.setenv("SESSION_TOKENS_TRACKER", str(tracker))
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text(
+        json.dumps({"message": {"model": "claude-opus-4", "usage": {"input_tokens": 10}}}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"session_id": "s1", "transcript_path": str(transcript)})))
+    assert stok.main() == 0
+    assert json.loads(tracker.read_text().strip())["input_tokens"] == 10
+
+
+# ---------------------------------------------------------------------------
+# kb_pre_filter helpers
+# ---------------------------------------------------------------------------
+
+
+def test_reading_a_head_is_empty_for_an_unreadable_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    f = tmp_path / "kb.md"
+    f.write_text("Last updated: 2026-04-15\n", encoding="utf-8")
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "open", boom)
+    assert kb_pre_filter._read_head(f) == []
+
+
+def test_reading_a_head_stops_at_the_scan_limit(tmp_path: Path) -> None:
+    """The date line lives near the top; scanning a long KB file in full would
+    blow the session-start budget."""
+    f = tmp_path / "kb.md"
+    f.write_text("\n".join(f"line {n}" for n in range(200)) + "\n", encoding="utf-8")
+    assert len(kb_pre_filter._read_head(f)) == kb_pre_filter.HEAD_SCAN_LINES
+    assert kb_pre_filter._read_head(f, n=3) == ["line 0", "line 1", "line 2"]
+
+
+def test_the_freshness_override_falls_back_to_the_default(tmp_path: Path) -> None:
+    """A file with no `freshness:` marker in its head uses the global default."""
+    f = tmp_path / "kb.md"
+    f.write_text("# People\n\nno freshness marker here\n", encoding="utf-8")
+    assert kb_pre_filter.freshness_hours_for(f) == kb_pre_filter.DEFAULT_FRESHNESS_HOURS
+
+
+def test_the_kb_walk_is_empty_without_a_knowledge_base_dir(tmp_path: Path) -> None:
+    assert kb_pre_filter.discover_kb_files(tmp_path / "nope") == []
+
+
+def test_the_kb_walk_takes_only_markdown_files(tmp_path: Path) -> None:
+    kb = tmp_path / "knowledge-base"
+    kb.mkdir()
+    (kb / "people.md").write_text("# People\n", encoding="utf-8")
+    (kb / "notes.txt").write_text("not markdown\n", encoding="utf-8")
+    # A *directory* named like a markdown file must not be walked as one.
+    (kb / "a-directory.md").mkdir()
+
+    names = [p.name for p in kb_pre_filter.discover_kb_files(tmp_path)]
+    assert names == ["people.md"]
+
+
+def test_one_unclassifiable_file_does_not_block_the_rest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The filter runs at session start over the whole KB; a single bad file
+    must degrade to NO_DATE rather than losing the report."""
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    kb = tmp_path / "knowledge-base"
+    kb.mkdir()
+    bad = kb / "bad.md"
+    bad.write_text("# Bad\n", encoding="utf-8")
+    (kb / "good.md").write_text("Last updated: 2026-04-15\n", encoding="utf-8")
+
+    real_classify = kb_pre_filter.classify
+
+    def maybe_boom(path: Path, now, scout_dir):
+        if path == bad:
+            raise RuntimeError("classifier blew up")
+        return real_classify(path, now, scout_dir)
+
+    monkeypatch.setattr(kb_pre_filter, "classify", maybe_boom)
+
+    event = kb_pre_filter.run("dreaming")
+    assert event is not None
+    # Both files are accounted for; the bad one lands in the NO_DATE bucket.
+    assert event.payload["stale"] + event.payload["no_date"] + event.payload["fresh"] == 2
+    assert event.payload["no_date"] >= 1
+
+
+def test_run_returns_none_without_a_knowledge_base_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    assert kb_pre_filter.run("dreaming") is None
+
+
+def test_writing_the_cache_never_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path))
+    kb = tmp_path / "knowledge-base"
+    kb.mkdir()
+    (kb / "people.md").write_text("Last updated: 2026-04-15\n", encoding="utf-8")
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(Path, "write_text", boom)
+    event = kb_pre_filter.run("dreaming")  # must not raise
+    assert event is not None
+
+
+# ---------------------------------------------------------------------------
+# schedule loader
+# ---------------------------------------------------------------------------
+
+
+def test_loading_a_missing_schedule_is_a_named_config_error(tmp_path: Path) -> None:
+    with pytest.raises(ConfigError, match="not found"):
+        load_schedule(tmp_path / "nope.yaml")
+
+
+def test_loading_malformed_schedule_yaml_is_a_named_config_error(tmp_path: Path) -> None:
+    p = tmp_path / "schedule.yaml"
+    p.write_text("slots: [unclosed\n", encoding="utf-8")
+    with pytest.raises(ConfigError, match="is malformed"):
+        load_schedule(p)
+
+
+@pytest.mark.parametrize("body", ["- a\n- list\n", "just a string\n", "42\n"])
+def test_a_non_mapping_schedule_is_a_named_config_error(tmp_path: Path, body: str) -> None:
+    p = tmp_path / "schedule.yaml"
+    p.write_text(body, encoding="utf-8")
+    with pytest.raises(ConfigError, match="is not a mapping"):
+        load_schedule(p)
+
+
+def test_a_slot_naming_an_unknown_timezone_is_rejected(tmp_path: Path) -> None:
+    """A slot's `tz` decides when it fires; an unloadable zone must fail the
+    load rather than silently resolve to UTC."""
+    p = tmp_path / "schedule.yaml"
+    p.write_text(
+        "schema_version: 1\n"
+        "slots:\n"
+        "  morning-briefing:\n"
+        "    type: briefing\n"
+        "    runner: run-scout.sh\n"
+        "    fires_at_local: '08:30'\n"
+        "    weekdays: [Mon]\n"
+        "    tz: Mars/Olympus_Mons\n"
+        "    on_miss: fire\n"
+        "    missed_window_hours: 4\n"
+        "    cooldown_minutes: 0\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError, match="unknown tz 'Mars/Olympus_Mons'"):
+        load_schedule(p)
+
+
+def test_target_today_requires_a_tz_aware_now() -> None:
+    """A naive `now` would compare against a tz-aware target and silently shift
+    the whole schedule."""
+    slot = next(iter(load_default_schedule().values()))
+    with pytest.raises(ValueError, match="now must be timezone-aware"):
+        slot.target_today(now=_dt.datetime(2026, 5, 28, 14, 0))
+
+
+def test_next_fires_requires_a_tz_aware_now() -> None:
+    with pytest.raises(ValueError, match="now must be timezone-aware"):
+        next_fires(load_default_schedule(), now=_dt.datetime(2026, 5, 28, 14, 0), window_hours=24)
+
+
+def test_next_fires_finds_the_upcoming_target_for_every_slot() -> None:
+    sched = load_default_schedule()
+    now = _dt.datetime(2026, 5, 28, 6, 0, tzinfo=ZoneInfo("America/New_York"))
+    fires = dict(next_fires(sched, now=now, window_hours=24 * 8))
+    assert set(fires) == set(sched)
+    assert all(dt > now for dt in fires.values())
+
+
+def test_next_fires_is_empty_for_a_zero_window() -> None:
+    now = _dt.datetime(2026, 5, 28, 6, 0, tzinfo=ZoneInfo("America/New_York"))
+    assert next_fires(load_default_schedule(), now=now, window_hours=0) == []
+
+
+def test_an_overlay_with_a_bad_schema_version_is_rejected(tmp_path: Path) -> None:
+    """The overlay is a user-editable file; loading it as v1 when it declares
+    something else would silently drop whatever the new shape added."""
+    import shutil
+
+    from scout import cli
+
+    canonical = tmp_path / "schedule.yaml"
+    shutil.copy2(Path(cli.__file__).parent / "defaults" / "schedule.yaml", canonical)
+    overlay = tmp_path / "schedule.local.yaml"
+    overlay.write_text("schema_version: 99\nslots: {}\n", encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="schema_version 99; engine supports 1"):
+        load_schedule(canonical, overlay=overlay)
+
+
+# ---------------------------------------------------------------------------
+# connector_log.classify
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "tool_input", "expected"),
+    [
+        ("Bash", {"command": "gh pr list"}, "github"),
+        ("Bash", {"command": "  git status  "}, "bash:git"),
+        ("Bash", {"command": ""}, "bash"),
+        ("Bash", {}, "bash"),
+        ("Bash", {"command": None}, "bash"),
+        ("mcp__slack__slack_read_channel", {}, "mcp:slack"),
+        ("mcp__linear__list_issues", {}, "mcp:linear"),
+        # No `__` separator at all -> plain lowercase.
+        ("mcpsomething", {}, "mcpsomething"),
+        ("Read", {}, "read"),
+        ("WebFetch", {}, "webfetch"),
+    ],
+)
+def test_classify_maps_a_tool_call_to_a_connector_key(tool_name: str, tool_input: dict, expected: str) -> None:
+    """These keys are the join column between the tool log and the connector
+    roster; a drift here silently orphans a connector's health row."""
+    assert connector_log.classify(tool_name, tool_input) == expected
+
+
+def test_fcntl_is_optional_at_import_time() -> None:
+    """The module guards the fcntl import for non-POSIX hosts. On POSIX it is
+    present; the guard's other arm is exercised by monkeypatching it to None
+    (see test_registry_idmap_and_log_edges.py)."""
+    assert hasattr(connector_log, "fcntl")
+
+
+# ---------------------------------------------------------------------------
+# phase_assembly / phase_backport / connector_probes parsers
+# ---------------------------------------------------------------------------
+
+
+def test_a_phase_file_without_frontmatter_is_rejected(tmp_path: Path) -> None:
+    from scout.scripts.phase_assembly import parse_phase_file
+
+    p = tmp_path / "10-intro.md"
+    p.write_text("# No frontmatter here\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="must start with '---' frontmatter fence"):
+        parse_phase_file(p)
+
+
+def test_a_phase_section_with_a_non_list_mode_is_rejected(tmp_path: Path) -> None:
+    from scout.scripts.phase_assembly import parse_phase_file
+
+    p = tmp_path / "10-intro.md"
+    p.write_text(
+        "---\nid: intro\nmode: briefing\n---\n\nbody\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="'mode' must be a YAML list, got str"):
+        parse_phase_file(p)
+
+
+def test_backport_rejects_an_unknown_brain_file_kind(tmp_path: Path) -> None:
+    from scout.scripts.phase_backport import build_rendered_sections
+
+    with pytest.raises(ValueError, match="unknown brain-file kind: 'SKILLZ'"):
+        build_rendered_sections(tmp_path, "SKILLZ", {}, set())
+
+
+def test_backport_skips_a_phase_file_it_cannot_parse(tmp_path: Path) -> None:
+    """One hand-broken fragment must not abort the whole back-port scan."""
+    from scout.scripts.phase_backport import _ASSEMBLY_MAP, build_rendered_sections
+
+    src_dirs, _modes = _ASSEMBLY_MAP["SKILL"]
+    phase_dir = tmp_path / src_dirs[0]
+    phase_dir.mkdir(parents=True)
+    (phase_dir / "10-broken.md").write_text("no frontmatter at all\n", encoding="utf-8")
+
+    assert build_rendered_sections(tmp_path, "SKILL", {}, set()) == []
+
+
+def test_a_probe_registry_entry_that_is_not_a_mapping_is_rejected(tmp_path: Path) -> None:
+    from scout.scripts.connector_probes import load_registry
+
+    p = tmp_path / "connector-probes.yaml"
+    # Top level is the connector map itself (no "connectors:" wrapper).
+    p.write_text("slack: just-a-string\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="connector 'slack': expected mapping, got str"):
+        load_registry(p)
+
+
+def test_an_invalid_shipped_probe_registry_is_a_named_config_error(tmp_path: Path) -> None:
+    """The shipped registry is a plugin asset; an invalid one is a packaging
+    bug, and the error must name the file rather than surface a bare
+    ValueError from the YAML layer."""
+    from scout.scripts import connector_probes
+
+    templates = tmp_path / "templates"
+    templates.mkdir()
+    (templates / "connector-probes.yaml").write_text("slack: just-a-string\n", encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="shipped connector-probes.yaml is invalid"):
+        connector_probes.resolve_registry(plugin_root=tmp_path, data_dir=tmp_path)
+
+
+def test_a_missing_shipped_probe_registry_is_a_named_config_error(tmp_path: Path) -> None:
+    from scout.scripts import connector_probes
+
+    with pytest.raises(ConfigError, match="shipped connector-probes.yaml not found"):
+        connector_probes.resolve_registry(plugin_root=tmp_path, data_dir=tmp_path)
+
+
+def test_the_connectors_snapshot_holds_only_official_connectors(tmp_path: Path) -> None:
+    """The snapshot is scout-app's bundled default roster; community/
+    auto-discovered rows are per-machine and must not ship in it."""
+    from scout.connectors import Tier, load_registry
+    from scout.scripts.connectors_snapshot import build_snapshot
+
+    state = tmp_path / ".scout-state"
+    state.mkdir(parents=True)
+    (state / "connectors.local.yaml").write_text(
+        "connectors:\n"
+        "  house-sensor:\n"
+        "    display_name: House Sensor\n"
+        "    tier: community\n"
+        "    capabilities: [inbound]\n",
+        encoding="utf-8",
+    )
+    # Sanity: the overlay really is visible to the registry loader.
+    assert load_registry(tmp_path)["house-sensor"].tier is Tier.COMMUNITY
+
+    snapshot = build_snapshot()
+    keys = {row["key"] for row in snapshot["connectors"]}
+    assert "house-sensor" not in keys
+
+
+# ---------------------------------------------------------------------------
+# three_way_merge / install_cron / launchd bootout
+# ---------------------------------------------------------------------------
+
+
+def test_a_signal_killed_git_merge_file_is_an_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """git merge-file returns the conflict count (0-127); anything outside that
+    means the process died, and treating it as "0 conflicts" would write a
+    silently-wrong merge."""
+    from scout.scripts import three_way_merge
+
+    class Proc:
+        returncode = -9
+        stderr = "Killed"
+        stdout = ""
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: Proc())
+    with pytest.raises(RuntimeError, match="git merge-file exited -9"):
+        three_way_merge.three_way_merge(base="a\n", ours="b\n", theirs="c\n")
+
+
+def test_a_backup_write_failure_does_not_mask_a_successful_crontab_apply(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from scout.scripts import install_cron
+
+    monkeypatch.setattr(install_cron, "_list_crontab", lambda: "# existing\n")
+    applied: list[str] = []
+    monkeypatch.setattr(install_cron, "_apply_crontab", lambda content: applied.append(content))
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(Path, "write_text", boom)
+
+    install_cron.install_cron(home=tmp_path, backup_dir=tmp_path / "backups")
+    assert applied, "the crontab apply must still happen"
+    assert "warning: failed to write crontab backup" in capsys.readouterr().err
+
+
+def test_the_managed_block_is_newline_terminated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """crontab(1) rejects a file whose last line has no newline."""
+    from scout.scripts import install_cron
+
+    monkeypatch.setattr(install_cron, "_list_crontab", lambda: "# existing without newline")
+    applied: list[str] = []
+    monkeypatch.setattr(install_cron, "_apply_crontab", lambda content: applied.append(content))
+
+    install_cron.install_cron(home=tmp_path, backup_dir=tmp_path / "backups")
+    assert applied[0].endswith("\n")
+    assert install_cron.BLOCK_OPEN in applied[0]
+
+
+def test_uninstalling_the_cron_block_leaves_a_newline_terminated_crontab(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from scout.scripts import install_cron
+
+    existing = f"# mine\n{install_cron.BLOCK_OPEN}\n* * * * * scout\n{install_cron.BLOCK_CLOSE}\n# also mine\n"
+    monkeypatch.setattr(install_cron, "_list_crontab", lambda: existing)
+    applied: list[str] = []
+    monkeypatch.setattr(install_cron, "_apply_crontab", lambda content: applied.append(content))
+
+    install_cron.uninstall_cron(home=tmp_path, backup_dir=tmp_path / "backups")
+    assert install_cron.BLOCK_OPEN not in applied[0]
+    # crontab(1) rejects a file whose last line has no newline.
+    assert applied[0].endswith("\n")
+    assert "# mine" in applied[0] and "# also mine" in applied[0]
+
+
+@pytest.mark.parametrize(
+    ("module", "label"),
+    [
+        ("scout.scripts.install_schedule_plist", "com.scout.schedule-tick"),
+        ("scout.scripts.install_heartbeat_plist", "com.scout.heartbeat"),
+    ],
+)
+def test_uninstalling_a_plist_boots_the_job_out_first(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, module: str, label: str
+) -> None:
+    """Removing the file without a `launchctl bootout` leaves the job loaded
+    until the next login — it keeps firing from a plist that no longer exists."""
+    import importlib
+
+    mod = importlib.import_module(module)
+    agents = tmp_path / "LaunchAgents"
+    agents.mkdir()
+    (agents / mod.PLIST_NAME).write_text("<plist/>", encoding="utf-8")
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(subprocess, "run", lambda argv, **k: calls.append(argv) or None)
+
+    mod.uninstall_plist(agents_dir=agents, bootout=True)
+    assert calls == [["launchctl", "bootout", f"gui/{os.getuid()}/{label}"]]
+    assert not (agents / mod.PLIST_NAME).exists()
+
+
+@pytest.mark.parametrize(
+    "module",
+    ["scout.scripts.install_schedule_plist", "scout.scripts.install_heartbeat_plist"],
+)
+def test_uninstalling_a_plist_can_skip_the_bootout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, module: str
+) -> None:
+    import importlib
+
+    mod = importlib.import_module(module)
+    agents = tmp_path / "LaunchAgents"
+    agents.mkdir()
+    (agents / mod.PLIST_NAME).write_text("<plist/>", encoding="utf-8")
+
+    def fail(*_a: object, **_k: object):
+        raise AssertionError("bootout=False must not shell out to launchctl")
+
+    monkeypatch.setattr(subprocess, "run", fail)
+    mod.uninstall_plist(agents_dir=agents, bootout=False)
+    assert not (agents / mod.PLIST_NAME).exists()
+
+
+def test_the_crontab_reader_cleans_up_its_tempfile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`_apply_crontab` writes a tempfile and hands it to crontab(1); the
+    `finally` must remove it even on a failed apply."""
+    from scout.scripts import install_cron
+
+    seen: list[str] = []
+
+    class Proc:
+        returncode = 0
+        stderr = ""
+
+    def spy(argv, **_k):
+        seen.append(argv[-1])
+        return Proc()
+
+    monkeypatch.setattr(subprocess, "run", spy)
+    install_cron._apply_crontab("* * * * * scout\n")
+
+    assert seen and not Path(seen[0]).exists()

--- a/engine/tests/unit/test_installers_and_lock_edges.py
+++ b/engine/tests/unit/test_installers_and_lock_edges.py
@@ -1,0 +1,422 @@
+"""Failure-path coverage for the installers and the bootstrap pipeline lock.
+
+Each of these modules already has a happy-path test file; what's missing is
+every branch that only fires when the host misbehaves — and those are the
+branches that decide whether Scout degrades gracefully or wedges:
+
+* `install_scoutctl_shim` must never raise and must never clobber a
+  user-managed `scoutctl` (scout-plugin#99).
+* `install_wake_schedule` must refuse rather than install a wrong wake time
+  when the schedule has no weekday slot.
+* `bootstrap_lock` guards the 8-stage pipeline against a concurrent dispatcher
+  tick; a mis-classified stale lock lets two pipelines interleave (#36).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scout.scripts import bootstrap_lock as lock
+from scout.scripts import install_scoutctl_shim as shim
+from scout.scripts import install_wake_schedule as wake
+from scout.scripts.bootstrap_lock import LockBusyError
+from scout.scripts.install_scoutctl_shim import SHIM_MARKER, install_scoutctl_shim, shim_dir
+
+
+class _Proc:
+    def __init__(self, returncode: int = 0, stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stderr = stderr
+        self.stdout = ""
+
+
+# ---------------------------------------------------------------------------
+# install_scoutctl_shim
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def real_bin(tmp_path: Path) -> Path:
+    p = tmp_path / "plugin" / ".venv" / "bin" / "scoutctl"
+    p.parent.mkdir(parents=True)
+    p.write_text("#!/bin/sh\n", encoding="utf-8")
+    p.chmod(0o755)
+    return p
+
+
+def test_shim_wraps_the_active_checkouts_scoutctl(tmp_path: Path, real_bin: Path) -> None:
+    home = tmp_path / "home"
+    written = install_scoutctl_shim(home=home, target_bin=real_bin)
+    assert written == shim_dir(home) / "scoutctl"
+    assert written is not None
+    body = written.read_text()
+    assert SHIM_MARKER in body
+    assert f'exec "{real_bin}" "$@"' in body
+    assert body.startswith("#!/bin/sh\n")
+    assert os.access(written, os.X_OK)
+
+
+def test_shim_is_skipped_when_the_target_scoutctl_is_missing(tmp_path: Path) -> None:
+    assert install_scoutctl_shim(home=tmp_path / "home", target_bin=tmp_path / "nope") is None
+
+
+def test_shim_is_skipped_when_the_bin_dir_cannot_be_created(
+    tmp_path: Path, real_bin: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A read-only home degrades to manual prefix-minting, not a crash."""
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(Path, "mkdir", boom)
+    assert install_scoutctl_shim(home=tmp_path / "home", target_bin=real_bin) is None
+
+
+def test_shim_refuses_to_replace_a_symlinked_scoutctl(tmp_path: Path, real_bin: Path) -> None:
+    """A symlink is presumed user-managed (pipx / a global venv); overwriting
+    it would hijack their install."""
+    home = tmp_path / "home"
+    d = shim_dir(home)
+    d.mkdir(parents=True)
+    (d / "scoutctl").symlink_to(real_bin)
+
+    assert install_scoutctl_shim(home=home, target_bin=real_bin) is None
+    assert (d / "scoutctl").is_symlink()
+
+
+def test_shim_refuses_to_replace_a_foreign_regular_file(tmp_path: Path, real_bin: Path) -> None:
+    home = tmp_path / "home"
+    d = shim_dir(home)
+    d.mkdir(parents=True)
+    foreign = d / "scoutctl"
+    foreign.write_text("#!/bin/sh\n# someone else's scoutctl\n", encoding="utf-8")
+
+    assert install_scoutctl_shim(home=home, target_bin=real_bin) is None
+    assert "someone else's" in foreign.read_text()
+
+
+def test_shim_refreshes_its_own_previous_shim(tmp_path: Path, real_bin: Path) -> None:
+    """The shim must re-point at the current venv on every upgrade, or it
+    dangles after a plugin update."""
+    home = tmp_path / "home"
+    d = shim_dir(home)
+    d.mkdir(parents=True)
+    (d / "scoutctl").write_text(f'#!/bin/sh\n{SHIM_MARKER}\nexec /old/path/scoutctl "$@"\n', encoding="utf-8")
+
+    written = install_scoutctl_shim(home=home, target_bin=real_bin)
+    assert written is not None
+    assert "/old/path/scoutctl" not in written.read_text()
+    assert str(real_bin) in written.read_text()
+
+
+def test_shim_is_skipped_when_the_existing_file_cannot_be_read(
+    tmp_path: Path, real_bin: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    d = shim_dir(home)
+    d.mkdir(parents=True)
+    existing = d / "scoutctl"
+    existing.write_text(f"{SHIM_MARKER}\n", encoding="utf-8")
+
+    real_read_text = Path.read_text
+
+    def maybe_boom(self: Path, *a: object, **k: object):
+        if self == existing:
+            raise OSError("permission denied")
+        return real_read_text(self, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", maybe_boom)
+    assert install_scoutctl_shim(home=home, target_bin=real_bin) is None
+
+
+def test_shim_is_skipped_when_the_write_fails(tmp_path: Path, real_bin: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    home = tmp_path / "home"
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(Path, "write_text", boom)
+    assert install_scoutctl_shim(home=home, target_bin=real_bin) is None
+
+
+def test_shim_resolves_the_target_from_the_running_engine_by_default(
+    tmp_path: Path, real_bin: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(shim, "resolve_scoutctl_bin", lambda: real_bin)
+    written = install_scoutctl_shim(home=tmp_path / "home")
+    assert written is not None
+    assert str(real_bin) in written.read_text()
+
+
+# ---------------------------------------------------------------------------
+# install_wake_schedule
+# ---------------------------------------------------------------------------
+
+
+def _slot(key: str, fires_at: str, weekdays: tuple[str, ...]):
+    from scout.schedule import load_default_schedule
+
+    sched = load_default_schedule()
+    template = next(iter(sched.values()))
+    import dataclasses
+
+    return dataclasses.replace(template, key=key, fires_at_local=fires_at, weekdays=weekdays)
+
+
+def _sched(*slots):
+    from scout.schedule import Schedule
+
+    return Schedule({s.key: s for s in slots})
+
+
+def test_earliest_weekday_slot_ignores_weekend_only_slots() -> None:
+    weekend = _slot("weekend-briefing", "07:00", ("Sat", "Sun"))
+    weekday = _slot("morning-briefing", "08:30", ("Mon", "Tue", "Wed", "Thu", "Fri"))
+    earliest = wake.compute_earliest_weekday_slot(_sched(weekend, weekday))
+    assert earliest is not None
+    assert earliest.key == "morning-briefing"
+
+
+def test_earliest_weekday_slot_is_none_when_every_slot_is_a_weekend_slot() -> None:
+    assert wake.compute_earliest_weekday_slot(_sched(_slot("w", "07:00", ("Sat", "Sun")))) is None
+
+
+def test_install_refuses_when_there_is_no_weekday_slot() -> None:
+    """Better to fail loudly than to install a pmset rule for the wrong day —
+    a silently wrong wake time means the briefing never fires."""
+    with pytest.raises(ValueError, match="no weekday slot found"):
+        wake.install_wake_schedule(_sched(_slot("w", "07:00", ("Sat",))))
+
+
+def test_install_refuses_a_slot_whose_weekdays_map_to_no_day_letters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A defensive guard: every name in `_WEEKDAYS` also has a `_WEEKDAY_LETTER`
+    entry, so the selector cannot currently hand `install` a slot that yields an
+    empty day string. Pin the guard anyway — the two tables are edited
+    independently, and a `_WEEKDAYS` entry added without its letter would
+    otherwise run `pmset repeat wakeorpoweron "" HH:MM:SS`."""
+    import dataclasses
+
+    weird = dataclasses.replace(_slot("weird", "08:00", ("Mon",)), weekdays=("Funday",))
+    monkeypatch.setattr(wake, "compute_earliest_weekday_slot", lambda _s: weird)
+
+    with pytest.raises(ValueError, match="slot weird has no recognizable weekdays"):
+        wake.install_wake_schedule(_sched(_slot("m", "08:00", ("Mon",))))
+
+
+def test_install_dry_run_reports_the_pmset_command_without_running_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail(*_a: object, **_k: object):
+        raise AssertionError("dry_run must not shell out")
+
+    monkeypatch.setattr(subprocess, "run", fail)
+    out = wake.install_wake_schedule(
+        _sched(_slot("morning-briefing", "08:30", ("Mon", "Tue", "Wed", "Thu", "Fri"))), dry_run=True
+    )
+    assert out == "[dry-run] would run: pmset repeat wakeorpoweron MTWRF 08:30:00"
+
+
+def test_install_runs_pmset_and_reports_the_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[list[str]] = []
+    monkeypatch.setattr(subprocess, "run", lambda cmd, **k: seen.append(cmd) or _Proc(0))
+    out = wake.install_wake_schedule(_sched(_slot("morning-briefing", "08:30", ("Mon", "Wed"))))
+    assert seen == [["pmset", "repeat", "wakeorpoweron", "MW", "08:30:00"]]
+    assert out.startswith("installed: pmset repeat wakeorpoweron MW")
+
+
+def test_install_surfaces_a_pmset_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Proc(1, "pmset: must be root\n"))
+    with pytest.raises(RuntimeError, match="pmset failed: pmset: must be root"):
+        wake.install_wake_schedule(_sched(_slot("m", "08:30", ("Mon",))))
+
+
+def test_uninstall_dry_run_reports_the_cancel_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail(*_a: object, **_k: object):
+        raise AssertionError("dry_run must not shell out")
+
+    monkeypatch.setattr(subprocess, "run", fail)
+    assert wake.uninstall_wake_schedule(dry_run=True) == "[dry-run] would run: pmset repeat cancel"
+
+
+def test_uninstall_runs_pmset_cancel(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[list[str]] = []
+    monkeypatch.setattr(subprocess, "run", lambda cmd, **k: seen.append(cmd) or _Proc(0))
+    assert wake.uninstall_wake_schedule() == "uninstalled"
+    assert seen == [["pmset", "repeat", "cancel"]]
+
+
+def test_uninstall_surfaces_a_pmset_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Proc(1, "pmset: no repeating events\n"))
+    with pytest.raises(RuntimeError, match="pmset failed"):
+        wake.uninstall_wake_schedule()
+
+
+# ---------------------------------------------------------------------------
+# bootstrap_lock
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def lock_path(tmp_path: Path) -> Path:
+    return tmp_path / ".scout-logs" / ".scout-session.lock"
+
+
+@pytest.mark.parametrize("pid", [0, -1, -12345])
+def test_a_nonpositive_pid_is_never_treated_as_alive(pid: int) -> None:
+    """os.kill(0, 0) signals the whole process group and os.kill(-1, 0) every
+    process the user owns — a corrupt lock must not reach either."""
+    assert lock._pid_alive(pid) is False
+
+
+def test_a_pid_we_cannot_signal_counts_as_alive(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A different-uid holder still holds the lock; treating EPERM as "dead"
+    would let us steal it."""
+
+    def boom(_pid: int, _sig: int) -> None:
+        raise PermissionError("operation not permitted")
+
+    monkeypatch.setattr(os, "kill", boom)
+    assert lock._pid_alive(4711) is True
+
+
+def test_a_dead_pid_is_not_alive(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(_pid: int, _sig: int) -> None:
+        raise ProcessLookupError("no such process")
+
+    monkeypatch.setattr(os, "kill", boom)
+    assert lock._pid_alive(4711) is False
+
+
+def test_our_own_pid_is_alive() -> None:
+    assert lock._pid_alive(os.getpid()) is True
+
+
+def test_lock_is_not_held_when_the_file_is_absent(lock_path: Path) -> None:
+    assert lock.is_lock_held_by_live_pid(lock_path) is False
+
+
+def test_lock_is_not_held_when_the_pid_is_unparseable(lock_path: Path) -> None:
+    """The empty file a racing winner leaves between its O_EXCL create and its
+    PID write reads as "not held by a live PID" — but acquire() still treats it
+    as busy (#36)."""
+    lock_path.parent.mkdir(parents=True)
+    lock_path.write_text("", encoding="utf-8")
+    assert lock.is_lock_held_by_live_pid(lock_path) is False
+    lock_path.write_text("not-a-pid", encoding="utf-8")
+    assert lock.is_lock_held_by_live_pid(lock_path) is False
+
+
+def test_acquire_writes_our_pid_and_release_removes_it(lock_path: Path) -> None:
+    lock.acquire_lock(lock_path)
+    assert lock_path.read_text().strip() == str(os.getpid())
+    assert lock.is_lock_held_by_live_pid(lock_path) is True
+
+    lock.release_lock(lock_path)
+    assert not lock_path.exists()
+
+
+def test_acquire_raises_lock_busy_for_a_live_holder(lock_path: Path) -> None:
+    lock.acquire_lock(lock_path)
+    with pytest.raises(LockBusyError) as exc:
+        lock.acquire_lock(lock_path)
+    assert exc.value.pid == os.getpid()
+    assert exc.value.lock_path == lock_path
+
+
+def test_acquire_reclaims_a_lock_left_by_a_dead_pid(lock_path: Path) -> None:
+    lock_path.parent.mkdir(parents=True)
+    lock_path.write_text("999999999", encoding="utf-8")  # a PID that cannot exist
+    lock.acquire_lock(lock_path)
+    assert lock_path.read_text().strip() == str(os.getpid())
+
+
+def test_acquire_treats_an_unparseable_lock_as_busy(lock_path: Path) -> None:
+    """This is the #36 window: an empty lock is a racing winner mid-write, not
+    a stale lock, so it must never be unlinked."""
+    lock_path.parent.mkdir(parents=True)
+    lock_path.write_text("", encoding="utf-8")
+    with pytest.raises(LockBusyError) as exc:
+        lock.acquire_lock(lock_path)
+    assert exc.value.pid == -1
+    assert lock_path.exists()
+
+
+def test_acquire_rolls_back_a_partial_claim_when_the_pid_write_fails(
+    lock_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A half-written lock would be unparseable forever, wedging every later
+    pipeline run — so the claim is rolled back instead."""
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(os, "fdopen", boom)
+    with pytest.raises(OSError, match="disk full"):
+        lock.acquire_lock(lock_path)
+    assert not lock_path.exists()
+
+
+def test_release_is_a_no_op_when_the_lock_is_absent(lock_path: Path) -> None:
+    lock.release_lock(lock_path)  # must not raise
+
+
+def test_release_clears_an_unparseable_lock(lock_path: Path) -> None:
+    lock_path.parent.mkdir(parents=True)
+    lock_path.write_text("garbage", encoding="utf-8")
+    lock.release_lock(lock_path)
+    assert not lock_path.exists()
+
+
+def test_release_leaves_another_processes_lock_alone(lock_path: Path) -> None:
+    lock_path.parent.mkdir(parents=True)
+    lock_path.write_text(str(os.getpid() + 1), encoding="utf-8")
+    lock.release_lock(lock_path)
+    assert lock_path.exists()
+
+
+def test_remove_stale_lock_only_removes_a_dead_holders_lock(lock_path: Path) -> None:
+    lock_path.parent.mkdir(parents=True)
+    lock_path.write_text("999999999", encoding="utf-8")
+    lock.remove_stale_lock(lock_path)
+    assert not lock_path.exists()
+
+    lock_path.write_text(str(os.getpid()), encoding="utf-8")
+    lock.remove_stale_lock(lock_path)
+    assert lock_path.exists()
+
+
+def test_remove_stale_lock_is_a_no_op_when_absent(lock_path: Path) -> None:
+    lock.remove_stale_lock(lock_path)  # must not raise
+
+
+def test_acquire_with_wait_returns_immediately_when_free(lock_path: Path) -> None:
+    lock.acquire_lock_with_wait(lock_path, timeout_s=1, poll_s=0)
+    assert lock_path.read_text().strip() == str(os.getpid())
+
+
+def test_acquire_with_wait_polls_then_succeeds(lock_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    lock.acquire_lock(lock_path)
+    slept: list[int] = []
+
+    def fake_sleep(seconds: int) -> None:
+        slept.append(seconds)
+        # The holder goes away after the first poll.
+        lock_path.unlink()
+
+    monkeypatch.setattr("time.sleep", fake_sleep)
+    lock.acquire_lock_with_wait(lock_path, timeout_s=300, poll_s=10)
+    assert slept == [10]
+    assert lock_path.read_text().strip() == str(os.getpid())
+
+
+def test_acquire_with_wait_raises_on_timeout(lock_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    lock.acquire_lock(lock_path)
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+    with pytest.raises(LockBusyError):
+        lock.acquire_lock_with_wait(lock_path, timeout_s=0, poll_s=0)

--- a/engine/tests/unit/test_kb_ontology_graph.py
+++ b/engine/tests/unit/test_kb_ontology_graph.py
@@ -1,0 +1,438 @@
+"""Graph-building, query and validation coverage for `scout.kb.ontology`.
+
+`test_kb_ontology.py` covers schema-load errors, the frontmatter fence bug
+(#64) and two smoke queries over the single-entity `kb-sample` fixture. The
+graph half — relationship expansion with inverses, the `deadline_before` /
+`birthday_month` special filters, `related()`, `export_json()` and each
+`validate()` error class — needs a multi-entity vault, so this file builds
+one per test.
+
+Entity names are anonymized per CLAUDE.md (Alex / Priya / Sam,
+`example-org` repos, `PROJ-` Linear prefixes).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scout.kb.ontology import KnowledgeGraph
+
+SCHEMA = Path(__file__).parent.parent / "fixtures" / "kb-sample" / "schema.yaml"
+
+
+def _graph(kb_root: Path) -> KnowledgeGraph:
+    return KnowledgeGraph(schema_path=str(SCHEMA), kb_root=str(kb_root))
+
+
+def _must(entity: dict[str, object] | None) -> dict[str, object]:
+    assert entity is not None
+    return entity
+
+
+def _entity(kb_root: Path, rel_path: str, frontmatter: str, body: str = "Body.\n") -> Path:
+    p = kb_root / rel_path
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(f"---\n{frontmatter}---\n\n{body}", encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# load() — entity collection
+# ---------------------------------------------------------------------------
+
+
+def test_load_indexes_entities_by_name_and_records_the_source_path(tmp_path: Path) -> None:
+    path = _entity(tmp_path, "people/alex.md", "name: Alex\ntype: person\nrole: Engineer\n")
+    g = _graph(tmp_path).load()
+
+    assert set(g.entities) == {"Alex"}
+    alex = _must(g.entity("Alex"))
+    assert alex["role"] == "Engineer"
+    assert alex["_source_path"] == str(path)
+
+
+def test_entity_returns_none_for_an_unknown_name(tmp_path: Path) -> None:
+    _entity(tmp_path, "people/alex.md", "name: Alex\ntype: person\n")
+    assert _graph(tmp_path).load().entity("Nobody") is None
+
+
+@pytest.mark.parametrize(
+    ("filename", "content"),
+    [
+        # No frontmatter at all.
+        ("plain.md", "# Just a note\n\nSome prose.\n"),
+        # Frontmatter opened but never closed.
+        ("unclosed.md", "---\nname: Alex\ntype: person\n"),
+        # Frontmatter present but missing the required index keys.
+        ("no-name.md", "---\ntype: person\n---\n\nBody.\n"),
+        ("no-type.md", "---\nname: Alex\n---\n\nBody.\n"),
+        # Malformed YAML inside the fence.
+        ("bad-yaml.md", "---\nname: [unclosed\n---\n\nBody.\n"),
+        # Empty frontmatter block.
+        ("empty-fm.md", "---\n---\n\nBody.\n"),
+    ],
+)
+def test_load_skips_files_that_are_not_indexable_entities(tmp_path: Path, filename: str, content: str) -> None:
+    """The KB is hand-written markdown; a prose note or a half-finished
+    frontmatter block must be skipped, never abort the walk."""
+    (tmp_path / filename).write_text(content, encoding="utf-8")
+    _entity(tmp_path, "people/alex.md", "name: Alex\ntype: person\n")
+
+    g = _graph(tmp_path).load()
+    assert set(g.entities) == {"Alex"}
+
+
+def test_load_skips_a_file_it_cannot_decode(tmp_path: Path) -> None:
+    (tmp_path / "binary.md").write_bytes(b"---\nname: \xff\xfe\ntype: person\n---\n")
+    _entity(tmp_path, "people/alex.md", "name: Alex\ntype: person\n")
+
+    g = _graph(tmp_path).load()
+    assert set(g.entities) == {"Alex"}
+
+
+def test_load_skips_a_file_it_cannot_read(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    unreadable = _entity(tmp_path, "people/priya.md", "name: Priya\ntype: person\n")
+    _entity(tmp_path, "people/alex.md", "name: Alex\ntype: person\n")
+
+    real_read_text = Path.read_text
+
+    def maybe_boom(self: Path, *a: object, **k: object):
+        if self == unreadable:
+            raise OSError("permission denied")
+        return real_read_text(self, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", maybe_boom)
+    assert set(_graph(tmp_path).load().entities) == {"Alex"}
+
+
+def test_load_is_idempotent(tmp_path: Path) -> None:
+    """load() resets state, so calling it twice must not duplicate
+    relationships — a stale double-load once inflated `related()`."""
+    _entity(
+        tmp_path,
+        "people/alex.md",
+        "name: Alex\ntype: person\nrelationships:\n  - type: works_with\n    target: '[[Priya]]'\n",
+    )
+    _entity(tmp_path, "people/priya.md", "name: Priya\ntype: person\n")
+
+    g = _graph(tmp_path)
+    first = len(g.load().relationships)
+    second = len(g.load().relationships)
+    assert first == second
+
+
+def test_load_returns_self_for_chaining(tmp_path: Path) -> None:
+    g = _graph(tmp_path)
+    assert g.load() is g
+
+
+# ---------------------------------------------------------------------------
+# load() — relationships and inverses
+# ---------------------------------------------------------------------------
+
+
+def test_load_expands_an_asymmetric_relationship_into_its_inverse(tmp_path: Path) -> None:
+    _entity(
+        tmp_path,
+        "people/alex.md",
+        "name: Alex\ntype: person\nrelationships:\n  - type: manages\n    target: '[[Priya]]'\n",
+    )
+    _entity(tmp_path, "people/priya.md", "name: Priya\ntype: person\n")
+
+    g = _graph(tmp_path).load()
+    assert {"source": "Alex", "type": "manages", "target": "Priya"} in g.relationships
+    # The schema declares manages.inverse == managed_by, so the reverse edge is
+    # synthesized — this is what makes `related("Priya")` useful.
+    assert {"source": "Priya", "type": "managed_by", "target": "Alex"} in g.relationships
+
+
+def test_load_expands_a_symmetric_relationship_in_both_directions(tmp_path: Path) -> None:
+    _entity(
+        tmp_path,
+        "people/alex.md",
+        "name: Alex\ntype: person\nrelationships:\n  - type: works_with\n    target: '[[Priya]]'\n",
+    )
+    _entity(tmp_path, "people/priya.md", "name: Priya\ntype: person\n")
+
+    g = _graph(tmp_path).load()
+    assert {"source": "Alex", "type": "works_with", "target": "Priya"} in g.relationships
+    assert {"source": "Priya", "type": "works_with", "target": "Alex"} in g.relationships
+
+
+def test_load_records_a_relationship_with_no_declared_inverse_one_way(tmp_path: Path) -> None:
+    """`blocks` has an inverse in the schema; a type the schema doesn't know
+    has none, so only the forward edge is recorded."""
+    _entity(
+        tmp_path,
+        "projects/rollout.md",
+        "name: Rollout\ntype: project\nstatus: active\npriority: high\n"
+        "relationships:\n  - type: invented_by\n    target: '[[Alex]]'\n",
+    )
+    _entity(tmp_path, "people/alex.md", "name: Alex\ntype: person\n")
+
+    g = _graph(tmp_path).load()
+    edges = [r for r in g.relationships if r["type"] == "invented_by"]
+    assert edges == [{"source": "Rollout", "type": "invented_by", "target": "Alex"}]
+    assert not [r for r in g.relationships if r["source"] == "Alex" and r["target"] == "Rollout"]
+
+
+@pytest.mark.parametrize(
+    "rel_block",
+    [
+        "relationships:\n  - type: manages\n",  # no target
+        "relationships:\n  - target: '[[Priya]]'\n",  # no type
+        "relationships:\n  - type: ''\n    target: ''\n",  # both blank
+        "relationships:\n",  # null list
+        "relationships: []\n",  # empty list
+    ],
+)
+def test_load_ignores_incomplete_relationship_entries(tmp_path: Path, rel_block: str) -> None:
+    _entity(tmp_path, "people/alex.md", f"name: Alex\ntype: person\n{rel_block}")
+    g = _graph(tmp_path).load()
+    assert g.relationships == []
+    # The entity itself still indexes, and `relationships` is popped off it.
+    assert "relationships" not in _must(g.entity("Alex"))
+
+
+def test_load_accepts_a_bare_target_without_wikilink_brackets(tmp_path: Path) -> None:
+    _entity(
+        tmp_path,
+        "people/alex.md",
+        "name: Alex\ntype: person\nrelationships:\n  - type: manages\n    target: Priya\n",
+    )
+    g = _graph(tmp_path).load()
+    assert {"source": "Alex", "type": "manages", "target": "Priya"} in g.relationships
+
+
+def test_load_resolves_a_wikilink_target_with_surrounding_prose(tmp_path: Path) -> None:
+    _entity(
+        tmp_path,
+        "people/alex.md",
+        "name: Alex\ntype: person\nrelationships:\n  - type: manages\n    target: 'see [[Priya]] for details'\n",
+    )
+    g = _graph(tmp_path).load()
+    assert {"source": "Alex", "type": "manages", "target": "Priya"} in g.relationships
+
+
+# ---------------------------------------------------------------------------
+# related()
+# ---------------------------------------------------------------------------
+
+
+def test_related_returns_only_outgoing_edges(tmp_path: Path) -> None:
+    _entity(
+        tmp_path,
+        "people/alex.md",
+        "name: Alex\ntype: person\nrelationships:\n"
+        "  - type: manages\n    target: '[[Priya]]'\n"
+        "  - type: works_with\n    target: '[[Sam]]'\n",
+    )
+    _entity(tmp_path, "people/priya.md", "name: Priya\ntype: person\n")
+    _entity(tmp_path, "people/sam.md", "name: Sam\ntype: person\n")
+
+    g = _graph(tmp_path).load()
+    alex = g.related("Alex")
+    assert {(r["type"], r["target"]) for r in alex} == {("manages", "Priya"), ("works_with", "Sam")}
+    assert all(r["source"] == "Alex" for r in alex)
+    # Priya's only edge is the synthesized inverse.
+    assert g.related("Priya") == [{"source": "Priya", "type": "managed_by", "target": "Alex"}]
+
+
+def test_related_is_empty_for_an_unknown_name(tmp_path: Path) -> None:
+    assert _graph(tmp_path).load().related("Nobody") == []
+
+
+# ---------------------------------------------------------------------------
+# query() — special filters
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def task_vault(tmp_path: Path) -> Path:
+    _entity(
+        tmp_path,
+        "tasks/near.md",
+        "name: Near task\ntype: task\nstatus: open\ndomain: personal\ndeadline: 2026-04-10\n",
+    )
+    _entity(
+        tmp_path,
+        "tasks/far.md",
+        "name: Far task\ntype: task\nstatus: open\ndomain: work\ndeadline: 2026-12-01\n",
+    )
+    _entity(tmp_path, "tasks/undated.md", "name: Undated task\ntype: task\nstatus: open\n")
+    return tmp_path
+
+
+def test_query_deadline_before_is_inclusive(task_vault: Path) -> None:
+    g = _graph(task_vault).load()
+    assert {e["name"] for e in g.query(deadline_before="2026-04-10")} == {"Near task"}
+    assert {e["name"] for e in g.query(deadline_before="2026-12-31")} == {"Near task", "Far task"}
+
+
+def test_query_deadline_before_excludes_undated_entities(task_vault: Path) -> None:
+    """An entity with no deadline can't satisfy a deadline window — including
+    it would put unscheduled work into "due this week"."""
+    g = _graph(task_vault).load()
+    assert "Undated task" not in {e["name"] for e in g.query(deadline_before="2099-01-01")}
+
+
+def test_query_combines_special_and_exact_filters(task_vault: Path) -> None:
+    g = _graph(task_vault).load()
+    assert g.query(deadline_before="2026-12-31", domain="work", status="open")[0]["name"] == "Far task"
+    assert g.query(deadline_before="2026-12-31", domain="work", status="done") == []
+
+
+def test_query_birthday_month_matches_on_the_month_component(tmp_path: Path) -> None:
+    _entity(tmp_path, "people/alex.md", "name: Alex\ntype: person\nbirthday: 1990-04-15\n")
+    _entity(tmp_path, "people/priya.md", "name: Priya\ntype: person\nbirthday: 1988-11-02\n")
+    _entity(tmp_path, "people/sam.md", "name: Sam\ntype: person\n")
+
+    g = _graph(tmp_path).load()
+    assert {e["name"] for e in g.query(birthday_month=4)} == {"Alex"}
+    assert {e["name"] for e in g.query(birthday_month=11)} == {"Priya"}
+    assert g.query(birthday_month=7) == []
+
+
+@pytest.mark.parametrize("birthday", ["1990", "not-a-date", "1990-xx-15"])
+def test_query_birthday_month_skips_unparseable_birthdays(tmp_path: Path, birthday: str) -> None:
+    _entity(tmp_path, "people/alex.md", f"name: Alex\ntype: person\nbirthday: '{birthday}'\n")
+    assert _graph(tmp_path).load().query(birthday_month=4) == []
+
+
+def test_query_with_no_filters_returns_everything(task_vault: Path) -> None:
+    g = _graph(task_vault).load()
+    assert len(g.query()) == 3
+
+
+# ---------------------------------------------------------------------------
+# export_json()
+# ---------------------------------------------------------------------------
+
+
+def test_export_json_drops_underscore_prefixed_internals(tmp_path: Path) -> None:
+    """`_source_path` is an absolute path on the author's machine — it must not
+    leak into an export that gets shared or committed."""
+    _entity(
+        tmp_path,
+        "people/alex.md",
+        "name: Alex\ntype: person\nrelationships:\n  - type: manages\n    target: '[[Priya]]'\n",
+    )
+    _entity(tmp_path, "people/priya.md", "name: Priya\ntype: person\n")
+
+    payload = json.loads(_graph(tmp_path).load().export_json())
+    assert set(payload) == {"entities", "relationships"}
+    assert set(payload["entities"]) == {"Alex", "Priya"}
+    for entity in payload["entities"].values():
+        assert not [k for k in entity if k.startswith("_")]
+    assert {"source": "Alex", "type": "manages", "target": "Priya"} in payload["relationships"]
+
+
+def test_export_json_stringifies_non_json_values(tmp_path: Path) -> None:
+    """YAML parses a bare date into a `datetime.date`, which json.dumps can't
+    serialize — the exporter's `default=str` must handle it."""
+    _entity(tmp_path, "people/alex.md", "name: Alex\ntype: person\nbirthday: 1990-04-15\n")
+    payload = json.loads(_graph(tmp_path).load().export_json())
+    assert payload["entities"]["Alex"]["birthday"] == "1990-04-15"
+
+
+def test_export_json_honours_the_indent_argument(tmp_path: Path) -> None:
+    _entity(tmp_path, "people/alex.md", "name: Alex\ntype: person\n")
+    g = _graph(tmp_path).load()
+    assert '\n    "entities"' in g.export_json(indent=4)
+    assert '\n  "entities"' in g.export_json()  # default indent=2
+
+
+# ---------------------------------------------------------------------------
+# validate()
+# ---------------------------------------------------------------------------
+
+
+def _messages(errors: list[dict[str, str]], entity: str) -> set[str]:
+    return {e["message"] for e in errors if e["entity"] == entity}
+
+
+def test_validate_flags_an_unknown_entity_type(tmp_path: Path) -> None:
+    _entity(tmp_path, "things/widget.md", "name: Widget\ntype: gizmo\n")
+    errors = _graph(tmp_path).load().validate()
+    assert _messages(errors, "Widget") == {"Unknown entity type: gizmo"}
+
+
+def test_validate_flags_missing_required_properties(tmp_path: Path) -> None:
+    # `project` requires name/type/status/priority; this one has half of them.
+    _entity(
+        tmp_path,
+        "projects/rollout.md",
+        "name: Rollout\ntype: project\nrelationships:\n  - type: blocks\n    target: '[[Launch]]'\n",
+    )
+    _entity(tmp_path, "projects/launch.md", "name: Launch\ntype: project\nstatus: open\npriority: high\n")
+
+    errors = _graph(tmp_path).load().validate()
+    assert _messages(errors, "Rollout") == {
+        "Missing required property: status",
+        "Missing required property: priority",
+    }
+
+
+def test_validate_flags_an_invalid_relationship_type(tmp_path: Path) -> None:
+    _entity(
+        tmp_path,
+        "people/alex.md",
+        "name: Alex\ntype: person\nrelationships:\n  - type: invented_by\n    target: '[[Priya]]'\n",
+    )
+    _entity(
+        tmp_path,
+        "people/priya.md",
+        "name: Priya\ntype: person\nrelationships:\n  - type: works_with\n    target: '[[Alex]]'\n",
+    )
+
+    errors = _graph(tmp_path).load().validate()
+    assert "Invalid relationship type: invented_by" in _messages(errors, "Alex")
+
+
+def test_validate_flags_an_orphaned_entity(tmp_path: Path) -> None:
+    _entity(tmp_path, "people/sam.md", "name: Sam\ntype: person\n")
+    errors = _graph(tmp_path).load().validate()
+    assert _messages(errors, "Sam") == {"Orphaned entity — no relationships"}
+
+
+def test_validate_counts_an_incoming_edge_as_not_orphaned(tmp_path: Path) -> None:
+    """Priya declares nothing herself but is the target of Alex's edge — she is
+    connected, so flagging her would be noise."""
+    _entity(
+        tmp_path,
+        "people/alex.md",
+        "name: Alex\ntype: person\nrelationships:\n  - type: manages\n    target: '[[Priya]]'\n",
+    )
+    _entity(tmp_path, "people/priya.md", "name: Priya\ntype: person\n")
+
+    errors = _graph(tmp_path).load().validate()
+    assert errors == []
+
+
+def test_validate_is_clean_for_a_well_formed_vault(tmp_path: Path) -> None:
+    _entity(
+        tmp_path,
+        "people/alex.md",
+        "name: Alex\ntype: person\nrelationships:\n  - type: works_on\n    target: '[[Rollout]]'\n",
+    )
+    _entity(tmp_path, "projects/rollout.md", "name: Rollout\ntype: project\nstatus: active\npriority: high\n")
+    assert _graph(tmp_path).load().validate() == []
+
+
+def test_validate_on_an_empty_vault_returns_no_errors(tmp_path: Path) -> None:
+    assert _graph(tmp_path).load().validate() == []
+
+
+def test_validate_tolerates_a_schema_with_no_sections(tmp_path: Path) -> None:
+    """A schema missing `entity_types` / `relationship_types` entirely must
+    produce errors, not a KeyError."""
+    schema = tmp_path / "bare-schema.yaml"
+    schema.write_text("version: 1\n", encoding="utf-8")
+    kb = tmp_path / "kb"
+    _entity(kb, "people/alex.md", "name: Alex\ntype: person\n")
+
+    g = KnowledgeGraph(schema_path=str(schema), kb_root=str(kb)).load()
+    assert _messages(g.validate(), "Alex") == {"Unknown entity type: person"}

--- a/engine/tests/unit/test_migrate_perfile_parsing.py
+++ b/engine/tests/unit/test_migrate_perfile_parsing.py
@@ -1,0 +1,523 @@
+"""Parser and rendering branches in the per-file migration.
+
+`test_migrate_perfile.py` covers the idempotent driver end-to-end.
+`migrate_perfile` is a **destructive one-shot** — it unlinks the single-file
+wishlists after splitting them — so every parsing branch it depends on is one
+where a bug means real data is silently dropped or mis-filed. This file drives
+the parsers directly against the legacy shapes a mature vault actually
+contains: `[in progress]` / `[done]` prefixes, `HIGH`/`MEDIUM`/`LOW` markers,
+`(2026-04-15 — source)` parentheticals, priority glyphs, `START IMMEDIATELY`
+leads, and `##`/`###` area headings.
+
+Fixture content is anonymized per CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scout.scripts.migrate_perfile import (
+    RUN_LOG_HEADER,
+    Item,
+    _heading_area,
+    _last_verified_body,
+    _research_queue_has_items,
+    _unique_path,
+    _yq,
+    filename_for,
+    main,
+    migrate_perfile,
+    migrate_research_file,
+    migrate_wishlist_file,
+    needs_migration,
+    parse_research_item,
+    parse_wishlist_item,
+    render_item,
+    slugify,
+    split_bullets,
+    split_research_items,
+)
+
+# ---------------------------------------------------------------------------
+# parse_wishlist_item
+# ---------------------------------------------------------------------------
+
+
+def test_a_plain_bold_wishlist_bullet() -> None:
+    item = parse_wishlist_item("**Add a status widget** Some longer body text.")
+    assert item == Item(
+        title="Add a status widget",
+        status="open",
+        priority="medium",
+        date=None,
+        source=None,
+        body="Some longer body text.",
+    )
+
+
+@pytest.mark.parametrize(
+    ("marker", "expected"),
+    [("[in progress]", "in-progress"), ("[In Progress]", "in-progress"), ("[done]", "done"), ("[DONE]", "done")],
+)
+def test_a_status_marker_is_stripped_from_the_title(marker: str, expected: str) -> None:
+    item = parse_wishlist_item(f"**{marker} Add a status widget**")
+    assert item.status == expected
+    assert item.title == "Add a status widget"
+
+
+@pytest.mark.parametrize(
+    ("marker", "expected"),
+    [("HIGH", "high"), ("MEDIUM", "medium"), ("LOW", "low")],
+)
+def test_a_priority_marker_is_stripped_from_the_title(marker: str, expected: str) -> None:
+    item = parse_wishlist_item(f"**{marker} — Add a status widget**")
+    assert item.priority == expected
+    assert item.title == "Add a status widget"
+
+
+def test_status_and_priority_markers_combine() -> None:
+    item = parse_wishlist_item("**[in progress] HIGH - Add a status widget**")
+    assert (item.status, item.priority, item.title) == ("in-progress", "high", "Add a status widget")
+
+
+def test_the_done_file_forces_done_regardless_of_the_marker() -> None:
+    """`Wishlist-done.md` is the archive; its rows are complete even when the
+    inline marker says otherwise."""
+    item = parse_wishlist_item("**[in progress] Add a status widget**", in_done_file=True)
+    assert item.status == "done"
+
+
+def test_a_parenthetical_splits_into_date_and_source() -> None:
+    item = parse_wishlist_item("**Add a status widget** (2026-04-15 — Priya in standup). The body.")
+    assert item.date == "2026-04-15"
+    assert item.source == "Priya in standup"
+    assert item.body == "The body."
+
+
+def test_a_parenthetical_with_only_a_date_has_no_source() -> None:
+    item = parse_wishlist_item("**Add a status widget** (2026-04-15)")
+    assert item.date == "2026-04-15"
+    assert item.source is None
+
+
+def test_a_parenthetical_with_only_a_source_has_no_date() -> None:
+    item = parse_wishlist_item("**Add a status widget** (Priya in standup)")
+    assert item.date is None
+    assert item.source == "Priya in standup"
+
+
+def test_a_bullet_with_no_bold_lead_uses_the_whole_line_as_the_title() -> None:
+    item = parse_wishlist_item("Add a status widget")
+    assert item.title == "Add a status widget"
+    assert item.body == ""
+
+
+def test_a_multiline_wishlist_bullet_keeps_its_body() -> None:
+    item = parse_wishlist_item("**Add a status widget**\n  More detail.\n  Even more.")
+    assert item.title == "Add a status widget"
+    assert "More detail." in item.body
+
+
+# ---------------------------------------------------------------------------
+# parse_research_item
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [("- [ ] Investigate the vendor API", "open"), ("- [x] Investigate", "done"), ("- [X] Investigate", "done")],
+)
+def test_a_research_checkbox_sets_the_status(line: str, expected: str) -> None:
+    assert parse_research_item(line).status == expected
+
+
+@pytest.mark.parametrize(
+    ("glyph", "expected"),
+    [("🔴", "urgent"), ("🟡", "medium"), ("🟢", "low"), ("🔵", "medium")],
+)
+def test_a_priority_glyph_is_read_and_stripped(glyph: str, expected: str) -> None:
+    item = parse_research_item(f"- [ ] {glyph} Investigate the vendor API")
+    assert item.priority == expected
+    assert item.title == "Investigate the vendor API"
+    assert glyph not in item.title
+
+
+def test_a_research_line_without_a_checkbox_defaults_to_open() -> None:
+    item = parse_research_item("Investigate the vendor API")
+    assert item.status == "open"
+    assert item.title == "Investigate the vendor API"
+
+
+def test_a_start_immediately_lead_becomes_urgent_and_is_stripped() -> None:
+    item = parse_research_item("- [ ] **START IMMEDIATELY — Investigate the outage**")
+    assert item.priority == "urgent"
+    assert item.title == "Investigate the outage"
+
+
+def test_a_start_immediately_lead_is_matched_case_insensitively() -> None:
+    item = parse_research_item("- [ ] **Start immediately - Investigate the outage**")
+    assert item.priority == "urgent"
+    assert item.title == "Investigate the outage"
+
+
+def test_a_date_in_the_research_body_is_captured() -> None:
+    item = parse_research_item("- [ ] **Investigate the vendor API** — raised 2026-04-15")
+    assert item.date == "2026-04-15"
+    assert item.body == "— raised 2026-04-15"
+
+
+def test_the_area_is_carried_onto_the_item() -> None:
+    assert parse_research_item("- [ ] Investigate", area="platform").area == "platform"
+
+
+# ---------------------------------------------------------------------------
+# slugify / filename_for / _unique_path / _yq / render_item
+# ---------------------------------------------------------------------------
+
+
+def test_slugify_drops_punctuation_and_caps_word_count() -> None:
+    assert slugify("Add a Status Widget!") == "add-a-status-widget"
+    assert slugify("one two three four five six seven eight nine ten") == ("one-two-three-four-five-six-seven-eight")
+    assert slugify("PROJ-1234: the fix") == "proj-1234-the-fix"
+    assert slugify("!!!") == ""
+
+
+def test_filename_prefers_the_items_own_date() -> None:
+    item = parse_wishlist_item("**Add a widget** (2026-04-15)")
+    assert filename_for(item, "2026-06-01") == "2026-04-15-add-a-widget.md"
+
+
+def test_filename_falls_back_to_the_default_date() -> None:
+    item = parse_wishlist_item("**Add a widget**")
+    assert filename_for(item, "2026-06-01") == "2026-06-01-add-a-widget.md"
+
+
+def test_unique_path_suffixes_on_collision(tmp_path: Path) -> None:
+    """Migration is destructive: two items sharing a date+slug must both
+    survive rather than one silently overwriting the other."""
+    assert _unique_path(tmp_path, "a.md") == tmp_path / "a.md"
+
+    (tmp_path / "a.md").write_text("first", encoding="utf-8")
+    assert _unique_path(tmp_path, "a.md") == tmp_path / "a-2.md"
+
+    (tmp_path / "a-2.md").write_text("second", encoding="utf-8")
+    (tmp_path / "a-3.md").write_text("third", encoding="utf-8")
+    assert _unique_path(tmp_path, "a.md") == tmp_path / "a-4.md"
+
+
+def test_yaml_quoting_escapes_backslashes_and_quotes() -> None:
+    assert _yq('say "hi"') == '"say \\"hi\\""'
+    assert _yq("path\\to\\thing") == '"path\\\\to\\\\thing"'
+
+
+def test_render_item_emits_every_populated_frontmatter_key() -> None:
+    item = Item(
+        title="Investigate the vendor API",
+        status="open",
+        priority="urgent",
+        date="2026-04-15",
+        source="Priya in standup",
+        body="Some detail.",
+        area="platform",
+    )
+    out = render_item(item)
+    assert out.startswith("---\n")
+    assert 'title: "Investigate the vendor API"' in out
+    assert "status: open" in out
+    assert "priority: urgent" in out
+    assert "date: 2026-04-15" in out
+    assert 'source: "Priya in standup"' in out
+    assert 'area: "platform"' in out
+    assert out.endswith("# Investigate the vendor API\n\nSome detail.\n")
+
+
+def test_render_item_omits_empty_optional_keys() -> None:
+    out = render_item(Item(title="t", status="open", priority="medium", date=None, source=None, body=""))
+    assert "date:" not in out
+    assert "source:" not in out
+    assert "area:" not in out
+
+
+# ---------------------------------------------------------------------------
+# split_bullets
+# ---------------------------------------------------------------------------
+
+
+def test_split_bullets_handles_both_markers_and_indented_continuations() -> None:
+    text = (
+        "# Wishlist\n"
+        "\n"
+        "- **First item**\n"
+        "  continuation of first\n"
+        "\n"
+        "* **Second item**\n"
+        "\tanother continuation\n"
+        "- **Third item**\n"
+    )
+    bullets = split_bullets(text)
+    assert len(bullets) == 3
+    assert "continuation of first" in bullets[0]
+    assert "another continuation" in bullets[1]
+
+
+def test_a_flush_left_non_bullet_line_closes_the_current_bullet() -> None:
+    """CommonMark continuation rules: an unindented paragraph is not part of
+    the bullet above it, so it must not be swept into that item's body."""
+    text = "- **First item**\nA flush-left paragraph.\n- **Second item**\n"
+    bullets = split_bullets(text)
+    assert len(bullets) == 2
+    assert "flush-left" not in bullets[0]
+    assert "flush-left" not in bullets[1]
+
+
+def test_split_bullets_ignores_leading_prose_and_empty_results() -> None:
+    assert split_bullets("# Wishlist\n\nJust prose, no bullets.\n") == []
+    assert split_bullets("") == []
+
+
+def test_split_bullets_requires_content_after_the_marker() -> None:
+    # "- " with nothing after it is not a bullet start.
+    assert split_bullets("-\n- **Real item**\n") == ["**Real item**"]
+
+
+# ---------------------------------------------------------------------------
+# _heading_area / split_research_items
+# ---------------------------------------------------------------------------
+
+
+def test_heading_area_slugifies_and_strips_a_leading_glyph() -> None:
+    assert _heading_area("🔴 Platform Reliability") == "platform-reliability"
+
+
+def test_heading_area_drops_a_trailing_status_segment() -> None:
+    """`## Platform — done` names the area "platform", not "platform-done"."""
+    for suffix in ("done", "WIP", "in progress", "in-progress", "✅", "🎯"):
+        assert _heading_area(f"Platform — {suffix}") == "platform"
+
+
+def test_heading_area_keeps_a_non_status_trailing_segment() -> None:
+    assert _heading_area("Platform — Q2 goals") == "platform-q2-goals"
+
+
+def test_the_queue_heading_is_not_an_area() -> None:
+    """`## Queue` is the container heading, not a topic — items under it get
+    no area rather than `area: "queue"`."""
+    assert _heading_area("Queue") is None
+    assert _heading_area("queue") is None
+
+
+def test_a_heading_that_slugifies_to_nothing_is_not_an_area() -> None:
+    assert _heading_area("🔴") is None
+    assert _heading_area("!!!") is None
+
+
+def test_split_research_items_attributes_the_nearest_heading() -> None:
+    text = (
+        "# Research Queue\n"
+        "\n"
+        "## Platform\n"
+        "\n"
+        "- [ ] Investigate the vendor API\n"
+        "\n"
+        "### Storage\n"
+        "\n"
+        "- [ ] Benchmark the new engine\n"
+        "\n"
+        "## People\n"
+        "\n"
+        "- [x] Read the postmortem\n"
+    )
+    pairs = list(split_research_items(text))
+    assert [(line.split("] ")[1], area) for line, area in pairs] == [
+        ("Investigate the vendor API", "platform"),
+        ("Benchmark the new engine", "storage"),
+        ("Read the postmortem", "people"),
+    ]
+
+
+def test_a_new_h2_clears_the_previous_h3_area() -> None:
+    text = "## Platform\n### Storage\n## People\n- [ ] Read the postmortem\n"
+    assert list(split_research_items(text)) == [("- [ ] Read the postmortem", "people")]
+
+
+def test_split_research_items_skips_non_checklist_lines() -> None:
+    text = "## Platform\n\nSome prose.\n- a plain bullet\n- [ ] A real item\n"
+    assert [line for line, _area in split_research_items(text)] == ["- [ ] A real item"]
+
+
+# ---------------------------------------------------------------------------
+# migrate_wishlist_file / migrate_research_file
+# ---------------------------------------------------------------------------
+
+
+def test_migrate_wishlist_file_writes_one_file_per_item(tmp_path: Path) -> None:
+    src = tmp_path / "Wishlist.md"
+    src.write_text(
+        "# Wishlist\n\n- **HIGH — Add a status widget** (2026-04-15 — Priya)\n- **Ship the docs**\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "wishlist"
+    assert migrate_wishlist_file(src, out, False, "2026-06-01") == 2
+    assert (out / "2026-04-15-add-a-status-widget.md").is_file()
+    assert (out / "2026-06-01-ship-the-docs.md").is_file()
+
+
+def test_migrate_wishlist_file_skips_a_titleless_bullet(tmp_path: Path) -> None:
+    """A bullet that is only markers (`- **HIGH —**`) has no title and no
+    filename; skip it rather than writing `2026-06-01-.md`."""
+    src = tmp_path / "Wishlist.md"
+    src.write_text("- **HIGH —**\n- **Ship the docs**\n", encoding="utf-8")
+    out = tmp_path / "wishlist"
+    assert migrate_wishlist_file(src, out, False, "2026-06-01") == 1
+    assert [p.name for p in out.iterdir()] == ["2026-06-01-ship-the-docs.md"]
+
+
+def test_migrate_research_file_writes_one_file_per_item_with_areas(tmp_path: Path) -> None:
+    src = tmp_path / "research-queue.md"
+    src.write_text(
+        "# Research Queue\n\n## Platform\n\n- [ ] 🔴 Investigate the vendor API\n- [x] Benchmark the engine\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "research-queue"
+    assert migrate_research_file(src, out, "2026-06-01") == 2
+    written = (out / "2026-06-01-investigate-the-vendor-api.md").read_text()
+    assert "priority: urgent" in written
+    assert 'area: "platform"' in written
+
+
+def test_migrate_research_file_skips_a_titleless_item(tmp_path: Path) -> None:
+    src = tmp_path / "research-queue.md"
+    src.write_text("- [ ] 🔴\n- [ ] A real item\n", encoding="utf-8")
+    out = tmp_path / "research-queue"
+    assert migrate_research_file(src, out, "2026-06-01") == 1
+
+
+# ---------------------------------------------------------------------------
+# _research_queue_has_items / _last_verified_body
+# ---------------------------------------------------------------------------
+
+
+def test_a_migrated_run_log_never_reads_as_needing_migration() -> None:
+    """A preserved continuity note can itself contain checklist lines; the
+    header short-circuit is what stops a re-migration on the next upgrade."""
+    run_log = RUN_LOG_HEADER + "**Last verified 2026-04-15** — see:\n- [ ] a quoted checklist line\n"
+    assert _research_queue_has_items(run_log) is False
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "# Research Queue\n\n## Queue\n\nsome prose\n",
+        "# Research Queue\n\n- [ ] an open item\n",
+        "# Research Queue\n\n* [x] a done item\n",
+    ],
+)
+def test_a_legacy_research_queue_reads_as_needing_migration(body: str) -> None:
+    assert _research_queue_has_items(body) is True
+
+
+def test_a_research_queue_with_neither_marker_does_not_need_migration() -> None:
+    assert _research_queue_has_items("# Research Queue\n\nJust prose.\n") is False
+
+
+def test_last_verified_body_takes_the_final_matching_paragraph() -> None:
+    text = (
+        "# Research Queue\n"
+        "\n"
+        "**Last verified 2026-03-01** — first note.\n"
+        "\n"
+        "some other paragraph\n"
+        "\n"
+        "**Last verified 2026-04-15** — the latest note.\n"
+        "Continued on a second line.\n"
+    )
+    body = _last_verified_body(text)
+    assert body.startswith("**Last verified 2026-04-15**")
+    assert "Continued on a second line." in body
+    assert "2026-03-01" not in body
+
+
+def test_last_verified_body_tolerates_indentation() -> None:
+    """The match is on the lstripped paragraph, and the returned body is
+    stripped — an indented note is still recognized."""
+    assert _last_verified_body("   **Last verified 2026-04-15** — note.\n") == ("**Last verified 2026-04-15** — note.")
+
+
+def test_last_verified_body_falls_back_when_there_is_no_note() -> None:
+    assert _last_verified_body("# Research Queue\n\nJust prose.\n") == "_No runs yet._"
+    assert _last_verified_body("") == "_No runs yet._"
+
+
+def test_last_verified_body_collapses_runs_of_blank_lines() -> None:
+    """Consecutive blank lines must not emit empty paragraphs — an empty one
+    would `lstrip().startswith(...)` to False and is just noise."""
+    text = "para one\n\n\n\n**Last verified 2026-04-15** — note.\n\n\n"
+    assert _last_verified_body(text) == "**Last verified 2026-04-15** — note."
+
+
+# ---------------------------------------------------------------------------
+# needs_migration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["Wishlist.md", "Wishlist-in-progress.md", "Wishlist-done.md"])
+def test_any_single_file_wishlist_means_the_vault_is_legacy(tmp_path: Path, name: str) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / name).write_text("- **Ship the docs**\n", encoding="utf-8")
+    assert needs_migration(tmp_path) is True
+
+
+def test_a_research_queue_still_holding_items_means_the_vault_is_legacy(tmp_path: Path) -> None:
+    kb = tmp_path / "knowledge-base"
+    kb.mkdir()
+    (kb / "research-queue.md").write_text("# Research Queue\n\n- [ ] an open item\n", encoding="utf-8")
+    assert needs_migration(tmp_path) is True
+
+
+def test_a_vault_that_never_had_these_files_needs_no_migration(tmp_path: Path) -> None:
+    assert needs_migration(tmp_path) is False
+
+
+def test_a_fully_migrated_vault_needs_no_migration(tmp_path: Path) -> None:
+    kb = tmp_path / "knowledge-base"
+    kb.mkdir()
+    (kb / "research-queue.md").write_text(RUN_LOG_HEADER + "_No runs yet._\n", encoding="utf-8")
+    (tmp_path / "docs" / "wishlist").mkdir(parents=True)
+    assert needs_migration(tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
+
+
+def test_main_without_a_vault_argument_prints_usage(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main([]) == 2
+    assert "usage: migrate_perfile.py <vault>" in capsys.readouterr().err
+
+
+def test_main_migrates_the_named_vault(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "Wishlist.md").write_text("- **Ship the docs**\n", encoding="utf-8")
+
+    assert main([str(tmp_path)]) == 0
+    out = capsys.readouterr().out
+    assert "'migrated': True" in out
+    assert not (docs / "Wishlist.md").exists()
+    assert list((docs / "wishlist").iterdir())
+
+
+def test_main_reads_sys_argv_when_no_argv_is_passed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr("sys.argv", ["migrate_perfile.py", str(tmp_path)])
+    assert main() == 0
+    assert "'migrated': False" in capsys.readouterr().out
+
+
+def test_migrate_is_a_no_op_on_an_already_migrated_vault(tmp_path: Path) -> None:
+    assert migrate_perfile(tmp_path) == {"migrated": False}

--- a/engine/tests/unit/test_pre_session_data_shell.py
+++ b/engine/tests/unit/test_pre_session_data_shell.py
@@ -1,0 +1,358 @@
+"""Coverage of pre_session_data's shell-out layer and failure tolerance.
+
+`test_pre_session_data.py` covers the KB date extractor, its mtime cache and
+two `gather()` shapes. What's left is every path that must degrade to an empty
+value rather than raise: the `_run` wrapper (nonzero exit / OSError /
+timeout), the two `gh` JSON readers, the ontology-parser probe, cache
+read/write corruption, and the `run()`/`main()` driver.
+
+Tolerance is the whole point of this module — it runs in the preamble of every
+scheduled session, so a raise here blocks the session rather than just
+omitting one field.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from scout.scripts import pre_session_data as psd
+
+
+@pytest.fixture
+def scout_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "Scout"
+    (d / "knowledge-base").mkdir(parents=True)
+    (d / ".scout-cache").mkdir(parents=True)
+    return d
+
+
+class _Proc:
+    def __init__(self, returncode: int = 0, stdout: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+# ---------------------------------------------------------------------------
+# _run
+# ---------------------------------------------------------------------------
+
+
+def test_run_returns_stripped_stdout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Proc(0, "  output  \n"))
+    assert psd._run(["true"]) == "output"
+
+
+def test_run_returns_empty_on_nonzero_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Proc(1, "partial output"))
+    assert psd._run(["false"]) == ""
+
+
+@pytest.mark.parametrize("exc", [OSError("no such binary"), subprocess.TimeoutExpired("gh", 10)])
+def test_run_returns_empty_when_the_process_cannot_run(monkeypatch: pytest.MonkeyPatch, exc: Exception) -> None:
+    def boom(*_a: object, **_k: object):
+        raise exc
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    assert psd._run(["gh"]) == ""
+
+
+def test_run_passes_cwd_and_timeout_through(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(subprocess, "run", lambda cmd, **k: seen.update(cmd=cmd, **k) or _Proc(0, ""))
+    psd._run(["git", "status"], cwd=tmp_path, timeout=3)
+    assert seen["cmd"] == ["git", "status"]
+    assert seen["cwd"] == str(tmp_path)
+    assert seen["timeout"] == 3
+
+
+def test_run_passes_no_cwd_when_none_given(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(subprocess, "run", lambda cmd, **k: seen.update(**k) or _Proc(0, ""))
+    psd._run(["gh"])
+    assert seen["cwd"] is None
+
+
+# ---------------------------------------------------------------------------
+# get_git_recent
+# ---------------------------------------------------------------------------
+
+
+def test_git_recent_is_empty_without_a_git_dir(scout_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail(*_a: object, **_k: object):
+        raise AssertionError("git must not run without a .git dir")
+
+    monkeypatch.setattr(subprocess, "run", fail)
+    assert psd.get_git_recent(scout_dir) == ""
+
+
+def test_git_recent_reads_the_oneline_log(scout_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (scout_dir / ".git").mkdir()
+    seen: list[list[str]] = []
+    monkeypatch.setattr(subprocess, "run", lambda cmd, **k: seen.append(cmd) or _Proc(0, "abc1234 update people.md\n"))
+    assert psd.get_git_recent(scout_dir) == "abc1234 update people.md"
+    assert seen[0][:3] == ["git", "log", "--oneline"]
+    assert seen[0][3] == f"--since={psd.DEFAULT_GIT_LOG_LOOKBACK}"
+
+
+def test_git_recent_honours_a_custom_since(scout_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (scout_dir / ".git").mkdir()
+    seen: list[list[str]] = []
+    monkeypatch.setattr(subprocess, "run", lambda cmd, **k: seen.append(cmd) or _Proc(0, ""))
+    psd.get_git_recent(scout_dir, since="3 days ago")
+    assert "--since=3 days ago" in seen[0]
+
+
+# ---------------------------------------------------------------------------
+# gh readers
+# ---------------------------------------------------------------------------
+
+
+def test_gh_json_parses_an_array(monkeypatch: pytest.MonkeyPatch) -> None:
+    rows = [{"number": 1, "title": "Fix the parser"}]
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Proc(0, json.dumps(rows)))
+    assert psd._gh_json(["pr", "list"]) == rows
+
+
+@pytest.mark.parametrize(
+    "stdout",
+    [
+        "",  # gh not authenticated / no output
+        "not json at all",
+        '{"number": 1}',  # a JSON object, not the expected array
+        "null",
+    ],
+)
+def test_gh_json_degrades_to_an_empty_list(monkeypatch: pytest.MonkeyPatch, stdout: str) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Proc(0, stdout))
+    assert psd._gh_json(["pr", "list"]) == []
+
+
+def test_get_pr_authored_queries_open_prs_by_me(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[list[str]] = []
+    monkeypatch.setattr(subprocess, "run", lambda cmd, **k: seen.append(cmd) or _Proc(0, "[]"))
+    assert psd.get_pr_authored() == []
+    argv = seen[0]
+    assert argv[:2] == ["gh", "pr"]
+    assert "--author" in argv and "@me" in argv
+    assert argv[argv.index("--limit") + 1] == str(psd.PR_LIST_LIMIT)
+
+
+def test_get_pr_review_requested_uses_gh_search(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[list[str]] = []
+    monkeypatch.setattr(subprocess, "run", lambda cmd, **k: seen.append(cmd) or _Proc(0, "[]"))
+    assert psd.get_pr_review_requested() == []
+    argv = seen[0]
+    assert argv[:3] == ["gh", "search", "prs"]
+    assert "--review-requested" in argv
+
+
+# ---------------------------------------------------------------------------
+# get_personal_tasks
+# ---------------------------------------------------------------------------
+
+
+def test_personal_tasks_is_empty_without_the_ontology_parser(scout_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The ontology parser is optional; its absence must be silent, not fatal."""
+
+    def fail(*_a: object, **_k: object):
+        raise AssertionError("must not shell out when parser.py is absent")
+
+    monkeypatch.setattr(subprocess, "run", fail)
+    assert psd.get_personal_tasks(scout_dir) == ""
+
+
+def test_personal_tasks_invokes_the_parser_when_present(scout_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    parser = scout_dir / "knowledge-base" / "ontology" / "parser.py"
+    parser.parent.mkdir(parents=True)
+    parser.write_text("# stub\n", encoding="utf-8")
+
+    seen: list[list[str]] = []
+    monkeypatch.setattr(subprocess, "run", lambda cmd, **k: seen.append(cmd) or _Proc(0, "- [ ] pay rent"))
+
+    assert psd.get_personal_tasks(scout_dir) == "- [ ] pay rent"
+    assert seen[0] == ["python3", str(parser), "query", "--type", "task"]
+
+
+# ---------------------------------------------------------------------------
+# KB dates cache read/write tolerance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "not json",
+        '["a", "list"]',  # right JSON, wrong shape
+        "null",
+    ],
+)
+def test_kb_dates_cache_load_rejects_a_corrupt_file(tmp_path: Path, body: str) -> None:
+    cache = tmp_path / "kb-dates.cache.json"
+    cache.write_text(body, encoding="utf-8")
+    assert psd._load_kb_dates_cache(cache) == {}
+
+
+def test_kb_dates_cache_load_skips_individual_bad_entries(tmp_path: Path) -> None:
+    """One malformed row must not discard the whole cache — the rest still
+    saves a file open each."""
+    cache = tmp_path / "kb-dates.cache.json"
+    cache.write_text(
+        json.dumps(
+            {
+                "knowledge-base/good.md": {"mtime_ns": 123, "last_updated": "2026-04-15"},
+                "knowledge-base/not-a-dict.md": "oops",
+                "knowledge-base/no-mtime.md": {"last_updated": "2026-04-15"},
+                "knowledge-base/bad-mtime.md": {"mtime_ns": "not-an-int"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    loaded = psd._load_kb_dates_cache(cache)
+    assert set(loaded) == {"knowledge-base/good.md"}
+    assert loaded["knowledge-base/good.md"].mtime_ns == 123
+
+
+def test_kb_dates_cache_load_is_empty_when_missing(tmp_path: Path) -> None:
+    assert psd._load_kb_dates_cache(tmp_path / "nope.json") == {}
+
+
+def test_kb_dates_cache_write_cleans_up_after_a_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed atomic write must not leave a .tmp turd next to the cache."""
+    cache = tmp_path / "kb-dates.cache.json"
+    real_open = Path.open
+
+    def maybe_boom(self: Path, *a: object, **k: object):
+        if self.name.endswith(".json.tmp"):
+            raise OSError("disk full")
+        return real_open(self, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "open", maybe_boom)
+    psd._write_kb_dates_cache(cache, {"a.md": psd._KbEntry(mtime_ns=1, last_updated="x")})
+    assert not cache.exists()
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_extract_last_updated_returns_empty_for_an_unreadable_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    f = tmp_path / "kb.md"
+    f.write_text("Last updated: 2026-04-15\n", encoding="utf-8")
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "open", boom)
+    assert psd.extract_last_updated(f) == ""
+
+
+def test_gather_kb_file_dates_skips_files_outside_the_scout_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """rglob returning a path that isn't under scout_dir (a symlink escape)
+    must be skipped, not crash `relative_to`."""
+    scout = tmp_path / "Scout"
+    kb = scout / "knowledge-base"
+    kb.mkdir(parents=True)
+    (kb / "inside.md").write_text("Last updated: 2026-04-15\n", encoding="utf-8")
+
+    outside = tmp_path / "elsewhere.md"
+    outside.write_text("Last updated: 2026-01-01\n", encoding="utf-8")
+
+    real_rglob = Path.rglob
+    monkeypatch.setattr(Path, "rglob", lambda self, pat: [*real_rglob(self, pat), outside])
+
+    out = psd.gather_kb_file_dates(kb, scout_dir=scout, cache_path=tmp_path / "c.json")
+    assert out == {"knowledge-base/inside.md": "2026-04-15"}
+
+
+def test_gather_kb_file_dates_skips_a_file_it_cannot_stat(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    scout = tmp_path / "Scout"
+    kb = scout / "knowledge-base"
+    kb.mkdir(parents=True)
+    gone = kb / "gone.md"
+    gone.write_text("Last updated: 2026-04-15\n", encoding="utf-8")
+    (kb / "kept.md").write_text("Last updated: 2026-04-16\n", encoding="utf-8")
+
+    real_stat = Path.stat
+
+    def maybe_boom(self: Path, *a: object, **k: object):
+        if self == gone:
+            raise OSError("vanished mid-walk")
+        return real_stat(self, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "stat", maybe_boom)
+    out = psd.gather_kb_file_dates(kb, scout_dir=scout, cache_path=tmp_path / "c.json")
+    assert out == {"knowledge-base/kept.md": "2026-04-16"}
+
+
+# ---------------------------------------------------------------------------
+# write_context / run / main
+# ---------------------------------------------------------------------------
+
+
+def test_write_context_cleans_up_after_a_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    out = tmp_path / "session-context.json"
+    ctx = psd.SessionContext(generated_at="2026-04-15T08:00:00", session_type="briefing")
+    real_open = Path.open
+
+    def maybe_boom(self: Path, *a: object, **k: object):
+        if self.name.endswith(".json.tmp"):
+            raise OSError("disk full")
+        return real_open(self, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "open", maybe_boom)
+    psd.write_context(ctx, out)
+    assert not out.exists()
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_gather_stamps_the_generated_at_in_the_given_timezone(scout_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Proc(1, ""))
+    noon_utc = datetime(2026, 4, 15, 16, 0, tzinfo=ZoneInfo("UTC"))
+    ctx = psd.gather("briefing", scout_dir=scout_dir, tz_name="America/New_York", now=noon_utc)
+    # 16:00 UTC is 12:00 EDT on 2026-04-15.
+    assert ctx.generated_at == "2026-04-15T12:00:00"
+    assert ctx.session_type == "briefing"
+
+
+def test_run_writes_the_context_into_the_cache_dir(scout_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Proc(1, ""))
+    out = psd.run("consolidation", data_dir=scout_dir)
+    assert out == scout_dir / ".scout-cache" / psd.OUTPUT_FILENAME
+    payload = json.loads(out.read_text())
+    assert payload["session_type"] == "consolidation"
+    assert payload["kb_file_dates"] == {}
+
+
+def test_run_resolves_the_data_dir_from_the_environment(scout_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(scout_dir))
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Proc(1, ""))
+    assert psd.run("research") == scout_dir / ".scout-cache" / psd.OUTPUT_FILENAME
+
+
+def test_main_prints_the_output_path(
+    scout_dir: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(scout_dir))
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Proc(1, ""))
+    assert psd.main("briefing") == 0
+    out = capsys.readouterr().out
+    assert "Pre-session data written to" in out
+    assert "(briefing)" in out
+
+
+def test_main_returns_zero_even_when_gathering_blows_up(monkeypatch: pytest.MonkeyPatch) -> None:
+    """This runs in the preamble of every scheduled session — a crash here must
+    never be the reason a session doesn't start."""
+
+    def boom(*_a: object, **_k: object):
+        raise RuntimeError("unreachable state")
+
+    monkeypatch.setattr(psd, "run", boom)
+    assert psd.main("briefing") == 0

--- a/engine/tests/unit/test_registry_idmap_and_log_edges.py
+++ b/engine/tests/unit/test_registry_idmap_and_log_edges.py
@@ -1,0 +1,544 @@
+"""Remaining branches in the connector registry, the id-map, and the
+PostToolUse connector log.
+
+Each of these has a happy-path test file; this one closes the branches those
+files don't reach:
+
+* `ConnectorRegistry`'s mapping protocol and the deprecated
+  `required_in`/`critical_in_mode` pair (still honoured for vault overlays that
+  haven't migrated to `required_in_types`).
+* `_load_yaml` / `_build_connector`'s malformed-input errors — a typo in an
+  overlay must be a named `ConfigError`, not a `KeyError` out of a loader.
+* `IdMap`'s schema-version gate, atomic-write rollback, and `reattach`'s
+  cross-file fallback (the path that recovers a task whose `[#XXXX]` prefix was
+  hand-deleted).
+* `connector_log`'s nested-content error detection, the no-fcntl fallback, and
+  `main()`'s swallow-everything contract.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from scout import connectors as conn
+from scout import id_map as idm
+from scout.connectors import Capability, Connector, ConnectorRegistry, Remediation, Tier, load_registry
+from scout.errors import ConfigError
+from scout.hooks import connector_log
+from scout.id_map import IdMap, IdMapEntry
+from scout.schedule import SlotType
+
+
+def _connector(key: str, **overrides) -> Connector:
+    base = {
+        "key": key,
+        "display_name": key.title(),
+        "tier": Tier.OFFICIAL,
+        "capabilities": (Capability.INBOUND,),
+        "required_in": (),
+        "required_in_types": (),
+        "remediation": Remediation(first_fix="fix it", detail="details"),
+    }
+    base.update(overrides)
+    return Connector(**base)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# ConnectorRegistry — the mapping protocol
+# ---------------------------------------------------------------------------
+
+
+def test_registry_supports_the_mapping_protocol() -> None:
+    a, b = _connector("slack"), _connector("github")
+    reg = ConnectorRegistry({"slack": a, "github": b})
+
+    assert "slack" in reg
+    assert "carrier_pigeon" not in reg
+    assert reg["slack"] is a
+    assert list(reg) == ["slack", "github"]
+    assert list(reg.keys()) == ["slack", "github"]
+    assert list(reg.values()) == [a, b]
+    assert dict(reg.items()) == {"slack": a, "github": b}
+
+
+def test_registry_getitem_raises_for_an_unknown_key() -> None:
+    with pytest.raises(KeyError):
+        ConnectorRegistry({})["nope"]
+
+
+# ---------------------------------------------------------------------------
+# The deprecated required_in / critical_in_mode pair
+# ---------------------------------------------------------------------------
+
+
+def test_required_in_all_matches_every_mode() -> None:
+    """An overlay can still say `required_in: all`; that must mean "every
+    slot", not the literal string."""
+    c = _connector("slack", required_in="all")
+    assert c.required_in_mode("morning-briefing") is True
+    assert c.required_in_mode("anything-at-all") is True
+
+
+def test_required_in_matches_only_the_listed_modes() -> None:
+    c = _connector("slack", required_in=("morning-briefing", "consolidation"))
+    assert c.required_in_mode("morning-briefing") is True
+    assert c.required_in_mode("dreaming") is False
+
+
+def test_required_in_is_empty_by_default() -> None:
+    assert _connector("slack").required_in_mode("morning-briefing") is False
+
+
+def test_critical_in_mode_lists_the_legacy_matches() -> None:
+    reg = ConnectorRegistry(
+        {
+            "slack": _connector("slack", required_in=("morning-briefing",)),
+            "github": _connector("github", required_in="all"),
+            "telegram": _connector("telegram"),
+        }
+    )
+    assert sorted(reg.critical_in_mode("morning-briefing")) == ["github", "slack"]
+    assert reg.critical_in_mode("dreaming") == ["github"]
+
+
+def test_required_in_type_is_the_canonical_check() -> None:
+    c = _connector("slack", required_in_types=(SlotType.BRIEFING,))
+    assert c.required_in_type(SlotType.BRIEFING) is True
+    assert c.required_in_type(SlotType.DREAMING) is False
+    # Outbound-only connectors declare none.
+    assert _connector("telegram").required_in_type(SlotType.BRIEFING) is False
+
+
+# ---------------------------------------------------------------------------
+# _load_yaml / _build_connector errors
+# ---------------------------------------------------------------------------
+
+
+def test_unreadable_yaml_is_a_named_config_error(tmp_path: Path) -> None:
+    with pytest.raises(ConfigError, match="could not be read"):
+        conn._load_yaml(tmp_path / "nope.yaml")
+
+
+def test_malformed_yaml_is_a_named_config_error(tmp_path: Path) -> None:
+    path = tmp_path / "connectors.yaml"
+    path.write_text("connectors: [unclosed\n", encoding="utf-8")
+    with pytest.raises(ConfigError, match="is malformed"):
+        conn._load_yaml(path)
+
+
+@pytest.mark.parametrize("body", ["- a\n- list\n", "just a string\n", "42\n"])
+def test_non_mapping_yaml_is_a_named_config_error(tmp_path: Path, body: str) -> None:
+    path = tmp_path / "connectors.yaml"
+    path.write_text(body, encoding="utf-8")
+    with pytest.raises(ConfigError, match="is not a mapping"):
+        conn._load_yaml(path)
+
+
+def test_a_connector_missing_display_name_is_a_named_config_error() -> None:
+    with pytest.raises(ConfigError, match="connector slack entry is malformed"):
+        conn._build_connector("slack", {"tier": "official"})
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        {"display_name": "Slack", "tier": "imaginary"},
+        {"display_name": "Slack", "capabilities": ["telepathy"]},
+        {"display_name": "Slack", "required_in_types": ["nap"]},
+    ],
+)
+def test_an_unknown_enum_value_is_a_named_config_error(raw: dict) -> None:
+    with pytest.raises(ConfigError, match="entry is malformed"):
+        conn._build_connector("slack", raw)
+
+
+def test_build_connector_defaults_every_optional_field() -> None:
+    c = conn._build_connector("slack", {"display_name": "Slack"})
+    assert c.tier is Tier.OFFICIAL
+    assert c.capabilities == ()
+    assert c.required_in == ()
+    assert c.required_in_types == ()
+    assert c.remediation == Remediation(first_fix="", detail="")
+    assert c.notes == ""
+
+
+def test_build_connector_normalizes_a_null_notes_to_empty() -> None:
+    """`notes:` with no value parses as None; the dataclass promises str."""
+    assert conn._build_connector("slack", {"display_name": "Slack", "notes": None}).notes == ""
+
+
+def test_build_connector_reads_required_in_all_as_the_sentinel_string() -> None:
+    c = conn._build_connector("slack", {"display_name": "Slack", "required_in": "all"})
+    assert c.required_in == "all"
+
+
+# ---------------------------------------------------------------------------
+# load_registry overlay merge
+# ---------------------------------------------------------------------------
+
+
+def test_overlay_can_add_a_connector(tmp_path: Path) -> None:
+    state = tmp_path / ".scout-state"
+    state.mkdir(parents=True)
+    (state / "connectors.local.yaml").write_text(
+        "connectors:\n"
+        "  house-sensor:\n"
+        "    display_name: House Sensor\n"
+        "    tier: community\n"
+        "    capabilities: [inbound]\n",
+        encoding="utf-8",
+    )
+    reg = load_registry(tmp_path)
+    assert "house-sensor" in reg
+    assert reg["house-sensor"].tier is Tier.COMMUNITY
+
+
+def test_overlay_deep_merges_remediation_onto_a_shipped_connector(tmp_path: Path) -> None:
+    """Only `remediation` merges a level deep, so an overlay can replace just
+    `first_fix` without restating `detail`."""
+    shipped = next(iter(load_registry(tmp_path).keys()))
+    original = load_registry(tmp_path)[shipped]
+
+    state = tmp_path / ".scout-state"
+    state.mkdir(parents=True)
+    (state / "connectors.local.yaml").write_text(
+        f"connectors:\n  {shipped}:\n    remediation:\n      first_fix: my custom fix\n",
+        encoding="utf-8",
+    )
+    merged = load_registry(tmp_path)[shipped]
+    assert merged.remediation.first_fix == "my custom fix"
+    assert merged.remediation.detail == original.remediation.detail
+    assert merged.display_name == original.display_name
+
+
+def test_overlay_replaces_a_scalar_field_outright(tmp_path: Path) -> None:
+    shipped = next(iter(load_registry(tmp_path).keys()))
+    state = tmp_path / ".scout-state"
+    state.mkdir(parents=True)
+    (state / "connectors.local.yaml").write_text(
+        f"connectors:\n  {shipped}:\n    display_name: Renamed\n", encoding="utf-8"
+    )
+    assert load_registry(tmp_path)[shipped].display_name == "Renamed"
+
+
+def test_deep_merge_leaves_the_input_dicts_untouched() -> None:
+    a = {"x": 1, "remediation": {"first_fix": "a"}}
+    b = {"remediation": {"detail": "b"}}
+    out = conn._deep_merge_dict(a, b)
+    assert out == {"x": 1, "remediation": {"first_fix": "a", "detail": "b"}}
+    assert a == {"x": 1, "remediation": {"first_fix": "a"}}
+
+
+# ---------------------------------------------------------------------------
+# IdMap
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    (tmp_path / ".scout-state").mkdir(parents=True)
+    return tmp_path
+
+
+def _entry(ulid: str, prefix: str, title: str, file: str, line: int = 3) -> IdMapEntry:
+    return IdMapEntry(ulid=ulid, short_prefix=prefix, last_title=title, last_file=file, last_line=line)
+
+
+def test_load_returns_an_empty_map_when_the_file_is_absent(vault: Path) -> None:
+    assert list(IdMap.load(vault).iter_entries()) == []
+
+
+def test_load_rejects_a_corrupt_json_file(vault: Path) -> None:
+    (vault / ".scout-state" / "id-map.json").write_text("{not json", encoding="utf-8")
+    with pytest.raises(ValueError, match="corrupt id-map at"):
+        IdMap.load(vault)
+
+
+@pytest.mark.parametrize("version", [None, 0, 2, "1", "one"])
+def test_load_rejects_an_unknown_schema_version(vault: Path, version: object) -> None:
+    """Reading a future schema as if it were v1 would silently drop fields and
+    then write them away on the next save()."""
+    (vault / ".scout-state" / "id-map.json").write_text(
+        json.dumps({"schema_version": version, "entries": {}}), encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="unknown schema_version"):
+        IdMap.load(vault)
+
+
+def test_save_then_load_round_trips(vault: Path) -> None:
+    m = IdMap.load(vault)
+    entry = _entry("01HXAAA0000000000000000000", "A3F7", "Land the fix", "action-items-2026-04-15.md")
+    m.register(entry)
+    m.save()
+
+    reloaded = IdMap.load(vault)
+    assert reloaded.lookup_by_ulid(entry.ulid) == entry
+    assert reloaded.lookup_by_prefix("A3F7") == entry
+    assert reloaded.in_use_prefixes() == {"A3F7"}
+
+
+def test_lookups_return_none_for_a_miss(vault: Path) -> None:
+    m = IdMap.load(vault)
+    m.register(_entry("01HXAAA0000000000000000000", "A3F7", "t", "f.md"))
+    assert m.lookup_by_prefix("ZZZZ") is None
+    assert m.lookup_by_ulid("01HXBBB0000000000000000000") is None
+
+
+def test_register_overwrites_an_existing_ulid(vault: Path) -> None:
+    m = IdMap.load(vault)
+    ulid = "01HXAAA0000000000000000000"
+    m.register(_entry(ulid, "A3F7", "old title", "f.md", line=3))
+    m.register(_entry(ulid, "A3F7", "new title", "f.md", line=9))
+    assert len(list(m.iter_entries())) == 1
+    found = m.lookup_by_ulid(ulid)
+    assert found is not None and found.last_title == "new title" and found.last_line == 9
+
+
+def test_save_creates_the_state_dir(tmp_path: Path) -> None:
+    m = IdMap(tmp_path, entries={})
+    m.register(_entry("01HXAAA0000000000000000000", "A3F7", "t", "f.md"))
+    m.save()
+    assert (tmp_path / ".scout-state" / "id-map.json").is_file()
+
+
+def test_save_removes_its_tempfile_when_the_write_fails(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed atomic write must not leave a `.id-map.*.json.tmp` behind —
+    those accumulate silently in the vault's state dir."""
+    m = IdMap.load(vault)
+    m.register(_entry("01HXAAA0000000000000000000", "A3F7", "t", "f.md"))
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(os, "fdopen", boom)
+    with pytest.raises(OSError, match="disk full"):
+        m.save()
+
+    state = vault / ".scout-state"
+    assert list(state.glob(".id-map.*.json.tmp")) == []
+    assert not (state / "id-map.json").exists()
+
+
+def test_save_removes_its_tempfile_on_a_keyboard_interrupt(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The rollback catches BaseException, not Exception, so a Ctrl-C mid-save
+    also cleans up."""
+    m = IdMap.load(vault)
+    m.register(_entry("01HXAAA0000000000000000000", "A3F7", "t", "f.md"))
+
+    real_replace = os.replace
+
+    def boom(*_a: object, **_k: object):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(os, "replace", boom)
+    with pytest.raises(KeyboardInterrupt):
+        m.save()
+    monkeypatch.setattr(os, "replace", real_replace)
+
+    assert list((vault / ".scout-state").glob(".id-map.*.json.tmp")) == []
+
+
+def test_save_writes_deterministic_sorted_json(vault: Path) -> None:
+    """Sorted keys keep the file diffable — it lives in a git-tracked vault."""
+    m = IdMap.load(vault)
+    m.register(_entry("01HXBBB0000000000000000000", "B5K2", "second", "f.md"))
+    m.register(_entry("01HXAAA0000000000000000000", "A3F7", "first", "f.md"))
+    m.save()
+
+    text = (vault / ".scout-state" / "id-map.json").read_text()
+    assert text.index("01HXAAA") < text.index("01HXBBB")
+    assert text.endswith("\n")
+
+
+def test_reattach_returns_none_without_a_title_match(vault: Path) -> None:
+    m = IdMap.load(vault)
+    m.register(_entry("01HXAAA0000000000000000000", "A3F7", "Land the fix", "today.md"))
+    assert m.reattach(title="Something else", file="today.md") is None
+
+
+def test_reattach_prefers_a_same_file_match(vault: Path) -> None:
+    m = IdMap.load(vault)
+    m.register(_entry("01HXAAA0000000000000000000", "A3F7", "Land the fix", "yesterday.md"))
+    m.register(_entry("01HXBBB0000000000000000000", "B5K2", "Land the fix", "today.md"))
+
+    found = m.reattach(title="Land the fix", file="today.md")
+    assert found is not None and found.short_prefix == "B5K2"
+
+
+def test_reattach_falls_back_to_a_cross_file_match(vault: Path) -> None:
+    """The carry-forward case: the task moved to today's file and lost its
+    prefix, so the only candidate is filed under yesterday."""
+    m = IdMap.load(vault)
+    m.register(_entry("01HXAAA0000000000000000000", "A3F7", "Land the fix", "yesterday.md"))
+
+    found = m.reattach(title="Land the fix", file="today.md")
+    assert found is not None and found.short_prefix == "A3F7"
+
+
+# ---------------------------------------------------------------------------
+# connector_log
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def log_vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    d = tmp_path / "Scout"
+    (d / ".scout-logs").mkdir(parents=True)
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(d))
+    monkeypatch.setenv("SCOUT_MODE", "dreaming")
+    return d
+
+
+def _rows(log_vault: Path) -> list[dict]:
+    out = next((log_vault / ".scout-logs").glob("connector-calls-*.jsonl"))
+    return [json.loads(ln) for ln in out.read_text().splitlines()]
+
+
+def test_a_nested_content_block_flagged_is_error_marks_the_row(log_vault: Path) -> None:
+    """MCP tools report failure inside a content block rather than at the top
+    level; missing this under-reports every MCP outage."""
+    payload = {
+        "tool_name": "mcp__slack__slack_read_channel",
+        "tool_input": {},
+        "tool_response": {"content": [{"isError": True, "text": "not_in_channel"}]},
+        "session_id": "s1",
+    }
+    connector_log.run(stdin=io.StringIO(json.dumps(payload)))
+
+    row = _rows(log_vault)[0]
+    assert row["error"] is True
+    assert row["err"] == "not_in_channel"
+    assert row["connector"] == "mcp:slack"
+
+
+def test_a_nested_error_block_with_no_text_yields_no_snippet(log_vault: Path) -> None:
+    payload = {"tool_name": "Read", "tool_response": {"content": [{"isError": True}]}, "session_id": "s1"}
+    connector_log.run(stdin=io.StringIO(json.dumps(payload)))
+    row = _rows(log_vault)[0]
+    assert row["error"] is True
+    assert "err" not in row
+
+
+def test_a_top_level_error_snippet_wins_over_a_nested_one(log_vault: Path) -> None:
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": "gh pr list"},
+        "tool_response": {"error": "outer", "content": [{"isError": True, "text": "inner"}]},
+        "session_id": "s1",
+    }
+    connector_log.run(stdin=io.StringIO(json.dumps(payload)))
+    row = _rows(log_vault)[0]
+    assert row["err"] == "outer"
+    assert row["connector"] == "github"
+
+
+def test_non_dict_content_items_are_ignored(log_vault: Path) -> None:
+    payload = {"tool_name": "Read", "tool_response": {"content": ["a string", None, 7]}, "session_id": "s1"}
+    connector_log.run(stdin=io.StringIO(json.dumps(payload)))
+    assert _rows(log_vault)[0]["error"] is False
+
+
+def test_a_non_dict_tool_response_is_treated_as_no_error(log_vault: Path) -> None:
+    payload = {"tool_name": "Read", "tool_response": "just a string", "session_id": "s1"}
+    connector_log.run(stdin=io.StringIO(json.dumps(payload)))
+    assert _rows(log_vault)[0]["error"] is False
+
+
+def test_locking_is_skipped_where_fcntl_is_unavailable(log_vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The import guard exists for non-POSIX hosts; the append must still
+    happen there, just unserialized."""
+    monkeypatch.setattr(connector_log, "fcntl", None)
+    connector_log.run(stdin=io.StringIO(json.dumps({"tool_name": "Read", "session_id": "s1"})))
+    assert _rows(log_vault)[0]["tool"] == "Read"
+
+
+def test_locking_uses_flock_when_available(log_vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+
+    class FakeFcntl:
+        LOCK_EX = 2
+
+        @staticmethod
+        def flock(fd: int, op: int) -> None:
+            calls.append(op)
+
+    monkeypatch.setattr(connector_log, "fcntl", FakeFcntl)
+    connector_log.run(stdin=io.StringIO(json.dumps({"tool_name": "Read", "session_id": "s1"})))
+    assert calls == [FakeFcntl.LOCK_EX]
+
+
+def test_an_mcp_tool_name_with_no_server_segment_falls_back_to_lowercase(log_vault: Path) -> None:
+    connector_log.run(stdin=io.StringIO(json.dumps({"tool_name": "mcp__", "session_id": "s1"})))
+    # "mcp__".split("__") == ["mcp", ""] -> len 2, so the server segment is "".
+    assert _rows(log_vault)[0]["connector"] == "mcp:"
+
+
+def test_a_bare_mcp_prefix_without_separators_lowercases(log_vault: Path) -> None:
+    assert connector_log.classify("mcp__x", {}) == "mcp:x"
+    assert connector_log.classify("MCP_NOT_PREFIXED", {}) == "mcp_not_prefixed"
+
+
+def test_a_write_failure_is_reported_to_stderr_and_still_returns_an_event(
+    log_vault: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A dropped row is an unsignalled gap in the audit log, so it warns — but
+    the hook still must not fail the session."""
+    real_open = Path.open
+
+    def maybe_boom(self: Path, *a: object, **k: object):
+        if self.suffix == ".jsonl":
+            raise OSError("read-only filesystem")
+        return real_open(self, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "open", maybe_boom)
+    event = connector_log.run(stdin=io.StringIO(json.dumps({"tool_name": "Read", "session_id": "s1"})))
+
+    assert event is not None
+    assert event.kind == "tool.call.logged"
+    assert "connector-log: failed to append row" in capsys.readouterr().err
+
+
+def test_run_reads_real_stdin_when_none_is_passed(log_vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"tool_name": "Read", "session_id": "s1"})))
+    event = connector_log.run()
+    assert event is not None
+    assert event.payload["tool"] == "Read"
+
+
+def test_main_returns_zero_even_when_run_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(**_k: object):
+        raise RuntimeError("unreachable state")
+
+    monkeypatch.setattr(connector_log, "run", boom)
+    assert connector_log.main() == 0
+
+
+def test_main_returns_zero_on_the_happy_path(log_vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"tool_name": "Read", "session_id": "s1"})))
+    assert connector_log.main() == 0
+    assert _rows(log_vault)[0]["tool"] == "Read"
+
+
+def test_idmap_tempfile_lives_beside_the_target(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The tempfile must be in the same directory as the target, or os.replace
+    can cross a filesystem boundary and stop being atomic."""
+    seen: dict[str, object] = {}
+    real_mkstemp = tempfile.mkstemp
+
+    def spy(*a: object, **k: object):
+        seen.update(k)
+        return real_mkstemp(*a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(tempfile, "mkstemp", spy)
+    m = IdMap.load(vault)
+    m.register(_entry("01HXAAA0000000000000000000", "A3F7", "t", "f.md"))
+    m.save()
+
+    assert seen["dir"] == str(vault / ".scout-state")
+    assert idm.paths.id_map_path(vault).is_file()

--- a/engine/tests/unit/test_schedule_tick_internals.py
+++ b/engine/tests/unit/test_schedule_tick_internals.py
@@ -1,0 +1,785 @@
+"""Internal helpers of the schedule dispatcher: timezone resolution, the
+last-fire index and its cache, the candidate/decision helpers, the network
+probe and `main()`'s error handling.
+
+`test_schedule_tick.py` covers the tick's decision matrix end-to-end.
+This file drives the plumbing under it — the parts where a bug is silent
+rather than loud:
+
+* `_local_tz_name` decides what "08:30 local" means. A wrong answer shifts
+  every slot by hours and the dispatcher still reports success, which is why
+  each fallback logs to stderr instead of returning "UTC" quietly (#50).
+* `_read_last_fire_index` / the `last-fire.json` cache decide whether a slot
+  already ran. A stale-cache read means a double fire; a mis-parsed row means
+  a missed one (#73).
+* `_network_ready` gates every fire on a post-wake network being up.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import socket
+from pathlib import Path
+
+import pytest
+
+from scout.schedule import OnMissPolicy, Schedule, SlotType, load_default_schedule
+from scout.scripts import schedule_tick as st
+from scout.scripts.schedule_tick import Decision, SlotCandidate
+
+NOW = _dt.datetime(2026, 5, 28, 14, 0, tzinfo=_dt.UTC)  # a Thursday
+
+
+@pytest.fixture(autouse=True)
+def _clear_schedule_cache() -> None:
+    """`_load_or_default` memoizes on mtime in a module global; reset it so
+    tests can't leak a schedule into each other."""
+    st._SCHEDULE_CACHE = None
+
+
+def _slot(key: str, **overrides):
+    import dataclasses
+
+    template = next(iter(load_default_schedule().values()))
+    return dataclasses.replace(template, key=key, **overrides)
+
+
+def _candidate(key: str, *, target: _dt.datetime, last_fire: _dt.datetime | None = None, **slot_kwargs):
+    return SlotCandidate(slot_key=key, slot=_slot(key, **slot_kwargs), target=target, last_fire=last_fire)
+
+
+# ---------------------------------------------------------------------------
+# _parse_iso_z / _weekday_name
+# ---------------------------------------------------------------------------
+
+
+def test_parse_iso_z_accepts_both_offset_forms() -> None:
+    assert st._parse_iso_z("2026-05-28T14:00:00Z") == st._parse_iso_z("2026-05-28T14:00:00+00:00")
+
+
+def test_parse_iso_z_rejects_a_non_date() -> None:
+    with pytest.raises(ValueError):
+        st._parse_iso_z("not-a-date")
+
+
+@pytest.mark.parametrize(
+    ("day", "name"),
+    [(25, "Mon"), (26, "Tue"), (27, "Wed"), (28, "Thu"), (29, "Fri"), (30, "Sat"), (31, "Sun")],
+)
+def test_weekday_name_matches_the_schedule_vocabulary(day: int, name: str) -> None:
+    """These strings are compared against `Slot.weekdays`; an off-by-one here
+    silently moves every weekday-gated slot."""
+    assert st._weekday_name(_dt.datetime(2026, 5, day, tzinfo=_dt.UTC)) == name
+
+
+# ---------------------------------------------------------------------------
+# _local_tz_name
+# ---------------------------------------------------------------------------
+
+
+def test_a_valid_tz_env_var_wins(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("TZ", "Europe/Prague")
+    assert st._local_tz_name(localtime=tmp_path / "localtime") == "Europe/Prague"
+
+
+def test_an_invalid_tz_env_var_is_reported_and_ignored(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("TZ", "Mars/Olympus_Mons")
+    assert st._local_tz_name(localtime=tmp_path / "not-a-symlink") == "UTC"
+    err = capsys.readouterr().err
+    assert "$TZ='Mars/Olympus_Mons' is not a valid IANA zone" in err
+
+
+def test_the_localtime_symlink_target_is_read(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """macOS resolves /etc/localtime through several zoneinfo layouts, so the
+    zone name is whatever follows the *deepest* zoneinfo* component."""
+    monkeypatch.delenv("TZ", raising=False)
+    zoneinfo_dir = tmp_path / "var" / "db" / "timezone" / "tz" / "2026a" / "zoneinfo" / "Europe"
+    zoneinfo_dir.mkdir(parents=True)
+    (zoneinfo_dir / "Prague").write_bytes(b"")
+
+    link = tmp_path / "localtime"
+    link.symlink_to(zoneinfo_dir / "Prague")
+    assert st._local_tz_name(localtime=link) == "Europe/Prague"
+
+
+def test_a_localtime_target_naming_an_unloadable_zone_is_reported(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv("TZ", raising=False)
+    zoneinfo_dir = tmp_path / "usr" / "share" / "zoneinfo" / "Mars"
+    zoneinfo_dir.mkdir(parents=True)
+    (zoneinfo_dir / "Olympus_Mons").write_bytes(b"")
+
+    link = tmp_path / "localtime"
+    link.symlink_to(zoneinfo_dir / "Olympus_Mons")
+
+    assert st._local_tz_name(localtime=link) == "UTC"
+    assert "is not loadable; falling back to UTC" in capsys.readouterr().err
+
+
+def test_a_localtime_target_with_no_zoneinfo_component_is_reported(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv("TZ", raising=False)
+    target = tmp_path / "somewhere" / "else"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"")
+    link = tmp_path / "localtime"
+    link.symlink_to(target)
+
+    assert st._local_tz_name(localtime=link) == "UTC"
+    err = capsys.readouterr().err
+    assert "has no zoneinfo directory component" in err
+    assert "set $TZ to your IANA zone" in err
+
+
+def test_a_localtime_that_is_not_a_symlink_is_reported(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv("TZ", raising=False)
+    plain = tmp_path / "localtime"
+    plain.write_bytes(b"")
+    assert st._local_tz_name(localtime=plain) == "UTC"
+    assert "is not a symlink; falling back to UTC" in capsys.readouterr().err
+
+
+def test_now_returns_a_tz_aware_datetime_in_the_resolved_zone(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TZ", "Europe/Prague")
+    now = st._now()
+    assert now.tzinfo is not None
+    assert str(now.tzinfo) == "Europe/Prague"
+
+
+def test_now_falls_back_to_utc_for_an_unloadable_resolved_zone(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`_local_tz_name` validates before returning, but keep the belt-and-braces
+    fallback honest — a bare `ZoneInfo(name)` raise must not crash the tick."""
+    monkeypatch.setattr(st, "_local_tz_name", lambda: "Mars/Olympus_Mons")
+    assert st._now().tzinfo is _dt.UTC
+
+
+# ---------------------------------------------------------------------------
+# _read_last_fire_index
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def logs(tmp_path: Path) -> Path:
+    d = tmp_path / ".scout-logs"
+    d.mkdir()
+    return d
+
+
+def _tracker(logs: Path, *rows: str) -> Path:
+    p = logs / "usage-tracker.jsonl"
+    p.write_text("\n".join(rows) + "\n", encoding="utf-8")
+    return p
+
+
+def test_the_index_takes_the_latest_timestamp_per_slot(logs: Path) -> None:
+    tracker = _tracker(
+        logs,
+        json.dumps({"ts": "2026-05-28T08:30:00Z", "slot_key": "morning-briefing"}),
+        json.dumps({"ts": "2026-05-28T12:30:00Z", "slot_key": "morning-briefing"}),
+        json.dumps({"ts": "2026-05-28T09:00:00Z", "slot_key": "midday-consolidation"}),
+    )
+    index = st._read_last_fire_index(tracker)
+    assert index["morning-briefing"] == st._parse_iso_z("2026-05-28T12:30:00Z")
+    assert index["midday-consolidation"] == st._parse_iso_z("2026-05-28T09:00:00Z")
+
+
+def test_the_index_keeps_the_newest_when_rows_arrive_out_of_order(logs: Path) -> None:
+    """Several writers append to this log, so rows are not guaranteed to be in
+    timestamp order — the index must keep the max, not the last seen."""
+    tracker = _tracker(
+        logs,
+        json.dumps({"ts": "2026-05-28T12:30:00Z", "slot_key": "morning-briefing"}),
+        json.dumps({"ts": "2026-05-28T08:30:00Z", "slot_key": "morning-briefing"}),
+    )
+    assert st._read_last_fire_index(tracker)["morning-briefing"] == st._parse_iso_z("2026-05-28T12:30:00Z")
+
+
+def test_the_index_merges_the_session_tokens_log(logs: Path) -> None:
+    """`session-tokens.jsonl` (the Stop hook) carries slot identity as
+    `scout_mode`; both files must feed one index."""
+    tracker = _tracker(logs, json.dumps({"ts": "2026-05-28T08:30:00Z", "slot_key": "morning-briefing"}))
+    (logs / st.SESSION_TOKENS_FILENAME).write_text(
+        json.dumps({"ts": "2026-05-28T13:00:00Z", "scout_mode": "morning-briefing"}) + "\n",
+        encoding="utf-8",
+    )
+    assert st._read_last_fire_index(tracker)["morning-briefing"] == st._parse_iso_z("2026-05-28T13:00:00Z")
+
+
+def test_the_index_renames_legacy_mode_names(logs: Path) -> None:
+    legacy, canonical = next(iter(st._LEGACY_MODE_RENAME.items()))
+    tracker = _tracker(logs, json.dumps({"ts": "2026-05-28T08:30:00Z", "scout_mode": legacy}))
+    index = st._read_last_fire_index(tracker)
+    assert canonical in index
+    assert legacy not in index
+
+
+def test_the_index_skips_unusable_rows(logs: Path) -> None:
+    """The tracker is appended by several writers (a shell script among them);
+    a torn or slot-less row must be dropped, not abort the scan."""
+    tracker = _tracker(
+        logs,
+        "",
+        "   ",
+        "{torn",
+        '"a bare string"',
+        "[1, 2]",
+        json.dumps({"ts": "2026-05-28T08:00:00Z"}),  # no slot identity (legacy budget row)
+        json.dumps({"ts": "2026-05-28T08:00:00Z", "slot_key": ""}),
+        json.dumps({"ts": "2026-05-28T08:00:00Z", "slot_key": 42}),
+        json.dumps({"slot_key": "morning-briefing"}),  # no ts
+        json.dumps({"ts": "", "slot_key": "morning-briefing"}),
+        json.dumps({"ts": 1700000000, "slot_key": "morning-briefing"}),
+        json.dumps({"ts": "not-a-date", "slot_key": "morning-briefing"}),
+        json.dumps({"ts": "2026-05-28T12:30:00Z", "slot_key": "morning-briefing"}),
+    )
+    assert st._read_last_fire_index(tracker) == {"morning-briefing": st._parse_iso_z("2026-05-28T12:30:00Z")}
+
+
+def test_the_index_is_empty_when_no_log_exists(logs: Path) -> None:
+    assert st._read_last_fire_index(logs / "usage-tracker.jsonl") == {}
+
+
+def test_the_index_skips_an_unreadable_log(logs: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    tracker = _tracker(logs, json.dumps({"ts": "2026-05-28T08:30:00Z", "slot_key": "morning-briefing"}))
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "open", boom)
+    assert st._read_last_fire_index(tracker) == {}
+
+
+# ---------------------------------------------------------------------------
+# last-fire cache
+# ---------------------------------------------------------------------------
+
+
+def test_the_cache_round_trips_and_is_reused(logs: Path, tmp_path: Path) -> None:
+    state = tmp_path / ".scout-state"
+    tracker = _tracker(logs, json.dumps({"ts": "2026-05-28T08:30:00Z", "slot_key": "morning-briefing"}))
+
+    first = st._get_last_fire_index(state, tracker)
+    assert (state / st.LAST_FIRE_CACHE_FILENAME).is_file()
+    assert st._get_last_fire_index(state, tracker) == first
+
+
+def test_a_tracker_write_invalidates_the_cache(logs: Path, tmp_path: Path) -> None:
+    """The cache is mtime-keyed; a new fire must be picked up on the next tick
+    or the dispatcher double-fires."""
+    state = tmp_path / ".scout-state"
+    tracker = _tracker(logs, json.dumps({"ts": "2026-05-28T08:30:00Z", "slot_key": "morning-briefing"}))
+    st._get_last_fire_index(state, tracker)
+
+    tracker.write_text(
+        json.dumps({"ts": "2026-05-28T13:00:00Z", "slot_key": "morning-briefing"}) + "\n", encoding="utf-8"
+    )
+    bumped = tracker.stat().st_mtime_ns + 1_000_000_000
+    os.utime(tracker, ns=(bumped, bumped))
+
+    assert st._get_last_fire_index(state, tracker)["morning-briefing"] == st._parse_iso_z("2026-05-28T13:00:00Z")
+
+
+def test_a_session_tokens_write_invalidates_the_cache(logs: Path, tmp_path: Path) -> None:
+    state = tmp_path / ".scout-state"
+    tracker = _tracker(logs, json.dumps({"ts": "2026-05-28T08:30:00Z", "slot_key": "morning-briefing"}))
+    st._get_last_fire_index(state, tracker)
+
+    (logs / st.SESSION_TOKENS_FILENAME).write_text(
+        json.dumps({"ts": "2026-05-28T13:00:00Z", "scout_mode": "morning-briefing"}) + "\n",
+        encoding="utf-8",
+    )
+    assert st._get_last_fire_index(state, tracker)["morning-briefing"] == st._parse_iso_z("2026-05-28T13:00:00Z")
+
+
+def test_a_missing_cache_file_is_a_miss(tmp_path: Path, logs: Path) -> None:
+    tracker = _tracker(logs, json.dumps({"ts": "2026-05-28T08:30:00Z", "slot_key": "b"}))
+    assert st._load_last_fire_cache(tmp_path, tracker, logs / st.SESSION_TOKENS_FILENAME) is None
+
+
+@pytest.mark.parametrize("body", ["{torn", '["a", "list"]', "null", "42"])
+def test_a_corrupt_cache_file_is_a_miss(tmp_path: Path, logs: Path, body: str) -> None:
+    (tmp_path / st.LAST_FIRE_CACHE_FILENAME).write_text(body, encoding="utf-8")
+    tracker = _tracker(logs, json.dumps({"ts": "2026-05-28T08:30:00Z", "slot_key": "b"}))
+    assert st._load_last_fire_cache(tmp_path, tracker, logs / st.SESSION_TOKENS_FILENAME) is None
+
+
+def test_a_cache_from_a_different_schema_version_is_a_miss(tmp_path: Path, logs: Path) -> None:
+    tracker = _tracker(logs, json.dumps({"ts": "2026-05-28T08:30:00Z", "slot_key": "b"}))
+    (tmp_path / st.LAST_FIRE_CACHE_FILENAME).write_text(
+        json.dumps({"schema_version": 999, "last_fire": {}}), encoding="utf-8"
+    )
+    assert st._load_last_fire_cache(tmp_path, tracker, logs / st.SESSION_TOKENS_FILENAME) is None
+
+
+def test_a_cache_with_a_non_mapping_index_is_a_miss(tmp_path: Path, logs: Path) -> None:
+    tracker = _tracker(logs, json.dumps({"ts": "2026-05-28T08:30:00Z", "slot_key": "b"}))
+    tokens = logs / st.SESSION_TOKENS_FILENAME
+    (tmp_path / st.LAST_FIRE_CACHE_FILENAME).write_text(
+        json.dumps(
+            {
+                "schema_version": st._LAST_FIRE_CACHE_SCHEMA_VERSION,
+                "tracker_mtime_ns": st._file_mtime_ns(tracker),
+                "session_tokens_mtime_ns": st._file_mtime_ns(tokens),
+                "last_fire": ["not", "a", "mapping"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert st._load_last_fire_cache(tmp_path, tracker, tokens) is None
+
+
+def test_individual_bad_cache_rows_are_skipped(tmp_path: Path, logs: Path) -> None:
+    tracker = _tracker(logs, json.dumps({"ts": "2026-05-28T08:30:00Z", "slot_key": "b"}))
+    tokens = logs / st.SESSION_TOKENS_FILENAME
+    (tmp_path / st.LAST_FIRE_CACHE_FILENAME).write_text(
+        json.dumps(
+            {
+                "schema_version": st._LAST_FIRE_CACHE_SCHEMA_VERSION,
+                "tracker_mtime_ns": st._file_mtime_ns(tracker),
+                "session_tokens_mtime_ns": st._file_mtime_ns(tokens),
+                "last_fire": {
+                    "morning-briefing": "2026-05-28T08:30:00Z",
+                    "bad-ts": "not-a-date",
+                    "bad-value": 42,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    loaded = st._load_last_fire_cache(tmp_path, tracker, tokens)
+    assert loaded is not None
+    assert set(loaded) == {"morning-briefing"}
+
+
+def test_file_mtime_ns_is_none_for_a_missing_file(tmp_path: Path) -> None:
+    assert st._file_mtime_ns(tmp_path / "nope") is None
+
+
+def test_a_failed_cache_write_leaves_no_tempfile(tmp_path: Path, logs: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state = tmp_path / ".scout-state"
+    state.mkdir()
+    tracker = _tracker(logs, json.dumps({"ts": "2026-05-28T08:30:00Z", "slot_key": "b"}))
+    real_open = Path.open
+
+    def maybe_boom(self: Path, *a: object, **k: object):
+        if self.name.endswith(".json.tmp"):
+            raise OSError("read-only filesystem")
+        return real_open(self, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "open", maybe_boom)
+    st._write_last_fire_cache(state, {"b": NOW}, tracker, logs / st.SESSION_TOKENS_FILENAME)
+
+    assert not (state / st.LAST_FIRE_CACHE_FILENAME).exists()
+    assert list(state.glob("*.tmp")) == []
+
+
+# ---------------------------------------------------------------------------
+# _compute_due_slots
+# ---------------------------------------------------------------------------
+
+
+def test_a_slot_already_fired_after_todays_target_is_not_a_candidate() -> None:
+    sched = Schedule({"b": _slot("b", fires_at_local="08:30", cooldown_minutes=0)})
+    target = sched["b"].target_today(now=NOW)
+    assert target is not None
+    fired = {"b": target + _dt.timedelta(minutes=1)}
+    assert st._compute_due_slots(sched, fired, NOW) == []
+
+
+def test_a_slot_inside_its_cooldown_is_not_a_candidate() -> None:
+    sched = Schedule({"b": _slot("b", fires_at_local="08:30", cooldown_minutes=600)})
+    target = sched["b"].target_today(now=NOW)
+    assert target is not None
+    # Fired before today's target (so not "already fired") but recently enough
+    # to still be inside the 10h cooldown.
+    fired = {"b": target - _dt.timedelta(minutes=30)}
+    assert st._compute_due_slots(sched, fired, NOW) == []
+
+
+def test_a_slot_whose_cooldown_has_elapsed_is_a_candidate() -> None:
+    """Cooldown suppresses a re-fire right after a run; once it lapses the slot
+    becomes eligible again."""
+    sched = Schedule({"b": _slot("b", fires_at_local="08:30", cooldown_minutes=30)})
+    target = sched["b"].target_today(now=NOW)
+    assert target is not None
+    fired = {"b": target - _dt.timedelta(hours=6)}
+    candidates = st._compute_due_slots(sched, fired, NOW)
+    assert [c.slot_key for c in candidates] == ["b"]
+    assert candidates[0].last_fire == fired["b"]
+
+
+def test_a_never_fired_due_slot_is_a_candidate() -> None:
+    sched = Schedule({"b": _slot("b", fires_at_local="08:30", cooldown_minutes=0)})
+    candidates = st._compute_due_slots(sched, {}, NOW)
+    assert [c.slot_key for c in candidates] == ["b"]
+    assert candidates[0].last_fire is None
+
+
+def test_a_future_target_is_not_a_candidate() -> None:
+    sched = Schedule({"b": _slot("b", fires_at_local="23:59", cooldown_minutes=0)})
+    assert st._compute_due_slots(sched, {}, NOW) == []
+
+
+def test_a_weekday_excluded_slot_is_not_a_candidate() -> None:
+    # NOW is a Thursday.
+    sched = Schedule({"b": _slot("b", fires_at_local="08:30", weekdays=("Sat", "Sun"))})
+    assert st._compute_due_slots(sched, {}, NOW) == []
+
+
+def test_candidates_by_key_indexes_by_slot_key() -> None:
+    a = _candidate("a", target=NOW - _dt.timedelta(hours=1))
+    b = _candidate("b", target=NOW - _dt.timedelta(hours=2))
+    assert st.candidates_by_key([a, b]) == {"a": a, "b": b}
+
+
+# ---------------------------------------------------------------------------
+# _apply_miss_rules
+# ---------------------------------------------------------------------------
+
+
+def test_no_candidates_yields_no_decisions() -> None:
+    assert st._apply_miss_rules([], now=NOW) == {}
+
+
+def test_on_miss_skip_fires_inside_the_window() -> None:
+    """#193: `skip` means "don't fire *late*", not "never fire". Every candidate
+    reaching the policy check is already past its target (`_compute_due_slots`
+    drops `target > now`), so skipping unconditionally left no path by which a
+    skip-policy slot could ever fire — silently disabling all dreaming and
+    research sessions."""
+    c = _candidate("b", target=NOW - _dt.timedelta(minutes=5), on_miss=OnMissPolicy.SKIP, missed_window_hours=4)
+    assert st._apply_miss_rules([c], now=NOW)["b"] == Decision(action="fire")
+
+
+def test_on_miss_skip_goes_stale_past_its_window() -> None:
+    """`missed_window_hours` is what bounds "late" — beyond it a skip-policy
+    slot goes stale exactly as it does under `fire`."""
+    c = _candidate("b", target=NOW - _dt.timedelta(hours=9), on_miss=OnMissPolicy.SKIP, missed_window_hours=4)
+    assert st._apply_miss_rules([c], now=NOW)["b"] == Decision(action="skip", reason="stale-after-window")
+
+
+def test_on_miss_fire_inside_the_window_fires() -> None:
+    c = _candidate("b", target=NOW - _dt.timedelta(hours=1), on_miss=OnMissPolicy.FIRE, missed_window_hours=4)
+    assert st._apply_miss_rules([c], now=NOW)["b"] == Decision(action="fire")
+
+
+def test_on_miss_fire_past_the_window_is_stale() -> None:
+    """A briefing that missed its whole window is worse than no briefing — it
+    would report yesterday's world as today's."""
+    c = _candidate("b", target=NOW - _dt.timedelta(hours=9), on_miss=OnMissPolicy.FIRE, missed_window_hours=4)
+    assert st._apply_miss_rules([c], now=NOW)["b"] == Decision(action="skip", reason="stale-after-window")
+
+
+def test_collapse_keeps_the_latest_target_within_a_type() -> None:
+    early = _candidate(
+        "early",
+        target=NOW - _dt.timedelta(hours=3),
+        on_miss=OnMissPolicy.COLLAPSE,
+        type=SlotType.CONSOLIDATION,
+        missed_window_hours=8,
+    )
+    late = _candidate(
+        "late",
+        target=NOW - _dt.timedelta(hours=1),
+        on_miss=OnMissPolicy.COLLAPSE,
+        type=SlotType.CONSOLIDATION,
+        missed_window_hours=8,
+    )
+    decisions = st._apply_miss_rules([early, late], now=NOW)
+    assert decisions["late"] == Decision(action="fire")
+    assert decisions["early"] == Decision(action="skip", reason="collapsed-into=late")
+
+
+def test_a_collapse_winner_past_its_window_is_still_stale() -> None:
+    late = _candidate(
+        "late",
+        target=NOW - _dt.timedelta(hours=9),
+        on_miss=OnMissPolicy.COLLAPSE,
+        type=SlotType.CONSOLIDATION,
+        missed_window_hours=4,
+    )
+    assert st._apply_miss_rules([late], now=NOW)["late"] == Decision(action="skip", reason="stale-after-window")
+
+
+def test_collapse_groups_are_per_slot_type() -> None:
+    """Two different types both collapsing must each keep their own winner —
+    a consolidation must not swallow a dreaming slot."""
+    cons = _candidate(
+        "cons",
+        target=NOW - _dt.timedelta(hours=1),
+        on_miss=OnMissPolicy.COLLAPSE,
+        type=SlotType.CONSOLIDATION,
+        missed_window_hours=8,
+    )
+    dream = _candidate(
+        "dream",
+        target=NOW - _dt.timedelta(hours=2),
+        on_miss=OnMissPolicy.COLLAPSE,
+        type=SlotType.DREAMING,
+        missed_window_hours=8,
+    )
+    decisions = st._apply_miss_rules([cons, dream], now=NOW)
+    assert decisions["cons"] == Decision(action="fire")
+    assert decisions["dream"] == Decision(action="fire")
+
+
+# ---------------------------------------------------------------------------
+# _filter_winner_by_priority
+# ---------------------------------------------------------------------------
+
+
+def test_no_fire_decisions_yields_no_winner() -> None:
+    sched = Schedule({"b": _slot("b")})
+    assert st._filter_winner_by_priority(sched, {"b": Decision(action="skip", reason="x")}) is None
+    assert st._filter_winner_by_priority(sched, {}) is None
+
+
+def test_the_highest_priority_slot_type_wins() -> None:
+    sched = Schedule(
+        {
+            "b": _slot("b", type=SlotType.BRIEFING),
+            "d": _slot("d", type=SlotType.DREAMING),
+        }
+    )
+    decisions = {"b": Decision(action="fire"), "d": Decision(action="fire")}
+    assert st._filter_winner_by_priority(sched, decisions) == "b"
+
+
+def test_a_priority_tie_breaks_deterministically_by_slot_key() -> None:
+    sched = Schedule(
+        {
+            "zebra": _slot("zebra", type=SlotType.BRIEFING),
+            "alpha": _slot("alpha", type=SlotType.BRIEFING),
+        }
+    )
+    decisions = {"zebra": Decision(action="fire"), "alpha": Decision(action="fire")}
+    assert st._filter_winner_by_priority(sched, decisions) == "alpha"
+
+
+# ---------------------------------------------------------------------------
+# _network_ready
+# ---------------------------------------------------------------------------
+
+
+def test_the_network_probe_can_be_short_circuited(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SCOUT_SCHEDULE_TICK_SKIP_NETWORK_PROBE", "1")
+
+    def fail(*_a: object, **_k: object):
+        raise AssertionError("the probe must not open a socket when short-circuited")
+
+    monkeypatch.setattr(socket, "create_connection", fail)
+    assert st._network_ready() is True
+
+
+def test_the_probe_succeeds_on_the_first_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SCOUT_SCHEDULE_TICK_SKIP_NETWORK_PROBE", raising=False)
+
+    class FakeSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+    calls: list[tuple] = []
+    monkeypatch.setattr(socket, "create_connection", lambda addr, timeout=None: calls.append(addr) or FakeSocket())
+    assert st._network_ready() is True
+    assert calls == [(st.NETWORK_PROBE_HOST, st.NETWORK_PROBE_PORT)]
+
+
+def test_the_probe_retries_then_gives_up(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The dispatcher fires right after a scheduled wake; DNS is often not up
+    for a second or two, which is why there are retries at all."""
+    monkeypatch.delenv("SCOUT_SCHEDULE_TICK_SKIP_NETWORK_PROBE", raising=False)
+    attempts: list[int] = []
+    slept: list[float] = []
+
+    def boom(*_a: object, **_k: object):
+        attempts.append(1)
+        raise OSError("network is unreachable")
+
+    monkeypatch.setattr(socket, "create_connection", boom)
+    monkeypatch.setattr(st._time, "sleep", lambda s: slept.append(s))
+
+    assert st._network_ready(retries=3, sleep_seconds=0.5) is False
+    assert len(attempts) == 3
+    # Sleeps between attempts only — not after the last one.
+    assert slept == [0.5, 0.5]
+
+
+def test_the_probe_recovers_on_a_later_attempt(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SCOUT_SCHEDULE_TICK_SKIP_NETWORK_PROBE", raising=False)
+
+    class FakeSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+    calls = {"n": 0}
+
+    def flaky(*_a: object, **_k: object):
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise OSError("network is unreachable")
+        return FakeSocket()
+
+    monkeypatch.setattr(socket, "create_connection", flaky)
+    monkeypatch.setattr(st._time, "sleep", lambda _s: None)
+    assert st._network_ready(retries=3, sleep_seconds=0.1) is True
+    assert calls["n"] == 2
+
+
+def test_a_retries_value_below_one_still_makes_one_attempt(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SCOUT_SCHEDULE_TICK_SKIP_NETWORK_PROBE", raising=False)
+    attempts: list[int] = []
+
+    def boom(*_a: object, **_k: object):
+        attempts.append(1)
+        raise OSError("network is unreachable")
+
+    monkeypatch.setattr(socket, "create_connection", boom)
+    assert st._network_ready(retries=0, sleep_seconds=0) is False
+    assert len(attempts) == 1
+
+
+def test_the_probe_skips_sleeping_when_the_interval_is_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SCOUT_SCHEDULE_TICK_SKIP_NETWORK_PROBE", raising=False)
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("network is unreachable")
+
+    def fail_sleep(_s: float) -> None:
+        raise AssertionError("must not sleep when sleep_seconds is 0")
+
+    monkeypatch.setattr(socket, "create_connection", boom)
+    monkeypatch.setattr(st._time, "sleep", fail_sleep)
+    assert st._network_ready(retries=2, sleep_seconds=0) is False
+
+
+# ---------------------------------------------------------------------------
+# _load_or_default
+# ---------------------------------------------------------------------------
+
+
+def test_load_or_default_falls_back_to_the_plugin_defaults(tmp_path: Path) -> None:
+    assert st._load_or_default(tmp_path).keys() == load_default_schedule().keys()
+
+
+def test_load_or_default_reads_the_vault_schedule_and_caches_it(tmp_path: Path) -> None:
+    state = tmp_path / ".scout-state"
+    state.mkdir()
+    import shutil
+
+    from scout import cli
+
+    shutil.copy2(Path(cli.__file__).parent / "defaults" / "schedule.yaml", state / "schedule.yaml")
+
+    first = st._load_or_default(tmp_path)
+    assert st._SCHEDULE_CACHE is not None
+    # Second call with an unchanged mtime returns the SAME object (cache hit).
+    assert st._load_or_default(tmp_path) is first
+
+
+def test_load_or_default_bypasses_the_cache_when_the_mtime_cannot_be_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = tmp_path / ".scout-state"
+    state.mkdir()
+    import shutil
+
+    from scout import cli
+
+    sched_path = state / "schedule.yaml"
+    shutil.copy2(Path(cli.__file__).parent / "defaults" / "schedule.yaml", sched_path)
+
+    real_stat = Path.stat
+    seen: list[int] = []
+
+    def maybe_boom(self: Path, *a: object, **k: object):
+        # `exists()` stats first; fail only the explicit mtime read after it.
+        if self == sched_path:
+            seen.append(1)
+            if len(seen) > 1:
+                raise OSError("stat failed")
+        return real_stat(self, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "stat", maybe_boom)
+    assert st._load_or_default(tmp_path).keys()
+    # The mtime is the cache key; without it the schedule is re-parsed every
+    # tick rather than cached under a bogus key.
+    assert st._SCHEDULE_CACHE is None
+
+
+# ---------------------------------------------------------------------------
+# payload helpers
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_target_iso_finds_the_named_candidate() -> None:
+    target = NOW - _dt.timedelta(hours=1)
+    candidates = [_candidate("a", target=target)]
+    assert st._candidate_target_iso(candidates, "a") == target.isoformat()
+    assert st._candidate_target_iso(candidates, "missing") is None
+    assert st._candidate_target_iso([], "a") is None
+
+
+def test_target_utc_iso_normalizes_to_a_z_suffix() -> None:
+    from zoneinfo import ZoneInfo
+
+    local = _dt.datetime(2026, 5, 28, 8, 30, tzinfo=ZoneInfo("America/New_York"))
+    assert st._target_utc_iso(local) == "2026-05-28T12:30:00Z"
+
+
+def test_the_skipped_payload_enriches_from_the_candidate_index() -> None:
+    target = NOW - _dt.timedelta(hours=1)
+    index = st.candidates_by_key([_candidate("a", target=target, type=SlotType.BRIEFING)])
+
+    enriched = st._skipped_payload(index, "a", "on_miss=skip")
+    assert enriched == {
+        "slot_key": "a",
+        "reason": "on_miss=skip",
+        "slot_type": "briefing",
+        "target_local": target.isoformat(),
+    }
+
+
+def test_the_skipped_payload_degrades_for_an_unknown_slot() -> None:
+    """A slot can be skipped before it ever became a candidate (e.g. the lock
+    was held), so the enrichment must be optional."""
+    assert st._skipped_payload({}, "a", "lock-held") == {"slot_key": "a", "reason": "lock-held"}
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
+
+
+def test_main_returns_zero_on_a_successful_tick(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(st, "run", lambda: None)
+    assert st.main() == 0
+
+
+def test_main_prints_the_traceback_and_returns_one_on_an_unhandled_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A silent exit-1 leaves no signal for why the tick stopped firing, so the
+    traceback goes to stderr where launchd/cron captures it."""
+
+    def boom() -> None:
+        raise RuntimeError("unreachable state")
+
+    monkeypatch.setattr(st, "run", boom)
+    assert st.main() == 1
+    err = capsys.readouterr().err
+    assert "RuntimeError: unreachable state" in err
+    assert "Traceback" in err

--- a/engine/tests/unit/test_scripts_connector_health_edges.py
+++ b/engine/tests/unit/test_scripts_connector_health_edges.py
@@ -1,0 +1,513 @@
+"""Tolerance, cleanup and notification branches of the connector health report.
+
+`test_scripts_connector_health.py` covers the alerting rules against
+well-formed logs. This file covers the surrounding I/O:
+
+* `load_records`'s skip rules — the JSONL is appended by a live hook, so torn
+  lines, out-of-window rows and interactive-session rows must all be dropped
+  rather than skewing the matrix or crashing the report.
+* `cleanup_old_jsonl`'s retention pass, which deletes files. A greedy or
+  crashing cleanup either loses audit history or wedges the report.
+* `fire_macos_notification`'s argv-not-source AppleScript construction (#51):
+  connector names come from user-editable YAML, so interpolating them into the
+  script source would allow AppleScript injection.
+* `run()`'s pending-file lifecycle and `main()`'s exit semantics.
+
+Payloads are anonymized per CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from scout.scripts import connector_health_report as chr_mod
+from scout.scripts.connector_health_report import Alert
+
+NOW = datetime(2026, 5, 28, 14, 0, tzinfo=UTC)
+
+
+def _row(ts: datetime, sid: str = "s1", mode: str = "morning-briefing", **fields) -> dict:
+    rec = {
+        "ts": ts.isoformat().replace("+00:00", "Z"),
+        "session_id": sid,
+        "mode": mode,
+        "tool": "Bash",
+        "connector": "slack",
+        "error": False,
+    }
+    rec.update(fields)
+    return rec
+
+
+def _log(log_dir: Path, date: str, *rows: str) -> Path:
+    log_dir.mkdir(parents=True, exist_ok=True)
+    p = log_dir / f"connector-calls-{date}.jsonl"
+    p.write_text("\n".join(rows) + "\n", encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# _default_now
+# ---------------------------------------------------------------------------
+
+
+def test_the_default_clock_is_tz_aware_utc() -> None:
+    """Every window comparison is against this; a naive value would raise on
+    the first `<` against a tz-aware record timestamp."""
+    assert chr_mod._default_now().tzinfo is UTC
+
+
+# ---------------------------------------------------------------------------
+# load_records
+# ---------------------------------------------------------------------------
+
+
+def test_records_are_loaded_from_every_matching_file(tmp_path: Path) -> None:
+    _log(tmp_path, "2026-05-27", json.dumps(_row(NOW - timedelta(days=1), sid="s0")))
+    _log(tmp_path, "2026-05-28", json.dumps(_row(NOW, sid="s1")))
+    records = chr_mod.load_records(tmp_path, window_days=14, now=NOW)
+    assert {r["session_id"] for r in records} == {"s0", "s1"}
+    assert all(isinstance(r["_ts"], datetime) for r in records)
+
+
+def test_records_outside_the_window_are_dropped(tmp_path: Path) -> None:
+    _log(
+        tmp_path,
+        "2026-05-28",
+        json.dumps(_row(NOW - timedelta(days=30), sid="ancient")),
+        json.dumps(_row(NOW, sid="recent")),
+    )
+    records = chr_mod.load_records(tmp_path, window_days=14, now=NOW)
+    assert {r["session_id"] for r in records} == {"recent"}
+
+
+@pytest.mark.parametrize("mode", ["interactive", "unknown"])
+def test_interactive_and_unknown_mode_rows_are_dropped(tmp_path: Path, mode: str) -> None:
+    """The report measures *scheduled* runs; a human's interactive session has
+    no expected connector profile and would poison the baseline."""
+    _log(
+        tmp_path,
+        "2026-05-28",
+        json.dumps(_row(NOW, sid="human", mode=mode)),
+        json.dumps(_row(NOW, sid="scheduled")),
+    )
+    records = chr_mod.load_records(tmp_path, window_days=14, now=NOW)
+    assert {r["session_id"] for r in records} == {"scheduled"}
+
+
+def test_a_row_with_no_mode_defaults_to_interactive_and_is_dropped(tmp_path: Path) -> None:
+    row = _row(NOW, sid="modeless")
+    del row["mode"]
+    _log(tmp_path, "2026-05-28", json.dumps(row), json.dumps(_row(NOW, sid="scheduled")))
+    records = chr_mod.load_records(tmp_path, window_days=14, now=NOW)
+    assert {r["session_id"] for r in records} == {"scheduled"}
+
+
+def test_unusable_rows_are_skipped(tmp_path: Path) -> None:
+    """The log is appended by a PostToolUse hook under an flock; a crash can
+    still leave a torn final line."""
+    bad_ts = _row(NOW, sid="bad-ts")
+    bad_ts["ts"] = "not-a-date"
+    no_ts = _row(NOW, sid="no-ts")
+    del no_ts["ts"]
+    non_str_ts = _row(NOW, sid="non-str-ts")
+    non_str_ts["ts"] = 1700000000
+
+    _log(
+        tmp_path,
+        "2026-05-28",
+        "{torn",
+        "",
+        json.dumps(bad_ts),
+        json.dumps(no_ts),
+        json.dumps(non_str_ts),
+        json.dumps(_row(NOW, sid="good")),
+    )
+    records = chr_mod.load_records(tmp_path, window_days=14, now=NOW)
+    assert {r["session_id"] for r in records} == {"good"}
+
+
+def test_an_unreadable_log_file_is_skipped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    bad = _log(tmp_path, "2026-05-27", json.dumps(_row(NOW, sid="unreadable")))
+    _log(tmp_path, "2026-05-28", json.dumps(_row(NOW, sid="good")))
+
+    import builtins
+
+    real_open = builtins.open
+
+    def maybe_boom(path, *a, **k):
+        if str(path) == str(bad):
+            raise OSError("permission denied")
+        return real_open(path, *a, **k)
+
+    monkeypatch.setattr(builtins, "open", maybe_boom)
+    records = chr_mod.load_records(tmp_path, window_days=14, now=NOW)
+    assert {r["session_id"] for r in records} == {"good"}
+
+
+def test_no_log_files_yields_no_records(tmp_path: Path) -> None:
+    assert chr_mod.load_records(tmp_path, window_days=14, now=NOW) == []
+
+
+# ---------------------------------------------------------------------------
+# cleanup_old_jsonl
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_deletes_only_files_older_than_the_retention_window(tmp_path: Path) -> None:
+    old = _log(tmp_path, "2026-01-01", json.dumps(_row(NOW)))
+    recent = _log(tmp_path, "2026-05-28", json.dumps(_row(NOW)))
+
+    chr_mod.cleanup_old_jsonl(tmp_path, retain_days=30, now=NOW)
+    assert not old.exists()
+    assert recent.exists()
+
+
+def test_cleanup_ignores_a_file_whose_name_is_not_a_date(tmp_path: Path) -> None:
+    """A hand-renamed or partially-written filename must be left alone, not
+    crash the retention pass mid-way and skip the rest."""
+    weird = tmp_path / "connector-calls-backup.jsonl"
+    weird.write_text("{}\n", encoding="utf-8")
+    old = _log(tmp_path, "2026-01-01", json.dumps(_row(NOW)))
+
+    chr_mod.cleanup_old_jsonl(tmp_path, retain_days=30, now=NOW)
+    assert weird.exists()
+    assert not old.exists()
+
+
+def test_cleanup_survives_a_failed_unlink(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    old = _log(tmp_path, "2026-01-01", json.dumps(_row(NOW)))
+    older = _log(tmp_path, "2026-01-02", json.dumps(_row(NOW)))
+
+    import os
+
+    real_remove = os.remove
+
+    def maybe_boom(path, *a, **k):
+        if str(path) == str(old):
+            raise OSError("permission denied")
+        return real_remove(path, *a, **k)
+
+    monkeypatch.setattr(os, "remove", maybe_boom)
+    chr_mod.cleanup_old_jsonl(tmp_path, retain_days=30, now=NOW)
+    assert old.exists()  # the failure is swallowed...
+    assert not older.exists()  # ...and the loop continues
+
+
+def test_cleanup_on_an_empty_dir_is_a_no_op(tmp_path: Path) -> None:
+    chr_mod.cleanup_old_jsonl(tmp_path, retain_days=30, now=NOW)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# fmt_ts / recent_error_sample / last_healthy_ts
+# ---------------------------------------------------------------------------
+
+
+def test_a_missing_timestamp_renders_as_never() -> None:
+    assert chr_mod.fmt_ts(None) == "never"
+
+
+def test_a_timestamp_renders_in_eastern_time() -> None:
+    out = chr_mod.fmt_ts(datetime(2026, 5, 28, 16, 30, tzinfo=UTC))
+    # The real zone abbreviation, not a literal "ET" — so it reads EDT in
+    # summer and EST in winter rather than being wrong for half the year.
+    assert out.endswith("EDT")
+    assert "12:30" in out  # 16:30 UTC is 12:30 EDT
+
+
+def test_the_error_sample_is_the_most_recent_non_empty_snippet() -> None:
+    records = [
+        {"connector": "slack", "error": True, "err": "first failure"},
+        {"connector": "slack", "error": True, "err": ""},  # blank -> keep looking back
+        {"connector": "github", "error": True, "err": "wrong connector"},
+        {"connector": "slack", "error": False, "err": "not an error"},
+    ]
+    assert chr_mod.recent_error_sample(records, "slack") == "first failure"
+
+
+def test_the_error_sample_is_truncated() -> None:
+    records = [{"connector": "slack", "error": True, "err": "x" * 500}]
+    assert len(chr_mod.recent_error_sample(records, "slack", limit=140)) == 140
+
+
+def test_the_error_sample_is_empty_when_nothing_matches() -> None:
+    assert chr_mod.recent_error_sample([], "slack") == ""
+    assert chr_mod.recent_error_sample([{"connector": "slack", "error": False}], "slack") == ""
+
+
+def test_last_healthy_ts_is_none_when_no_prior_run_was_healthy() -> None:
+    stats = {"slack": {"s1": {"ok": 0, "err": 3}, "s2": {"ok": 1, "err": 0}}}
+    by_id: dict[str, list[dict]] = {
+        "s1": [{"_ts": NOW - timedelta(days=2)}],
+        "s2": [{"_ts": NOW - timedelta(days=1)}],
+    }
+    prior = [("s1", by_id["s1"]), ("s2", by_id["s2"])]
+    assert chr_mod.last_healthy_ts(stats, "slack", prior, by_id, threshold=3) is None
+
+
+def test_last_healthy_ts_finds_the_most_recent_healthy_prior_run() -> None:
+    stats = {"slack": {"s1": {"ok": 5, "err": 0}, "s2": {"ok": 0, "err": 2}}}
+    by_id: dict[str, list[dict]] = {
+        "s1": [{"_ts": NOW - timedelta(days=2)}],
+        "s2": [{"_ts": NOW - timedelta(days=1)}],
+    }
+    prior = [("s1", by_id["s1"]), ("s2", by_id["s2"])]
+    assert chr_mod.last_healthy_ts(stats, "slack", prior, by_id, threshold=3) == NOW - timedelta(days=2)
+
+
+def test_no_sessions_yields_no_critical_alerts() -> None:
+    assert chr_mod.compute_critical_alerts({}, [], {}, {}, [], data_dir=Path("/nonexistent")) == []
+
+
+# ---------------------------------------------------------------------------
+# fire_macos_notification
+# ---------------------------------------------------------------------------
+
+
+def _alert(name: str) -> Alert:
+    return Alert(
+        level="CRITICAL",
+        connector_key=name.lower(),
+        name=name,
+        reason="dark for 1 run",
+        err_sample="",
+    )
+
+
+def test_no_alerts_means_no_notification(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail(*_a: object, **_k: object):
+        raise AssertionError("must not shell out with no alerts")
+
+    monkeypatch.setattr(subprocess, "run", fail)
+    chr_mod.fire_macos_notification([])
+
+
+def test_the_notification_passes_names_as_argv_not_as_script_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#51: connector names come from user-editable YAML. Interpolating them
+    into the AppleScript source would let a name containing quotes or newlines
+    inject arbitrary AppleScript; as argv they are pure data."""
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(subprocess, "run", lambda argv, **k: seen.update(argv=argv, **k) or None)
+
+    hostile = 'Slack" & (do shell script "rm -rf ~") & "'
+    chr_mod.fire_macos_notification([_alert(hostile)])
+
+    argv = seen["argv"]
+    assert isinstance(argv, list)
+    assert argv[0] == "osascript"
+    assert argv[1] == "-", "the script must come from stdin, not the command line"
+    assert argv[2] == "Scout: connector degradation"
+    assert argv[3] == hostile, "the name rides as data in argv"
+
+    script = seen["input"]
+    assert isinstance(script, str)
+    assert "on run argv" in script
+    assert "item 2 of argv" in script
+    assert hostile not in script, "the name must never appear in the script source"
+
+
+def test_the_notification_summarizes_at_most_three_alerts(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(subprocess, "run", lambda argv, **k: seen.update(argv=argv) or None)
+
+    chr_mod.fire_macos_notification([_alert(f"conn{n}") for n in range(5)])
+    body = seen["argv"][3]  # type: ignore[index]
+    assert body == "conn0; conn1; conn2 (+2 more)"
+
+
+def test_the_notification_lists_all_alerts_when_there_are_three_or_fewer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(subprocess, "run", lambda argv, **k: seen.update(argv=argv) or None)
+
+    chr_mod.fire_macos_notification([_alert("slack"), _alert("github")])
+    assert seen["argv"][3] == "slack; github"  # type: ignore[index]
+    assert "more)" not in str(seen["argv"][3])  # type: ignore[index]
+
+
+def test_a_notification_failure_is_swallowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The notification is a nicety; on a Linux host `osascript` doesn't exist
+    and the report must still complete."""
+
+    def boom(*_a: object, **_k: object):
+        raise FileNotFoundError("osascript")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    chr_mod.fire_macos_notification([_alert("slack")])  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# run() — pending-file lifecycle and write tolerance
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    v = tmp_path / "Scout"
+    for sub in (".scout-logs", ".scout-cache", "knowledge-base", ".scout-state"):
+        (v / sub).mkdir(parents=True)
+    return v
+
+
+def _seed_healthy_run(vault: Path) -> None:
+    _log(
+        vault / ".scout-logs",
+        "2026-05-28",
+        *[json.dumps(_row(NOW, connector="slack")) for _ in range(4)],
+    )
+
+
+def test_a_malformed_vault_schedule_falls_back_to_the_plugin_defaults(vault: Path) -> None:
+    """The health report must not crash over a broken schedule.yaml — it only
+    needs the slot *types* to decide which connectors are required."""
+    (vault / ".scout-state" / "schedule.yaml").write_text("slots: [unclosed\n", encoding="utf-8")
+    _seed_healthy_run(vault)
+
+    event = chr_mod.run(data_dir=vault, now=NOW)
+    assert event is not None
+    assert (vault / "knowledge-base" / "connector-health.md").exists()
+
+
+def test_a_run_with_no_alerts_clears_a_stale_pending_file(vault: Path) -> None:
+    """The pending file is what the next session announces; leaving a resolved
+    alert in it re-announces a problem that already fixed itself."""
+    pending = vault / ".scout-cache" / "connector-alerts-pending.md"
+    pending.write_text("# stale alert from a previous run\n", encoding="utf-8")
+    _seed_healthy_run(vault)
+
+    event = chr_mod.run(data_dir=vault, now=NOW)
+    assert event is not None
+    assert event.payload["alerts"] == []
+    assert not pending.exists()
+
+
+def test_clearing_an_absent_pending_file_is_a_no_op(vault: Path) -> None:
+    _seed_healthy_run(vault)
+    event = chr_mod.run(data_dir=vault, now=NOW)
+    assert event is not None
+    assert not (vault / ".scout-cache" / "connector-alerts-pending.md").exists()
+
+
+def test_an_unremovable_pending_file_does_not_fail_the_run(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pending = vault / ".scout-cache" / "connector-alerts-pending.md"
+    pending.write_text("# stale\n", encoding="utf-8")
+    _seed_healthy_run(vault)
+
+    def boom(*_a: object, **_k: object):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "unlink", boom)
+    assert chr_mod.run(data_dir=vault, now=NOW) is not None
+
+
+def test_run_short_circuits_when_every_record_is_interactive(vault: Path) -> None:
+    _log(vault / ".scout-logs", "2026-05-28", json.dumps(_row(NOW, mode="interactive")))
+    assert chr_mod.run(data_dir=vault, now=NOW) is None
+
+
+def test_run_cleans_up_old_logs_when_asked(vault: Path) -> None:
+    old = _log(vault / ".scout-logs", "2026-01-01", json.dumps(_row(NOW - timedelta(days=200))))
+    _seed_healthy_run(vault)
+
+    chr_mod.run(data_dir=vault, now=NOW, cleanup=True)
+    assert not old.exists()
+
+
+def test_run_leaves_old_logs_alone_by_default(vault: Path) -> None:
+    old = _log(vault / ".scout-logs", "2026-01-01", json.dumps(_row(NOW - timedelta(days=200))))
+    _seed_healthy_run(vault)
+
+    chr_mod.run(data_dir=vault, now=NOW)
+    assert old.exists()
+
+
+def test_an_unwritable_alerts_log_does_not_fail_the_run(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The rendered health doc is the durable surface; the append-only alert
+    log and the pending file are conveniences."""
+    _seed_healthy_run(vault)
+    monkeypatch.setattr(chr_mod, "compute_warning_alerts", lambda *a, **k: [_alert("slack")])
+    monkeypatch.setattr(chr_mod, "fire_macos_notification", lambda _alerts: None)
+
+    real_open = Path.open
+
+    def maybe_boom(self: Path, *a: object, **k: object):
+        if self.name == "connector-alerts.log":
+            raise OSError("read-only filesystem")
+        return real_open(self, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "open", maybe_boom)
+    event = chr_mod.run(data_dir=vault, now=NOW)
+    assert event is not None
+    assert len(event.payload["alerts"]) == 1
+
+
+def test_an_unwritable_pending_file_does_not_fail_the_run(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _seed_healthy_run(vault)
+    monkeypatch.setattr(chr_mod, "compute_warning_alerts", lambda *a, **k: [_alert("slack")])
+    monkeypatch.setattr(chr_mod, "fire_macos_notification", lambda _alerts: None)
+
+    real_write_text = Path.write_text
+
+    def maybe_boom(self: Path, *a: object, **k: object):
+        if self.name == "connector-alerts-pending.md":
+            raise OSError("read-only filesystem")
+        return real_write_text(self, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "write_text", maybe_boom)
+    event = chr_mod.run(data_dir=vault, now=NOW)
+    assert event is not None
+    assert (vault / ".scout-logs" / "connector-alerts.log").exists()
+
+
+def test_run_resolves_the_vault_from_the_environment(vault: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(vault))
+    _seed_healthy_run(vault)
+    assert chr_mod.run(now=NOW) is not None
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
+
+
+def test_main_reports_the_no_records_short_circuit(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(chr_mod, "run", lambda **_k: None)
+    assert chr_mod.main() == 0
+    assert "no scheduled-run records yet" in capsys.readouterr().out
+
+
+def test_main_summarizes_the_report(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    from scout.events import Event
+
+    monkeypatch.setattr(
+        chr_mod,
+        "run",
+        lambda **_k: Event(
+            id="01HXAAA0000000000000000000",
+            ts="2026-05-28T14:00:00.000Z",
+            kind="connector_health.report.generated",
+            source="script:connector_health_report",
+            payload={"sessions_in_window": 7, "alerts": [{"name": "slack"}, {"name": "github"}]},
+        ),
+    )
+    assert chr_mod.main() == 0
+    assert "7 sessions in window, 2 alert(s)" in capsys.readouterr().out
+
+
+def test_main_requests_the_cleanup_pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CLI entry point is the retention pass's only caller; if it stopped
+    asking for cleanup, the JSONL log would grow without bound."""
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(chr_mod, "run", lambda **k: seen.update(k) or None)
+    chr_mod.main()
+    assert seen == {"cleanup": True}

--- a/engine/tests/unit/test_scripts_notify_telegram_main.py
+++ b/engine/tests/unit/test_scripts_notify_telegram_main.py
@@ -1,0 +1,203 @@
+"""Coverage of `notify_telegram.main()` and the remaining `_read_secret` paths.
+
+`test_scripts_notify_telegram.py` covers `send()`, `_split_message`, the
+permission checks and the Typer command. `main()` — the argparse entry point a
+Python caller or a bare `python -m` invocation reaches — is untested, and it
+carries its own copy of the exit-code map and the bot-token redaction. A
+divergence between the two copies is exactly the kind of thing that leaks a
+token, so pin both.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from scout.errors import ConfigError
+from scout.scripts import notify_telegram
+
+FAKE_TOKEN = "1234567:FAKE-TOKEN-DO-NOT-USE"
+FAKE_CHAT_ID = "-1009999999999"
+
+
+def _write_secret(path: Path, value: str) -> None:
+    path.write_text(value + "\n", encoding="utf-8")
+    path.chmod(0o600)
+
+
+@pytest.fixture
+def secrets_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    d = tmp_path / "secrets"
+    d.mkdir()
+    _write_secret(d / "telegram-bot-token", FAKE_TOKEN)
+    _write_secret(d / "telegram-chat-id", FAKE_CHAT_ID)
+    monkeypatch.setattr(notify_telegram, "SECRETS_DIR", d)
+    return d
+
+
+@pytest.fixture
+def empty_secrets_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    d = tmp_path / "secrets"
+    monkeypatch.setattr(notify_telegram, "SECRETS_DIR", d)
+    return d
+
+
+def _ok_response() -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# _read_secret — the two paths the existing suite doesn't reach
+# ---------------------------------------------------------------------------
+
+
+def test_read_secret_rejects_an_empty_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A touched-but-never-filled secret is a common half-finished install; the
+    error must name the file rather than failing later with a 401."""
+    d = tmp_path / "secrets"
+    d.mkdir()
+    _write_secret(d / "telegram-bot-token", "   ")
+    monkeypatch.setattr(notify_telegram, "SECRETS_DIR", d)
+
+    with pytest.raises(ConfigError, match="Secret file is empty"):
+        notify_telegram._read_secret("telegram-bot-token")
+
+
+def test_read_secret_surfaces_an_unreadable_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    d = tmp_path / "secrets"
+    d.mkdir()
+    secret = d / "telegram-bot-token"
+    _write_secret(secret, FAKE_TOKEN)
+    monkeypatch.setattr(notify_telegram, "SECRETS_DIR", d)
+
+    real_read_text = Path.read_text
+
+    def maybe_boom(self: Path, *a: object, **k: object):
+        if self == secret:
+            raise OSError("input/output error")
+        return real_read_text(self, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", maybe_boom)
+    with pytest.raises(ConfigError, match="Could not read"):
+        notify_telegram._read_secret("telegram-bot-token")
+
+
+def test_read_secret_names_the_setup_doc_when_the_file_is_absent(empty_secrets_dir: Path) -> None:
+    with pytest.raises(ConfigError, match="telegram-setup.md"):
+        notify_telegram._read_secret("telegram-bot-token")
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
+
+
+def test_main_dry_run_prints_the_event_json(secrets_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert notify_telegram.main(["--body", "hello", "--dry-run"]) == 0
+    captured = capsys.readouterr()
+    # stdout is pure JSON; the [dry-run] preamble goes to stderr.
+    payload = json.loads(captured.out)
+    assert payload["kind"] == "notification.sent"
+    assert payload["payload"] == {
+        "tier": "info",
+        "channel": "telegram",
+        "body_chars": 5,
+        "dry_run": True,
+    }
+    assert "[dry-run] POST" in captured.err
+    assert FAKE_TOKEN not in captured.err
+
+
+def test_main_real_send_prints_the_event_json(secrets_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    with patch("scout.scripts.notify_telegram.requests.post") as mock_post:
+        mock_post.return_value = _ok_response()
+        assert notify_telegram.main(["--tier", "action_required", "--body", "ship it"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["payload"]["tier"] == "action_required"
+    assert "dry_run" not in payload["payload"]
+    assert mock_post.call_count == 1
+
+
+def test_main_missing_secrets_exits_with_the_configerror_code(
+    empty_secrets_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The runner keys off exit 10 to distinguish "not installed" from
+    "send failed"."""
+    assert notify_telegram.main(["--body", "hello"]) == ConfigError.exit_code
+    assert "notify-telegram: Missing secret" in capsys.readouterr().out
+
+
+def test_main_empty_body_exits_one(secrets_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert notify_telegram.main(["--body", ""]) == 1
+    assert "body cannot be empty" in capsys.readouterr().out
+
+
+def test_main_rejects_an_unknown_tier_at_the_argparse_layer(secrets_dir: Path) -> None:
+    """argparse `choices` fails before send() is reached, so this is a
+    SystemExit(2), not a mapped return code."""
+    with pytest.raises(SystemExit) as exc:
+        notify_telegram.main(["--tier", "shout", "--body", "hello"])
+    assert exc.value.code == 2
+
+
+def test_main_requires_a_body(secrets_dir: Path) -> None:
+    with pytest.raises(SystemExit):
+        notify_telegram.main([])
+
+
+def test_main_http_error_redacts_the_bot_token(secrets_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """`str(HTTPError)` embeds the request URL, and the Telegram URL carries
+    the bot token in its path — a 401 must not print it."""
+    resp = MagicMock()
+    resp.status_code = 401
+    resp.reason = "Unauthorized"
+    err = requests.HTTPError(
+        f"401 Client Error: Unauthorized for url: https://api.telegram.org/bot{FAKE_TOKEN}/sendMessage",
+        response=resp,
+    )
+
+    with patch("scout.scripts.notify_telegram.requests.post") as mock_post:
+        mock_post.return_value.raise_for_status.side_effect = err
+        assert notify_telegram.main(["--body", "hello"]) == 2
+
+    out = capsys.readouterr().out
+    assert "HTTP 401 Unauthorized (token redacted in URL)" in out
+    assert FAKE_TOKEN not in out
+
+
+def test_main_http_error_without_a_response_degrades_gracefully(
+    secrets_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with patch("scout.scripts.notify_telegram.requests.post") as mock_post:
+        mock_post.return_value.raise_for_status.side_effect = requests.HTTPError("boom", response=None)  # type: ignore[arg-type]
+        assert notify_telegram.main(["--body", "hello"]) == 2
+    assert "HTTP ? Unknown" in capsys.readouterr().out
+
+
+def test_main_transport_error_exits_two(secrets_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    with patch("scout.scripts.notify_telegram.requests.post") as mock_post:
+        mock_post.side_effect = requests.ConnectTimeout("connect timed out")
+        assert notify_telegram.main(["--body", "hello"]) == 2
+    assert "HTTP error: connect timed out" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# _split_message — the line-boundary branch
+# ---------------------------------------------------------------------------
+
+
+def test_split_prefers_a_line_boundary_when_there_is_no_blank_line() -> None:
+    """Boundary preference is paragraph > line > word > hard cut. The existing
+    suite covers paragraph, word and hard cut; this is the line rung."""
+    limit = 20
+    body = "a" * 15 + "\n" + "b" * 15
+    chunks = notify_telegram._split_message(body, limit=limit)
+    assert chunks == ["a" * 15, "b" * 15]
+    assert all(len(c) <= limit for c in chunks)

--- a/engine/tests/unit/test_self_update.py
+++ b/engine/tests/unit/test_self_update.py
@@ -46,3 +46,96 @@ def test_check_propagates_runtime_error_from_available_fetcher():
             installed_fetcher=lambda: "0.5.0",
             available_fetcher=failing_fetcher,
         )
+
+
+# --- default fetchers -------------------------------------------------------
+#
+# check()'s injected seams are covered above; these exercise the fetchers that
+# actually run in production. `_available_version` reaches the network, so the
+# urlopen is stubbed — the point is the error mapping, which is what
+# /scout-status and the /scout-update nudge surface to the user.
+
+
+def test_installed_version_reads_the_package_version():
+    from scout import __version__
+
+    assert self_update._installed_version() == __version__
+
+
+class _FakeResponse:
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+
+def test_available_version_reads_the_first_plugins_entry(monkeypatch):
+    import json
+
+    body = json.dumps({"plugins": [{"name": "scout", "version": "0.9.0"}]}).encode()
+    seen: list[str] = []
+
+    def fake_urlopen(url, timeout=None):  # noqa: ARG001
+        seen.append(url)
+        return _FakeResponse(body)
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    assert self_update._available_version() == "0.9.0"
+    assert seen == [self_update.RAW_MARKETPLACE_URL]
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        __import__("urllib.error", fromlist=["URLError"]).URLError("dns failure"),
+        TimeoutError("timed out"),
+        OSError("connection reset"),
+    ],
+)
+def test_available_version_maps_network_failure_to_a_named_runtime_error(monkeypatch, exc):
+    """The message must name the URL so an operator behind a proxy knows what
+    to allow — a bare URLError traceback doesn't say that."""
+
+    def boom(*_a, **_k):
+        raise exc
+
+    monkeypatch.setattr("urllib.request.urlopen", boom)
+    with pytest.raises(RuntimeError, match="could not reach marketplace at"):
+        self_update._available_version()
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        b"not json",
+        b"{}",  # no "plugins"
+        b'{"plugins": []}',  # empty list
+        b'{"plugins": [{"name": "scout"}]}',  # no "version"
+        b'{"plugins": "scout"}',  # wrong type
+    ],
+)
+def test_available_version_maps_a_malformed_marketplace_to_a_runtime_error(monkeypatch, body):
+    monkeypatch.setattr("urllib.request.urlopen", lambda *_a, **_k: _FakeResponse(body))
+    with pytest.raises(RuntimeError, match="could not parse marketplace.json"):
+        self_update._available_version()
+
+
+def test_check_defaults_use_both_real_fetchers(monkeypatch):
+    import json
+
+    from scout import __version__
+
+    body = json.dumps({"plugins": [{"version": "99.0.0"}]}).encode()
+    monkeypatch.setattr("urllib.request.urlopen", lambda *_a, **_k: _FakeResponse(body))
+
+    status = self_update.check()
+    assert status.installed == __version__
+    assert status.available == "99.0.0"
+    assert status.update_available is True

--- a/engine/tests/unit/test_session_tool_log_resolution.py
+++ b/engine/tests/unit/test_session_tool_log_resolution.py
@@ -1,0 +1,386 @@
+"""Transcript discovery, row-parsing tolerance and error classification for
+the `session-tool-log` Stop hook.
+
+`test_session_tool_log.py` covers `extract_tool_calls`, `write_records` and
+the `run()` happy path. This file covers the parts that decide *whether the
+hook finds anything at all*:
+
+* `_resolve_transcript_path`'s three-step fallback (explicit path → cwd-encoded
+  project dir → full project scan). If it picks nothing, a whole session's
+  tool-call accounting silently vanishes from `connector-health.md`.
+* `_iter_rows`'s tolerance for a transcript being appended to as we read it.
+* `_is_error`'s four independent error signals — a missed one under-reports
+  connector failures, which is the exact metric the health report exists for.
+* `main()`'s swallow-everything contract: a Stop hook that raises blocks the
+  session.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scout.hooks import session_tool_log as stl
+from scout.hooks.session_tool_log import ToolCallRecord
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A tmp HOME so `~/.claude/projects` lookups are hermetic."""
+    h = tmp_path / "home"
+    h.mkdir()
+    monkeypatch.setenv("HOME", str(h))
+    return h
+
+
+def _transcript(path: Path, *rows: dict[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    return path
+
+
+def _use(tool_id: str, name: str = "Bash", **inp: Any) -> dict[str, Any]:
+    return {
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": tool_id, "name": name, "input": inp}],
+        }
+    }
+
+
+def _result(tool_id: str, **fields: Any) -> dict[str, Any]:
+    block: dict[str, Any] = {"type": "tool_result", "tool_use_id": tool_id}
+    block.update(fields)
+    return {"message": {"role": "user", "content": [block]}}
+
+
+# ---------------------------------------------------------------------------
+# _resolve_transcript_path
+# ---------------------------------------------------------------------------
+
+
+def test_an_explicit_transcript_path_wins(home: Path, tmp_path: Path) -> None:
+    explicit = _transcript(tmp_path / "explicit.jsonl", _use("t1"))
+    assert stl._resolve_transcript_path({"transcript_path": str(explicit)}) == explicit
+
+
+def test_an_explicit_path_is_tilde_expanded(home: Path) -> None:
+    target = _transcript(home / "sessions" / "abc.jsonl", _use("t1"))
+    assert stl._resolve_transcript_path({"transcript_path": "~/sessions/abc.jsonl"}) == target
+
+
+def test_a_nonexistent_explicit_path_falls_through_to_the_session_id(home: Path) -> None:
+    """The Stop payload's transcript_path can point at a file that was already
+    rotated away; the session_id lookup is the safety net."""
+    encoded = "-Users-alex-Scout"
+    target = _transcript(home / ".claude" / "projects" / encoded / "sess-1.jsonl", _use("t1"))
+
+    resolved = stl._resolve_transcript_path(
+        {"transcript_path": "/nope/gone.jsonl", "session_id": "sess-1", "cwd": "/Users/alex/Scout"}
+    )
+    assert resolved == target
+
+
+def test_the_cwd_is_encoded_by_replacing_slashes_with_dashes(home: Path) -> None:
+    target = _transcript(home / ".claude" / "projects" / "-Users-alex-Scout" / "sess-1.jsonl", _use("t1"))
+    assert stl._resolve_transcript_path({"session_id": "sess-1", "cwd": "/Users/alex/Scout"}) == target
+
+
+def test_a_missing_cwd_falls_back_to_scanning_every_project_dir(home: Path) -> None:
+    projects = home / ".claude" / "projects"
+    (projects / "-Users-alex-other").mkdir(parents=True)
+    target = _transcript(projects / "-Users-alex-Scout" / "sess-1.jsonl", _use("t1"))
+    assert stl._resolve_transcript_path({"session_id": "sess-1"}) == target
+
+
+def test_a_wrong_cwd_still_finds_the_transcript_by_scanning(home: Path) -> None:
+    target = _transcript(home / ".claude" / "projects" / "-Users-alex-Scout" / "sess-1.jsonl", _use("t1"))
+    resolved = stl._resolve_transcript_path({"session_id": "sess-1", "cwd": "/somewhere/else"})
+    assert resolved == target
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"transcript_path": ""},
+        {"transcript_path": 123},
+        {"session_id": ""},
+        {"session_id": None},
+        {"session_id": 42},
+    ],
+)
+def test_resolution_returns_none_without_a_usable_identifier(home: Path, payload: dict) -> None:
+    assert stl._resolve_transcript_path(payload) is None
+
+
+def test_resolution_returns_none_when_no_project_dir_exists(home: Path) -> None:
+    assert stl._resolve_transcript_path({"session_id": "sess-1"}) is None
+
+
+def test_resolution_returns_none_when_the_session_is_in_no_project_dir(home: Path) -> None:
+    (home / ".claude" / "projects" / "-Users-alex-Scout").mkdir(parents=True)
+    assert stl._resolve_transcript_path({"session_id": "sess-missing"}) is None
+
+
+# ---------------------------------------------------------------------------
+# _iter_rows
+# ---------------------------------------------------------------------------
+
+
+def test_iter_rows_skips_blank_and_malformed_lines(tmp_path: Path) -> None:
+    """The transcript is appended to live, so the hook can read a torn final
+    line — that must not abort the whole walk."""
+    path = tmp_path / "t.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps({"a": 1}),
+                "",
+                "   ",
+                '{"partial": ',  # torn append
+                '"a bare string"',  # valid JSON, not an object
+                "[1, 2]",
+                json.dumps({"b": 2}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    assert list(stl._iter_rows(path)) == [{"a": 1}, {"b": 2}]
+
+
+def test_iter_rows_is_empty_for_a_missing_file(tmp_path: Path) -> None:
+    assert list(stl._iter_rows(tmp_path / "nope.jsonl")) == []
+
+
+def test_iter_rows_replaces_undecodable_bytes(tmp_path: Path) -> None:
+    path = tmp_path / "t.jsonl"
+    path.write_bytes(b'{"tool": "caf\xe9"}\n' + json.dumps({"a": 1}).encode() + b"\n")
+    rows = list(stl._iter_rows(path))
+    # The mojibake row still decodes (errors="replace") and parses.
+    assert {"a": 1} in rows
+
+
+# ---------------------------------------------------------------------------
+# _tool_response_from_result
+# ---------------------------------------------------------------------------
+
+
+def test_snake_case_is_error_is_normalized_to_the_posttooluse_camel_case() -> None:
+    """The transcript writes `is_error`; `connector_log.classify`'s consumer
+    reads `isError`. Dropping the translation makes every failure look OK."""
+    assert stl._tool_response_from_result({"is_error": True})["isError"] is True
+    assert "isError" not in stl._tool_response_from_result({"is_error": False})
+    assert "isError" not in stl._tool_response_from_result({})
+
+
+def test_a_string_content_is_wrapped_in_a_text_block() -> None:
+    out = stl._tool_response_from_result({"content": "command not found"})
+    assert out["content"] == [{"type": "text", "text": "command not found"}]
+
+
+def test_a_list_content_passes_through() -> None:
+    blocks = [{"type": "text", "text": "ok"}]
+    assert stl._tool_response_from_result({"content": blocks})["content"] == blocks
+
+
+def test_a_content_of_another_type_is_dropped() -> None:
+    assert "content" not in stl._tool_response_from_result({"content": {"unexpected": "shape"}})
+
+
+# ---------------------------------------------------------------------------
+# _is_error — the four independent signals
+# ---------------------------------------------------------------------------
+
+
+def test_no_error_signals_reads_as_success() -> None:
+    assert stl._is_error({}) == (False, "")
+    assert stl._is_error({"returncode": 0, "content": [{"type": "text", "text": "ok"}]}) == (False, "")
+
+
+def test_is_error_flag_marks_a_failure() -> None:
+    assert stl._is_error({"isError": True}) == (True, "")
+
+
+def test_a_nonzero_returncode_marks_a_failure() -> None:
+    assert stl._is_error({"returncode": 127}) == (True, "")
+    # A non-int returncode is not a signal.
+    assert stl._is_error({"returncode": "127"}) == (False, "")
+
+
+def test_an_error_field_marks_a_failure_and_supplies_the_snippet() -> None:
+    is_err, snippet = stl._is_error({"error": "gh: not logged in"})
+    assert is_err is True
+    assert snippet == "gh: not logged in"
+
+
+def test_an_error_snippet_is_truncated_to_160_chars() -> None:
+    _is_err, snippet = stl._is_error({"error": "x" * 500})
+    assert len(snippet) == 160
+
+
+def test_a_content_block_flagged_is_error_marks_a_failure() -> None:
+    is_err, snippet = stl._is_error({"content": [{"isError": True, "text": "connector unavailable"}]})
+    assert is_err is True
+    assert snippet == "connector unavailable"
+
+
+def test_a_content_block_with_no_text_yields_an_empty_snippet() -> None:
+    assert stl._is_error({"content": [{"isError": True}]}) == (True, "")
+
+
+def test_the_first_snippet_wins_over_later_ones() -> None:
+    _is_err, snippet = stl._is_error(
+        {
+            "error": "outer error",
+            "content": [{"isError": True, "text": "inner error"}],
+        }
+    )
+    assert snippet == "outer error"
+
+
+def test_non_dict_content_items_are_ignored() -> None:
+    assert stl._is_error({"content": ["a string", None, 42]}) == (False, "")
+
+
+# ---------------------------------------------------------------------------
+# write_records
+# ---------------------------------------------------------------------------
+
+
+def test_write_records_survives_an_unwritable_log_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Stop hook must not raise; a failed write returns 0 written."""
+    log_dir = tmp_path / "logs"
+    real_open = Path.open
+
+    def maybe_boom(self: Path, *a: object, **k: object):
+        if self.suffix == ".jsonl":
+            raise OSError("read-only filesystem")
+        return real_open(self, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "open", maybe_boom)
+    written = stl.write_records(
+        [ToolCallRecord(tool_name="Bash", tool_input={}, tool_response={})],
+        mode="dreaming",
+        session_id="s1",
+        log_dir=log_dir,
+    )
+    assert written == 0
+
+
+def test_write_records_appends_to_an_existing_day_file(tmp_path: Path) -> None:
+    """Two hook invocations on the same ET day accumulate rather than
+    truncate — a Scout day can run several sessions."""
+    rec = [ToolCallRecord(tool_name="Bash", tool_input={"command": "ls"}, tool_response={})]
+    assert stl.write_records(rec, mode="dreaming", session_id="s1", log_dir=tmp_path) == 1
+    assert stl.write_records(rec, mode="briefing", session_id="s2", log_dir=tmp_path) == 1
+
+    out = next(tmp_path.glob("connector-calls-*.jsonl"))
+    rows = [json.loads(ln) for ln in out.read_text().splitlines()]
+    assert [r["session_id"] for r in rows] == ["s1", "s2"]
+    assert [r["mode"] for r in rows] == ["dreaming", "briefing"]
+
+
+def test_write_records_creates_the_log_dir(tmp_path: Path) -> None:
+    nested = tmp_path / "a" / "b" / ".scout-logs"
+    stl.write_records(
+        [ToolCallRecord(tool_name="Bash", tool_input={}, tool_response={})],
+        mode="dreaming",
+        session_id="s1",
+        log_dir=nested,
+    )
+    assert nested.is_dir()
+
+
+# ---------------------------------------------------------------------------
+# run() / main()
+# ---------------------------------------------------------------------------
+
+
+def test_run_returns_none_for_a_non_object_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SCOUT_MODE", "dreaming")
+    assert stl.run(stdin=io.StringIO('"just a string"')) is None
+    assert stl.run(stdin=io.StringIO("[1, 2, 3]")) is None
+
+
+def test_run_falls_back_to_the_transcript_stem_for_the_session_id(
+    tmp_path: Path, home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A Stop payload can carry transcript_path without session_id; the stem is
+    the id, so the row still attributes to the right session."""
+    monkeypatch.setenv("SCOUT_MODE", "dreaming")
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path / "Scout"))
+    (tmp_path / "Scout" / ".scout-logs").mkdir(parents=True)
+
+    transcript = _transcript(tmp_path / "sess-xyz.jsonl", _use("t1", command="ls"), _result("t1"))
+    event = stl.run(stdin=io.StringIO(json.dumps({"transcript_path": str(transcript)})))
+
+    assert event is not None
+    assert event.payload["session_id"] == "sess-xyz"
+    assert event.payload["calls_written"] == 1
+    assert event.kind == "session.tool_log.written"
+
+
+def test_run_reads_real_stdin_when_none_is_passed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SCOUT_MODE", "dreaming")
+    monkeypatch.setattr("sys.stdin", io.StringIO("not json"))
+    assert stl.run() is None
+
+
+def test_main_returns_zero_even_when_run_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The Stop hook's exit code gates the session; it must always be 0."""
+
+    def boom(**_k: object):
+        raise RuntimeError("unreachable state")
+
+    monkeypatch.setattr(stl, "run", boom)
+    assert stl.main() == 0
+
+
+def test_main_returns_zero_on_the_happy_path(tmp_path: Path, home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SCOUT_MODE", "dreaming")
+    monkeypatch.setenv("SCOUT_DATA_DIR", str(tmp_path / "Scout"))
+    (tmp_path / "Scout" / ".scout-logs").mkdir(parents=True)
+    transcript = _transcript(tmp_path / "sess-1.jsonl", _use("t1", command="ls"), _result("t1"))
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"transcript_path": str(transcript)})))
+    assert stl.main() == 0
+    assert list((tmp_path / "Scout" / ".scout-logs").glob("connector-calls-*.jsonl"))
+
+
+# ---------------------------------------------------------------------------
+# extract_tool_calls — the remaining skip branches
+# ---------------------------------------------------------------------------
+
+
+def test_extract_skips_blocks_and_ids_it_cannot_use() -> None:
+    rows = [
+        {"message": "not a dict"},
+        {"message": {"role": "assistant", "content": "not a list"}},
+        {"message": {"role": "assistant", "content": ["a bare string", None]}},
+        {"message": {"role": "assistant", "content": [{"type": "text", "text": "thinking"}]}},
+        # tool_use with a non-string id
+        {"message": {"role": "assistant", "content": [{"type": "tool_use", "id": 7, "name": "Bash"}]}},
+        {"message": {"role": "user", "content": ["a bare string"]}},
+        {"message": {"role": "user", "content": [{"type": "text", "text": "hi"}]}},
+        # tool_result with a non-string id, and one for an unknown call
+        {"message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": 7}]}},
+        {"message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "never-used"}]}},
+        {"message": {"role": "system", "content": [{"type": "tool_use", "id": "sys", "name": "Bash"}]}},
+        _use("t1", command="ls"),
+        _result("t1"),
+    ]
+    calls = stl.extract_tool_calls(rows)
+    assert [c.tool_name for c in calls] == ["Bash"]
+    assert calls[0].tool_input == {"command": "ls"}
+
+
+def test_extract_defaults_a_missing_tool_name_to_unknown() -> None:
+    rows = [{"message": {"role": "assistant", "content": [{"type": "tool_use", "id": "t1"}]}}]
+    calls = stl.extract_tool_calls(rows)
+    assert [c.tool_name for c in calls] == ["unknown"]
+    assert calls[0].tool_input == {}

--- a/engine/tests/unit/test_trigger_pipeline_edges.py
+++ b/engine/tests/unit/test_trigger_pipeline_edges.py
@@ -1,0 +1,363 @@
+"""Remaining branches across the trigger pipeline's dedup store, engine and
+action handlers.
+
+`test_triggers_dedup.py` / `test_triggers_evaluate.py` / `test_triggers_dispatch.py`
+cover the mainline. What's left is the "the host misbehaved" set: a corrupt
+dedup cache, an unwritable dedup cache, a source that raises at construction
+time, a truncated summary, the optional `link`/`preload` lines, and the real
+detached spawn in `run_skill`.
+
+Dedup is the at-most-once guard on automated actions — a mis-handled corrupt
+cache means either duplicate fires or a permanently wedged trigger.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scout.errors import ConfigError
+from scout.triggers import dedup as dedup_mod
+from scout.triggers import engine as engine_mod
+from scout.triggers.actions import run_skill as run_skill_mod
+from scout.triggers.actions._summary import MAX_SUMMARY_CHARS, summarize
+from scout.triggers.config import Action, ActionKind, Trigger
+from scout.triggers.dedup import DedupStore
+from scout.triggers.sources.base import ConnectorEvent
+
+NOW = dt.datetime(2026, 5, 28, 14, 0, tzinfo=dt.UTC)
+
+
+def _trigger(trigger_id: str = "t1", *, kind: str = "notify", **params) -> Trigger:
+    return Trigger(
+        id=trigger_id,
+        source="scout_internal",
+        match={"type": "slot.fire_failed"},
+        action=Action(kind=ActionKind(kind), params=params),
+        daily_fire_cap=3,
+    )
+
+
+def _event(**fields: Any) -> ConnectorEvent:
+    return ConnectorEvent(
+        source="scout_internal",
+        source_event_id=fields.pop("event_id", "01HXAAA0000000000000000000"),
+        ts="2026-05-28T13:59:00Z",
+        raw_payload={},
+        normalized_match_fields={"type": "slot.fire_failed", **fields},
+    )
+
+
+# ---------------------------------------------------------------------------
+# _parse_iso_z
+# ---------------------------------------------------------------------------
+
+
+def test_parse_iso_z_accepts_both_offset_forms() -> None:
+    assert dedup_mod._parse_iso_z("2026-05-28T14:00:00Z") == dedup_mod._parse_iso_z("2026-05-28T14:00:00+00:00")
+
+
+# ---------------------------------------------------------------------------
+# DedupStore load tolerance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "{torn",
+        '["a", "list"]',
+        "null",
+        "42",
+        '"a string"',
+    ],
+)
+def test_a_corrupt_dedup_cache_starts_fresh(tmp_path: Path, body: str) -> None:
+    """At-least-once is the documented contract: a corrupt cache re-fires
+    rather than wedging the trigger forever."""
+    path = tmp_path / "trigger-fires.json"
+    path.write_text(body, encoding="utf-8")
+    store = DedupStore(path)
+    assert store.is_new("t1", "e1") is True
+    assert store.state("t1") == {}
+
+
+def test_non_dict_entries_are_dropped_on_load(tmp_path: Path) -> None:
+    path = tmp_path / "trigger-fires.json"
+    path.write_text(json.dumps({"t1": {"last_seen_event_id": "e1"}, "t2": "oops", "t3": [1, 2]}), encoding="utf-8")
+    store = DedupStore(path)
+    assert store.is_new("t1", "e1") is False
+    assert store.is_new("t2", "anything") is True
+    assert store.is_new("t3", "anything") is True
+
+
+def test_a_missing_dedup_cache_starts_fresh(tmp_path: Path) -> None:
+    assert DedupStore(tmp_path / "nope.json").is_new("t1", "e1") is True
+
+
+# ---------------------------------------------------------------------------
+# in_cooldown
+# ---------------------------------------------------------------------------
+
+
+def test_cooldown_is_off_when_the_window_is_zero_or_negative(tmp_path: Path) -> None:
+    store = DedupStore(tmp_path / "d.json")
+    store.record_fire("t1", "e1", NOW)
+    assert store.in_cooldown("t1", 0, NOW) is False
+    assert store.in_cooldown("t1", -5, NOW) is False
+
+
+def test_cooldown_is_off_for_a_trigger_that_never_fired(tmp_path: Path) -> None:
+    store = DedupStore(tmp_path / "d.json")
+    assert store.in_cooldown("t1", 3600, NOW) is False
+
+
+def test_cooldown_is_off_when_the_stored_timestamp_is_unparseable(tmp_path: Path) -> None:
+    """A corrupt `last_fire_ts` must not hold a trigger in cooldown forever."""
+    path = tmp_path / "d.json"
+    path.write_text(json.dumps({"t1": {"last_fire_ts": "not-a-date"}}), encoding="utf-8")
+    assert DedupStore(path).in_cooldown("t1", 3600, NOW) is False
+
+
+def test_cooldown_is_off_when_the_stored_timestamp_is_blank(tmp_path: Path) -> None:
+    path = tmp_path / "d.json"
+    path.write_text(json.dumps({"t1": {"last_fire_ts": ""}}), encoding="utf-8")
+    assert DedupStore(path).in_cooldown("t1", 3600, NOW) is False
+
+
+def test_cooldown_holds_inside_the_window_and_lifts_after(tmp_path: Path) -> None:
+    store = DedupStore(tmp_path / "d.json")
+    store.record_fire("t1", "e1", NOW)
+    assert store.in_cooldown("t1", 3600, NOW + dt.timedelta(minutes=30)) is True
+    assert store.in_cooldown("t1", 3600, NOW + dt.timedelta(minutes=61)) is False
+
+
+# ---------------------------------------------------------------------------
+# _save tolerance
+# ---------------------------------------------------------------------------
+
+
+def test_a_failed_dedup_save_never_raises_and_leaves_no_tempfile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The dispatcher already fired the action by this point; a cache-write
+    failure must not turn a successful fire into a traceback."""
+    path = tmp_path / "d.json"
+    store = DedupStore(path)
+
+    real_open = Path.open
+
+    def maybe_boom(self: Path, *a: object, **k: object):
+        if self.name.endswith(".json.tmp"):
+            raise OSError("read-only filesystem")
+        return real_open(self, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "open", maybe_boom)
+    store.record_fire("t1", "e1", NOW)  # must not raise
+
+    assert not path.exists()
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_dedup_save_creates_the_parent_dir(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "state" / "trigger-fires.json"
+    store = DedupStore(path)
+    store.record_fire("t1", "e1", NOW)
+    assert path.is_file()
+    assert json.loads(path.read_text())["t1"]["last_seen_event_id"] == "e1"
+
+
+# ---------------------------------------------------------------------------
+# engine — unavailable source
+# ---------------------------------------------------------------------------
+
+
+def _seed_triggers_yaml(vault: Path) -> None:
+    state = vault / ".scout-state"
+    state.mkdir(parents=True, exist_ok=True)
+    (state / "triggers.yaml").write_text(
+        "schema_version: 1\n"
+        "triggers:\n"
+        "  - id: t1\n"
+        "    source: scout_internal\n"
+        "    match: {type: slot.fire_failed}\n"
+        "    action: {kind: notify, tier: info, body: hi}\n"
+        "    daily_fire_cap: 3\n",
+        encoding="utf-8",
+    )
+
+
+def test_an_unavailable_source_is_reported_not_raised(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """One broken connector must not stop the tick from evaluating the others —
+    the error is collected and the loop continues."""
+    _seed_triggers_yaml(tmp_path)
+
+    def boom(_name: str, *, vault: Path):
+        raise ConfigError("slack trigger source: user_slack_id is not configured")
+
+    # engine.py does `from ... import get_source`, so patch its own binding.
+    monkeypatch.setattr(engine_mod, "get_source", boom)
+
+    result = engine_mod.evaluate(vault=tmp_path, now=NOW)
+    assert result.fired == []
+    assert len(result.errors) == 1
+    assert result.errors[0]["source"] == "scout_internal"
+    assert "unavailable:" in result.errors[0]["error"]
+
+
+def test_a_source_the_seam_dict_does_not_hold_is_reported(tmp_path: Path) -> None:
+    """The `sources` seam is a plain dict; a trigger naming a key it lacks
+    raises KeyError, which must surface as a collected error."""
+    _seed_triggers_yaml(tmp_path)
+    result = engine_mod.evaluate(vault=tmp_path, now=NOW, sources={})
+    assert result.errors and "unavailable:" in result.errors[0]["error"]
+
+
+# ---------------------------------------------------------------------------
+# _summary
+# ---------------------------------------------------------------------------
+
+
+def test_summary_prefers_the_first_populated_content_field() -> None:
+    assert "the text" in summarize(_trigger(), _event(text="the text", title="the title"))
+    assert "the title" in summarize(_trigger(), _event(title="the title", slot_key="morning"))
+    assert "morning" in summarize(_trigger(), _event(slot_key="morning", reason="because"))
+    assert "because" in summarize(_trigger(), _event(reason="because"))
+
+
+def test_summary_falls_back_to_the_event_id() -> None:
+    out = summarize(_trigger(), _event(event_id="01HXBBB0000000000000000000"))
+    assert out.endswith("01HXBBB0000000000000000000")
+
+
+def test_summary_is_truncated_with_an_ellipsis() -> None:
+    """This string goes into a Telegram push and a markdown artifact; an
+    unbounded event body would blow both budgets."""
+    out = summarize(_trigger(), _event(text="x" * 1000))
+    content = out.split(": ", 1)[1]
+    assert len(content) == MAX_SUMMARY_CHARS
+    assert content.endswith("…")
+
+
+def test_summary_carries_the_trigger_and_source_labels() -> None:
+    out = summarize(_trigger("nightly-check"), _event(text="hi"))
+    assert out.startswith("[trigger:nightly-check] scout_internal/slot.fire_failed: ")
+
+
+# ---------------------------------------------------------------------------
+# interactive action — the optional lines
+# ---------------------------------------------------------------------------
+
+
+def test_interactive_artifact_includes_a_permalink_when_present(tmp_path: Path) -> None:
+    from scout.triggers.actions.interactive import ARTIFACT_FILENAME, run
+
+    run(
+        _trigger(kind="interactive"),
+        _event(text="ping", permalink="https://acme-co.slack.com/archives/C0123456789/p1700000000000000"),
+        vault=tmp_path,
+        send_telegram=lambda **_k: None,
+    )
+    text = (tmp_path / ARTIFACT_FILENAME).read_text()
+    assert "- link: https://acme-co.slack.com/archives/C0123456789/p1700000000000000" in text
+
+
+def test_interactive_artifact_falls_back_to_url_for_the_link(tmp_path: Path) -> None:
+    from scout.triggers.actions.interactive import ARTIFACT_FILENAME, run
+
+    run(
+        _trigger(kind="interactive"),
+        _event(text="ping", url="https://api.github.com/repos/example-org/widgets/pulls/42"),
+        vault=tmp_path,
+        send_telegram=lambda **_k: None,
+    )
+    assert "- link: https://api.github.com/" in (tmp_path / ARTIFACT_FILENAME).read_text()
+
+
+def test_interactive_artifact_omits_the_link_line_when_there_is_none(tmp_path: Path) -> None:
+    from scout.triggers.actions.interactive import ARTIFACT_FILENAME, run
+
+    run(
+        _trigger(kind="interactive"),
+        _event(text="ping"),
+        vault=tmp_path,
+        send_telegram=lambda **_k: None,
+    )
+    assert "- link:" not in (tmp_path / ARTIFACT_FILENAME).read_text()
+
+
+# ---------------------------------------------------------------------------
+# run_skill — the real detached spawn
+# ---------------------------------------------------------------------------
+
+
+def test_default_spawn_detaches_and_silences_the_child(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A trigger fires from a 5-minute dispatcher tick; the runner must outlive
+    that tick and must not write into its stdout."""
+    seen: dict[str, object] = {}
+
+    class FakePopen:
+        pid = 4711
+
+        def __init__(self, cmd, **kwargs):
+            seen["cmd"] = cmd
+            seen.update(kwargs)
+
+    monkeypatch.setattr(subprocess, "Popen", FakePopen)
+
+    pid = run_skill_mod._default_spawn(["/vault/run-scout.sh"], {"SCOUT_DATA_DIR": "/vault"})
+    assert pid == 4711
+    assert seen["cmd"] == ["/vault/run-scout.sh"]
+    assert seen["cwd"] == "/vault"
+    assert seen["start_new_session"] is True
+    assert seen["stdin"] is subprocess.DEVNULL
+    assert seen["stdout"] is subprocess.DEVNULL
+    assert seen["stderr"] is subprocess.DEVNULL
+
+
+def test_default_spawn_tolerates_a_missing_scout_data_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(subprocess, "Popen", lambda cmd, **k: seen.update(k) or type("P", (), {"pid": 1})())
+    run_skill_mod._default_spawn(["/bin/true"], {})
+    assert seen["cwd"] is None
+
+
+def test_default_spawn_really_runs_a_script(tmp_path: Path) -> None:
+    """One unmocked spawn, to prove the Popen wiring works end-to-end."""
+    import os
+
+    marker = tmp_path / "ran"
+    script = tmp_path / "run.sh"
+    script.write_text(f"#!/bin/sh\ntouch {marker}\n", encoding="utf-8")
+    script.chmod(0o755)
+
+    pid = run_skill_mod._default_spawn([str(script)], {"SCOUT_DATA_DIR": str(tmp_path), "PATH": os.environ["PATH"]})
+    assert pid > 0
+    try:
+        os.waitpid(pid, 0)
+    except (ChildProcessError, OSError):
+        pass
+    assert marker.exists()
+
+
+def test_safe_filename_strips_path_and_shell_characters() -> None:
+    """The event id becomes a filename under `.scout-cache/trigger-events/`;
+    a Slack `ts` or a GitHub thread id can contain `/`, `.` and `:`."""
+    assert run_skill_mod._safe_filename("t1-1782910800.000200") == "t1-1782910800.000200"
+    assert run_skill_mod._safe_filename("t1-../../etc/passwd") == "t1-.._.._etc_passwd"
+    assert run_skill_mod._safe_filename("t1-a b;c") == "t1-a_b_c"
+
+
+def test_write_event_payload_records_the_whole_event(tmp_path: Path) -> None:
+    path = run_skill_mod.write_event_payload(_trigger("nightly"), _event(text="ping", event_id="e1"), vault=tmp_path)
+    assert path == tmp_path / run_skill_mod.EVENT_PAYLOAD_DIR / "nightly-e1.json"
+    payload = json.loads(path.read_text())
+    assert payload["trigger_id"] == "nightly"
+    assert payload["source"] == "scout_internal"
+    assert payload["event"]["normalized_match_fields"]["text"] == "ping"
+    assert payload["event"]["ts"] == "2026-05-28T13:59:00Z"

--- a/engine/tests/unit/test_triggers_sources_io.py
+++ b/engine/tests/unit/test_triggers_sources_io.py
@@ -1,0 +1,483 @@
+"""The trigger sources' real I/O layer: secret reading, config lookup, the
+`gh` subprocess wrapper, and the malformed-input guards.
+
+`test_triggers_sources.py` drives each source through its injected seams
+(`token_reader`, `http_get`, `run_gh`) — which is right for the normalization
+logic but leaves the *default* implementations untested. Those defaults are
+what run in production: `_read_token` (mode-600 enforcement),
+`_user_id_from_config` (YAML lookup), `_default_run_gh` (missing/hung `gh`),
+`_default_http_get` (requests). Each has a failure path an operator hits on a
+half-finished install.
+
+Payloads are anonymized per CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scout.errors import ConfigError
+from scout.triggers.sources import github as gh_source
+from scout.triggers.sources import slack as slack_source
+from scout.triggers.sources.github import GitHubSource
+from scout.triggers.sources.scout_internal import ScoutInternalSource
+from scout.triggers.sources.slack import SlackSource
+
+SINCE = "2026-07-01T12:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# slack._read_token
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def secrets_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    d = tmp_path / ".scout-secrets"
+    d.mkdir()
+    monkeypatch.setattr(slack_source, "SECRETS_DIR", d)
+    return d
+
+
+def test_read_token_returns_the_stripped_value(secrets_dir: Path) -> None:
+    token = secrets_dir / slack_source.TOKEN_FILENAME
+    token.write_text("xoxp-test-token\n", encoding="utf-8")
+    token.chmod(0o600)
+    assert slack_source._read_token() == "xoxp-test-token"
+
+
+def test_read_token_names_the_file_when_absent(secrets_dir: Path) -> None:
+    with pytest.raises(ConfigError, match="Missing secret:.*slack-search-token"):
+        slack_source._read_token()
+    # The message must say what scope the token needs.
+    with pytest.raises(ConfigError, match="search:read"):
+        slack_source._read_token()
+
+
+@pytest.mark.parametrize("mode", [0o644, 0o640, 0o604, 0o666, 0o755])
+def test_read_token_rejects_anything_looser_than_600(secrets_dir: Path, mode: int) -> None:
+    """A token saved with the default umask is readable by every process on the
+    host; refusing to read it is the safe default."""
+    token = secrets_dir / slack_source.TOKEN_FILENAME
+    token.write_text("xoxp-test-token\n", encoding="utf-8")
+    token.chmod(mode)
+    with pytest.raises(ConfigError, match="insecure permissions"):
+        slack_source._read_token()
+
+
+def test_read_token_rejects_an_empty_file(secrets_dir: Path) -> None:
+    token = secrets_dir / slack_source.TOKEN_FILENAME
+    token.write_text("  \n", encoding="utf-8")
+    token.chmod(0o600)
+    with pytest.raises(ConfigError, match="Secret file is empty"):
+        slack_source._read_token()
+
+
+# ---------------------------------------------------------------------------
+# slack._user_id_from_config / SlackSource.for_vault
+# ---------------------------------------------------------------------------
+
+
+def test_user_id_is_read_from_the_vault_config(tmp_path: Path) -> None:
+    (tmp_path / "scout-config.yaml").write_text(
+        "connectors:\n  inputs:\n    user_slack_id: U0123456789\n", encoding="utf-8"
+    )
+    assert slack_source._user_id_from_config(tmp_path) == "U0123456789"
+    assert SlackSource.for_vault(tmp_path)._user_id == "U0123456789"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "",  # empty file -> `or {}`
+        "connectors: {}\n",  # no inputs
+        "connectors:\n  inputs: {}\n",  # no user_slack_id
+        "connectors:\n  inputs:\n    user_slack_id: ''\n",  # blank value
+        "connectors:\n  inputs: null\n",  # explicit null
+        "connectors: null\n",
+    ],
+)
+def test_user_id_is_none_when_the_config_does_not_declare_one(tmp_path: Path, body: str) -> None:
+    (tmp_path / "scout-config.yaml").write_text(body, encoding="utf-8")
+    assert slack_source._user_id_from_config(tmp_path) is None
+
+
+def test_user_id_is_none_without_a_config_file(tmp_path: Path) -> None:
+    assert slack_source._user_id_from_config(tmp_path) is None
+
+
+def test_user_id_is_none_for_a_malformed_config(tmp_path: Path) -> None:
+    """A broken scout-config.yaml must degrade to "slack not configured", which
+    the health check reports cleanly — not raise out of the source factory."""
+    (tmp_path / "scout-config.yaml").write_text("connectors: [unclosed\n", encoding="utf-8")
+    assert slack_source._user_id_from_config(tmp_path) is None
+
+
+def test_user_id_is_none_for_an_unreadable_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = tmp_path / "scout-config.yaml"
+    cfg.write_text("connectors:\n  inputs:\n    user_slack_id: U1\n", encoding="utf-8")
+
+    real_read_text = Path.read_text
+
+    def maybe_boom(self: Path, *a: object, **k: object):
+        if self == cfg:
+            raise OSError("permission denied")
+        return real_read_text(self, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", maybe_boom)
+    assert slack_source._user_id_from_config(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# slack scan/health edges
+# ---------------------------------------------------------------------------
+
+
+def test_slack_scan_without_a_user_id_raises_configerror() -> None:
+    src = SlackSource(user_id=None, token_reader=lambda: "t", http_get=lambda *a, **k: {"ok": True})
+    with pytest.raises(ConfigError, match="user_slack_id is not configured"):
+        src.scan_since(SINCE)
+
+
+def test_slack_scan_skips_a_match_with_an_unparseable_timestamp() -> None:
+    """Slack's `ts` is a float-as-string; a row we can't parse is skipped rather
+    than crashing the whole tick."""
+    payload = {
+        "ok": True,
+        "messages": {
+            "matches": [
+                {"ts": "not-a-float", "user": "U2", "text": "bad row"},
+                {"ts": "", "user": "U2", "text": "missing ts"},
+                {"user": "U2", "text": "no ts key at all"},
+                {
+                    "ts": "1782910800.000200",
+                    "user": "U0000000002",
+                    "username": "priya",
+                    "text": "ping <@U0123456789>",
+                    "channel": {"id": "C0123456789", "name": "general"},
+                },
+            ]
+        },
+    }
+    src = SlackSource(user_id="U0123456789", token_reader=lambda: "t", http_get=lambda *a, **k: payload)
+    events = src.scan_since(SINCE)
+    assert [e.normalized_match_fields["text"] for e in events] == ["ping <@U0123456789>"]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [{"ok": True}, {"ok": True, "messages": {}}, {"ok": True, "messages": None}],
+)
+def test_slack_scan_tolerates_a_response_with_no_matches(payload: dict) -> None:
+    src = SlackSource(user_id="U1", token_reader=lambda: "t", http_get=lambda *a, **k: payload)
+    assert src.scan_since(SINCE) == []
+
+
+def test_slack_scan_flags_self_authored_mentions() -> None:
+    payload = {
+        "ok": True,
+        "messages": {
+            "matches": [
+                {"ts": "1782910900.000300", "user": "U0123456789", "text": "note to self"},
+                {"ts": "1782910800.000200", "user": "U0000000002", "text": "ping"},
+            ]
+        },
+    }
+    src = SlackSource(user_id="U0123456789", token_reader=lambda: "t", http_get=lambda *a, **k: payload)
+    by_self = {e.source_event_id: e.normalized_match_fields["is_self"] for e in src.scan_since(SINCE)}
+    assert by_self == {"1782910900.000300": True, "1782910800.000200": False}
+
+
+def test_slack_health_check_reports_a_missing_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(slack_source, "SECRETS_DIR", tmp_path / "nope")
+    healthy, reason = SlackSource(user_id="U1").health_check()
+    assert healthy is False
+    assert "Missing secret" in reason
+
+
+def test_slack_default_http_get_uses_requests(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            seen["raised_for_status"] = True
+
+        def json(self) -> dict:
+            return {"ok": True}
+
+    def fake_get(url: str, **kwargs: object):
+        seen.update(url=url, **kwargs)
+        return FakeResponse()
+
+    monkeypatch.setattr("requests.get", fake_get)
+    out = slack_source._default_http_get(
+        slack_source.SEARCH_URL, params={"query": "x"}, headers={"Authorization": "Bearer t"}, timeout=1.0
+    )
+    assert out == {"ok": True}
+    assert seen["url"] == slack_source.SEARCH_URL
+    assert seen["timeout"] == 1.0
+    # A non-2xx must surface, not be swallowed into an "ok: false" dict.
+    assert seen["raised_for_status"] is True
+
+
+def test_slack_parse_iso_z_handles_both_offset_forms() -> None:
+    with_z = slack_source._parse_iso_z("2026-07-01T12:00:00Z")
+    with_offset = slack_source._parse_iso_z("2026-07-01T12:00:00+00:00")
+    assert with_z == with_offset
+
+
+# ---------------------------------------------------------------------------
+# github._default_run_gh
+# ---------------------------------------------------------------------------
+
+
+def test_default_run_gh_returns_the_completed_process_triple(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Proc:
+        returncode = 0
+        stdout = "[]"
+        stderr = ""
+
+    seen: list[list[str]] = []
+    monkeypatch.setattr(subprocess, "run", lambda argv, **k: seen.append(argv) or Proc())
+    assert gh_source._default_run_gh(["api", "notifications"]) == (0, "[]", "")
+    assert seen == [["gh", "api", "notifications"]]
+
+
+def test_default_run_gh_reports_a_missing_gh_as_127(monkeypatch: pytest.MonkeyPatch) -> None:
+    """127 is the shell's "command not found"; the health check surfaces it as
+    an actionable "install gh" rather than a traceback."""
+
+    def boom(*_a: object, **_k: object):
+        raise FileNotFoundError("gh")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    rc, stdout, stderr = gh_source._default_run_gh(["auth", "status"])
+    assert (rc, stdout) == (127, "")
+    assert "command not found" in stderr
+
+
+def test_default_run_gh_reports_a_timeout_as_124(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(*_a: object, **_k: object):
+        raise subprocess.TimeoutExpired("gh", gh_source.GH_TIMEOUT_SECONDS)
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    rc, _stdout, stderr = gh_source._default_run_gh(["api", "notifications"])
+    assert rc == 124
+    assert f"timed out after {gh_source.GH_TIMEOUT_SECONDS}s" in stderr
+
+
+def test_github_source_uses_the_default_runner_when_none_is_injected() -> None:
+    assert GitHubSource()._run_gh is gh_source._default_run_gh
+
+
+# ---------------------------------------------------------------------------
+# github scan guards
+# ---------------------------------------------------------------------------
+
+
+def _gh(stdout: str, rc: int = 0, stderr: str = "") -> GitHubSource:
+    return GitHubSource(run_gh=lambda _args: (rc, stdout, stderr))
+
+
+def test_github_scan_rejects_non_json_output() -> None:
+    with pytest.raises(ConfigError, match="non-JSON output"):
+        _gh("<html>rate limited</html>").scan_since(SINCE)
+
+
+def test_github_scan_rejects_a_json_object() -> None:
+    """`gh api` returns an object for an error body; treating it as a thread
+    list would silently yield zero events instead of surfacing the failure."""
+    with pytest.raises(ConfigError, match="expected a JSON array"):
+        _gh('{"message": "Bad credentials"}').scan_since(SINCE)
+
+
+def test_github_scan_treats_empty_output_as_no_threads() -> None:
+    assert _gh("").scan_since(SINCE) == []
+
+
+def test_github_scan_skips_non_dict_and_stale_threads() -> None:
+    threads = [
+        "not a dict",
+        {"id": "1", "updated_at": "2026-07-01T11:00:00Z", "reason": "mention"},  # older than SINCE
+        {"id": "2", "reason": "mention"},  # no updated_at
+        {"id": "3", "updated_at": SINCE, "reason": "mention"},  # exactly SINCE -> excluded
+        {
+            "id": "4",
+            "updated_at": "2026-07-01T13:00:00Z",
+            "reason": "review_requested",
+            "subject": {"title": "Fix the parser", "type": "PullRequest", "url": "https://api.github.com/x"},
+            "repository": {"full_name": "example-org/widgets"},
+        },
+    ]
+    events = _gh(json.dumps(threads)).scan_since(SINCE)
+    assert [e.source_event_id for e in events] == ["4:2026-07-01T13:00:00Z"]
+    assert events[0].normalized_match_fields["repo"] == "example-org/widgets"
+    assert events[0].normalized_match_fields["type"] == "review_requested"
+
+
+def test_github_scan_tolerates_threads_with_no_subject_or_repository() -> None:
+    threads = [{"id": "5", "updated_at": "2026-07-01T13:00:00Z", "reason": "subscribed"}]
+    fields = _gh(json.dumps(threads)).scan_since(SINCE)[0].normalized_match_fields
+    assert fields["title"] == "" and fields["repo"] == "" and fields["subject_type"] == ""
+
+
+def test_github_scan_failure_message_falls_back_to_stdout() -> None:
+    """`gh` sometimes writes the error to stdout; the raised message must carry
+    whichever stream has content."""
+    with pytest.raises(ConfigError, match="gh: not logged in"):
+        _gh("gh: not logged in", rc=1, stderr="").scan_since(SINCE)
+
+
+def test_github_events_sort_by_timestamp() -> None:
+    threads = [
+        {"id": "b", "updated_at": "2026-07-01T15:00:00Z", "reason": "mention"},
+        {"id": "a", "updated_at": "2026-07-01T13:00:00Z", "reason": "mention"},
+    ]
+    assert [e.normalized_match_fields["thread_id"] for e in _gh(json.dumps(threads)).scan_since(SINCE)] == [
+        "a",
+        "b",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# scout_internal scan guards
+# ---------------------------------------------------------------------------
+
+
+def _log(log_dir: Path, date: str, *rows: str) -> Path:
+    log_dir.mkdir(parents=True, exist_ok=True)
+    p = log_dir / f"schedule-events-{date}.jsonl"
+    p.write_text("\n".join(rows) + "\n", encoding="utf-8")
+    return p
+
+
+def _row(event_id: str, ts: str, kind: str, **payload: object) -> str:
+    return json.dumps({"id": event_id, "ts": ts, "kind": kind, "source": "test", "payload": payload})
+
+
+def test_scout_internal_skips_log_files_dated_before_the_scan_window(tmp_path: Path) -> None:
+    """Filenames are UTC-dated, so a whole earlier file can be skipped without
+    reading it — this is the optimization that keeps a tick cheap on a mature
+    vault with months of logs."""
+    _log(tmp_path, "2026-06-30", _row("old", "2026-06-30T23:59:00Z", "slot.fired"))
+    _log(tmp_path, "2026-07-01", _row("new", "2026-07-01T13:00:00Z", "slot.fired"))
+
+    events = ScoutInternalSource(tmp_path).scan_since(SINCE)
+    assert [e.source_event_id for e in events] == ["new"]
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        "",
+        "   ",
+        "{not json",
+        '"a bare string"',
+        "[1, 2]",
+        json.dumps({"ts": "2026-07-01T13:00:00Z", "kind": "slot.fired"}),  # no id
+        json.dumps({"id": "x", "kind": "slot.fired"}),  # no ts
+        json.dumps({"id": "x", "ts": "2026-07-01T13:00:00Z"}),  # no kind
+        json.dumps({"id": 1, "ts": "2026-07-01T13:00:00Z", "kind": "slot.fired"}),  # non-str id
+    ],
+)
+def test_scout_internal_skips_unusable_rows(tmp_path: Path, row: str) -> None:
+    _log(tmp_path, "2026-07-01", row, _row("good", "2026-07-01T13:00:00Z", "slot.fired"))
+    events = ScoutInternalSource(tmp_path).scan_since(SINCE)
+    assert [e.source_event_id for e in events] == ["good"]
+
+
+def test_scout_internal_excludes_rows_at_or_before_the_scan_timestamp(tmp_path: Path) -> None:
+    _log(
+        tmp_path,
+        "2026-07-01",
+        _row("before", "2026-07-01T11:00:00Z", "slot.fired"),
+        _row("exactly", SINCE, "slot.fired"),
+        _row("after", "2026-07-01T13:00:00Z", "slot.fired"),
+    )
+    events = ScoutInternalSource(tmp_path).scan_since(SINCE)
+    assert [e.source_event_id for e in events] == ["after"]
+
+
+def test_scout_internal_survives_an_unreadable_log_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    bad = _log(tmp_path, "2026-07-01", _row("a", "2026-07-01T13:00:00Z", "slot.fired"))
+    _log(tmp_path, "2026-07-02", _row("b", "2026-07-02T13:00:00Z", "slot.fired"))
+
+    real_read_text = Path.read_text
+
+    def maybe_boom(self: Path, *a: object, **k: object):
+        if self == bad:
+            raise OSError("permission denied")
+        return real_read_text(self, *a, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", maybe_boom)
+    assert [e.source_event_id for e in ScoutInternalSource(tmp_path).scan_since(SINCE)] == ["b"]
+
+
+def test_scout_internal_normalizes_kind_over_a_payload_type_key(tmp_path: Path) -> None:
+    """`type` in the match fields must be the event *kind*; a payload that also
+    carries a `type` key must not shadow it, or the matcher fires on the wrong
+    events."""
+    _log(
+        tmp_path,
+        "2026-07-01",
+        _row("a", "2026-07-01T13:00:00Z", "slot.fired", type="something-else", slot_key="morning-briefing"),
+    )
+    fields = ScoutInternalSource(tmp_path).scan_since(SINCE)[0].normalized_match_fields
+    assert fields["type"] == "slot.fired"
+    assert fields["slot_key"] == "morning-briefing"
+    assert fields["event_source"] == "test"
+
+
+def test_scout_internal_tolerates_a_row_with_a_non_dict_payload(tmp_path: Path) -> None:
+    _log(
+        tmp_path,
+        "2026-07-01",
+        json.dumps({"id": "a", "ts": "2026-07-01T13:00:00Z", "kind": "slot.fired", "payload": "oops"}),
+    )
+    fields = ScoutInternalSource(tmp_path).scan_since(SINCE)[0].normalized_match_fields
+    assert fields["type"] == "slot.fired"
+    assert fields["event_source"] == ""
+
+
+def test_scout_internal_events_sort_by_timestamp_across_files(tmp_path: Path) -> None:
+    _log(tmp_path, "2026-07-02", _row("second", "2026-07-02T09:00:00Z", "slot.fired"))
+    _log(tmp_path, "2026-07-01", _row("first", "2026-07-01T13:00:00Z", "slot.fired"))
+    events = ScoutInternalSource(tmp_path).scan_since(SINCE)
+    assert [e.source_event_id for e in events] == ["first", "second"]
+
+
+def test_scout_internal_is_healthy_with_a_log_dir(tmp_path: Path) -> None:
+    assert ScoutInternalSource(tmp_path).health_check() == (True, "ok")
+
+
+# ---------------------------------------------------------------------------
+# Registry / ConnectorEvent
+# ---------------------------------------------------------------------------
+
+
+def test_supported_match_types_returns_each_sources_constant() -> None:
+    from scout.triggers.sources import supported_match_types
+
+    assert supported_match_types("slack") == slack_source.SUPPORTED_MATCH_TYPES
+    assert supported_match_types("github") == gh_source.SUPPORTED_MATCH_TYPES
+    # The returned list is a copy — a caller mutating it must not corrupt the
+    # module constant that config validation reads on every load.
+    got = supported_match_types("github")
+    got.append("mutated")
+    assert "mutated" not in gh_source.SUPPORTED_MATCH_TYPES
+
+
+def test_connector_event_match_type_reads_the_type_field() -> None:
+    from scout.triggers.sources.base import ConnectorEvent
+
+    with_type = ConnectorEvent(
+        source="github", source_event_id="1", ts=SINCE, normalized_match_fields={"type": "mention"}
+    )
+    assert with_type.match_type == "mention"
+    # No `type` key at all -> empty string, not a KeyError, so the matcher can
+    # compare it like any other event.
+    assert ConnectorEvent(source="github", source_event_id="1", ts=SINCE).match_type == ""

--- a/engine/tests/unit/test_tui_config_and_spawn.py
+++ b/engine/tests/unit/test_tui_config_and_spawn.py
@@ -1,0 +1,248 @@
+"""Coverage of the TUI's non-widget helpers: path resolution, prompt building,
+the session spawner, and the two placeholder screens.
+
+`test_tui_spawn_cmd.py` covers `session_slug` / `applescript_literal` /
+`build_terminal_applescript` — the security-critical escaping. What's left is
+`tui.config`'s path resolution (which decides *which* daily file the TUI
+edits), `build_prompt`'s per-link-kind branches, and `spawn_session`'s
+subprocess wiring.
+
+`tui.config` derives its paths from `Path.home()` at import time, so
+`ACTION_ITEMS_DIR` is patched directly rather than via HOME.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("textual")
+
+from scout.action_items.parser import ActionItem  # noqa: E402
+from scout.tui import config as tui_config  # noqa: E402
+from scout.tui.screens.spawn import build_prompt, spawn_session  # noqa: E402
+
+
+def _item(**kwargs) -> ActionItem:
+    base: dict = {"priority": "", "title": "Land the parser fix", "status": "open", "section": "Urgent"}
+    base.update(kwargs)
+    return ActionItem(**base)
+
+
+# ---------------------------------------------------------------------------
+# tui.config path resolution
+# ---------------------------------------------------------------------------
+
+
+def test_action_items_path_defaults_to_today(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(tui_config, "ACTION_ITEMS_DIR", tmp_path)
+    expected = tmp_path / f"action-items-{dt.date.today().isoformat()}.md"
+    assert tui_config.action_items_path() == expected
+
+
+def test_action_items_path_accepts_an_explicit_date(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(tui_config, "ACTION_ITEMS_DIR", tmp_path)
+    assert tui_config.action_items_path(dt.date(2026, 4, 15)) == tmp_path / "action-items-2026-04-15.md"
+
+
+def test_latest_action_items_path_picks_the_newest_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Names sort lexicographically because the dates are ISO — that's what
+    makes reverse-sorting the glob correct."""
+    monkeypatch.setattr(tui_config, "ACTION_ITEMS_DIR", tmp_path)
+    for date in ("2026-04-13", "2026-04-15", "2026-04-14"):
+        (tmp_path / f"action-items-{date}.md").write_text("# x\n", encoding="utf-8")
+    # A non-matching file must not win.
+    (tmp_path / "README.md").write_text("# readme\n", encoding="utf-8")
+
+    assert tui_config.latest_action_items_path() == tmp_path / "action-items-2026-04-15.md"
+
+
+def test_latest_action_items_path_falls_back_to_today_when_the_dir_is_empty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(tui_config, "ACTION_ITEMS_DIR", tmp_path)
+    assert tui_config.latest_action_items_path() == tui_config.action_items_path()
+
+
+def test_latest_action_items_path_falls_back_to_today_without_the_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(tui_config, "ACTION_ITEMS_DIR", tmp_path / "nope")
+    assert tui_config.latest_action_items_path() == tui_config.action_items_path()
+
+
+def test_keybindings_cover_every_documented_action() -> None:
+    """The dashboard's BINDINGS and this table must not drift — the footer
+    reads the bindings, the docs read this dict."""
+    assert set(tui_config.KEYBINDINGS) == {
+        "mark_done",
+        "add_note",
+        "open_context",
+        "spawn_session",
+        "refresh",
+        "filter",
+        "quit",
+    }
+    assert len(set(tui_config.KEYBINDINGS.values())) == len(tui_config.KEYBINDINGS)
+
+
+# ---------------------------------------------------------------------------
+# build_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_leads_with_the_task_and_names_the_section() -> None:
+    prompt = build_prompt(_item())
+    assert prompt.startswith("Work on: Land the parser fix")
+    assert "Context: From the 'Urgent' section" in prompt
+
+
+def test_prompt_omits_the_section_line_when_there_is_no_section() -> None:
+    assert "Context: From the" not in build_prompt(_item(section=""))
+
+
+def test_prompt_includes_at_most_five_detail_lines() -> None:
+    item = _item(details=[f"  - detail {n}" for n in range(8)])
+    prompt = build_prompt(item)
+    assert "Details:" in prompt
+    assert "detail 0" in prompt and "detail 4" in prompt
+    assert "detail 5" not in prompt
+
+
+def test_prompt_omits_the_details_block_when_there_are_none() -> None:
+    assert "Details:" not in build_prompt(_item(details=[]))
+
+
+def test_prompt_surfaces_the_first_link_of_each_kind() -> None:
+    """A task can carry several links; the prompt names one per kind so the
+    session gets the right starting point without a wall of URLs."""
+    item = _item(
+        context_links=[
+            "https://linear.app/acme-co/issue/PROJ-1234",
+            "https://linear.app/acme-co/issue/PROJ-9999",
+            "https://github.com/example-org/widgets/pull/42",
+            "https://github.com/example-org/widgets/pull/43",
+            "kb://knowledge-base/rollout-plan",
+            "kb://knowledge-base/people",
+            "kb://knowledge-base/projects",
+            "kb://knowledge-base/dropped",
+            "https://example.com/other",
+        ]
+    )
+    prompt = build_prompt(item)
+    assert "Linear: https://linear.app/acme-co/issue/PROJ-1234" in prompt
+    assert "PROJ-9999" not in prompt
+    assert "GitHub: https://github.com/example-org/widgets/pull/42" in prompt
+    assert "pull/43" not in prompt
+    # kb:// links are listed by name, capped at three.
+    assert "KB files: knowledge-base/rollout-plan, knowledge-base/people, knowledge-base/projects" in prompt
+    assert "dropped" not in prompt
+
+
+def test_prompt_omits_every_link_line_when_there_are_no_links() -> None:
+    prompt = build_prompt(_item(context_links=["https://example.com/unrelated"]))
+    assert "Linear:" not in prompt
+    assert "GitHub:" not in prompt
+    assert "KB files:" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# spawn_session
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_session_launches_osascript_detached_from_the_ui(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, object] = {}
+
+    class FakePopen:
+        def __init__(self, argv, **kwargs):
+            seen["argv"] = argv
+            seen.update(kwargs)
+
+    monkeypatch.setattr(subprocess, "Popen", FakePopen)
+
+    item = _item(title="Land the parser fix")
+    cmd = spawn_session(item)
+
+    argv = seen["argv"]
+    assert isinstance(argv, list)
+    assert argv[:2] == ["osascript", "-e"]
+    # The AppleScript carries the escaped prompt; the returned value is the
+    # shell command that will run inside the new Terminal window.
+    assert "Land the parser fix" in argv[2]
+    assert "claude" in cmd
+    # Output is discarded so a chatty osascript can't corrupt the TUI's screen.
+    assert seen["stdout"] is subprocess.DEVNULL
+    assert seen["stderr"] is subprocess.DEVNULL
+
+
+def test_spawn_session_neutralizes_shell_metacharacters_in_the_title(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#52: an action-item title is untrusted text (it can come from a Slack
+    message or a Linear title). It reaches `claude -p` as ONE argument, with
+    every metacharacter inert."""
+    import shlex
+
+    captured: list[str] = []
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **k: captured.append(argv[2]) or None)
+
+    hostile = 'Fix "$(rm -rf ~)" now; really'
+    cmd = spawn_session(_item(title=hostile))
+
+    # Re-parse the command the way a shell would: the payload must survive as a
+    # single -p argument, not split into extra words or a second command.
+    argv = shlex.split(cmd)
+    assert argv[0] == "claude"
+    assert argv[argv.index("-p") + 1].startswith(f"Work on: {hostile}")
+    assert ";" not in argv and "$(rm" not in argv
+
+    # The session name is slugified to [A-Za-z0-9-] only.
+    name = argv[argv.index("--name") + 1]
+    assert name.startswith("scout-action-")
+    assert all(c.isalnum() or c == "-" for c in name)
+
+    # ...and the whole thing rides inside ONE AppleScript string literal whose
+    # every embedded quote is backslash-escaped, so the title cannot terminate
+    # the `do script` argument early.
+    script = captured[0]
+    assert script.count("do script") == 1
+    literal = script.split("do script ", 1)[1].split("\nend tell", 1)[0]
+    assert literal.startswith('"') and literal.endswith('"')
+    body = literal[1:-1]
+    unescaped = [i for i, ch in enumerate(body) if ch == '"' and (i == 0 or body[i - 1] != "\\")]
+    assert unescaped == [], f"unescaped quote(s) at {unescaped} in {body!r}"
+
+
+# ---------------------------------------------------------------------------
+# Placeholder screens
+#
+# `context.py` and `note_modal.py` are declared-but-unwired placeholders. The
+# live note flow is `dashboard.NoteInputScreen`; these two are reachable only
+# by import. Compose them so a stale placeholder can't silently break the
+# module import that `test_tui_smoke.py` asserts.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("module", "cls_name"),
+    [
+        ("scout.tui.screens.context", "ContextPanel"),
+        ("scout.tui.screens.note_modal", "NoteModal"),
+    ],
+)
+def test_placeholder_screens_compose_a_single_static(module: str, cls_name: str) -> None:
+    import importlib
+
+    from textual.widgets import Static
+
+    cls = getattr(importlib.import_module(module), cls_name)
+    widgets = list(cls().compose())
+    assert len(widgets) == 1
+    assert isinstance(widgets[0], Static)
+    assert widgets[0].id == "placeholder"

--- a/engine/tests/unit/test_tui_dashboard.py
+++ b/engine/tests/unit/test_tui_dashboard.py
@@ -1,0 +1,635 @@
+"""Behavioural coverage of the Textual TUI (`scoutctl tui`).
+
+`test_tui_smoke.py` only asserts the modules import and that the filter-index
+guard logic is sound. This file drives the real widgets through Textual's
+`run_test()` pilot: item rendering, the filter cycle, the detail panel, and
+each keybinding's side effect (`d` writes a checkbox flip, `n` opens the note
+modal and writes a note line, `o` opens a browser, `s` opens the spawn modal).
+
+Textual lives in the `[full]` extra, so every test here skips on a `[dev]`-only
+install — same contract as `test_tui_smoke.py`. `run_test()` is an async
+context manager and the suite has no asyncio plugin, so each test wraps its
+body in `asyncio.run`.
+
+`latest_action_items_path` resolves `~/Scout/action-items` from a module
+constant bound at import, so it is patched at the dashboard's import site
+rather than via HOME.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+from collections.abc import Callable, Coroutine
+from pathlib import Path
+from typing import Any, TypeVar
+
+import pytest
+
+pytest.importorskip("textual")
+
+from textual.widgets import Input, Label, ListView, Static  # noqa: E402
+
+from scout.tui.app import ScoutApp  # noqa: E402
+from scout.tui.screens.dashboard import (  # noqa: E402
+    FILTER_OPTIONS,
+    ActionItemWidget,
+    DashboardScreen,
+    NoteInputScreen,
+    _make_tui_note_line,
+)
+
+T = TypeVar("T")
+
+DAILY = """# Action Items — 2026-04-15
+
+## 🔴 Urgent
+
+- [ ] Land the parser fix
+  - Source: https://example.com/thread
+  - See [[knowledge-base/rollout-plan]]
+- [ ] 🟡 Reply to Priya
+
+## To Do
+
+- [ ] 🟢 Read the postmortem
+- [x] Sent the weekly status
+
+## In Progress
+
+- 🔴 Draft the migration note
+"""
+
+
+def _run(coro_factory: Callable[[], Coroutine[Any, Any, T]]) -> T:
+    return asyncio.run(coro_factory())
+
+
+@pytest.fixture
+def daily(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    items_dir = tmp_path / "action-items"
+    items_dir.mkdir()
+    path = items_dir / "action-items-2026-04-15.md"
+    path.write_text(DAILY, encoding="utf-8")
+    monkeypatch.setattr("scout.tui.screens.dashboard.latest_action_items_path", lambda: path)
+    return path
+
+
+def _text(widget: Any) -> str:
+    """Read a Static/Label's text across Textual versions.
+
+    Textual 8 exposes `.content`; earlier releases (the `>=0.63` floor in
+    pyproject) exposed `.renderable`. Support both so a `[full]` install on
+    either side of that change still runs these tests.
+    """
+    for attr in ("content", "renderable"):
+        if hasattr(widget, attr):
+            return str(getattr(widget, attr))
+    raise AssertionError(f"no text accessor on {type(widget).__name__}")
+
+
+def _labels(screen: DashboardScreen) -> list[str]:
+    list_view = screen.query_one("#item-list", ListView)
+    out: list[str] = []
+    for child in list_view.children:
+        assert isinstance(child, ActionItemWidget)
+        out.append(_text(child.query_one(Label)))
+    return out
+
+
+def _status(screen: DashboardScreen) -> str:
+    return _text(screen.query_one("#status-bar", Static))
+
+
+def _detail(screen: DashboardScreen) -> str:
+    return _text(screen.query_one("#detail-panel", Static))
+
+
+def _highlight(screen: DashboardScreen, title: str) -> None:
+    """Highlight the row for `title`.
+
+    Rows are sorted by status then priority, so a positional index is not
+    stable against a fixture edit — look the row up by title instead.
+    """
+    widgets = list(screen.query(ActionItemWidget))
+    idx = next(i for i, w in enumerate(widgets) if w.item.title == title)
+    screen.query_one("#item-list", ListView).index = idx
+
+
+# ---------------------------------------------------------------------------
+# _make_tui_note_line
+# ---------------------------------------------------------------------------
+
+
+def test_note_line_is_an_indented_dated_sub_bullet() -> None:
+    line = _make_tui_note_line("looked into it")
+    assert line.startswith("  - **[TUI note, ")
+    assert line.endswith("]:** looked into it")
+    # The stamp is Eastern wall-clock, not UTC — a hardcoded offset silently
+    # drifted an hour across DST.
+    stamp = line.split("[TUI note, ", 1)[1].split("]:", 1)[0]
+    # The real zone abbreviation (EDT/EST), not a literal "ET".
+    zone = stamp.rsplit(" ", 1)[1]
+    assert zone in {"EDT", "EST"}, f"unexpected zone in {stamp!r}"
+    parsed = dt.datetime.strptime(stamp.rsplit(" ", 1)[0], "%Y-%m-%d %I:%M %p")
+    assert parsed.year >= 2024
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_lists_every_parsed_item(daily: Path) -> None:
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            labels = _labels(screen)
+            assert len(labels) == 5
+            assert any("Land the parser fix" in ln for ln in labels)
+
+    _run(body)
+
+
+def test_done_items_render_struck_through(daily: Path) -> None:
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            done = [ln for ln in _labels(screen) if "Sent the weekly status" in ln]
+            assert done and "~~Sent the weekly status~~" in done[0]
+            assert "[x]" in done[0]
+
+    _run(body)
+
+
+def test_item_rows_carry_priority_status_and_section(daily: Path) -> None:
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            row = next(ln for ln in _labels(screen) if "Land the parser fix" in ln)
+            assert row.startswith("🔴 [ ] ")
+            # The section suffix is the parsed section label verbatim, glyph
+            # included ("## 🔴 Urgent").
+            assert row.endswith("(🔴 Urgent)")
+
+    _run(body)
+
+
+def test_status_bar_counts_shown_actionable_and_total(daily: Path) -> None:
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            status = _status(screen)
+            assert daily.name in status
+            assert "5 shown" in status
+            assert "4 actionable" in status
+            assert "5 total" in status
+            assert "Filter: all" in status
+
+    _run(body)
+
+
+def test_missing_file_yields_an_empty_list(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A vault with no daily file yet must render an empty dashboard, not
+    crash on startup."""
+    monkeypatch.setattr(
+        "scout.tui.screens.dashboard.latest_action_items_path",
+        lambda: tmp_path / "action-items" / "action-items-2026-04-15.md",
+    )
+
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            assert _labels(screen) == []
+            assert "0 shown" in _status(screen)
+
+    _run(body)
+
+
+def test_a_parser_error_is_surfaced_and_does_not_crash(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "action-items-2026-04-15.md"
+    path.write_text(DAILY, encoding="utf-8")
+    monkeypatch.setattr("scout.tui.screens.dashboard.latest_action_items_path", lambda: path)
+
+    def boom(_p: Path):
+        raise RuntimeError("corrupt file")
+
+    monkeypatch.setattr("scout.tui.screens.dashboard.parse_action_items", boom)
+
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            assert _labels(screen) == []
+
+    _run(body)
+
+
+def test_a_vault_that_disappears_under_a_refresh_empties_the_list(daily: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`refresh_items` guards FileNotFoundError so an `r` press (or a return
+    from the note modal) after the vault moves warns instead of crashing.
+
+    Note: `DashboardScreen.__init__` calls the same resolver *unguarded*, so a
+    resolver that fails at construction time still takes the app down — this
+    test covers the guarded refresh path only.
+    """
+
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            assert len(_labels(screen)) == 5
+
+            def boom() -> Path:
+                raise FileNotFoundError("no vault")
+
+            monkeypatch.setattr("scout.tui.screens.dashboard.latest_action_items_path", boom)
+            await pilot.press("r")
+            await pilot.pause()
+            assert _labels(screen) == []
+
+    _run(body)
+
+
+# ---------------------------------------------------------------------------
+# Filter cycle
+# ---------------------------------------------------------------------------
+
+
+def test_f_cycles_through_every_filter_option(daily: Path) -> None:
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            seen = [screen.filter_mode]
+            for _ in FILTER_OPTIONS:
+                await pilot.press("f")
+                seen.append(screen.filter_mode)
+            # A full cycle returns to where it started.
+            assert seen[0] == seen[-1] == "all"
+            assert set(seen) == set(FILTER_OPTIONS)
+
+    _run(body)
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_titles"),
+    [
+        ("🔴", {"Land the parser fix", "Draft the migration note"}),
+        ("🟡", {"Reply to Priya"}),
+        ("🟢", {"Read the postmortem"}),
+        ("open", {"Land the parser fix", "Reply to Priya", "Read the postmortem", "Draft the migration note"}),
+        ("done", {"Sent the weekly status"}),
+    ],
+)
+def test_each_filter_narrows_the_list(daily: Path, mode: str, expected_titles: set[str]) -> None:
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            screen.filter_mode = mode
+            await pilot.pause()
+            shown = {i.item.title for i in screen.query(ActionItemWidget)}
+            assert shown == expected_titles
+            assert f"Filter: {mode}" in _status(screen)
+
+    _run(body)
+
+
+def test_a_stale_filter_mode_resets_instead_of_raising(daily: Path) -> None:
+    """#59: `action_cycle_filter` guards `FILTER_OPTIONS.index` — a filter_mode
+    left over from an older build must not raise ValueError."""
+
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            screen.filter_mode = "stale-mode-xyz"
+            await pilot.pause()
+            # An unknown mode filters to everything rather than nothing.
+            assert len(screen.query(ActionItemWidget)) == 5
+            await pilot.press("f")
+            assert screen.filter_mode == FILTER_OPTIONS[1]
+
+    _run(body)
+
+
+# ---------------------------------------------------------------------------
+# Detail panel
+# ---------------------------------------------------------------------------
+
+
+def test_detail_panel_shows_details_and_links_for_the_highlighted_item(daily: Path) -> None:
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            _highlight(screen, "Land the parser fix")
+            await pilot.pause()
+            detail = _detail(screen)
+            assert "Source: https://example.com/thread" in detail
+            assert "Links: https://example.com/thread" in detail
+            assert "kb://knowledge-base/rollout-plan" in detail
+
+    _run(body)
+
+
+def test_detail_panel_says_no_details_for_a_bare_item(daily: Path) -> None:
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            _highlight(screen, "Reply to Priya")
+            await pilot.pause()
+            assert _detail(screen) == "No details"
+
+    _run(body)
+
+
+def test_detail_panel_reports_a_note_count(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "action-items-2026-04-15.md"
+    path.write_text(
+        "## 🔴 Urgent\n\n- [ ] Land the fix\n  - **[TUI note, 2026-04-15 09:00 AM ET]:** looked\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("scout.tui.screens.dashboard.latest_action_items_path", lambda: path)
+
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            _highlight(screen, "Land the fix")
+            await pilot.pause()
+            assert "Notes: 1" in _detail(screen)
+
+    _run(body)
+
+
+# ---------------------------------------------------------------------------
+# Keybindings
+# ---------------------------------------------------------------------------
+
+
+def test_d_flips_the_checkbox_on_disk_and_refreshes(daily: Path) -> None:
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            _highlight(screen, "Land the parser fix")
+            await pilot.pause()
+            await pilot.press("d")
+            await pilot.pause()
+
+    _run(body)
+    assert "- [x] Land the parser fix" in daily.read_text()
+
+
+def test_d_is_a_no_op_on_an_already_done_item(daily: Path) -> None:
+    before = daily.read_text()
+
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            _highlight(screen, "Sent the weekly status")
+            await pilot.pause()
+            await pilot.press("d")
+            await pilot.pause()
+
+    _run(body)
+    assert daily.read_text() == before
+
+
+def test_d_with_nothing_highlighted_does_nothing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "action-items-2026-04-15.md"
+    path.write_text("## 🔴 Urgent\n", encoding="utf-8")  # no items
+    monkeypatch.setattr("scout.tui.screens.dashboard.latest_action_items_path", lambda: path)
+    before = path.read_text()
+
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            await pilot.press("d")
+            await pilot.pause()
+
+    _run(body)
+    assert path.read_text() == before
+
+
+def test_n_opens_the_note_modal_and_saves_the_note(daily: Path) -> None:
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            _highlight(screen, "Land the parser fix")
+            await pilot.pause()
+
+            await pilot.press("n")
+            await pilot.pause()
+            assert isinstance(pilot.app.screen, NoteInputScreen)
+
+            pilot.app.screen.query_one("#note-input", Input).value = "looked into it"
+            await pilot.press("enter")
+            await pilot.pause()
+            assert isinstance(pilot.app.screen, DashboardScreen)
+
+    _run(body)
+    text = daily.read_text()
+    assert "**[TUI note, " in text
+    assert "looked into it" in text
+
+
+def test_the_note_modal_discards_an_empty_note(daily: Path) -> None:
+    before = daily.read_text()
+
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            _highlight(screen, "Land the parser fix")
+            await pilot.pause()
+            await pilot.press("n")
+            await pilot.pause()
+            pilot.app.screen.query_one("#note-input", Input).value = "   "
+            await pilot.press("enter")
+            await pilot.pause()
+
+    _run(body)
+    assert daily.read_text() == before
+
+
+def test_escape_cancels_the_note_modal(daily: Path) -> None:
+    before = daily.read_text()
+
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            _highlight(screen, "Land the parser fix")
+            await pilot.pause()
+            await pilot.press("n")
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(pilot.app.screen, DashboardScreen)
+
+    _run(body)
+    assert daily.read_text() == before
+
+
+def test_n_with_nothing_highlighted_does_not_open_the_modal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "action-items-2026-04-15.md"
+    path.write_text("## 🔴 Urgent\n", encoding="utf-8")
+    monkeypatch.setattr("scout.tui.screens.dashboard.latest_action_items_path", lambda: path)
+
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            await pilot.press("n")
+            await pilot.pause()
+            assert isinstance(pilot.app.screen, DashboardScreen)
+
+    _run(body)
+
+
+def test_o_opens_the_first_http_context_link(daily: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    opened: list[str] = []
+    monkeypatch.setattr("webbrowser.open", lambda url: opened.append(url))
+
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            _highlight(screen, "Land the parser fix")
+            await pilot.pause()
+            await pilot.press("o")
+            await pilot.pause()
+
+    _run(body)
+    # Only the http link is opened; the kb:// pseudo-link is skipped.
+    assert opened == ["https://example.com/thread"]
+
+
+def test_o_on_an_item_with_no_links_opens_nothing(daily: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    opened: list[str] = []
+    monkeypatch.setattr("webbrowser.open", lambda url: opened.append(url))
+
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            _highlight(screen, "Reply to Priya")
+            await pilot.pause()
+            await pilot.press("o")
+            await pilot.pause()
+
+    _run(body)
+    assert opened == []
+
+
+def test_s_opens_the_spawn_modal_and_launching_is_deferred_to_a_worker(
+    daily: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#52: osascript fork+exec must run off the Textual event loop, so the
+    confirm handler hands it to a thread worker rather than calling it inline."""
+    from scout.tui.screens.spawn import SpawnConfirmScreen
+
+    launched: list[Any] = []
+    monkeypatch.setattr("scout.tui.screens.spawn.spawn_session", lambda item: launched.append(item.title) or "cmd")
+
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            _highlight(screen, "Land the parser fix")
+            await pilot.pause()
+
+            await pilot.press("s")
+            await pilot.pause()
+            assert isinstance(pilot.app.screen, SpawnConfirmScreen)
+            assert "Land the parser fix" in pilot.app.screen.prompt
+
+            await pilot.press("enter")
+            await pilot.pause()
+            assert isinstance(pilot.app.screen, DashboardScreen)
+
+    _run(body)
+    assert launched == ["Land the parser fix"]
+
+
+def test_escape_cancels_the_spawn_modal(daily: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from scout.tui.screens.spawn import SpawnConfirmScreen
+
+    launched: list[Any] = []
+    monkeypatch.setattr("scout.tui.screens.spawn.spawn_session", lambda item: launched.append(item) or "cmd")
+
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            _highlight(screen, "Land the parser fix")
+            await pilot.pause()
+            await pilot.press("s")
+            await pilot.pause()
+            assert isinstance(pilot.app.screen, SpawnConfirmScreen)
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(pilot.app.screen, DashboardScreen)
+
+    _run(body)
+    assert launched == []
+
+
+def test_s_with_nothing_highlighted_does_not_open_the_modal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "action-items-2026-04-15.md"
+    path.write_text("## 🔴 Urgent\n", encoding="utf-8")
+    monkeypatch.setattr("scout.tui.screens.dashboard.latest_action_items_path", lambda: path)
+
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            await pilot.press("s")
+            await pilot.pause()
+            assert isinstance(pilot.app.screen, DashboardScreen)
+
+    _run(body)
+
+
+def test_r_reloads_from_disk(daily: Path) -> None:
+    """The app-level refresh binding must pick up an external edit — the
+    briefing rewrites this file while the TUI is open."""
+
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            assert len(screen.query(ActionItemWidget)) == 5
+
+            daily.write_text(DAILY + "- [ ] A brand new task\n", encoding="utf-8")
+            await pilot.press("r")
+            await pilot.pause()
+            assert any(w.item.title == "A brand new task" for w in screen.query(ActionItemWidget))
+
+    _run(body)
+
+
+def test_app_refresh_is_a_no_op_on_a_non_dashboard_screen(daily: Path) -> None:
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            _highlight(screen, "Land the parser fix")
+            await pilot.pause()
+            await pilot.press("n")
+            await pilot.pause()
+            assert isinstance(pilot.app.screen, NoteInputScreen)
+            # The note modal has no refresh_items; the action must not raise.
+            app = pilot.app
+            assert isinstance(app, ScoutApp)
+            app.action_refresh()
+            await pilot.pause()
+            assert isinstance(pilot.app.screen, NoteInputScreen)
+
+    _run(body)

--- a/engine/tests/unit/test_versioning_cli.py
+++ b/engine/tests/unit/test_versioning_cli.py
@@ -1,0 +1,157 @@
+"""Coverage of `versioning.main()` — the argv surface `scripts/release.sh` calls.
+
+`test_versioning.py` covers the library functions against a synthetic plugin
+tree. `main()` is untested and is the part the release script actually shells
+out to, so an argv regression breaks a release rather than a test.
+
+`main()` calls `read_versions` / `assert_in_sync` / `set_version` with their
+default `root=PLUGIN_ROOT` — the *real* checkout. A default argument is bound
+at import, so monkeypatching `versioning.PLUGIN_ROOT` would not redirect it;
+these tests stub the three functions instead, which also keeps the suite from
+ever rewriting the repo's own version files.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scout.scripts import versioning
+
+
+@pytest.fixture(autouse=True)
+def no_real_writes(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Fence off every function that would touch the real checkout."""
+    written: list[str] = []
+    monkeypatch.setattr(versioning, "read_versions", lambda *a, **k: {"plugin.json": "1.2.3"})
+    monkeypatch.setattr(versioning, "assert_in_sync", lambda *a, **k: "1.2.3")
+    monkeypatch.setattr(versioning, "set_version", lambda *, version, **k: written.append(version))
+    return written
+
+
+def test_no_args_prints_usage_and_exits_two(capsys: pytest.CaptureFixture[str]) -> None:
+    assert versioning.main([]) == 2
+    assert "usage: versioning.py" in capsys.readouterr().err
+
+
+def test_check_prints_the_in_sync_version(capsys: pytest.CaptureFixture[str]) -> None:
+    assert versioning.main(["check"]) == 0
+    assert capsys.readouterr().out.strip() == "1.2.3"
+
+
+def test_check_propagates_a_drift_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Release must abort loudly on drift, not print a wrong version."""
+
+    def boom(*_a: object, **_k: object) -> str:
+        raise ValueError("version drift across manifests: {...}")
+
+    monkeypatch.setattr(versioning, "assert_in_sync", boom)
+    with pytest.raises(ValueError, match="version drift"):
+        versioning.main(["check"])
+
+
+def test_current_prints_the_canonical_version(capsys: pytest.CaptureFixture[str]) -> None:
+    assert versioning.main(["current"]) == 0
+    assert capsys.readouterr().out.strip() == "1.2.3"
+
+
+@pytest.mark.parametrize(
+    ("level", "expected"),
+    [("patch", "1.2.4"), ("minor", "1.3.0"), ("major", "2.0.0"), ("9.9.9", "9.9.9")],
+)
+def test_bump_writes_and_echoes_the_new_version(
+    no_real_writes: list[str], capsys: pytest.CaptureFixture[str], level: str, expected: str
+) -> None:
+    assert versioning.main(["bump", level]) == 0
+    assert capsys.readouterr().out.strip() == expected
+    assert no_real_writes == [expected]
+
+
+def test_set_writes_the_given_version(no_real_writes: list[str], capsys: pytest.CaptureFixture[str]) -> None:
+    assert versioning.main(["set", "2.5.0"]) == 0
+    assert capsys.readouterr().out.strip() == "2.5.0"
+    assert no_real_writes == ["2.5.0"]
+
+
+@pytest.mark.parametrize("cmd", ["bump", "set"])
+def test_bump_and_set_require_an_argument(
+    cmd: str, no_real_writes: list[str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert versioning.main([cmd]) == 2
+    assert f"{cmd} requires an argument" in capsys.readouterr().err
+    assert no_real_writes == []
+
+
+@pytest.mark.parametrize("bad", ["patch", "1.2", "v1.2.3", "1.2.3-rc1"])
+def test_set_rejects_anything_that_is_not_x_y_z(
+    bad: str, no_real_writes: list[str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`set` is the escape hatch for an exact version — accepting a bump level
+    there would silently write the literal string "patch" into four manifests."""
+    assert versioning.main(["set", bad]) == 2
+    assert "set requires an X.Y.Z version" in capsys.readouterr().err
+    assert no_real_writes == []
+
+
+def test_bump_rejects_an_invalid_level(no_real_writes: list[str]) -> None:
+    with pytest.raises(ValueError, match="invalid bump level"):
+        versioning.main(["bump", "beta"])
+    assert no_real_writes == []
+
+
+def test_unknown_command_exits_two(no_real_writes: list[str], capsys: pytest.CaptureFixture[str]) -> None:
+    assert versioning.main(["publish"]) == 2
+    assert "unknown command: publish" in capsys.readouterr().err
+    assert no_real_writes == []
+
+
+def test_main_reads_sys_argv_when_no_argv_is_passed(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr("sys.argv", ["versioning.py", "current"])
+    assert versioning.main() == 0
+    assert capsys.readouterr().out.strip() == "1.2.3"
+
+
+# --- library-level gaps -----------------------------------------------------
+
+
+def test_read_versions_rejects_a_file_with_no_version_field(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A manifest we can read but can't find a version in must be an error, not
+    a silently-missing key — the release script reads this dict by label."""
+    monkeypatch.undo()  # drop the autouse stubs; exercise the real function
+    (tmp_path / ".claude-plugin").mkdir()
+    (tmp_path / ".claude-plugin" / "plugin.json").write_text('{"name": "scout"}\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="no version field found in .claude-plugin/plugin.json"):
+        versioning.read_versions(tmp_path)
+
+
+@pytest.mark.parametrize("current", ["1.2", "1.2.3.4", "v1.2.3", "1.2.x", ""])
+def test_bump_rejects_a_non_semver_current_version(current: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bumping off a malformed current version would compute a nonsense next
+    one, so it must raise instead."""
+    monkeypatch.undo()
+    with pytest.raises(ValueError, match="is not semver"):
+        versioning.bump(current, "patch")
+
+
+def test_set_version_requires_a_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.undo()
+    with pytest.raises(ValueError, match="set_version requires a version"):
+        versioning.set_version(version=None)
+
+
+def test_set_version_rejects_a_manifest_it_cannot_rewrite(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.undo()
+    (tmp_path / ".claude-plugin").mkdir()
+    (tmp_path / ".claude-plugin" / "plugin.json").write_text('{"name": "scout"}\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="failed to rewrite version"):
+        versioning.set_version(tmp_path, "1.3.0")
+
+
+def test_plugin_root_points_at_the_checkout_root() -> None:
+    """`PLUGIN_ROOT` is `parents[3]` of this module — if the file ever moves,
+    every default-root call silently targets the wrong tree."""
+    assert (versioning.PLUGIN_ROOT / ".claude-plugin" / "plugin.json").is_file()
+    assert (versioning.PLUGIN_ROOT / "engine" / "pyproject.toml").is_file()


### PR DESCRIPTION
## Why

The engine runs unattended on a schedule. An uncovered failure path is one that first executes at 03:00 with nobody watching — and coverage was **80%**, with the gaps clustered exactly where that matters: the CLI surface the runners shell out to, and the tolerance branches over files another process is concurrently writing.

## What

**25 new test files, 1,131 new tests** (1,000 → 2,131). Coverage **80% → 99.04%** (statement + branch), locked in by a CI gate.

Modules taken from partial to complete:

| Module | Before | After |
|---|---|---|
| `scout/cli.py` | 55% | 100% |
| `action_items/cli.py` | 24% | 100% |
| `tui/screens/dashboard.py` | 27% | 100% |
| `action_items/watch.py` | 42% | 100% |
| `scripts/versioning.py` | 61% | 100% |
| `kb/ontology.py` | 63% | 100% |
| `action_items/render.py` | 73% | 100% |
| `scripts/heartbeat.py` | 73% | ~99% |
| `hooks/session_tool_log.py` | 79% | 100% |

…plus `bootstrap`, `bootstrap_doctor`, `cc_session_cache`, `migrate_perfile`, `pre_session_data`, `notify_telegram`, `self_update`, `action_items/parser`, the trigger sources and the whole `tui/` package (84–90% → ~100%).

**No production code is touched.** Beyond tests, the diff is config and CI only.

## What the tests actually target

The bias is toward branches where a bug is *silent* rather than loud:

- **Hook `main()`s that must always exit 0** — a Stop hook that raises blocks the session.
- **`schedule_tick._local_tz_name`'s fallbacks.** A wrong zone shifts every slot by hours and the dispatcher still reports success, which is why each fallback logs to stderr instead of returning `"UTC"` quietly (#50).
- **The last-fire index and its mtime cache** — a stale read double-fires a slot, a mis-parsed row misses one (#73).
- **Two security guards that only fail silently:** the bot-token redaction in `notify telegram` (`str(HTTPError)` embeds the token-bearing URL), and the argv-not-source AppleScript construction in the health report, where connector names come from user-editable YAML (#51).
- **`migrate_perfile`'s parsers**, which back a destructive one-shot that unlinks the single-file wishlists after splitting them.

## The coverage gate

- `engine/pyproject.toml`: `[tool.coverage]` with branch coverage and `fail_under = 98`.
- `.github/workflows/test.yml`: a **separate `coverage` job** rather than adding `--cov` to the 2×2 matrix, for two reasons — it needs `[dev,full]` (every TUI test is `importorskip("textual")`, so a `[dev]`-only install skips ~3 points of the total), and coverage's tracer would skew `tests/perf/`, which measures `scoutctl`'s cold-start latency.
- `.gitignore`: coverage artifacts.

Three lines stay uncovered rather than being papered over with a `pragma`: `schedule_tick.py`'s and `install_wake_schedule.py`'s exhaustive-enum fallbacks, and `connector_log.py`'s non-POSIX `fcntl` import arm. The 98% floor leaves room for them.

## Rebased onto v0.9.0

This work was written against the pre-v0.9.0 tree. Rebasing onto current `main` surfaced **6 failures — all of them my tests encoding v0.8.0 behavior that v0.9.0 deliberately changed**, not regressions. Each is updated to the current contract, with the reason recorded in the test:

- **3×** the config file is `scout-config.yaml`, no dot — the dotted file was a dotfile nothing ever wrote, which silently disabled the whole user-override layer (#207/#202).
- **2×** timestamps now render the real zone abbreviation (`EDT`/`EST`) rather than a literal `ET`, from the TZ-localization work.
- **1×** `on_miss=skip` now means "don't fire *late*", not "never fire" (#193/#198). My test asserted the old, buggy semantics.

I also added coverage for two branches v0.9.0 introduced: `budget_check`'s out-of-range-override warning, and `heartbeat._log_line`'s zone-resolution fallback.

## Verification

Both CI job shapes, run locally:

- **coverage job** (3.12, `[dev,full]`): 2131 passed, 1 skipped, **99.04%**, gate met.
- **matrix job** (3.11, `[dev]` only): 2073 passed, 13 skipped.

`ruff check`, `ruff format --check` and `mypy scout` clean. The parser-corpus contract + checksum, both snapshot drift guards, and the version-sync guard all pass.

> The `[dev]`-only run earned its keep: it caught a defect in my own work — one TUI test patched `scout.tui.app` without an `importorskip`, which would have failed all four matrix legs.

## One thing worth a follow-up (not in this PR)

`DashboardScreen.__init__` calls `latest_action_items_path()` unguarded, while `refresh_items()` wraps the same call in try/except. If resolution raises at construction, the TUI dies with a traceback instead of showing the empty-list warning that handler exists to produce. Out of scope for a coverage change, so it's left alone — one test's docstring records the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
