### PR TITLE
fix(tui): resolve the action-items path in refresh_items, not __init__

### DIFF
--- a/engine/scout/tui/screens/dashboard.py
+++ b/engine/scout/tui/screens/dashboard.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as _dt
+from pathlib import Path
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -30,6 +31,12 @@ STATUS_DISPLAY = {
 }
 
 FILTER_OPTIONS = ["all", "🔴", "🟡", "🟢", "open", "done"]
+
+# Display-only stand-in for the action-items file until refresh_items resolves
+# the real one. Never a write target: the write paths (action_mark_done,
+# action_add_note) are gated on a selected item, and an unresolved path always
+# comes with an empty list, so nothing is selectable.
+UNRESOLVED_PATH = Path("(no action-items file)")
 
 
 def _make_tui_note_line(note_text: str) -> str:
@@ -115,7 +122,11 @@ class DashboardScreen(Screen):
     def __init__(self) -> None:
         super().__init__()
         self.all_items: list[ActionItem] = []
-        self.filepath = latest_action_items_path()
+        # Resolve in refresh_items (called from on_mount), never here: that is
+        # the single place that handles a resolver failure. Resolving in
+        # __init__ propagates out of ScoutApp.on_mount -> push_screen() and
+        # takes the whole TUI down instead of showing the empty + warning state.
+        self.filepath: Path = UNRESOLVED_PATH
 
     def compose(self) -> ComposeResult:
         yield Header()

--- a/engine/tests/unit/test_tui_dashboard.py
+++ b/engine/tests/unit/test_tui_dashboard.py
@@ -230,13 +230,42 @@ def test_a_parser_error_is_surfaced_and_does_not_crash(tmp_path: Path, monkeypat
     _run(body)
 
 
+def test_a_resolver_that_raises_at_construction_yields_an_empty_dashboard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A resolver that fails before `on_mount` must not take the app down.
+
+    `ScoutApp.on_mount` constructs the screen, so a raise in `__init__` escapes
+    into the app's mount handler rather than into `refresh_items`' guard. The
+    screen must instead reach the same empty state the refresh path produces.
+    """
+
+    def boom() -> Path:
+        raise OSError("action-items dir is unreadable")
+
+    monkeypatch.setattr("scout.tui.screens.dashboard.latest_action_items_path", boom)
+
+    async def body() -> None:
+        async with ScoutApp().run_test() as pilot:
+            screen = pilot.app.screen
+            assert isinstance(screen, DashboardScreen)
+            assert screen.all_items == []
+            assert _labels(screen) == []
+            # `_update_list` renders `self.filepath.name`, so it must have run
+            # to completion against the placeholder rather than a None.
+            assert "0 shown, 0 actionable, 0 total" in _status(screen)
+
+    _run(body)
+
+
 def test_a_vault_that_disappears_under_a_refresh_empties_the_list(daily: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """`refresh_items` guards FileNotFoundError so an `r` press (or a return
     from the note modal) after the vault moves warns instead of crashing.
 
-    Note: `DashboardScreen.__init__` calls the same resolver *unguarded*, so a
-    resolver that fails at construction time still takes the app down — this
-    test covers the guarded refresh path only.
+    This covers the refresh path; the construction path is covered by
+    `test_a_resolver_that_raises_at_construction_yields_an_empty_dashboard`.
+    `DashboardScreen.__init__` no longer resolves at all, so `refresh_items` is
+    the single place that handles a resolution failure.
     """
 
     async def body() -> None:


### PR DESCRIPTION
Stacked on #226 — please merge that first. Based on `claude/engine-test-coverage` so the new test lands in the `test_tui_dashboard.py` that PR introduces, rather than colliding with it.

## Problem

`DashboardScreen.__init__` called `latest_action_items_path()` unguarded, while `refresh_items` wrapped the same call in `try/except FileNotFoundError` + `except Exception` + `notify(...)`. A resolver that raised at construction time therefore propagated out of `ScoutApp.on_mount` → `push_screen(DashboardScreen())` and took the whole TUI down with a traceback, bypassing the empty-list + warning state `refresh_items` exists to produce.

## Fix

`__init__` no longer resolves anything — it assigns a display-only placeholder, leaving `refresh_items` (via `on_mount`) as the single place that handles a resolution failure.

The placeholder is never a write target: `action_mark_done` and `action_add_note` are both gated on `_selected_item()`, and a failed resolution always leaves the list empty, so nothing is selectable. That reasoning is recorded in a comment next to the constant rather than duplicated as a runtime guard.

## Scope note — this is defence in depth, not a live crash fix

Worth being explicit, since the issue framing implied a reproducible crash. On CPython 3.11 `latest_action_items_path()` is effectively total, so I could not reproduce a construction-time failure:

- **Unreadable vault dir** — `Path.exists()` returns `True` and `Path.glob()` swallows `PermissionError`, returning `[]`. Verified empirically on 3.11.8.
- **`ACTION_ITEMS_DIR`'s parent moved** — `Path.exists()` returns `False`.
- Both fall through to `action_items_path()`, whose only non-trivial call is `resolve_timezone()`, which is implemented and documented never to raise (bare `except Exception` → `DEFAULT_TIMEZONE`).

So the asymmetry was latent rather than live. It is still worth closing: it is one edit to `latest_action_items_path` away from being real, and the guard in `refresh_items` already documents the intended contract.

## Tests

Added `test_a_resolver_that_raises_at_construction_yields_an_empty_dashboard`, driving the real pilot through `ScoutApp` with a raising resolver. It asserts the empty state *and* that the status bar rendered — `_update_list` reads `self.filepath.name`, so a `None` placeholder would fail there rather than silently pass.

Also updated `test_a_vault_that_disappears_under_a_refresh_empties_the_list`'s docstring, which explicitly recorded this gap ("`DashboardScreen.__init__` calls the same resolver *unguarded*").

Confirmed the new test fails against the pre-fix `dashboard.py` with `OSError` propagating from `__init__`, and passes after.

## Verification

- TUI suite: 45 passed.
- Full suite: 2126 passed, 6 failed. Those 6 are pre-existing and environment-bound — they fail identically with `dashboard.py` reverted to the base commit, and are CLI/telegram/schedule tests that never import the TUI.
- `ruff check .` and `ruff format --check` clean; `mypy` clean.
- Coverage gate passes at 99.02% (threshold 98), with `dashboard.py` at zero missing statements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
